### PR TITLE
feat(indexer): add startup reconciliation against on-chain escrow ATA balances [PRO-920]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 url = "2.5.7"
 yellowstone-grpc-client = "9.0.1"
 yellowstone-grpc-proto = { version = "9.0.1", features = ["convert"] }
+contra-core = { path = "core" }
 contra-escrow-program-client = { path = "contra-escrow-program/clients/rust", features = [
     "fetch",
 ] }

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -47,6 +47,7 @@ futures = { workspace = true }
 async-trait = "0.1"
 borsh = { workspace = true }
 const-crypto = { workspace = true }
+contra-core = { workspace = true }
 contra-escrow-program-client = { workspace = true }
 once_cell = "1.20"
 thiserror = { workspace = true }

--- a/indexer/config/example-indexer.toml
+++ b/indexer/config/example-indexer.toml
@@ -67,3 +67,22 @@ max_gap_slots = 10000000
 
 # RPC URL for backfill (optional, defaults to common.rpc_url)
 # rpc_url = "http://localhost:8899"
+
+# === Startup Reconciliation Configuration ===
+# Runs automatically on startup when program_type = "escrow".
+# Skipped automatically for "withdraw".
+[indexer.reconciliation]
+# Maximum absolute mismatch allowed (in raw token units, not UI decimals).
+#
+# 0 (default) = strict: any mismatch blocks startup.
+# > 0 = tolerance: mismatches up to this value log a warning and continue;
+#        mismatches above this value log an error with reconciliation_alert=true
+#        and abort startup.
+#
+# Note on false positives: there is a small race window between the DB balance
+# query and the on-chain RPC fetch. A deposit that arrives on-chain in that
+# window will appear in the ATA balance but not yet in the DB, producing a
+# transient mismatch even when the indexer state is otherwise correct.
+# If you observe spurious startup failures caused by this, set this to a small
+# value (e.g. the raw amount of one or two minimum deposits for this mint).
+mismatch_threshold_raw = 0

--- a/indexer/src/bin/indexer.rs
+++ b/indexer/src/bin/indexer.rs
@@ -1,7 +1,8 @@
 use clap::{Parser, Subcommand};
 use contra_indexer::{
     BackfillConfig, ContraIndexerConfig, DatasourceType, IndexerConfig, OperatorConfig,
-    PostgresConfig, ProgramType, RpcPollingConfig, StorageType, YellowstoneConfig,
+    PostgresConfig, ProgramType, ReconciliationConfig, RpcPollingConfig, StorageType,
+    YellowstoneConfig,
 };
 use figment::{
     providers::{Env, Format, Toml},
@@ -33,12 +34,20 @@ struct StorageSection {
     max_connections: u32,
 }
 
+#[derive(Deserialize, Default)]
+struct ReconciliationSection {
+    #[serde(default)]
+    mismatch_threshold_raw: u64,
+}
+
 #[derive(Deserialize)]
 struct IndexerSection {
     datasource_type: DatasourceType,
     rpc_polling: Option<RpcPollingSection>,
     yellowstone: Option<YellowstoneSection>,
     backfill: BackfillSection,
+    #[serde(default)]
+    reconciliation: ReconciliationSection,
 }
 
 #[derive(Deserialize)]
@@ -131,6 +140,8 @@ fn map_env_to_config_path(
                 format!("indexer.rpc_polling.{}", suffix)
             } else if let Some(suffix) = key_lower.strip_prefix("backfill_") {
                 format!("indexer.backfill.{}", suffix)
+            } else if let Some(suffix) = key_lower.strip_prefix("reconciliation_") {
+                format!("indexer.reconciliation.{}", suffix)
             } else {
                 format!("indexer.{}", key_lower)
             }
@@ -260,11 +271,16 @@ async fn run_indexer(figment: Figment, verbose: bool) -> Result<(), Box<dyn std:
         escrow_instance_id,
     };
 
+    let reconciliation_config = ReconciliationConfig {
+        mismatch_threshold_raw: indexer.reconciliation.mismatch_threshold_raw,
+    };
+
     let indexer_config = IndexerConfig {
         datasource_type: indexer.datasource_type,
         rpc_polling: rpc_polling_config,
         yellowstone: yellowstone_config,
         backfill: backfill_config,
+        reconciliation: reconciliation_config,
     };
 
     common_config.validate()?;

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -148,6 +148,23 @@ impl ContraIndexerConfig {
     }
 }
 
+/// Configuration for startup reconciliation against on-chain state.
+///
+/// Only applies when `program_type = escrow`. Skipped for `withdraw` indexers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReconciliationConfig {
+    /// Maximum absolute mismatch (in raw token units) allowed before blocking startup.
+    /// 0 (default) means any mismatch blocks startup.
+    /// Mismatches above this value log error + emit alert and abort.
+    /// Mismatches at or below this value (but > 0) log a warning and continue.
+    ///
+    /// There is a small race window between the DB balance query and the on-chain RPC
+    /// fetch: a deposit arriving in that window will appear in the ATA but not yet in
+    /// the DB, producing a transient false positive. If spurious failures occur in
+    /// production, set this to the raw amount of one or two minimum deposits.
+    pub mismatch_threshold_raw: u64,
+}
+
 /// Indexer-specific configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexerConfig {
