### PR TITLE
feat(scripts): add per-mint escrow balance reconciliation script [PRO-904]

### DIFF
--- a/contra-withdraw-program/idl/contra_withdraw_program.json
+++ b/contra-withdraw-program/idl/contra_withdraw_program.json
@@ -87,6 +87,11 @@
       "code": 0,
       "name": "InvalidMint",
       "msg": "Invalid mint provided"
+    },
+    {
+      "code": 1,
+      "name": "ZeroAmount",
+      "msg": "Withdrawal amount must be greater than zero"
     }
   ],
   "metadata": {

--- a/contra-withdraw-program/program/src/error.rs
+++ b/contra-withdraw-program/program/src/error.rs
@@ -7,6 +7,10 @@ pub enum ContraWithdrawProgramError {
     /// (0) Invalid mint provided
     #[error("Invalid mint provided")]
     InvalidMint,
+
+    /// (1) Withdrawal amount must be greater than zero
+    #[error("Withdrawal amount must be greater than zero")]
+    ZeroAmount,
 }
 
 impl From<ContraWithdrawProgramError> for ProgramError {

--- a/contra-withdraw-program/program/src/processor/withdraw_funds.rs
+++ b/contra-withdraw-program/program/src/processor/withdraw_funds.rs
@@ -5,6 +5,7 @@ use pinocchio::{
 };
 
 use crate::{
+    error::ContraWithdrawProgramError,
     events::WithdrawFundsEvent,
     processor::{
         validate_ata, verify_ata_program, verify_mint_account, verify_signer, verify_token_program,
@@ -31,6 +32,11 @@ pub fn process_withdraw_funds(
     instruction_data: &[u8],
 ) -> ProgramResult {
     let args = process_instruction_data(instruction_data)?;
+
+    if args.amount == 0 {
+        return Err(ContraWithdrawProgramError::ZeroAmount.into());
+    }
+
     let [user_info, mint_info, token_account_info, token_program_info, associated_token_program_info] =
         accounts
     else {

--- a/contra-withdraw-program/tests/integration-tests/src/lib.rs
+++ b/contra-withdraw-program/tests/integration-tests/src/lib.rs
@@ -5,4 +5,6 @@ pub mod state_utils;
 #[cfg(test)]
 pub mod test_withdraw_funds;
 #[cfg(test)]
+pub mod test_withdraw_funds_edge_cases;
+#[cfg(test)]
 pub mod utils;

--- a/contra-withdraw-program/tests/integration-tests/src/test_withdraw_funds.rs
+++ b/contra-withdraw-program/tests/integration-tests/src/test_withdraw_funds.rs
@@ -11,6 +11,7 @@ use crate::{
     utils::{
         assert_program_error, set_mint, setup_test_balances, TestContext, ATA_PROGRAM_ID,
         CONTRA_WITHDRAW_PROGRAM_ID, INVALID_INSTRUCTION_DATA_ERROR, TOKEN_INSUFFICIENT_FUNDS_ERROR,
+        ZERO_AMOUNT_ERROR,
     },
 };
 
@@ -85,6 +86,31 @@ fn test_withdraw_funds_insufficient_funds() {
     let result = context.send_transaction_with_signers(instruction, &[&user]);
 
     assert_program_error(result, TOKEN_INSUFFICIENT_FUNDS_ERROR);
+}
+
+#[test]
+fn test_withdraw_funds_zero_amount() {
+    let mut context = TestContext::new();
+    let user = Keypair::new();
+    let mint = Keypair::new();
+
+    set_mint(&mut context, &mint.pubkey());
+    setup_test_balances(&mut context, &user, &mint.pubkey(), INITIAL_BALANCE);
+
+    let user_ata = get_associated_token_address(&user.pubkey(), &mint.pubkey());
+
+    let instruction = WithdrawFundsBuilder::new()
+        .user(user.pubkey())
+        .mint(mint.pubkey())
+        .token_account(user_ata)
+        .token_program(TOKEN_PROGRAM_ID)
+        .associated_token_program(ATA_PROGRAM_ID)
+        .amount(0)
+        .instruction();
+
+    let result = context.send_transaction_with_signers(instruction, &[&user]);
+
+    assert_program_error(result, ZERO_AMOUNT_ERROR);
 }
 
 #[test]

--- a/contra-withdraw-program/tests/integration-tests/src/test_withdraw_funds_edge_cases.rs
+++ b/contra-withdraw-program/tests/integration-tests/src/test_withdraw_funds_edge_cases.rs
@@ -1,0 +1,71 @@
+use contra_withdraw_program_client::instructions::WithdrawFundsBuilder;
+use solana_sdk::{
+    instruction::AccountMeta,
+    signature::{Keypair, Signer},
+};
+use spl_associated_token_account::get_associated_token_address;
+use spl_token::ID as TOKEN_PROGRAM_ID;
+
+use crate::utils::{
+    assert_program_error, set_mint, setup_test_balances, TestContext, ATA_PROGRAM_ID,
+    INVALID_MINT_ERROR, MISSING_REQUIRED_SIGNATURE_ERROR,
+};
+
+const INITIAL_BALANCE: u64 = 1_000_000;
+const WITHDRAW_AMOUNT: u64 = 500_000;
+
+/// Wrong mint account should fail with InvalidMint.
+#[test]
+fn test_withdraw_funds_wrong_mint() {
+    let mut context = TestContext::new();
+    let user = Keypair::new();
+    let mint = Keypair::new();
+    let wrong_mint = Keypair::new();
+
+    set_mint(&mut context, &mint.pubkey());
+    setup_test_balances(&mut context, &user, &mint.pubkey(), INITIAL_BALANCE);
+
+    let user_ata = get_associated_token_address(&user.pubkey(), &mint.pubkey());
+
+    let instruction = WithdrawFundsBuilder::new()
+        .user(user.pubkey())
+        .mint(wrong_mint.pubkey()) // Wrong mint — no valid Mint data in SVM
+        .token_account(user_ata)
+        .token_program(TOKEN_PROGRAM_ID)
+        .associated_token_program(ATA_PROGRAM_ID)
+        .amount(WITHDRAW_AMOUNT)
+        .instruction();
+
+    let result = context.send_transaction_with_signers(instruction, &[&user]);
+
+    assert_program_error(result, INVALID_MINT_ERROR);
+}
+
+/// Non-signer user should fail with MissingRequiredSignature.
+#[test]
+fn test_withdraw_funds_non_signer_user() {
+    let mut context = TestContext::new();
+    let user = Keypair::new();
+    let mint = Keypair::new();
+
+    set_mint(&mut context, &mint.pubkey());
+    setup_test_balances(&mut context, &user, &mint.pubkey(), INITIAL_BALANCE);
+
+    let user_ata = get_associated_token_address(&user.pubkey(), &mint.pubkey());
+
+    // Build canonical instruction, then strip the signer flag from user account
+    let mut instruction = WithdrawFundsBuilder::new()
+        .user(user.pubkey())
+        .mint(mint.pubkey())
+        .token_account(user_ata)
+        .token_program(TOKEN_PROGRAM_ID)
+        .associated_token_program(ATA_PROGRAM_ID)
+        .amount(WITHDRAW_AMOUNT)
+        .instruction();
+
+    instruction.accounts[0] = AccountMeta::new_readonly(user.pubkey(), false);
+
+    let result = context.send_transaction_with_signers(instruction, &[]);
+
+    assert_program_error(result, MISSING_REQUIRED_SIGNATURE_ERROR);
+}

--- a/contra-withdraw-program/tests/integration-tests/src/utils.rs
+++ b/contra-withdraw-program/tests/integration-tests/src/utils.rs
@@ -29,6 +29,7 @@ pub const CONTRA_WITHDRAW_PROGRAM_ID: Pubkey =
 
 // Contra Withdraw Program Error Codes (using generated error enum)
 pub const INVALID_MINT_ERROR: u32 = ContraWithdrawProgramError::InvalidMint as u32;
+pub const ZERO_AMOUNT_ERROR: u32 = ContraWithdrawProgramError::ZeroAmount as u32;
 
 // Standard Solana Program Error Codes
 pub const INVALID_ARGUMENT_ERROR: u32 = 5; // ProgramError::InvalidArgument

--- a/scripts/reconcile-escrow-balance.sh
+++ b/scripts/reconcile-escrow-balance.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# reconcile-escrow-balance.sh — Reconcile on-chain escrow balance vs DB expected balance per mint
+#
+# Usage: ./scripts/reconcile-escrow-balance.sh <ESCROW_OWNER> <MINT> <DB_CONNECTION_STRING>
+#
+# Arguments:
+#   ESCROW_OWNER       — Instance PDA that owns escrow token accounts
+#   MINT               — Token mint address to reconcile
+#   DB_CONNECTION_STRING — Postgres connection URL to indexer DB
+#
+# Environment variables:
+#   SOLANA_RPC_URL  — RPC endpoint (default: http://localhost:8899)
+#   ALERT_WEBHOOK   — Optional webhook URL for mismatch alerts
+#
+# Requirements: spl-token CLI, psql, jq, curl
+#
+# Exit codes:
+#   0 — balances match
+#   1 — mismatch detected (ALERT)
+#   2 — usage/connection error
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <ESCROW_OWNER> <MINT> <DB_CONNECTION_STRING>"
+    echo ""
+    echo "Example:"
+    echo "  $0 5xYz...PDA So11...mint 'postgresql://user:pass@localhost:5432/contra'"
+    echo ""
+    echo "Environment variables:"
+    echo "  SOLANA_RPC_URL  — RPC endpoint (default: http://localhost:8899)"
+    echo "  ALERT_WEBHOOK   — Optional webhook URL for mismatch alerts"
+    exit 2
+fi
+
+ESCROW_OWNER="$1"
+MINT="$2"
+DB_URL="$3"
+RPC_URL="${SOLANA_RPC_URL:-http://localhost:8899}"
+
+echo "=== Contra Escrow Balance Reconciliation ==="
+echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Escrow owner: ${ESCROW_OWNER}"
+echo "Mint:         ${MINT}"
+echo "RPC:          ${RPC_URL}"
+echo ""
+
+# Step 1: Get on-chain token balance (raw units)
+echo "Fetching on-chain balance..."
+SPL_OUTPUT=$(spl-token balance --owner "$ESCROW_OWNER" "$MINT" --url "$RPC_URL" --output json 2>&1) || {
+    echo "ERROR: Failed to fetch on-chain token balance for mint ${MINT}."
+    echo "Detail: ${SPL_OUTPUT}"
+    exit 2
+}
+
+ONCHAIN_BALANCE=$(echo "$SPL_OUTPUT" | jq -r '.amount') || {
+    echo "ERROR: Failed to parse spl-token JSON output."
+    echo "Raw output: ${SPL_OUTPUT}"
+    exit 2
+}
+
+if [ -z "$ONCHAIN_BALANCE" ] || [ "$ONCHAIN_BALANCE" = "null" ]; then
+    echo "ERROR: No token account found for owner ${ESCROW_OWNER}, mint ${MINT}."
+    exit 2
+fi
+
+echo "On-chain balance (raw): ${ONCHAIN_BALANCE}"
+
+# Step 2: Query database for expected balance (raw units)
+echo "Querying database for expected balance..."
+DB_EXPECTED=$(psql "$DB_URL" -t -A -v "mint=${MINT}" -c "
+    SELECT
+        COALESCE(SUM(CASE WHEN transaction_type = 'deposit' THEN amount ELSE 0 END), 0) -
+        COALESCE(SUM(CASE WHEN transaction_type = 'withdrawal' THEN amount ELSE 0 END), 0)
+        AS expected_balance
+    FROM transactions
+    WHERE mint = :'mint' AND status = 'completed';
+" 2>&1) || {
+    echo "ERROR: Failed to query database."
+    echo "Detail: ${DB_EXPECTED}"
+    exit 2
+}
+DB_EXPECTED=$(echo "$DB_EXPECTED" | tr -d '[:space:]')
+
+echo "DB expected balance (raw): ${DB_EXPECTED}"
+
+# Step 3: Compare (both in raw token units)
+if ! [[ "$ONCHAIN_BALANCE" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: On-chain balance is not a valid integer: '${ONCHAIN_BALANCE}'"
+    exit 2
+fi
+if ! [[ "$DB_EXPECTED" =~ ^-?[0-9]+$ ]]; then
+    echo "ERROR: DB expected balance is not a valid integer: '${DB_EXPECTED}'"
+    exit 2
+fi
+
+DELTA=$((ONCHAIN_BALANCE - DB_EXPECTED))
+
+echo ""
+echo "=== Result ==="
+echo "On-chain: ${ONCHAIN_BALANCE}"
+echo "Expected: ${DB_EXPECTED}"
+echo "Delta:    ${DELTA}"
+
+if [ "$DELTA" -eq 0 ]; then
+    echo ""
+    echo "PASS — Balances reconcile."
+    exit 0
+else
+    echo ""
+    echo "FAIL — Mismatch detected!"
+
+    if [ -n "${ALERT_WEBHOOK:-}" ]; then
+        PAYLOAD=$(jq -n \
+            --arg text "Escrow balance mismatch! On-chain: ${ONCHAIN_BALANCE}, Expected: ${DB_EXPECTED}, Delta: ${DELTA}, Owner: ${ESCROW_OWNER}, Mint: ${MINT}" \
+            --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{text: $text, timestamp: $ts}')
+        HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "${ALERT_WEBHOOK}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD") || {
+            echo "ERROR: Alert webhook request failed (curl error)."
+            exit 2
+        }
+        if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "ERROR: Alert webhook returned HTTP ${HTTP_CODE}."
+            exit 2
+        fi
+        echo "Alert sent (HTTP ${HTTP_CODE})."
+    fi
+
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/reconcile-escrow-balance.sh` — compares on-chain escrow token balance against DB expected balance per mint
- Queries `transactions` table with `transaction_type`/`status` enums (correct schema)
- Accepts `ESCROW_OWNER` (instance PDA) + `MINT` args; uses `spl-token balance --owner` for raw token units
- Hardened error handling: separated pipeline stages, captured stderr, numeric validation, parameterized SQL, webhook HTTP status checks

## Test Plan
- [ ] `shellcheck scripts/reconcile-escrow-balance.sh` passes
- [ ] Run against local validator + test DB with known deposit/withdrawal amounts
- [ ] Verify mismatch path triggers webhook with correct HTTP status check
- [ ] Verify bad RPC URL surfaces diagnostic error (not generic message)
- [ ] Verify malformed MINT input is rejected by psql variable binding

Closes PRO-904