### PR TITLE
fix(rpc): use real_number_string_trimmed for precise ui_amount_string

### DIFF
--- a/core/src/rpc/get_token_account_balance_impl.rs
+++ b/core/src/rpc/get_token_account_balance_impl.rs
@@ -3,7 +3,7 @@ use crate::rpc::{
     ReadDeps,
 };
 use jsonrpsee::core::RpcResult;
-use solana_account_decoder_client_types::token::UiTokenAmount;
+use solana_account_decoder_client_types::token::{real_number_string_trimmed, UiTokenAmount};
 use solana_rpc_client_types::config::RpcContextConfig;
 use solana_rpc_client_types::response::{Response, RpcResponseContext};
 use solana_sdk::{account::ReadableAccount, pubkey::Pubkey};
@@ -58,8 +58,11 @@ pub async fn get_token_account_balance_impl(
     })?;
     let decimals = mint.decimals;
 
+    // Use f64 only for the optional numeric field (lossy for large amounts, matches Solana RPC)
     let ui_amount = amount as f64 / 10_f64.powi(decimals as i32);
-    let ui_amount_string = ui_amount.to_string();
+
+    // Use Solana's canonical formatter to avoid f64 precision loss in the string field
+    let ui_amount_string = real_number_string_trimmed(amount, decimals);
 
     let slot =
         read_deps.accounts_db.get_latest_slot().await.map_err(|e| {


### PR DESCRIPTION
## Summary
- Replaces `ui_amount.to_string()` (f64-derived) with Solana's canonical `real_number_string_trimmed` from `solana-account-decoder-client-types`, eliminating precision loss in `ui_amount_string` for token amounts > 2^53

## Test Plan
- `real_number_string_trimmed` is Solana's own tested utility — no custom unit tests needed
- Existing integration tests exercise `getTokenAccountBalance` end-to-end

Closes PRO-922