### PR TITLE
refactor(core-rpc): replace magic JSON-RPC error codes with named constants

### DIFF
--- a/core/src/rpc/error.rs
+++ b/core/src/rpc/error.rs
@@ -1,5 +1,12 @@
 use jsonrpsee::types::ErrorObjectOwned;
 
+pub use jsonrpsee::types::error::{
+    INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE, INVALID_REQUEST_CODE, PARSE_ERROR_CODE,
+};
+
+/// Generic JSON-RPC server error (base of the -32000..-32099 reserved range).
+pub const JSON_RPC_SERVER_ERROR: i32 = -32000;
+
 pub fn custom_error(code: i32, message: impl ToString) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(code, message.to_string(), None::<()>)
 }

--- a/core/src/rpc/get_account_info_impl.rs
+++ b/core/src/rpc/get_account_info_impl.rs
@@ -1,6 +1,9 @@
 use crate::{
     accounts::bob::BOB,
-    rpc::{error::custom_error, ReadDeps},
+    rpc::{
+        error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
+        ReadDeps,
+    },
 };
 use jsonrpsee::core::RpcResult;
 use solana_account_decoder::encode_ui_account;
@@ -21,7 +24,7 @@ pub async fn get_account_info_impl(
     config: Option<RpcAccountInfoConfig>,
 ) -> RpcResult<Response<Option<UiAccount>>> {
     let pubkey = Pubkey::from_str(&pubkey)
-        .map_err(|e| custom_error(-32602, format!("Invalid pubkey: {}", e)))?;
+        .map_err(|e| custom_error(INVALID_PARAMS_CODE, format!("Invalid pubkey: {}", e)))?;
 
     let config = config.unwrap_or_default();
 
@@ -29,7 +32,7 @@ pub async fn get_account_info_impl(
         .accounts_db
         .get_latest_slot()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get slot: {}", e)))?;
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get slot: {}", e)))?;
 
     // Get account from database
     let (_settled_accounts_tx, settled_accounts_rx) = mpsc::unbounded_channel();

--- a/core/src/rpc/get_blocks_impl.rs
+++ b/core/src/rpc/get_blocks_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_rpc_client_types::config::RpcContextConfig;
 
@@ -12,5 +15,5 @@ pub async fn get_blocks_impl(
         .accounts_db
         .get_blocks(start_slot, end_slot)
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get blocks: {}", e)))
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get blocks: {}", e)))
 }

--- a/core/src/rpc/get_epoch_info_impl.rs
+++ b/core/src/rpc/get_epoch_info_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_epoch_info::EpochInfo;
 use solana_rpc_client_types::config::RpcEpochConfig;
@@ -11,5 +14,5 @@ pub async fn get_epoch_info_impl(
         .accounts_db
         .get_epoch_info()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get epoch info: {}", e)))
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get epoch info: {}", e)))
 }

--- a/core/src/rpc/get_first_available_block_impl.rs
+++ b/core/src/rpc/get_first_available_block_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 
 pub async fn get_first_available_block_impl(read_deps: &ReadDeps) -> RpcResult<u64> {
@@ -8,7 +11,7 @@ pub async fn get_first_available_block_impl(read_deps: &ReadDeps) -> RpcResult<u
         .await
         .map_err(|e| {
             custom_error(
-                -32000,
+                JSON_RPC_SERVER_ERROR,
                 format!("Failed to get first available block: {}", e),
             )
         })

--- a/core/src/rpc/get_latest_blockhash_impl.rs
+++ b/core/src/rpc/get_latest_blockhash_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_rpc_client_types::config::RpcContextConfig;
 use solana_rpc_client_types::response::{Response, RpcBlockhash, RpcResponseContext};
@@ -12,12 +15,12 @@ pub async fn get_latest_blockhash_impl(
         .accounts_db
         .get_latest_slot()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get slot: {}", e)))?;
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get slot: {}", e)))?;
     let blockhash = read_deps
         .accounts_db
         .get_latest_blockhash()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get blockhash: {}", e)))?;
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get blockhash: {}", e)))?;
 
     // Calculate last valid block height
     // In Solana, a blockhash is valid for approximately 150 blocks

--- a/core/src/rpc/get_recent_performance_samples_impl.rs
+++ b/core/src/rpc/get_recent_performance_samples_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_rpc_client_types::response::RpcPerfSample;
 
@@ -16,7 +19,7 @@ pub async fn get_recent_performance_samples_impl(
         .await
         .map_err(|e| {
             custom_error(
-                -32000,
+                JSON_RPC_SERVER_ERROR,
                 format!("Failed to get recent performance samples: {}", e),
             )
         })

--- a/core/src/rpc/get_signature_statuses_impl.rs
+++ b/core/src/rpc/get_signature_statuses_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_rpc_client_types::config::RpcSignatureStatusConfig;
 use solana_rpc_client_types::response::{Response, RpcResponseContext};
@@ -17,7 +20,7 @@ pub async fn get_signature_statuses_impl(
         .accounts_db
         .get_latest_slot()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get slot: {}", e)))?;
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get slot: {}", e)))?;
 
     let mut statuses = Vec::with_capacity(signatures.len());
 

--- a/core/src/rpc/get_slot_impl.rs
+++ b/core/src/rpc/get_slot_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_rpc_client_types::config::RpcContextConfig;
 
@@ -10,5 +13,5 @@ pub async fn get_slot_impl(
         .accounts_db
         .get_latest_slot()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get slot: {}", e)))
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get slot: {}", e)))
 }

--- a/core/src/rpc/get_supply_impl.rs
+++ b/core/src/rpc/get_supply_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_rpc_client_types::config::RpcSupplyConfig;
 use solana_rpc_client_types::response::{Response, RpcResponseContext, RpcSupply};
@@ -12,7 +15,7 @@ pub async fn get_supply_impl(
         .accounts_db
         .get_latest_slot()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get latest slot: {}", e)))?;
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get latest slot: {}", e)))?;
 
     // Contra has no native token supply, so all values are 0
     Ok(Response {

--- a/core/src/rpc/get_token_account_balance_impl.rs
+++ b/core/src/rpc/get_token_account_balance_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, INVALID_PARAMS_CODE},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_account_decoder_client_types::token::UiTokenAmount;
 use solana_rpc_client_types::config::RpcContextConfig;
@@ -12,7 +15,7 @@ pub async fn get_token_account_balance_impl(
     _config: Option<RpcContextConfig>,
 ) -> RpcResult<Response<UiTokenAmount>> {
     // Parse the pubkey
-    let pubkey = Pubkey::from_str(&pubkey).map_err(|_| custom_error(-32602, "Invalid pubkey"))?;
+    let pubkey = Pubkey::from_str(&pubkey).map_err(|_| custom_error(INVALID_PARAMS_CODE, "Invalid pubkey"))?;
 
     // Get the token account data
     let account = read_deps.accounts_db.get_account_shared_data(&pubkey).await;
@@ -23,14 +26,14 @@ pub async fn get_token_account_balance_impl(
             .expect("Valid token program ID");
 
         if *account.owner() != token_program_id {
-            return Err(custom_error(-32602, "Account is not a token account"));
+            return Err(custom_error(INVALID_PARAMS_CODE, "Account is not a token account"));
         }
 
         // Parse the token account data
         let data = account.data();
         if data.len() < 165 {
             // SPL Token account size
-            return Err(custom_error(-32602, "Invalid token account data"));
+            return Err(custom_error(INVALID_PARAMS_CODE, "Invalid token account data"));
         }
 
         // Extract the amount (bytes 64-72) and decimals (byte 44)
@@ -38,7 +41,7 @@ pub async fn get_token_account_balance_impl(
         let amount = u64::from_le_bytes(
             amount_bytes
                 .try_into()
-                .map_err(|_| custom_error(-32602, "Invalid token amount"))?,
+                .map_err(|_| custom_error(INVALID_PARAMS_CODE, "Invalid token amount"))?,
         );
 
         // For simplicity, we'll use a fixed decimal value of 6 (common for many tokens)
@@ -60,6 +63,6 @@ pub async fn get_token_account_balance_impl(
             },
         })
     } else {
-        Err(custom_error(-32602, "Account not found"))
+        Err(custom_error(INVALID_PARAMS_CODE, "Account not found"))
     }
 }

--- a/core/src/rpc/get_transaction_count_impl.rs
+++ b/core/src/rpc/get_transaction_count_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_rpc_client_types::config::RpcContextConfig;
 
@@ -10,5 +13,5 @@ pub async fn get_transaction_count_impl(
         .accounts_db
         .get_transaction_count()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get transaction count: {}", e)))
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get transaction count: {}", e)))
 }

--- a/core/src/rpc/get_transaction_impl.rs
+++ b/core/src/rpc/get_transaction_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, INVALID_PARAMS_CODE},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use serde_json::{json, Value};
 use solana_rpc_client_types::config::{RpcEncodingConfigWrapper, RpcTransactionConfig};
@@ -12,7 +15,7 @@ pub async fn get_transaction_impl(
     config: Option<RpcEncodingConfigWrapper<RpcTransactionConfig>>,
 ) -> RpcResult<Option<Value>> {
     let sig = Signature::from_str(&signature)
-        .map_err(|e| custom_error(-32602, format!("Invalid signature: {}", e)))?;
+        .map_err(|e| custom_error(INVALID_PARAMS_CODE, format!("Invalid signature: {}", e)))?;
 
     // Extract encoding from config (default to "json")
     let config = config.map(|c| c.convert_to_current()).unwrap_or_default();

--- a/core/src/rpc/handler.rs
+++ b/core/src/rpc/handler.rs
@@ -1,6 +1,9 @@
 use {
     super::{api::ContraRpcServer, rpc_impl::ContraRpcImpl},
-    crate::rpc::rpc_impl::{ReadDeps, WriteDeps},
+    crate::rpc::{
+        error::{INTERNAL_ERROR_CODE, PARSE_ERROR_CODE},
+        rpc_impl::{ReadDeps, WriteDeps},
+    },
     http_body_util::{BodyExt, Full},
     hyper::{body::Bytes, Method, Request, Response, StatusCode},
     jsonrpsee::server::RpcModule,
@@ -18,7 +21,7 @@ pub async fn handle_request(
             // Process the JSON-RPC request using jsonrpsee
             // Convert body_bytes to a String first
             let json_str = String::from_utf8(body_bytes.to_vec())
-                .unwrap_or_else(|_| String::from(r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error: Invalid UTF-8"},"id":null}"#));
+                .unwrap_or_else(|_| format!(r#"{{"jsonrpc":"2.0","error":{{"code":{},"message":"Parse error: Invalid UTF-8"}},"id":null}}"#, PARSE_ERROR_CODE));
 
             // The second parameter is the maximum response size (10MB)
             let max_response_size = 10 * 1024 * 1024;
@@ -32,8 +35,8 @@ pub async fn handle_request(
                 Err(e) => {
                     // Create a JSON-RPC error response
                     format!(
-                        r#"{{"jsonrpc":"2.0","error":{{"code":-32603,"message":"Internal error: {}"}},"id":null}}"#,
-                        e
+                        r#"{{"jsonrpc":"2.0","error":{{"code":{},"message":"Internal error: {}"}},"id":null}}"#,
+                        INTERNAL_ERROR_CODE, e
                     )
                 }
             };

--- a/core/src/rpc/is_blockhash_valid_impl.rs
+++ b/core/src/rpc/is_blockhash_valid_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, ReadDeps};
+use crate::rpc::{
+    error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
+};
 use jsonrpsee::core::RpcResult;
 use solana_rpc_client_types::config::RpcContextConfig;
 use solana_rpc_client_types::response::{Response, RpcResponseContext};
@@ -15,18 +18,18 @@ pub async fn is_blockhash_valid_impl(
         .accounts_db
         .get_latest_slot()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get slot: {}", e)))?;
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get slot: {}", e)))?;
 
     // Parse the provided blockhash
     let provided_hash = Hash::from_str(&blockhash)
-        .map_err(|e| custom_error(-32602, format!("Invalid blockhash: {}", e)))?;
+        .map_err(|e| custom_error(INVALID_PARAMS_CODE, format!("Invalid blockhash: {}", e)))?;
 
     // Get the latest blockhash
     let latest_hash = read_deps
         .accounts_db
         .get_latest_blockhash()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get blockhash: {}", e)))?;
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get blockhash: {}", e)))?;
 
     // Check if the blockhash matches the latest one
     // In a production system, you'd want to check a range of recent blockhashes

--- a/core/src/rpc/send_transaction_impl.rs
+++ b/core/src/rpc/send_transaction_impl.rs
@@ -1,4 +1,7 @@
-use crate::rpc::{error::custom_error, WriteDeps};
+use crate::rpc::{
+    error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
+    WriteDeps,
+};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use bincode::Options;
 use jsonrpsee::core::RpcResult;
@@ -19,13 +22,13 @@ pub async fn send_transaction_impl(
     // Decode the base64 transaction
     let tx_data = STANDARD
         .decode(&transaction)
-        .map_err(|e| custom_error(-32602, format!("Invalid base64 encoding: {}", e)))?;
+        .map_err(|e| custom_error(INVALID_PARAMS_CODE, format!("Invalid base64 encoding: {}", e)))?;
 
     // Check packet size limit (1232 bytes is Solana's PACKET_DATA_SIZE)
     const PACKET_DATA_SIZE: usize = 1232;
     if tx_data.len() > PACKET_DATA_SIZE {
         return Err(custom_error(
-            -32602,
+            INVALID_PARAMS_CODE,
             format!(
                 "Transaction too large: {} bytes (max: {} bytes)",
                 tx_data.len(),
@@ -43,7 +46,7 @@ pub async fn send_transaction_impl(
     // Try to deserialize as VersionedTransaction first (standard format)
     let versioned_tx = bincode_options
         .deserialize::<VersionedTransaction>(&tx_data)
-        .map_err(|e| custom_error(-32602, format!("Failed to deserialize transaction: {}", e)))?;
+        .map_err(|e| custom_error(INVALID_PARAMS_CODE, format!("Failed to deserialize transaction: {}", e)))?;
 
     let runtime_tx = RuntimeTransaction::try_create(
         versioned_tx,
@@ -55,7 +58,7 @@ pub async fn send_transaction_impl(
         }),
         &HashSet::new(),
     )
-    .map_err(|err| custom_error(-32602, format!("invalid transaction: {err}")))?;
+    .map_err(|err| custom_error(INVALID_PARAMS_CODE, format!("invalid transaction: {err}")))?;
     let sanitized_tx = runtime_tx.into_inner_transaction();
 
     // Filter: only accept SPL token, ATA, System Program, and Withdraw Program transactions
@@ -83,7 +86,7 @@ pub async fn send_transaction_impl(
             program_ids
         );
         return Err(custom_error(
-            -32602,
+            INVALID_PARAMS_CODE,
             "Only SPL token, ATA, System, and Withdraw program transactions are accepted",
         ));
     }
@@ -96,7 +99,7 @@ pub async fn send_transaction_impl(
     write_deps
         .dedup_tx
         .send(sanitized_tx)
-        .map_err(|_| custom_error(-32000, "Internal error: dedup channel closed"))?;
+        .map_err(|_| custom_error(JSON_RPC_SERVER_ERROR, "Internal error: dedup channel closed"))?;
 
     debug!("Transaction {} sent to dedup stage", signature);
     Ok(signature)

--- a/core/src/rpc/simulate_transaction_impl.rs
+++ b/core/src/rpc/simulate_transaction_impl.rs
@@ -1,6 +1,9 @@
 use crate::{
     accounts::utils::encode_transaction_data,
-    rpc::{error::custom_error, ReadDeps},
+    rpc::{
+        error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
+        ReadDeps,
+    },
     scheduler::{ConflictFreeBatch, TransactionWithIndex},
     stages::{execute_batch, get_execution_deps, sigverify_transaction, SigverifyResult},
 };
@@ -42,13 +45,13 @@ pub async fn simulate_transaction(
     // Decode the base64 transaction
     let tx_data = STANDARD
         .decode(&transaction)
-        .map_err(|e| custom_error(-32602, format!("Invalid base64 encoding: {}", e)))?;
+        .map_err(|e| custom_error(INVALID_PARAMS_CODE, format!("Invalid base64 encoding: {}", e)))?;
 
     // Check packet size limit (1232 bytes is Solana's PACKET_DATA_SIZE)
     const PACKET_DATA_SIZE: usize = 1232;
     if tx_data.len() > PACKET_DATA_SIZE {
         return Err(custom_error(
-            -32602,
+            INVALID_PARAMS_CODE,
             format!(
                 "Transaction too large: {} bytes (max: {} bytes)",
                 tx_data.len(),
@@ -66,7 +69,7 @@ pub async fn simulate_transaction(
     // Try to deserialize as VersionedTransaction first (standard format)
     let versioned_tx = bincode_options
         .deserialize::<VersionedTransaction>(&tx_data)
-        .map_err(|e| custom_error(-32602, format!("Failed to deserialize transaction: {}", e)))?;
+        .map_err(|e| custom_error(INVALID_PARAMS_CODE, format!("Failed to deserialize transaction: {}", e)))?;
 
     let runtime_tx = RuntimeTransaction::try_create(
         versioned_tx,
@@ -78,7 +81,7 @@ pub async fn simulate_transaction(
         }),
         &HashSet::new(),
     )
-    .map_err(|err| custom_error(-32602, format!("invalid transaction: {err}")))?;
+    .map_err(|err| custom_error(INVALID_PARAMS_CODE, format!("invalid transaction: {err}")))?;
     let sanitized_tx = runtime_tx.into_inner_transaction();
 
     if config.sig_verify {
@@ -86,18 +89,18 @@ pub async fn simulate_transaction(
         match sigverify_result {
             SigverifyResult::InvalidTransaction(transaction_type) => {
                 return Err(custom_error(
-                    -32602,
+                    INVALID_PARAMS_CODE,
                     format!("Invalid transaction: {:?}", transaction_type),
                 ));
             }
             SigverifyResult::NotSignedByAdmin => {
                 return Err(custom_error(
-                    -32602,
+                    INVALID_PARAMS_CODE,
                     "Transaction not signed by admin".to_string(),
                 ));
             }
             SigverifyResult::SigverifyFailed(e) => {
-                return Err(custom_error(-32602, format!("Sigverify failed: {}", e)));
+                return Err(custom_error(INVALID_PARAMS_CODE, format!("Sigverify failed: {}", e)));
             }
             SigverifyResult::Valid(_) => (),
         }
@@ -110,7 +113,7 @@ pub async fn simulate_transaction(
         .accounts_db
         .get_latest_slot()
         .await
-        .map_err(|e| custom_error(-32000, format!("Failed to get slot: {}", e)))?;
+        .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get slot: {}", e)))?;
 
     let mut batch = ConflictFreeBatch::new();
     batch.add_transaction(TransactionWithIndex {
@@ -127,7 +130,7 @@ pub async fn simulate_transaction(
     } else if let Some(admin_results) = execution_result.admin_results {
         admin_results
     } else {
-        return Err(custom_error(-32602, "No execution result found"));
+        return Err(custom_error(INVALID_PARAMS_CODE, "No execution result found"));
     };
 
     // Extract execution results
@@ -245,13 +248,13 @@ pub async fn simulate_transaction(
             }
             Err(e) => {
                 return Err(custom_error(
-                    -32602,
+                    INVALID_PARAMS_CODE,
                     format!("Transaction processing error: {:?}", e),
                 ));
             }
         }
     } else {
-        return Err(custom_error(-32602, "No execution result found"));
+        return Err(custom_error(INVALID_PARAMS_CODE, "No execution result found"));
     };
 
     Ok(Response {


### PR DESCRIPTION
## Summary

- Re-exports `INVALID_PARAMS_CODE`, `PARSE_ERROR_CODE`, `INVALID_REQUEST_CODE`, `INTERNAL_ERROR_CODE` from `jsonrpsee::types::error` in `error.rs`
- Defines `JSON_RPC_SERVER_ERROR = -32000` for the server error range (no upstream constant exists for this)
- Replaces all hardcoded `-32602`, `-32700`, `-32603`, `-32000` literals across 17 files in `core/src/rpc/` with named constants
- Zero behavior change — purely mechanical find-and-replace

Closes PRO-925