@@ -159,6 +176,9 @@ pub struct IndexerConfig {
     pub yellowstone: Option<YellowstoneConfig>,
     /// Backfill configuration for crash recovery
     pub backfill: BackfillConfig,
+    /// Startup reconciliation configuration
+    #[serde(default)]
+    pub reconciliation: ReconciliationConfig,
 }
 
 impl IndexerConfig {
@@ -298,6 +318,7 @@ mod tests {
                 exit_after_backfill: false,
                 rpc_url: "http://localhost:8899".to_string(),
             },
+            reconciliation: ReconciliationConfig::default(),
         }
     }
 

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -27,6 +27,25 @@ pub enum IndexerError {
 
     #[error("Checkpoint error: {0}")]
     Checkpoint(#[from] CheckpointError),
+
+    #[error("Reconciliation failed: {0}")]
+    Reconciliation(#[from] ReconciliationError),
+}
+
+/// Errors from startup reconciliation against on-chain state
+#[derive(Debug, thiserror::Error)]
+pub enum ReconciliationError {
+    #[error("Storage error: {0}")]
+    Storage(#[from] StorageError),
+
+    #[error("RPC error for mint {mint}: {reason}")]
+    Rpc { mint: String, reason: String },
+
+    #[error("{count} mint(s) exceed mismatch threshold of {threshold} raw units; see logs for per-mint details")]
+    MismatchExceedsThreshold { count: usize, threshold: u64 },
+
+    #[error("Invalid pubkey '{pubkey}': {reason}")]
+    InvalidPubkey { pubkey: String, reason: String },
 }
 
 /// Errors from data sources (RPC polling, Yellowstone, backfill operations)

--- a/indexer/src/error/mod.rs
+++ b/indexer/src/error/mod.rs
@@ -7,7 +7,9 @@ pub mod transaction;
 
 pub use account::AccountError;
 pub use datasource_rpc::DataSourceRpcError;
-pub use indexer::{BackfillError, CheckpointError, DataSourceError, IndexerError, ParserError};
+pub use indexer::{
+    BackfillError, CheckpointError, DataSourceError, IndexerError, ParserError, ReconciliationError,
+};
 pub use operator::OperatorError;
 pub use storage::StorageError;
 pub use transaction::{ProgramError, TransactionError};

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -1,8 +1,9 @@
-use crate::error::{DataSourceError, IndexerError};
+use crate::config::ProgramType;
+use crate::error::{DataSourceError, IndexerError, ReconciliationError};
 use crate::{
     indexer::{
         checkpoint::CheckpointWriter, datasource::common::datasource::DataSource,
-        transaction_processor::TransactionProcessor,
+        reconciliation::run_startup_reconciliation, transaction_processor::TransactionProcessor,
     },
     shutdown_utils::{cleanup_after_backfill, shutdown_indexer},
     storage::{PostgresDb, Storage},
@@ -45,16 +46,55 @@ pub async fn run(
     storage.init_schema().await?;
     info!("Storage initialized");
 
-    // 2. Create channels
+    // 2. Startup reconciliation (escrow only, before any data processing).
+    //
+    // Skip when running in backfill-only mode (backfill.enabled &&
+    // backfill.exit_after_backfill). In that mode the DB is intentionally
+    // incomplete — reconciling it against the current on-chain state would
+    // produce false positives and block the very operation that repairs the
+    // discrepancy. Concurrent backfill (exit_after_backfill = false) still
+    // runs reconciliation because the live datasource is about to start.
+    let backfill_only =
+        indexer_config.backfill.enabled && indexer_config.backfill.exit_after_backfill;
+    if !backfill_only {
+        match (common_config.program_type, common_config.escrow_instance_id) {
+            (ProgramType::Escrow, Some(seed)) => {
+                run_startup_reconciliation(
+                    &indexer_config.reconciliation,
+                    common_config.program_type,
+                    &storage,
+                    &common_config.rpc_url,
+                    &seed,
+                )
+                .await?;
+            }
+            (ProgramType::Escrow, None) => {
+                return Err(IndexerError::Reconciliation(
+                    ReconciliationError::InvalidPubkey {
+                        pubkey: "<missing>".to_string(),
+                        reason: "escrow_instance_id is required for escrow reconciliation"
+                            .to_string(),
+                    },
+                ));
+            }
+            _ => {
+                info!("Startup reconciliation skipped (non-escrow program)");
+            }
+        }
+    } else {
+        info!("Startup reconciliation skipped (backfill-only mode)");
+    }
+
+    // 3. Create channels
     let (instruction_tx, instruction_rx) = mpsc::channel(1000);
     let (checkpoint_tx, checkpoint_rx) = mpsc::channel(1000);
 
-    // 3. Start checkpoint writer service
+    // 4. Start checkpoint writer service
     let checkpoint_writer = CheckpointWriter::new(storage.clone());
     let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
     info!("CheckpointWriter service started");
 
-    // 4. Run backfill if enabled
+    // 5. Run backfill if enabled
     if indexer_config.backfill.enabled {
         #[cfg(not(feature = "datasource-rpc"))]
         return Err(DataSourceError::InvalidConfig {
@@ -109,7 +149,7 @@ pub async fn run(
         }
     }
 
-    // 5. Start datasource
+    // 6. Start datasource
     let mut datasource: Box<dyn DataSource> = match indexer_config.datasource_type {
         #[cfg(feature = "datasource-rpc")]
         DatasourceType::RpcPolling => {
@@ -167,7 +207,7 @@ pub async fn run(
         }
     };
 
-    // 6. Create cancellation token for graceful shutdown
+    // 7. Create cancellation token for graceful shutdown
     let cancellation_token = CancellationToken::new();
 
     info!("Starting datasource...");
@@ -175,7 +215,7 @@ pub async fn run(
         .start(instruction_tx.clone(), cancellation_token.clone())
         .await?;
 
-    // 6. Start transaction processor
+    // 8. Start transaction processor
     let transaction_processor = TransactionProcessor::new(storage.clone(), checkpoint_tx.clone());
     let processor_handle = tokio::spawn(async move {
         if let Err(e) = transaction_processor.start(instruction_rx).await {
@@ -185,13 +225,13 @@ pub async fn run(
 
     info!("Indexer started, waiting for shutdown signal...");
 
-    // 7. Wait for shutdown signal
+    // 9. Wait for shutdown signal
     signal::ctrl_c()
         .await
         .map_err(|_| IndexerError::ShutdownChannelSend)?;
     info!("Shutdown signal received, initiating graceful shutdown...");
 
-    // 8. Graceful shutdown
+    // 10. Graceful shutdown
     shutdown_indexer(
         cancellation_token,
         storage,

--- a/indexer/src/indexer/mod.rs
+++ b/indexer/src/indexer/mod.rs
@@ -4,6 +4,7 @@ pub mod checkpoint;
 pub mod datasource;
 #[allow(clippy::module_inception)]
 pub mod indexer;
+pub mod reconciliation;
 pub mod transaction_processor;
 
 pub use checkpoint::CheckpointUpdate;

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -1,0 +1,947 @@
+//! Startup reconciliation of DB state against on-chain escrow ATA balances.
+//!
+//! On startup, before processing any new data, the escrow indexer verifies that its
+//! stored deposit/withdrawal totals match the actual token balances held in the escrow
+//! instance's Associated Token Accounts (ATAs).
+//!
+//! The DB-side formula mirrors exactly what is on-chain:
+//!   `db_expected = all_indexed_deposits − completed_withdrawals`
+//!
+//! Deposits increase the ATA balance on-chain the moment they are observed, regardless of
+//! the operator's contra minting status (`pending`/`processing`/`completed`/`failed`).
+//! Only completed withdrawals (`release_funds`) reduce the ATA balance.
+//!
+//! Flow:
+//! 1. Query the DB for per-mint aggregate balances (all deposits − completed withdrawals).
+//! 2. Derive the escrow ATA for each mint (instance PDA + mint + token program).
+//! 3. Fetch the live ATA balance via RPC.
+//! 4. If any |on_chain - db_expected| > threshold → log error, emit alert, abort startup.
+//! 5. If any mismatch ≤ threshold (but > 0) → log warning, continue.
+//! 6. If all balanced → log info, continue.
+
+use crate::{
+    config::{ProgramType, ReconciliationConfig},
+    error::{IndexerError, ReconciliationError},
+    operator::{
+        account_util::find_instance_pda, rpc_util::RpcClientWithRetry, RetryConfig, RetryPolicy,
+    },
+    storage::Storage,
+};
+use contra_core::rpc::error::INVALID_PARAMS_CODE;
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use std::str::FromStr;
+use tracing::{error, info, warn};
+
+/// Per-mint result produced during reconciliation.
+#[derive(Debug, Clone)]
+pub struct MintReconciliation {
+    pub mint: String,
+    /// Expected balance according to DB: all indexed deposits − completed withdrawals.
+    pub db_expected: i64,
+    /// Actual raw token balance in the escrow ATA on-chain.
+    pub on_chain_actual: u64,
+    /// Absolute difference: |on_chain_actual − db_expected|.  Derived from the
+    /// two fields above — use `MintReconciliation::new` to ensure consistency.
+    pub mismatch: u64,
+}
+
+impl MintReconciliation {
+    pub fn new(mint: String, db_expected: i64, on_chain_actual: u64) -> Self {
+        let mismatch = compute_mismatch(db_expected, on_chain_actual);
+        Self {
+            mint,
+            db_expected,
+            on_chain_actual,
+            mismatch,
+        }
+    }
+}
+
+/// Run startup reconciliation for the escrow indexer.
+///
+/// Returns `Ok(())` if all mints are within tolerance.
+/// Returns `Err(IndexerError::Reconciliation(_))` if any mint exceeds the
+/// mismatch threshold – callers should treat this as a fatal startup error.
+///
+/// Does nothing when `program_type` is not `Escrow` (only the escrow program
+/// has ATAs to check).
+pub async fn run_startup_reconciliation(
+    config: &ReconciliationConfig,
+    program_type: ProgramType,
+    storage: &Storage,
+    rpc_url: &str,
+    escrow_instance_seed: &Pubkey,
+) -> Result<(), IndexerError> {
+    if program_type != ProgramType::Escrow {
+        info!("Startup reconciliation skipped (program_type is not Escrow)");
+        return Ok(());
+    }
+
+    let instance_pda = find_instance_pda(escrow_instance_seed);
+    info!(
+        instance_pda = %instance_pda,
+        "Running startup reconciliation"
+    );
+
+    let rpc_client = RpcClientWithRetry::with_retry_config(
+        rpc_url.to_string(),
+        RetryConfig::default(),
+        CommitmentConfig::finalized(),
+    );
+
+    let mint_balances = storage
+        .get_mint_balances_for_reconciliation()
+        .await
+        .map_err(ReconciliationError::Storage)?;
+
+    if mint_balances.is_empty() {
+        info!("No mints in storage; reconciliation passed (empty state)");
+        return Ok(());
+    }
+
+    info!(
+        mint_count = mint_balances.len(),
+        "Comparing DB totals against on-chain escrow ATA balances"
+    );
+
+    let mut results = Vec::with_capacity(mint_balances.len());
+
+    for balance in &mint_balances {
+        let mint_pk = Pubkey::from_str(&balance.mint_address).map_err(|e| {
+            ReconciliationError::InvalidPubkey {
+                pubkey: balance.mint_address.clone(),
+                reason: e.to_string(),
+            }
+        })?;
+
+        let token_program_pk = Pubkey::from_str(&balance.token_program).map_err(|e| {
+            ReconciliationError::InvalidPubkey {
+                pubkey: balance.token_program.clone(),
+                reason: e.to_string(),
+            }
+        })?;
+
+        let instance_ata = get_associated_token_address_with_program_id(
+            &instance_pda,
+            &mint_pk,
+            &token_program_pk,
+        );
+
+        let on_chain_actual =
+            fetch_ata_balance(&rpc_client, &instance_ata, &balance.mint_address).await?;
+
+        let db_expected = balance.total_deposits - balance.total_withdrawals;
+
+        results.push(MintReconciliation::new(
+            balance.mint_address.clone(),
+            db_expected,
+            on_chain_actual,
+        ));
+    }
+
+    classify_and_report(config, &results)
+}
+
+/// Fetch the raw token balance for an ATA.
+///
+/// Returns `Ok(0)` if the account does not exist yet (valid before the first
+/// deposit for that mint). "Not found" is handled inside the retry closure as
+/// `Ok(None)` so it is never retried — only genuine transient failures are
+/// retried with exponential backoff.
+async fn fetch_ata_balance(
+    rpc_client: &RpcClientWithRetry,
+    ata: &Pubkey,
+    mint_address: &str,
+) -> Result<u64, IndexerError> {
+    let rpc = rpc_client.rpc_client.clone();
+    let ata = *ata;
+
+    let result = rpc_client
+        .with_retry("get_token_account_balance", RetryPolicy::Idempotent, || {
+            let rpc = rpc.clone();
+            async move {
+                match rpc.get_token_account_balance(&ata).await {
+                    Ok(ui_amount) => Ok(Some(ui_amount)),
+                    Err(e) if is_account_not_found(&e) => Ok(None),
+                    Err(e) => Err(e),
+                }
+            }
+        })
+        .await;
+
+    match result {
+        Ok(Some(ui_amount)) => ui_amount.amount.parse::<u64>().map_err(|e| {
+            IndexerError::Reconciliation(ReconciliationError::Rpc {
+                mint: mint_address.to_string(),
+                reason: format!(
+                    "Failed to parse token balance '{}': {}",
+                    ui_amount.amount, e
+                ),
+            })
+        }),
+        Ok(None) => Ok(0),
+        Err(e) => Err(IndexerError::Reconciliation(ReconciliationError::Rpc {
+            mint: mint_address.to_string(),
+            reason: e.to_string(),
+        })),
+    }
+}
+
+/// Returns true when the RPC error indicates the account simply does not exist.
+///
+/// Uses structured `ErrorKind` inspection rather than raw string matching:
+/// - Primary: `INVALID_PARAMS_CODE` (`-32602`, JSON-RPC "Invalid params"), which
+///   is what Solana validators return for a missing account.
+/// - Fallback: substring match on the error message for non-standard RPC
+///   providers that may emit the same wording with a different code.
+///
+/// This function only receives errors from `rpc.get_token_account_balance`, so
+/// it cannot be triggered by a DB error — DB failures propagate as a different
+/// error type entirely and never reach this function.
+fn is_account_not_found(e: &solana_rpc_client_api::client_error::Error) -> bool {
+    use solana_rpc_client_api::{client_error::ErrorKind, request::RpcError};
+
+    if let ErrorKind::RpcError(RpcError::RpcResponseError { code, message, .. }) = &e.kind {
+        if *code == INVALID_PARAMS_CODE as i64 {
+            return true;
+        }
+        let msg = message.to_lowercase();
+        msg.contains("could not find account") || msg.contains("account not found")
+    } else {
+        false
+    }
+}
+
+/// Compute the absolute difference between on-chain balance and DB expected value.
+/// Uses i128 internally to avoid overflow when subtracting.
+pub fn compute_mismatch(db_expected: i64, on_chain_actual: u64) -> u64 {
+    let diff = (on_chain_actual as i128) - (db_expected as i128);
+    // unsigned_abs() returns u128; cap at u64::MAX to keep the type consistent
+    diff.unsigned_abs().min(u64::MAX as u128) as u64
+}
+
+/// Log results and decide whether to allow or block startup.
+fn classify_and_report(
+    config: &ReconciliationConfig,
+    results: &[MintReconciliation],
+) -> Result<(), IndexerError> {
+    let exceeding: Vec<&MintReconciliation> = results
+        .iter()
+        .filter(|r| r.mismatch > config.mismatch_threshold_raw)
+        .collect();
+
+    let within_tolerance: Vec<&MintReconciliation> = results
+        .iter()
+        .filter(|r| r.mismatch > 0 && r.mismatch <= config.mismatch_threshold_raw)
+        .collect();
+
+    if !exceeding.is_empty() {
+        for r in &exceeding {
+            error!(
+                reconciliation_alert = true,
+                mint = %r.mint,
+                db_expected = r.db_expected,
+                on_chain_actual = r.on_chain_actual,
+                mismatch = r.mismatch,
+                threshold = config.mismatch_threshold_raw,
+                "RECONCILIATION ALERT: escrow ATA balance mismatch exceeds threshold"
+            );
+        }
+
+        return Err(IndexerError::Reconciliation(
+            ReconciliationError::MismatchExceedsThreshold {
+                count: exceeding.len(),
+                threshold: config.mismatch_threshold_raw,
+            },
+        ));
+    }
+
+    for r in &within_tolerance {
+        warn!(
+            mint = %r.mint,
+            db_expected = r.db_expected,
+            on_chain_actual = r.on_chain_actual,
+            mismatch = r.mismatch,
+            threshold = config.mismatch_threshold_raw,
+            "Reconciliation: balance mismatch within tolerance, continuing startup"
+        );
+    }
+
+    let balanced = results.iter().filter(|r| r.mismatch == 0).count();
+    info!(
+        total_mints = results.len(),
+        balanced,
+        within_tolerance = within_tolerance.len(),
+        "Startup reconciliation passed"
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // compute_mismatch tests
+    // =========================================================================
+
+    #[test]
+    fn test_compute_mismatch_balanced() {
+        assert_eq!(compute_mismatch(1000, 1000), 0);
+    }
+
+    #[test]
+    fn test_compute_mismatch_on_chain_excess() {
+        // on-chain has 100 more than DB expects (unlikely but defensively handled)
+        assert_eq!(compute_mismatch(900, 1000), 100);
+    }
+
+    #[test]
+    fn test_compute_mismatch_db_excess() {
+        // DB expects 100 more than on-chain (tokens not yet settled or slippage)
+        assert_eq!(compute_mismatch(1100, 1000), 100);
+    }
+
+    #[test]
+    fn test_compute_mismatch_db_negative() {
+        // Impossible state: more completed withdrawals than deposits in DB.
+        // Mismatch is the absolute difference from 0.
+        assert_eq!(compute_mismatch(-50, 0), 50);
+    }
+
+    #[test]
+    fn test_compute_mismatch_zero_both() {
+        assert_eq!(compute_mismatch(0, 0), 0);
+    }
+
+    // =========================================================================
+    // is_account_not_found tests
+    // =========================================================================
+
+    fn make_rpc_response_error(
+        code: i64,
+        message: &str,
+    ) -> solana_rpc_client_api::client_error::Error {
+        use solana_rpc_client_api::{
+            client_error::ErrorKind,
+            request::{RpcError, RpcResponseErrorData},
+        };
+        ErrorKind::RpcError(RpcError::RpcResponseError {
+            code,
+            message: message.to_string(),
+            data: RpcResponseErrorData::Empty,
+        })
+        .into()
+    }
+
+    #[test]
+    fn test_is_account_not_found_by_code() {
+        // INVALID_PARAMS_CODE matches regardless of message wording
+        let err = make_rpc_response_error(
+            INVALID_PARAMS_CODE as i64,
+            "Invalid param: some unrecognized wording",
+        );
+        assert!(is_account_not_found(&err));
+    }
+
+    #[test]
+    fn test_is_account_not_found_standard_message() {
+        // Standard Solana validator message — also matches via INVALID_PARAMS_CODE
+        let err = make_rpc_response_error(
+            INVALID_PARAMS_CODE as i64,
+            "Invalid param: could not find account",
+        );
+        assert!(is_account_not_found(&err));
+    }
+
+    #[test]
+    fn test_is_account_not_found_message_fallback() {
+        // Non-standard provider: different code but recognizable message
+        let err = make_rpc_response_error(-32000, "could not find account");
+        assert!(is_account_not_found(&err));
+    }
+
+    #[test]
+    fn test_is_account_not_found_account_not_found_variant() {
+        // Alternative message wording — message fallback
+        let err = make_rpc_response_error(-32000, "account not found");
+        assert!(is_account_not_found(&err));
+    }
+
+    #[test]
+    fn test_is_account_not_found_unrelated_error() {
+        // Unrelated RPC error — should not match
+        let err = make_rpc_response_error(-32005, "Node is unhealthy");
+        assert!(!is_account_not_found(&err));
+    }
+
+    #[test]
+    fn test_is_account_not_found_non_rpc_error() {
+        use solana_rpc_client_api::client_error::ErrorKind;
+        let err = ErrorKind::Custom("connection refused".to_string()).into();
+        assert!(!is_account_not_found(&err));
+    }
+
+    // =========================================================================
+    // classify_and_report tests
+    // =========================================================================
+
+    fn make_result(mint: &str, db_expected: i64, on_chain_actual: u64) -> MintReconciliation {
+        MintReconciliation::new(mint.to_string(), db_expected, on_chain_actual)
+    }
+
+    #[test]
+    fn test_classify_all_balanced() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let results = vec![
+            make_result("mint1", 1000, 1000),
+            make_result("mint2", 500, 500),
+        ];
+        assert!(classify_and_report(&config, &results).is_ok());
+    }
+
+    #[test]
+    fn test_classify_mismatch_within_tolerance() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 10,
+        };
+        // mismatch = 5, threshold = 10 → should pass with warning
+        let results = vec![make_result("mint1", 1000, 1005)];
+        assert!(classify_and_report(&config, &results).is_ok());
+    }
+
+    #[test]
+    fn test_classify_mismatch_equals_threshold() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 5,
+        };
+        // mismatch == threshold → within tolerance (not exceeding)
+        let results = vec![make_result("mint1", 1000, 1005)];
+        assert!(classify_and_report(&config, &results).is_ok());
+    }
+
+    #[test]
+    fn test_classify_mismatch_exceeds_threshold_blocks() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 4,
+        };
+        // mismatch = 5 > threshold = 4 → error
+        let results = vec![make_result("mint1", 1000, 1005)];
+        let err = classify_and_report(&config, &results).unwrap_err();
+        match err {
+            IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
+                count,
+                threshold,
+            }) => {
+                assert_eq!(count, 1);
+                assert_eq!(threshold, 4);
+            }
+            other => panic!("Unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_strict_zero_threshold_any_mismatch_blocks() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let results = vec![make_result("mint1", 1000, 1001)];
+        assert!(classify_and_report(&config, &results).is_err());
+    }
+
+    #[test]
+    fn test_classify_multiple_mints_one_exceeds() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 10,
+        };
+        let results = vec![
+            make_result("mint1", 1000, 1000), // balanced
+            make_result("mint2", 1000, 1005), // mismatch 5 ≤ 10 → warn
+            make_result("mint3", 1000, 1020), // mismatch 20 > 10 → error
+        ];
+        let err = classify_and_report(&config, &results).unwrap_err();
+        match err {
+            IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
+                count,
+                threshold,
+            }) => {
+                assert_eq!(count, 1);
+                assert_eq!(threshold, 10);
+            }
+            other => panic!("Unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_empty_results_passes() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        assert!(classify_and_report(&config, &[]).is_ok());
+    }
+
+    #[test]
+    fn test_classify_pending_deposit_included_in_db_expected() {
+        // Regression: total_deposits must include all statuses (pending/processing/failed),
+        // not just completed. If the SQL is wrong, db_expected would be 0 (only completed=0),
+        // and the on-chain balance of 500 would produce a false mismatch.
+        // With the correct SQL, total_deposits = 500 (all indexed), so db_expected = 500
+        // and there is no mismatch.
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        // Simulate: 500 tokens deposited (pending, not yet operator-completed),
+        // db_expected = all_deposits(500) - completed_withdrawals(0) = 500
+        // on_chain_actual = 500 → balanced
+        let results = vec![make_result("mint1", 500, 500)];
+        assert!(
+            classify_and_report(&config, &results).is_ok(),
+            "pending deposits should be included in db_expected; should not cause false mismatch"
+        );
+    }
+
+    // =========================================================================
+    // run_startup_reconciliation skip / pass tests
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_reconciliation_skipped_for_withdraw_program() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+
+        #[cfg(test)]
+        {
+            use crate::storage::common::storage::mock::MockStorage;
+            let storage = Storage::Mock(MockStorage::new());
+            let seed = Pubkey::new_unique();
+
+            let result = run_startup_reconciliation(
+                &config,
+                ProgramType::Withdraw,
+                &storage,
+                "http://localhost:8899",
+                &seed,
+            )
+            .await;
+
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_empty_mints_passes() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+
+        #[cfg(test)]
+        {
+            use crate::storage::common::storage::mock::MockStorage;
+            // Empty mock: no mints → should pass immediately
+            let storage = Storage::Mock(MockStorage::new());
+            let seed = Pubkey::new_unique();
+
+            let result = run_startup_reconciliation(
+                &config,
+                ProgramType::Escrow,
+                &storage,
+                "http://localhost:8899",
+                &seed,
+            )
+            .await;
+
+            // Empty state always passes (no mints to compare)
+            assert!(result.is_ok());
+        }
+    }
+
+    // =========================================================================
+    // InvalidPubkey error path tests (comment 4)
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_reconciliation_invalid_mint_pubkey_returns_error() {
+        use crate::storage::common::storage::mock::MockStorage;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![crate::storage::common::models::MintDbBalance {
+            mint_address: "not-a-valid-pubkey".to_string(),
+            token_program: spl_token::id().to_string(),
+            total_deposits: 1000,
+            total_withdrawals: 0,
+        }]);
+        let storage = Storage::Mock(mock_storage);
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            "http://localhost:8899",
+            &seed,
+        )
+        .await;
+
+        match result {
+            Err(IndexerError::Reconciliation(ReconciliationError::InvalidPubkey {
+                pubkey,
+                reason: _,
+            })) => {
+                assert_eq!(pubkey, "not-a-valid-pubkey");
+            }
+            other => panic!("Expected InvalidPubkey error, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_invalid_token_program_pubkey_returns_error() {
+        use crate::storage::common::storage::mock::MockStorage;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![crate::storage::common::models::MintDbBalance {
+            mint_address: Pubkey::new_unique().to_string(),
+            token_program: "not-a-valid-token-program".to_string(),
+            total_deposits: 500,
+            total_withdrawals: 0,
+        }]);
+        let storage = Storage::Mock(mock_storage);
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            "http://localhost:8899",
+            &seed,
+        )
+        .await;
+
+        match result {
+            Err(IndexerError::Reconciliation(ReconciliationError::InvalidPubkey {
+                pubkey,
+                reason: _,
+            })) => {
+                assert_eq!(pubkey, "not-a-valid-token-program");
+            }
+            other => panic!("Expected InvalidPubkey error, got: {:?}", other),
+        }
+    }
+
+    // =========================================================================
+    // RPC integration tests (mockito)
+    // =========================================================================
+
+    use crate::storage::common::storage::mock::MockStorage;
+
+    fn token_account_balance_response(amount: u64) -> String {
+        format!(
+            r#"{{
+                "context": {{"slot": 100}},
+                "value": {{
+                    "amount": "{}",
+                    "decimals": 6,
+                    "uiAmount": null,
+                    "uiAmountString": "{}"
+                }}
+            }}"#,
+            amount, amount
+        )
+    }
+
+    fn account_not_found_error() -> (i32, &'static str) {
+        (-32602, "Invalid param: could not find account")
+    }
+
+    fn make_mint_balance(
+        mint_address: &str,
+        total_deposits: i64,
+        total_withdrawals: i64,
+    ) -> crate::storage::common::models::MintDbBalance {
+        crate::storage::common::models::MintDbBalance {
+            mint_address: mint_address.to_string(),
+            token_program: spl_token::id().to_string(),
+            total_deposits,
+            total_withdrawals,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_balanced_passes() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
+                token_account_balance_response(1000)
+            ))
+            .create_async()
+            .await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(
+            &Pubkey::new_unique().to_string(),
+            1000,
+            0,
+        )]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &server.url(),
+            &seed,
+        )
+        .await;
+
+        assert!(result.is_ok(), "balanced state should pass: {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_mismatch_within_threshold_passes() {
+        let mut server = mockito::Server::new_async().await;
+        // DB expects 1000, on-chain has 1005 → mismatch = 5 ≤ threshold 10 → ok
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
+                token_account_balance_response(1005)
+            ))
+            .create_async()
+            .await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(
+            &Pubkey::new_unique().to_string(),
+            1000,
+            0,
+        )]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 10,
+        };
+        let seed = Pubkey::new_unique();
+
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &server.url(),
+            &seed,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "mismatch within threshold should pass: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_mismatch_exceeds_threshold_blocks() {
+        let mut server = mockito::Server::new_async().await;
+        // DB expects 1000, on-chain has 1020 → mismatch = 20 > threshold 10 → err
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
+                token_account_balance_response(1020)
+            ))
+            .create_async()
+            .await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(
+            &Pubkey::new_unique().to_string(),
+            1000,
+            0,
+        )]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 10,
+        };
+        let seed = Pubkey::new_unique();
+
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &server.url(),
+            &seed,
+        )
+        .await;
+
+        match result {
+            Err(IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
+                count,
+                threshold,
+            })) => {
+                assert_eq!(count, 1);
+                assert_eq!(threshold, 10);
+            }
+            other => panic!("Expected MismatchExceedsThreshold, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_ata_not_found_treated_as_zero() {
+        let mut server = mockito::Server::new_async().await;
+        let (code, message) = account_not_found_error();
+        // Return "account not found" error → treated as balance 0
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","error":{{"code":{},"message":"{}"}},"id":1}}"#,
+                code, message
+            ))
+            .create_async()
+            .await;
+
+        let mock_storage = MockStorage::new();
+        // DB also expects 0 (no completed deposits) → balanced → should pass
+        mock_storage.set_mint_balances(vec![make_mint_balance(
+            &Pubkey::new_unique().to_string(),
+            0,
+            0,
+        )]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &server.url(),
+            &seed,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "account not found should be treated as 0 balance: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_with_nonzero_withdrawals_balanced() {
+        // Exercises total_deposits - total_withdrawals: 1500 deposits, 500 withdrawals → db_expected 1000
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
+                token_account_balance_response(1000)
+            ))
+            .create_async()
+            .await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(
+            &Pubkey::new_unique().to_string(),
+            1500,
+            500,
+        )]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &server.url(),
+            &seed,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "1500 deposits - 500 withdrawals = 1000 on-chain should balance: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_with_nonzero_withdrawals_mismatch_blocks() {
+        // 1500 deposits, 500 withdrawals → db_expected 1000
+        // on-chain = 1050 → mismatch 50 > threshold 10 → error
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
+                token_account_balance_response(1050)
+            ))
+            .create_async()
+            .await;
+
+        let mock_storage = MockStorage::new();
+        mock_storage.set_mint_balances(vec![make_mint_balance(
+            &Pubkey::new_unique().to_string(),
+            1500,
+            500,
+        )]);
+        let storage = Storage::Mock(mock_storage);
+
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 10,
+        };
+        let seed = Pubkey::new_unique();
+
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &server.url(),
+            &seed,
+        )
+        .await;
+
+        match result {
+            Err(IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
+                count,
+                threshold,
+            })) => {
+                assert_eq!(count, 1);
+                assert_eq!(threshold, 10);
+            }
+            other => panic!(
+                "Expected MismatchExceedsThreshold for withdrawal mismatch, got: {:?}",
+                other
+            ),
+        }
+    }
+}

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -11,6 +11,7 @@ pub mod test_utils;
 
 pub use config::{
     BackfillConfig, ContraIndexerConfig, DatasourceType, IndexerConfig, OperatorConfig,
-    PostgresConfig, ProgramType, RpcPollingConfig, StorageType, YellowstoneConfig,
+    PostgresConfig, ProgramType, ReconciliationConfig, RpcPollingConfig, StorageType,
+    YellowstoneConfig,
 };
 pub use indexer::run;

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -53,6 +53,21 @@ pub struct DbTransaction {
     pub counterpart_signature: Option<String>,
 }
 
