### PR TITLE
feat(health): add GET /health endpoints to core RPC and gateway [PRO-901, PRO-902]

### DIFF
--- a/core/src/rpc/handler.rs
+++ b/core/src/rpc/handler.rs
@@ -15,6 +15,47 @@ pub async fn handle_request(
     rpc_module: Arc<RpcModule<()>>,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let response = match (req.method(), req.uri().path()) {
+        (&Method::GET, "/health") => {
+            // Health check endpoint for monitoring and load balancers.
+            // Returns 200 with slot when the node is responsive, 503 otherwise.
+            let slot_request = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot"}"#;
+            match rpc_module.raw_json_request(slot_request, 1024).await {
+                Ok((resp, _)) => {
+                    match serde_json::from_str::<serde_json::Value>(&resp)
+                        .ok()
+                        .and_then(|v| v.get("result").and_then(|r| r.as_u64()))
+                    {
+                        Some(slot) => Response::builder()
+                            .status(StatusCode::OK)
+                            .header("Content-Type", "application/json")
+                            .body(Full::new(Bytes::from(
+                                format!(r#"{{"status":"ok","slot":{}}}"#, slot),
+                            )))
+                            .unwrap(),
+                        None => {
+                            tracing::warn!("Health check: getSlot returned unexpected response: {}", resp);
+                            Response::builder()
+                                .status(StatusCode::SERVICE_UNAVAILABLE)
+                                .header("Content-Type", "application/json")
+                                .body(Full::new(Bytes::from(
+                                    r#"{"status":"degraded","error":"unexpected getSlot response"}"#,
+                                )))
+                                .unwrap()
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Health check: getSlot RPC call failed: {}", e);
+                    Response::builder()
+                        .status(StatusCode::SERVICE_UNAVAILABLE)
+                        .header("Content-Type", "application/json")
+                        .body(Full::new(Bytes::from(
+                            r#"{"status":"error","error":"RPC unavailable"}"#,
+                        )))
+                        .unwrap()
+                }
+            }
+        }
         (&Method::POST, "/") => {
             let body_bytes = req.collect().await?.to_bytes();
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -85,6 +85,24 @@ impl Gateway {
                 .unwrap());
         }
 
+        // Shallow liveness check — verifies the gateway process is running.
+        // Does not probe backend read/write nodes.
+        if req.method() == hyper::Method::GET && req.uri().path() == "/health" {
+            return Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .header(
+                    "Access-Control-Allow-Origin",
+                    self.cors_allowed_origin.as_str(),
+                )
+                .body(
+                    Full::new(Bytes::from(r#"{"status":"ok"}"#))
+                        .map_err(|never| match never {})
+                        .boxed_unsync(),
+                )
+                .unwrap());
+        }
+
         // Only accept POST requests
         if req.method() != hyper::Method::POST {
             return Ok(Response::builder()


### PR DESCRIPTION
## Summary

- Add `GET /health` to Core RPC (`core/src/rpc/handler.rs`): issues an internal `getSlot` call and returns `{"status":"ok","slot":<n>}` on success, `503` with `{"status":"error"}` / `{"status":"degraded"}` if the RPC module is unresponsive or returns unexpected output
- Add `GET /health` to Gateway (`gateway/src/lib.rs`): shallow process-liveness check returning `{"status":"ok"}` with CORS headers — intentionally does not probe backend nodes
- Enables load balancer health checks and operator monitoring for both services

## Test Plan

- `GET /health` on a running Core RPC node → `200 {"status":"ok","slot":<n>}`
- `GET /health` on a running Gateway → `200 {"status":"ok"}`
- Core RPC with a broken RPC module → `503 {"status":"error","error":"RPC unavailable"}`

Closes PRO-901
Closes PRO-902