### PR TITLE
ci: add hardening branch to all workflow triggers

### DIFF
--- a/.github/workflows/program-coverage.yml
+++ b/.github/workflows/program-coverage.yml
@@ -7,11 +7,11 @@ on:
       - completed
   workflow_dispatch:
   push:
-    branches: [main, feat/coverage-ci]
+    branches: [main, feat/coverage-ci, hardening/pre-release-audit]
     paths:
       - ".github/workflows/program-coverage.yml"
   pull_request:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
     paths:
       - ".github/workflows/program-coverage.yml"
 

--- a/.github/workflows/program-integration.yml
+++ b/.github/workflows/program-integration.yml
@@ -2,7 +2,7 @@ name: Program Integration Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
     paths:
       - "contra-escrow-program/**"
       - "contra-withdraw-program/**"
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/program-integration.yml"
       - "scripts/**"
   pull_request:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
     paths:
       - "contra-escrow-program/**"
       - "contra-withdraw-program/**"

--- a/.github/workflows/program-unit.yml
+++ b/.github/workflows/program-unit.yml
@@ -2,14 +2,14 @@ name: Program Unit Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
     paths:
       - "contra-escrow-program/**"
       - "contra-withdraw-program/**"
       - "Cargo.*"
       - ".github/workflows/program-unit.yml"
   pull_request:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
     paths:
       - "contra-escrow-program/**"
       - "contra-withdraw-program/**"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust Checks
 
 on:
   push:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
   pull_request:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sdk-unit.yml
+++ b/.github/workflows/sdk-unit.yml
@@ -3,7 +3,7 @@ name: TypeScript SDK Unit Tests
 on:
   workflow_call:
   push:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
     paths:
       - "contra-escrow-program/clients/typescript/**"
       - ".github/workflows/sdk-unit.yml"
@@ -12,7 +12,7 @@ on:
       - "contra-escrow-program/package.json"
 
   pull_request:
-    branches: [main]
+    branches: [main, hardening/pre-release-audit]
     paths:
       - "contra-escrow-program/clients/typescript/**"
       - ".github/workflows/sdk-unit.yml"


### PR DESCRIPTION
## Summary
- Add `hardening/pre-release-audit` to push/pull_request branch triggers across all 5 CI workflows
- Ensures PRs targeting the sprint branch get the same CI checks as PRs to main
- Workflows updated: rust.yml, program-unit.yml, program-integration.yml, sdk-unit.yml, program-coverage.yml

Temporary — revert after the hardening sprint is complete.