+/// Per-mint balance aggregate used during startup reconciliation.
+/// Returned by the reconciliation storage query.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct MintDbBalance {
+    pub mint_address: String,
+    pub token_program: String,
+    /// Sum of amounts for all indexed deposits (any status).
+    /// Deposits increase the on-chain ATA balance the moment they are observed,
+    /// regardless of whether the operator has completed the corresponding contra mint.
+    pub total_deposits: i64,
+    /// Sum of amounts for completed withdrawals only.
+    /// Only a completed `release_funds` call actually reduces the on-chain ATA balance.
+    pub total_withdrawals: i64,
+}
+
 /// Mint metadata stored
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct DbMint {

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -6,6 +6,7 @@ pub mod get_and_lock_pending_transactions;
 pub mod get_committed_checkpoint;
 pub mod get_completed_withdrawal_nonces;
 pub mod get_mint;
+pub mod get_mint_balances_for_reconciliation;
 pub mod get_pending_db_transactions;
 pub mod init_schema;
 pub mod insert_db_transaction;
@@ -126,6 +127,13 @@ impl Storage {
     /// Get mint metadata by address
     pub async fn get_mint(&self, mint_address: &str) -> Result<Option<DbMint>, StorageError> {
         get_mint::get_mint(self, mint_address).await
+    }
+
+    /// Return per-mint aggregate balances (completed deposits minus withdrawals) for startup reconciliation.
+    pub async fn get_mint_balances_for_reconciliation(
+        &self,
+    ) -> Result<Vec<MintDbBalance>, StorageError> {
+        get_mint_balances_for_reconciliation::get_mint_balances_for_reconciliation(self).await
     }
 
     /// Close the storage connection pool gracefully

--- a/indexer/src/storage/common/storage/get_mint_balances_for_reconciliation.rs
+++ b/indexer/src/storage/common/storage/get_mint_balances_for_reconciliation.rs
@@ -1,0 +1,18 @@
+use crate::{
+    error::StorageError,
+    storage::{common::models::MintDbBalance, common::storage::Storage, postgres::db::PostgresDb},
+};
+
+pub async fn get_mint_balances_for_reconciliation(
+    storage: &Storage,
+) -> Result<Vec<MintDbBalance>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => get_mint_balances_postgres(db).await,
+        #[cfg(test)]
+        Storage::Mock(mock) => mock.get_mint_balances_for_reconciliation().await,
+    }
+}
+
+async fn get_mint_balances_postgres(db: &PostgresDb) -> Result<Vec<MintDbBalance>, StorageError> {
+    Ok(db.get_mint_balances_for_reconciliation_internal().await?)
+}

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -1,5 +1,7 @@
 use crate::error::StorageError;
