### PR TITLE
fix: add SMT root mismatch verification in operator sender

### DIFF
--- a/indexer/src/error/transaction.rs
+++ b/indexer/src/error/transaction.rs
@@ -39,4 +39,10 @@ pub enum ProgramError {
         expected_tree_index: u64,
         current_tree_index: u64,
     },
+
+    #[error("SMT root mismatch: local root {local_root:?} does not match on-chain root {onchain_root:?}. Database may be out of sync with on-chain state.")]
+    SmtRootMismatch {
+        local_root: [u8; 32],
+        onchain_root: [u8; 32],
+    },
 }

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -10,7 +10,7 @@ use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_sdk::pubkey::Pubkey;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::info;
+use tracing::{error, info};
 
 use super::types::{SenderSMTState, SenderState};
 
@@ -96,6 +96,38 @@ impl SenderState {
             tree_index,
             nonces.len()
         );
+
+        // CRITICAL: Verify local SMT root matches on-chain root
+        // This ensures database is in sync with on-chain state
+        let computed_root = smt_state.current_root();
+        let onchain_root = instance.withdrawal_transactions_root;
+
+        if computed_root != onchain_root {
+            error!("SMT root mismatch detected! Database out of sync with on-chain state.");
+            error!("  Instance PDA: {}", instance_pda);
+            error!("  Tree Index: {}", tree_index);
+            error!("  Nonces from DB: {:?}", nonces);
+            error!("  Local root:    {:?}", computed_root);
+            error!("  On-chain root: {:?}", onchain_root);
+            error!("");
+            error!("This typically means:");
+            error!("  1. A withdrawal was successfully processed on-chain");
+            error!("  2. But the operator crashed before updating the database");
+            error!("  3. The database is now missing transaction records");
+            error!("");
+            error!("Resolution options:");
+            error!("  1. Reset and resync the database from on-chain events");
+            error!("  2. Manually reconcile missing transactions");
+            error!("  3. Reset the on-chain SMT tree (requires admin)");
+
+            return Err(crate::error::ProgramError::SmtRootMismatch {
+                local_root: computed_root,
+                onchain_root,
+            }
+            .into());
+        }
+
+        info!("SMT root verification passed: {:?}", computed_root);
 
         self.smt_state = Some(SenderSMTState {
             smt_state,


### PR DESCRIPTION
## Summary

- Adds a critical safety check: before the operator proceeds with a withdrawal batch, it now verifies that the locally-computed SMT root matches the on-chain root stored in the instance account.
- If a mismatch is detected (e.g. after an operator crash between on-chain tx confirmation and local DB update), it logs detailed diagnostic info and returns a `SmtRootMismatch` error instead of silently diverging.

## Changed files

- `indexer/src/error/transaction.rs` -- new `SmtRootMismatch` error variant
- `indexer/src/operator/sender/state.rs` -- root verification logic before withdrawal processing

---
_Ported from #1 by @gitteri onto `hardening/pre-release-audit`._