### PR TITLE
test(core): add BOB sync-or-ahead invariant unit tests [PRO-915]

### DIFF
--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -316,3 +316,552 @@ impl TransactionProcessingCallback for BOB {
             .and_then(|account| owners.iter().position(|key| account.owner().eq(key)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::accounts::{AccountsDB, PostgresAccountsDB},
+        solana_svm_callback::TransactionProcessingCallback,
+        sqlx::postgres::PgPoolOptions,
+        std::sync::Arc,
+    };
+
+    /// Creates a dummy AccountsDB backed by a lazily-connected pool.
+    /// No real connection is ever established because none of these tests
+    /// call through to the database.
+    fn dummy_accounts_db() -> AccountsDB {
+        let pool = PgPoolOptions::new()
+            .connect_lazy("postgres://test@localhost:1/test")
+            .expect("connect_lazy should not fail");
+        AccountsDB::Postgres(PostgresAccountsDB {
+            pool: Arc::new(pool),
+            read_only: true,
+        })
+    }
+
+    fn create_test_bob() -> (BOB, mpsc::UnboundedSender<Vec<(Pubkey, AccountSettlement)>>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let bob = BOB {
+            accounts: HashMap::new(),
+            precompiles: HashMap::new(),
+            settled_accounts_rx: rx,
+            accounts_db: dummy_accounts_db(),
+        };
+        (bob, tx)
+    }
+
+    fn make_account(lamports: u64, data: &[u8], owner: &Pubkey) -> AccountSharedData {
+        AccountSharedData::from(Account {
+            lamports,
+            data: data.to_vec(),
+            owner: *owner,
+            executable: false,
+            rent_epoch: 0,
+        })
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    // -----------------------------------------------------------------------
+    // Invariant C2: BOB MUST be in sync or ahead of DB on disk
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn gc_marks_matching_account_as_synced() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        let account = make_account(1000, &[1, 2, 3], &Pubkey::default());
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: account.clone(),
+                synced_since: None,
+                deleted: false,
+            },
+        );
+
+        settled_tx
+            .send(vec![(
+                pubkey,
+                AccountSettlement {
+                    account: account.clone(),
+                    deleted: false,
+                },
+            )])
+            .unwrap();
+
+        bob.garbage_collect();
+
+        let meta = bob.accounts.get(&pubkey).unwrap();
+        assert!(
+            meta.synced_since.is_some(),
+            "Account matching settler feedback should be marked as synced"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_preserves_ahead_state_when_data_differs() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        let newer = make_account(2000, &[9, 9, 9], &Pubkey::default());
+        let older = make_account(1000, &[1, 2, 3], &Pubkey::default());
+
+        // Executor wrote newer state to BOB
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: newer.clone(),
+                synced_since: None,
+                deleted: false,
+            },
+        );
+
+        // Settler sends older (now-stale) feedback
+        settled_tx
+            .send(vec![(
+                pubkey,
+                AccountSettlement {
+                    account: older,
+                    deleted: false,
+                },
+            )])
+            .unwrap();
+
+        bob.garbage_collect();
+
+        let meta = bob.accounts.get(&pubkey).unwrap();
+        assert_eq!(
+            meta.account, newer,
+            "In-memory state must not be overwritten by stale settler feedback"
+        );
+        assert!(
+            meta.synced_since.is_none(),
+            "Account ahead of DB must keep synced_since=None"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_preserves_deleted_tombstone_against_non_deleted_settlement() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        let account = make_account(1000, &[1], &Pubkey::default());
+
+        // BOB has account marked as deleted (tombstone)
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: account.clone(),
+                synced_since: None,
+                deleted: true,
+            },
+        );
+
+        // Settler sends non-deleted settlement (from before the delete)
+        settled_tx
+            .send(vec![(
+                pubkey,
+                AccountSettlement {
+                    account,
+                    deleted: false,
+                },
+            )])
+            .unwrap();
+
+        bob.garbage_collect();
+
+        let meta = bob.accounts.get(&pubkey).unwrap();
+        assert!(
+            meta.deleted,
+            "Deleted tombstone must not be overwritten by stale non-deleted settlement"
+        );
+        assert!(meta.synced_since.is_none());
+    }
+
+    #[tokio::test]
+    async fn gc_removes_tombstone_on_deleted_settlement() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        let account = make_account(0, &[], &Pubkey::default());
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: account.clone(),
+                synced_since: None,
+                deleted: true,
+            },
+        );
+
+        // Settler confirms deletion was persisted to DB
+        settled_tx
+            .send(vec![(
+                pubkey,
+                AccountSettlement {
+                    account,
+                    deleted: true,
+                },
+            )])
+            .unwrap();
+
+        bob.garbage_collect();
+
+        assert!(
+            !bob.accounts.contains_key(&pubkey),
+            "Tombstoned account must be removed once settler confirms deletion"
+        );
+    }
+
+    #[tokio::test]
+    async fn eviction_never_removes_unsynced_accounts() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(1000, &[1], &Pubkey::default()),
+                synced_since: None, // Ahead of DB — must never be evicted
+                deleted: false,
+            },
+        );
+
+        bob.garbage_collect();
+
+        assert!(
+            bob.accounts.contains_key(&pubkey),
+            "Accounts with synced_since=None (ahead of DB) must never be evicted"
+        );
+    }
+
+    #[tokio::test]
+    async fn eviction_removes_old_synced_accounts() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(1000, &[1], &Pubkey::default()),
+                synced_since: Some(now_secs() - OLDEST_SYNCED_ACCOUNT_AGE - 1),
+                deleted: false,
+            },
+        );
+
+        bob.garbage_collect();
+
+        assert!(
+            !bob.accounts.contains_key(&pubkey),
+            "Synced accounts older than OLDEST_SYNCED_ACCOUNT_AGE should be evicted"
+        );
+    }
+
+    #[tokio::test]
+    async fn eviction_keeps_recently_synced_accounts() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(1000, &[1], &Pubkey::default()),
+                synced_since: Some(now_secs()),
+                deleted: false,
+            },
+        );
+
+        bob.garbage_collect();
+
+        assert!(
+            bob.accounts.contains_key(&pubkey),
+            "Recently synced accounts must not be evicted"
+        );
+    }
+
+    #[test]
+    fn preload_or_insert_preserves_inflight_state() {
+        // Directly tests the HashMap pattern used by preload_accounts.
+        // Verifies that entry().or_insert_with() does not overwrite
+        // an existing in-flight account with stale DB data.
+        let mut accounts: HashMap<Pubkey, AccountWithMeta> = HashMap::new();
+        let pubkey = Pubkey::new_unique();
+
+        let newer = make_account(2000, &[9, 9], &Pubkey::default());
+        let older_from_db = make_account(1000, &[1, 2], &Pubkey::default());
+
+        // Executor already wrote newer state
+        accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: newer.clone(),
+                synced_since: None,
+                deleted: false,
+            },
+        );
+
+        // Simulate what preload_accounts does with DB results
+        accounts.entry(pubkey).or_insert_with(|| AccountWithMeta {
+            account: older_from_db,
+            synced_since: None,
+            deleted: false,
+        });
+
+        assert_eq!(
+            accounts[&pubkey].account, newer,
+            "or_insert_with must not overwrite existing in-flight state"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_preload_and_settle_preserves_newer_state() {
+        // Simulates the race condition: executor writes v2 after settler
+        // sends v1 feedback but before GC runs.
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+
+        let v1 = make_account(1000, &[1], &Pubkey::default());
+        let v2 = make_account(2000, &[2], &Pubkey::default());
+
+        // Step 1: Executor writes v1 to BOB
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: v1.clone(),
+                synced_since: None,
+                deleted: false,
+            },
+        );
+
+        // Step 2: Settler settles v1 and sends feedback
+        settled_tx
+            .send(vec![(
+                pubkey,
+                AccountSettlement {
+                    account: v1,
+                    deleted: false,
+                },
+            )])
+            .unwrap();
+
+        // Step 3: Before GC runs, executor updates BOB to v2
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: v2.clone(),
+                synced_since: None,
+                deleted: false,
+            },
+        );
+
+        // Step 4: GC runs (triggered by next preload_accounts)
+        bob.garbage_collect();
+
+        let meta = bob.accounts.get(&pubkey).unwrap();
+        assert_eq!(
+            meta.account, v2,
+            "GC must not regress to v1 when BOB already has v2"
+        );
+        assert!(
+            meta.synced_since.is_none(),
+            "Account ahead of DB must keep synced_since=None"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_multi_batch_settlement_applies_all_in_order() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+
+        let v1 = make_account(1000, &[1], &Pubkey::default());
+        let v2 = make_account(2000, &[2], &Pubkey::default());
+        let v3 = make_account(3000, &[3], &Pubkey::default());
+
+        // BOB has v3 (latest from executor)
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: v3.clone(),
+                synced_since: None,
+                deleted: false,
+            },
+        );
+
+        // Two settlement batches queue up before GC runs
+        settled_tx
+            .send(vec![(
+                pubkey,
+                AccountSettlement {
+                    account: v1,
+                    deleted: false,
+                },
+            )])
+            .unwrap();
+        settled_tx
+            .send(vec![(
+                pubkey,
+                AccountSettlement {
+                    account: v2,
+                    deleted: false,
+                },
+            )])
+            .unwrap();
+
+        bob.garbage_collect();
+
+        let meta = bob.accounts.get(&pubkey).unwrap();
+        assert_eq!(
+            meta.account, v3,
+            "BOB must preserve v3 when neither settlement batch matches"
+        );
+        assert!(
+            meta.synced_since.is_none(),
+            "Account ahead of all settled versions must keep synced_since=None"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_settlement_for_missing_account_does_not_panic() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let missing_pubkey = Pubkey::new_unique();
+
+        // Settler sends feedback for an account that was never in BOB
+        settled_tx
+            .send(vec![(
+                missing_pubkey,
+                AccountSettlement {
+                    account: make_account(1000, &[1], &Pubkey::default()),
+                    deleted: false,
+                },
+            )])
+            .unwrap();
+
+        // Should not panic; just logs a warning
+        bob.garbage_collect();
+
+        assert!(
+            !bob.accounts.contains_key(&missing_pubkey),
+            "Settlement for missing account must not create a new entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn eviction_mixed_population() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let now = now_secs();
+
+        let old_synced = Pubkey::new_unique();
+        let recent_synced = Pubkey::new_unique();
+        let unsynced = Pubkey::new_unique();
+
+        bob.accounts.insert(
+            old_synced,
+            AccountWithMeta {
+                account: make_account(100, &[1], &Pubkey::default()),
+                synced_since: Some(now - OLDEST_SYNCED_ACCOUNT_AGE - 1),
+                deleted: false,
+            },
+        );
+        bob.accounts.insert(
+            recent_synced,
+            AccountWithMeta {
+                account: make_account(200, &[2], &Pubkey::default()),
+                synced_since: Some(now),
+                deleted: false,
+            },
+        );
+        bob.accounts.insert(
+            unsynced,
+            AccountWithMeta {
+                account: make_account(300, &[3], &Pubkey::default()),
+                synced_since: None,
+                deleted: false,
+            },
+        );
+
+        bob.garbage_collect();
+
+        assert!(
+            !bob.accounts.contains_key(&old_synced),
+            "Old synced account must be evicted"
+        );
+        assert!(
+            bob.accounts.contains_key(&recent_synced),
+            "Recently synced account must survive eviction"
+        );
+        assert!(
+            bob.accounts.contains_key(&unsynced),
+            "Unsynced (ahead of DB) account must survive eviction"
+        );
+    }
+
+    #[tokio::test]
+    async fn eviction_boundary_exact_age_is_kept() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+
+        // synced_since + OLDEST_SYNCED_ACCOUNT_AGE == now → should be kept (>= check)
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(1000, &[1], &Pubkey::default()),
+                synced_since: Some(now_secs() - OLDEST_SYNCED_ACCOUNT_AGE),
+                deleted: false,
+            },
+        );
+
+        bob.garbage_collect();
+
+        assert!(
+            bob.accounts.contains_key(&pubkey),
+            "Account synced exactly OLDEST_SYNCED_ACCOUNT_AGE ago must be kept (>= boundary)"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_account_returns_none_for_deleted() {
+        let (mut bob, _tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(1000, &[1], &Pubkey::default()),
+                synced_since: None,
+                deleted: true,
+            },
+        );
+
+        assert!(
+            TransactionProcessingCallback::get_account_shared_data(&bob, &pubkey).is_none(),
+            "Deleted (tombstoned) accounts must return None to SVM"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_account_returns_live_account() {
+        let (mut bob, _tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        let account = make_account(1000, &[1, 2, 3], &Pubkey::default());
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: account.clone(),
+                synced_since: None,
+                deleted: false,
+            },
+        );
+
+        let result = TransactionProcessingCallback::get_account_shared_data(&bob, &pubkey);
+        assert_eq!(
+            result.unwrap(),
+            account,
+            "Live account must be returned to SVM"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 15 unit tests to `core/src/accounts/bob.rs` verifying invariant C2: BOB (in-memory account cache) must always be in sync or ahead of Postgres
- Tests cover `garbage_collect` behavior under matching, stale, and deleted settlement feedback; eviction policy (accounts with `synced_since=None` are never evicted); multi-batch queue draining; mixed-population eviction; exact age boundary; and the `entry().or_insert_with()` pattern that prevents stale DB reads from overwriting in-flight state
- Uses `PgPoolOptions::connect_lazy` to construct a dummy `AccountsDB` with no real Postgres connection — safe because none of the tests exercise the DB path
- No production code modified

## Test Plan

```
cargo test -p contra-core --lib accounts::bob::tests
# 15 passed, 0 failed
```

Closes PRO-915