-use crate::storage::common::models::{DbMint, DbTransaction, TransactionStatus, TransactionType};
+use crate::storage::common::models::{
+    DbMint, DbTransaction, MintDbBalance, TransactionStatus, TransactionType,
+};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -9,6 +11,7 @@ pub struct MockStorage {
     pub committed_checkpoints: std::sync::Arc<Mutex<HashMap<String, u64>>>,
     pub should_fail: std::sync::Arc<Mutex<HashMap<String, bool>>>,
     pub mints: std::sync::Arc<Mutex<HashMap<String, DbMint>>>,
+    pub mint_balances: std::sync::Arc<Mutex<Vec<MintDbBalance>>>,
 }
 
 impl MockStorage {
@@ -125,6 +128,16 @@ impl MockStorage {
 
     pub async fn get_mint(&self, mint_address: &str) -> Result<Option<DbMint>, StorageError> {
         Ok(self.mints.lock().unwrap().get(mint_address).cloned())
+    }
+
+    pub fn set_mint_balances(&self, balances: Vec<MintDbBalance>) {
+        *self.mint_balances.lock().unwrap() = balances;
+    }
+
+    pub async fn get_mint_balances_for_reconciliation(
+        &self,
+    ) -> Result<Vec<MintDbBalance>, StorageError> {
+        Ok(self.mint_balances.lock().unwrap().clone())
     }
 
     pub async fn close(&self) -> Result<(), StorageError> {

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -3,7 +3,9 @@ use tracing::info;
 
 use crate::{
     error::StorageError,
-    storage::common::models::{DbMint, DbTransaction, TransactionStatus, TransactionType},
+    storage::common::models::{
+        DbMint, DbTransaction, MintDbBalance, TransactionStatus, TransactionType,
+    },
     PostgresConfig,
 };
 
@@ -688,6 +690,41 @@ impl PostgresDb {
         .await?;
 
         Ok(mint)
+    }
+
+    /// Return per-mint aggregate balances for startup reconciliation.
+    ///
+    /// For each mint known to the DB, sums:
+    /// - `total_deposits`  : ALL indexed deposits (any status), because a deposit increases
+    ///   the escrow ATA balance on-chain the moment it is observed — the operator's contra minting
+    ///   status (`pending`/`processing`/`completed`/`failed`) does not change what is on-chain.
+    /// - `total_withdrawals`: only `completed` withdrawals, because only a completed
+    ///   `release_funds` call actually moves tokens out of the ATA.
+    ///
+    /// Mints with no transactions still appear (with totals = 0) because of the LEFT JOIN.
+    pub async fn get_mint_balances_for_reconciliation_internal(
+        &self,
+    ) -> Result<Vec<MintDbBalance>, sqlx::Error> {
+        sqlx::query_as::<_, MintDbBalance>(
+            r#"
+            SELECT
+                m.mint_address,
+                m.token_program,
+                COALESCE(
+                    SUM(CASE WHEN t.transaction_type = 'deposit' THEN t.amount ELSE 0 END),
+                    0
+                )::BIGINT AS total_deposits,
+                COALESCE(
+                    SUM(CASE WHEN t.transaction_type = 'withdrawal' AND t.status = 'completed' THEN t.amount ELSE 0 END),
+                    0
+                )::BIGINT AS total_withdrawals
+            FROM mints m
+            LEFT JOIN transactions t ON t.mint = m.mint_address
+            GROUP BY m.mint_address, m.token_program
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await
     }
 
     pub async fn close(&self) -> Result<(), sqlx::Error> {

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -11,6 +11,10 @@ path = "tests/contra/integration.rs"
 name = "indexer_integration"
 path = "tests/indexer/integration.rs"
 
+[[test]]
+name = "reconciliation_integration"
+path = "tests/indexer/reconciliation.rs"
+
 [features]
 test-tree = ["contra-indexer/test-tree"]
 

--- a/integration/tests/indexer/reconciliation.rs
+++ b/integration/tests/indexer/reconciliation.rs
@@ -1,0 +1,252 @@
+//! Integration tests for startup reconciliation against on-chain escrow ATA balances.
+//!
+//! Each test starts an isolated Postgres container and a real Solana test validator.
+//! `run_startup_reconciliation` is called directly so tests focus exclusively on
+//! reconciliation behaviour without starting the full indexer stack.
+//!
+//! Scenarios covered:
+//! 1. Empty DB (no mints) → passes trivially without hitting RPC.
+//! 2. DB has a phantom deposit (mint registered, tokens never on-chain) → blocks startup.
+//! 3. Same phantom deposit but threshold covers the gap → passes with warning.
+//! 4. Real tokens minted to escrow ATA, DB matches → passes with strict threshold.
+
+#[path = "helpers/mod.rs"]
+mod helpers;
+
+use contra_escrow_program_client::CONTRA_ESCROW_PROGRAM_ID;
+use contra_indexer::{
+    config::{ProgramType, ReconciliationConfig},
+    error::{IndexerError, ReconciliationError},
+    indexer::reconciliation::run_startup_reconciliation,
+    storage::{PostgresDb, Storage},
+    PostgresConfig,
+};
+use helpers::{generate_mint, mint_to_owner, setup_wallets};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+};
+use sqlx::PgPool;
+use std::sync::Arc;
+use test_utils::validator_helper::start_test_validator;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Derive the escrow instance PDA from a seed pubkey.
+fn instance_pda(seed: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"instance", seed.as_ref()], &CONTRA_ESCROW_PROGRAM_ID).0
+}
+
+/// Register a mint in the `mints` table and insert a single `pending` deposit of
+/// `amount` raw tokens. Uses `pending` status to exercise the all-statuses fix —
+/// all indexed deposits count toward the DB-expected balance regardless of status.
+async fn seed_mint_and_deposit(
+    pool: &PgPool,
+    mint_address: &str,
+    amount: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO mints (mint_address, decimals, token_program, created_at)
+         VALUES ($1, 6, $2, NOW())",
+    )
+    .bind(mint_address)
+    .bind(spl_token::id().to_string())
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO transactions
+         (signature, slot, initiator, recipient, mint, amount,
+          transaction_type, status, created_at, updated_at)
+         VALUES ($1, 1, 'recon_test', 'recon_test', $2, $3,
+                 'deposit'::transaction_type, 'pending'::transaction_status, NOW(), NOW())",
+    )
+    .bind(format!("recon_test_sig_{}", mint_address))
+    .bind(mint_address)
+    .bind(amount)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Start a fresh Postgres container and return (pool, Storage, container).
+/// The container must be kept alive for the duration of the test.
+async fn start_postgres(
+) -> Result<(PgPool, Storage, testcontainers::ContainerAsync<Postgres>), Box<dyn std::error::Error>>
+{
+    let container = Postgres::default()
+        .with_db_name("recon_test")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await?;
+
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let db_url = format!("postgres://postgres:password@{}:{}/recon_test", host, port);
+
+    let pool = PgPool::connect(&db_url).await?;
+    let storage = Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: db_url,
+            max_connections: 5,
+        })
+        .await?,
+    );
+    storage.init_schema().await?;
+
+    Ok((pool, storage, container))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// No mints registered in the DB → reconciliation returns immediately without
+/// hitting the RPC at all (empty-mints fast path).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reconciliation_empty_db_passes() -> Result<(), Box<dyn std::error::Error>> {
+    let (test_validator, _faucet, _geyser_port) = start_test_validator().await;
+    let (_pool, storage, _pg) = start_postgres().await?;
+
+    let result = run_startup_reconciliation(
+        &ReconciliationConfig::default(),
+        ProgramType::Escrow,
+        &storage,
+        &test_validator.rpc_url(),
+        &Keypair::new().pubkey(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "empty DB must pass: {:?}", result);
+    Ok(())
+}
+
+/// DB has a deposit for a mint whose escrow ATA does not exist on-chain (balance 0).
+/// With strict threshold (0) reconciliation must block startup.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reconciliation_blocks_on_phantom_deposit() -> Result<(), Box<dyn std::error::Error>> {
+    let (test_validator, _faucet, _geyser_port) = start_test_validator().await;
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    let mint = Pubkey::new_unique();
+    seed_mint_and_deposit(&pool, &mint.to_string(), 1_000_000).await?;
+
+    let result = run_startup_reconciliation(
+        &ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        },
+        ProgramType::Escrow,
+        &storage,
+        &test_validator.rpc_url(),
+        &Keypair::new().pubkey(),
+    )
+    .await;
+
+    match result {
+        Err(IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
+            count,
+            threshold,
+        })) => {
+            assert_eq!(count, 1, "exactly one mint should exceed threshold");
+            assert_eq!(threshold, 0);
+        }
+        other => panic!("expected MismatchExceedsThreshold, got: {:?}", other),
+    }
+    Ok(())
+}
+
+/// Same phantom deposit, but the configured threshold is larger than the mismatch →
+/// reconciliation logs a warning and returns Ok.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reconciliation_passes_within_threshold() -> Result<(), Box<dyn std::error::Error>> {
+    let (test_validator, _faucet, _geyser_port) = start_test_validator().await;
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    // DB expects 500_000; ATA absent → on-chain = 0; mismatch = 500_000 ≤ threshold 1_000_000
+    let mint = Pubkey::new_unique();
+    seed_mint_and_deposit(&pool, &mint.to_string(), 500_000).await?;
+
+    let result = run_startup_reconciliation(
+        &ReconciliationConfig {
+            mismatch_threshold_raw: 1_000_000,
+        },
+        ProgramType::Escrow,
+        &storage,
+        &test_validator.rpc_url(),
+        &Keypair::new().pubkey(),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "mismatch within threshold should pass: {:?}",
+        result
+    );
+    Ok(())
+}
+
+/// Tokens are minted directly to the escrow ATA on-chain; the DB records the
+/// matching pending deposit. With strict threshold (0) reconciliation must pass.
+///
+/// This also exercises the all-statuses deposit fix: the DB row has
+/// `status = 'pending'` (operator has not yet acted on contra) but the tokens are
+/// already reflected in the ATA, so the DB-expected balance should include it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reconciliation_passes_with_matching_on_chain_balance(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (test_validator, faucet_keypair, _geyser_port) = start_test_validator().await;
+    let client = Arc::new(RpcClient::new_with_commitment(
+        test_validator.rpc_url(),
+        CommitmentConfig::confirmed(),
+    ));
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    // Fund an authority keypair that will pay for transactions and sign minting.
+    let authority = Keypair::new();
+    setup_wallets(client.as_ref(), &faucet_keypair, &[&authority]).await?;
+
+    // Create an SPL mint with `authority` as the mint authority.
+    let mint_keypair = Keypair::new();
+    let mint_pubkey = generate_mint(client.as_ref(), &authority, &authority, &mint_keypair).await?;
+
+    // Derive the escrow instance PDA and mint tokens directly to its ATA.
+    let seed_keypair = Keypair::new();
+    let pda = instance_pda(&seed_keypair.pubkey());
+
+    const AMOUNT: u64 = 1_000_000;
+    mint_to_owner(
+        client.as_ref(),
+        &authority,
+        mint_pubkey,
+        pda,
+        &authority,
+        AMOUNT,
+    )
+    .await?;
+
+    // Seed the DB with a matching pending deposit — pending status is intentional
+    // to confirm that all deposit statuses contribute to the DB-expected balance.
+    seed_mint_and_deposit(&pool, &mint_pubkey.to_string(), AMOUNT as i64).await?;
+
+    let result = run_startup_reconciliation(
+        &ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        },
+        ProgramType::Escrow,
+        &storage,
+        &test_validator.rpc_url(),
+        &seed_keypair.pubkey(),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "DB matching real on-chain balance must pass: {:?}",
+        result
+    );
+    Ok(())
+}

