### PR TITLE
fix(core-rpc): update handler test for /health endpoint [PRO-890]

### DIFF
--- a/core/src/rpc/handler.rs
+++ b/core/src/rpc/handler.rs
@@ -338,11 +338,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn returns_404_for_non_root_path() {
+    async fn returns_404_for_unknown_path() {
+        let addr = start_test_rpc_server().await;
+        let req = "GET /unknown HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let response = send_raw(addr, req.as_bytes()).await;
+        assert_status(&response, 404);
+    }
+
+    #[tokio::test]
+    async fn health_returns_503_when_rpc_has_no_methods() {
         let addr = start_test_rpc_server().await;
         let req = "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n";
         let response = send_raw(addr, req.as_bytes()).await;
-        assert_status(&response, 404);
+        assert_status(&response, 503);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- The /health endpoint was added but `returns_404_for_non_root_path` still sent `GET /health` expecting 404, now returns 503 since the health check calls `getSlot` on an empty RPC module
- Renamed test to `returns_404_for_unknown_path` hitting `/unknown` instead
- Added `health_returns_503_when_rpc_has_no_methods` to cover the health endpoint behavior

Closes PRO-890