--- a/test_utils/src/indexer_helper.rs
+++ b/test_utils/src/indexer_helper.rs
@@ -92,6 +92,7 @@ pub async fn start_contra_indexer(
         rpc_polling: Some(rpc_polling_config),
         yellowstone: yellowstone_config,
         backfill: backfill_config,
+        reconciliation: contra_indexer::ReconciliationConfig::default(),
     };
 
     indexer_config.validate()?;
@@ -181,6 +182,7 @@ pub async fn start_l1_indexer(
         rpc_polling: Some(rpc_polling_config),
         yellowstone: Some(yellowstone_config),
         backfill: backfill_config,
+        reconciliation: contra_indexer::ReconciliationConfig::default(),
     };
 
     common_config.validate()?;


### PR DESCRIPTION
## Summary

- On escrow indexer startup, before any data processing, optionally verify that per-mint DB totals (completed deposits − completed withdrawals) match the actual token balances in the escrow ATAs on-chain
- Mismatches exceeding `mismatch_threshold_raw` emit a `reconciliation_alert=true` tracing event and block startup; mismatches within tolerance log a warning and continue
- Opt-in (`enabled: false` by default) so existing deployments are unaffected — no config changes required to upgrade

## Changes

**New files**
- `indexer/src/indexer/reconciliation.rs` — core reconciliation logic with unit tests
- `indexer/src/storage/common/storage/get_mint_balances_for_reconciliation.rs` — storage routing

**Modified files**
- `indexer/src/bin/indexer.rs` — wires `ReconciliationConfig` from TOML/env (`INDEXER_RECONCILIATION_*`)
- `indexer/src/config.rs` — adds `ReconciliationConfig` struct and field on `IndexerConfig`
- `indexer/src/error/indexer.rs` — adds `ReconciliationError` enum and `IndexerError::Reconciliation` variant
- `indexer/src/indexer/indexer.rs` — calls `run_startup_reconciliation` after schema init, before backfill/datasource
- `indexer/src/storage/common/models.rs` — adds `MintDbBalance` struct
- `indexer/src/storage/common/storage.rs` / `mock.rs` / `postgres/db.rs` — storage layer support
- `indexer/config/example-indexer.toml` — documents `[indexer.reconciliation]` section

## Notes

No metrics library exists in the codebase; alerting is via structured tracing (`reconciliation_alert = true` field) which is filterable in any log aggregator.