### PR TITLE
ci: bring CI improvements into hardening branch

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -10,6 +10,34 @@ inputs:
     description: "Additional cargo tools to install (comma-separated)"
     required: false
     default: ""
+  install-base-cargo-tools:
+    description: "Install base cargo tools (shank-cli, cargo-llvm-cov)"
+    required: false
+    default: "true"
+  install-system-dependencies:
+    description: "Install apt system dependencies"
+    required: false
+    default: "true"
+  setup-node:
+    description: "Setup Node.js runtime"
+    required: false
+    default: "true"
+  setup-pnpm:
+    description: "Setup pnpm and pnpm cache"
+    required: false
+    default: "true"
+  setup-solana:
+    description: "Setup Solana CLI"
+    required: false
+    default: "true"
+  install-dependencies:
+    description: "Run project dependency installation (make install)"
+    required: false
+    default: "true"
+  build-programs:
+    description: "Build programs and generate clients (make build)"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -22,6 +50,7 @@ runs:
         echo "LLVM_COV_VERSION=0.6.21" >> $GITHUB_ENV
 
     - name: Install system dependencies
+      if: inputs.install-system-dependencies == 'true'
       shell: bash
       run: |
         sudo apt-get update
@@ -41,6 +70,7 @@ runs:
         toolchain: ${{ env.RUST_VERSION }}
 
     - name: Cache cargo binaries
+      if: inputs.install-base-cargo-tools == 'true'
       uses: actions/cache@v4
       id: cargo-bin-cache
       with:
@@ -50,11 +80,12 @@ runs:
         key: cargo-bins-v7-${{ runner.os }}-rust-${{ env.RUST_VERSION }}-shank-${{ env.SHANK_VERSION }}-llvm-cov-${{ env.LLVM_COV_VERSION }}
 
     - name: Add cargo bin to PATH
+      if: inputs.install-base-cargo-tools == 'true' || inputs.install-cargo-tools != ''
       shell: bash
       run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Install base cargo tools
-      if: steps.cargo-bin-cache.outputs.cache-hit != 'true'
+      if: inputs.install-base-cargo-tools == 'true' && steps.cargo-bin-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         echo "Installing shank-cli@${SHANK_VERSION}..."
@@ -78,18 +109,22 @@ runs:
       with:
         cache-on-failure: true
 
+    # install-dependencies implies Node.js + pnpm prerequisites.
     - name: Setup Node.js
+      if: inputs.setup-node == 'true' || inputs.install-dependencies == 'true'
       uses: actions/setup-node@v4
       with:
         node-version: "22"
         registry-url: "https://registry.npmjs.org"
 
     - name: Setup pnpm
+      if: inputs.setup-pnpm == 'true' || inputs.install-dependencies == 'true'
       uses: pnpm/action-setup@v2
       with:
         version: 10.14.0
 
     - name: Setup pnpm cache
+      if: inputs.setup-pnpm == 'true' || inputs.install-dependencies == 'true'
       uses: actions/cache@v4
       with:
         path: ~/.pnpm-store
@@ -98,17 +133,21 @@ runs:
           ${{ runner.os }}-pnpm-
 
     - name: Setup Solana CLI
+      if: inputs.setup-solana == 'true'
       uses: ./.github/actions/setup-solana
 
     - name: Add Solana to PATH
+      if: inputs.setup-solana == 'true'
       shell: bash
       run: echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
+      if: inputs.install-dependencies == 'true'
       shell: bash
       run: make install
 
     - name: Build program and generate clients
+      if: inputs.build-programs == 'true'
       shell: bash
       run: |
         echo "🔨 Building programs and generating clients..."

--- a/.github/actions/setup-solana/action.yml
+++ b/.github/actions/setup-solana/action.yml
@@ -4,18 +4,13 @@ description: "Install and cache Solana CLI"
 runs:
   using: "composite"
   steps:
-    - name: Get current week for cache key
-      id: week
-      shell: bash
-      run: echo "week=$(date +'%Y-W%U')" >> $GITHUB_OUTPUT
-
     - name: Cache Solana CLI installation
       uses: actions/cache@v4
       with:
         path: ~/.local/share/solana
-        key: solana-cli-stable-${{ runner.os }}-${{ steps.week.outputs.week }}
+        key: solana-cli-stable-${{ runner.os }}-${{ runner.arch }}-v2.2.19
         restore-keys: |
-          solana-cli-stable-${{ runner.os }}-
+          solana-cli-stable-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Install Solana CLI
       shell: bash

--- a/.github/workflows/program-integration.yml
+++ b/.github/workflows/program-integration.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   integration-test:
-    name: Integration Tests
+    name: Program Integration Tests
     runs-on: contra-runner-1
     timeout-minutes: 20
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,21 +10,103 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+concurrency:
+  group: rust-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  check:
-    name: Check
+  changes:
+    name: Detect Changed Areas
+    runs-on: contra-runner-1
+    outputs:
+      rust_checks: ${{ steps.filter.outputs.rust_checks }}
+      integration: ${{ steps.filter.outputs.integration }}
+      core_indexer: ${{ steps.filter.outputs.core_indexer }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust_checks:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'Makefile'
+              - '.github/workflows/rust.yml'
+              - '.github/actions/setup-environment/**'
+              - '.github/actions/setup-solana/**'
+              - 'core/**'
+              - 'indexer/**'
+              - 'integration/**'
+              - 'test_utils/**'
+              - 'contra-escrow-program/**'
+              - 'contra-withdraw-program/**'
+            integration:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Makefile'
+              - '.github/workflows/rust.yml'
+              - '.github/actions/setup-environment/**'
+              - '.github/actions/setup-solana/**'
+              - 'core/**'
+              - 'indexer/**'
+              - 'integration/**'
+              - 'test_utils/**'
+              - 'contra-escrow-program/**'
+              - 'contra-withdraw-program/**'
+            core_indexer:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Makefile'
+              - '.github/workflows/rust.yml'
+              - '.github/actions/setup-environment/**'
+              - 'core/**'
+              - 'indexer/**'
+
+  build-artifacts:
+    name: Build Shared Artifacts
+    needs: changes
+    if: needs.changes.outputs.integration == 'true' || needs.changes.outputs.core_indexer == 'true'
     runs-on: contra-runner-1
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
+        with:
+          build-programs: "false"
 
-      - name: Run cargo check
-        run: cargo check --all-features
+      - name: Build programs and generate clients
+        run: |
+          make -C contra-escrow-program build
+          make -C contra-withdraw-program build
 
-  fmt:
-    name: Format
+      - name: Package shared artifacts
+        run: |
+          tar -czf ci-build-artifacts.tgz \
+            target/deploy/contra_escrow_program.so \
+            target/deploy/contra_withdraw_program.so \
+            contra-escrow-program/idl \
+            contra-escrow-program/clients \
+            contra-withdraw-program/idl \
+            contra-withdraw-program/clients
+
+      - name: Upload shared artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-build-artifacts
+          path: ci-build-artifacts.tgz
+          retention-days: 1
+
+  check:
+    name: Check
+    needs: changes
+    if: needs.changes.outputs.rust_checks == 'true'
     runs-on: contra-runner-1
     steps:
       - uses: actions/checkout@v4
@@ -33,12 +115,24 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           rust-components: rustfmt
+          setup-solana: "false"
+          build-programs: "false"
 
-      - name: Check formatting
-        run: cargo fmt -- --check
+      - name: Generate clients
+        run: make generate-clients
 
-  clippy:
-    name: Clippy
+      - name: Run cargo check
+        run: |
+          cargo check --workspace --all-features \
+            --exclude contra-core \
+            --exclude contra-integration \
+            --exclude tests-contra-escrow-program \
+            --exclude tests-contra-withdraw-program
+
+  fmt:
+    name: Format
+    needs: changes
+    if: needs.changes.outputs.rust_checks == 'true'
     runs-on: contra-runner-1
     steps:
       - uses: actions/checkout@v4
@@ -46,31 +140,100 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
-          rust-components: clippy
+          install-base-cargo-tools: "false"
+          install-system-dependencies: "false"
+          setup-solana: "false"
+          build-programs: "false"
+          rust-components: rustfmt
 
-      - name: Run clippy
-        run: cargo clippy --all-features -- -D warnings
+      - name: Check formatting
+        run: |
+          cargo fmt \
+            -p contra-escrow-program \
+            -p tests-contra-escrow-program \
+            -p contra-withdraw-program \
+            -p tests-contra-withdraw-program \
+            -p contra-core \
+            -p contra-gateway \
+            -p contra-indexer \
+            -p contra-integration \
+            -p test_utils \
+            -p devnet-scripts \
+            -- --check
 
-  integration-test:
-    name: Integration Tests
+  clippy:
+    name: Clippy
+    needs: changes
+    if: needs.changes.outputs.rust_checks == 'true'
     runs-on: contra-runner-1
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
+        with:
+          rust-components: clippy,rustfmt
+          setup-solana: "false"
+          build-programs: "false"
+
+      - name: Generate clients
+        run: make generate-clients
+
+      - name: Run clippy
+        run: |
+          cargo clippy --workspace --all-features \
+            --exclude contra-core \
+            --exclude contra-integration \
+            --exclude tests-contra-escrow-program \
+            --exclude tests-contra-withdraw-program \
+            -- -D warnings
+
+  integration-test:
+    name: Rust Integration Tests
+    needs: [changes, build-artifacts]
+    if: needs.changes.outputs.integration == 'true'
+    runs-on: contra-runner-1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          build-programs: "false"
+
+      - name: Download shared artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ci-build-artifacts
+
+      - name: Restore shared artifacts
+        run: tar -xzf ci-build-artifacts.tgz
 
       - name: Run integration tests
-        run: make integration-test
+        run: make integration-test-ci-build-test-tree
 
   unit-tests:
     name: Indexer Unit Tests
+    needs: [changes, build-artifacts]
+    if: needs.changes.outputs.core_indexer == 'true'
     runs-on: contra-runner-1
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
+        with:
+          rust-components: rustfmt
+          setup-solana: "false"
+          build-programs: "false"
 
-      - name: Run indexer unit tests (yellowstone)
-        run: make unit-test
+      - name: Download shared artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ci-build-artifacts
+
+      - name: Restore shared artifacts
+        run: tar -xzf ci-build-artifacts.tgz
+
+      - name: Run core + indexer unit tests
+        run: make unit-test-ci

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Delegates to subdirectory Makefiles
 
 .PHONY: install build fmt generate-idl generate-clients
-.PHONY: unit-test integration-test all-test
+.PHONY: unit-test unit-test-ci integration-test integration-test-ci integration-test-ci-build-test-tree integration-test-ci-prebuilt integration-test-ci-no-build all-test
 .PHONY: unit-coverage integration-coverage coverage-html all-coverage
 .PHONY: build-devnet deploy-devnet
 .PHONY: download-yellowstone-grpc build-geyser-plugin clean-geyser
@@ -50,6 +50,13 @@ unit-test:
 	@$(MAKE) -C core unit-test
 	@$(MAKE) -C indexer unit-test
 
+# CI-focused unit tests for non-program crates.
+# Program unit tests run in a dedicated workflow.
+unit-test-ci:
+	@echo "🧪 Running CI unit tests for core + indexer..."
+	@$(MAKE) -C core unit-test
+	@$(MAKE) -C indexer unit-test
+
 integration-test:
 	@echo "🔗 Running integration tests for all projects..."
 	@$(MAKE) -C contra-escrow-program integration-test
@@ -60,6 +67,34 @@ integration-test:
 	@$(MAKE) -C contra-escrow-program build-test
 	@echo "🔗 Running indexer integration test (with test-tree build)..."
 	@cd integration && cargo test --features test-tree --test indexer_integration -- --nocapture
+
+# CI-focused integration target that avoids running program integration
+# suites already covered in the dedicated program workflow.
+integration-test-ci:
+	@echo "🔗 Running CI integration tests (non-program suites)..."
+	@echo "🔨 Building program artifacts once for integration crate tests..."
+	@$(MAKE) -C contra-escrow-program build
+	@$(MAKE) -C contra-withdraw-program build
+	@$(MAKE) integration-test-ci-build-test-tree
+
+# CI-focused integration target that assumes production program artifacts
+# and generated clients are already available.
+integration-test-ci-build-test-tree:
+	@$(MAKE) integration-test-ci-prebuilt
+	@echo "🔗 Building escrow with test-tree for indexer tests..."
+	@$(MAKE) -C contra-escrow-program build-test
+	@echo "🔗 Running indexer integration test (with test-tree build)..."
+	@cd integration && cargo test --features test-tree --test indexer_integration -- --nocapture
+
+# CI-focused integration target that runs production-artifact integration tests only.
+integration-test-ci-prebuilt:
+	@echo "🔗 Running contra integration test (with production build)..."
+	@cd integration && cargo test --test contra_integration -- --nocapture
+
+# Backward-compatible alias for historical target name.
+integration-test-ci-no-build:
+	@echo "⚠️  Deprecated: use integration-test-ci-build-test-tree"
+	@$(MAKE) integration-test-ci-build-test-tree
 
 all-test: unit-test integration-test
 
@@ -222,7 +257,12 @@ help:
 	@echo ""
 	@echo "🧪 Testing:"
 	@echo "  unit-test            - Run unit tests for all projects"
+	@echo "  unit-test-ci         - Run CI unit tests for core + indexer"
 	@echo "  integration-test     - Run integration tests for all projects"
+	@echo "  integration-test-ci  - Build prod artifacts, build test-tree, and run CI integration suites"
+	@echo "  integration-test-ci-build-test-tree - Run contra integration, then build test-tree artifact and run indexer integration"
+	@echo "  integration-test-ci-prebuilt - Run contra integration using prebuilt production artifacts only"
+	@echo "  integration-test-ci-no-build - Deprecated alias to integration-test-ci-build-test-tree"
 	@echo "  all-test             - Run all tests for all projects"
 	@echo ""
 	@echo "📊 Coverage:"

--- a/contra-escrow-program/Makefile
+++ b/contra-escrow-program/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install build fmt generate-idl generate-clients
-.PHONY: unit-test integration-test all-test
-.PHONY: unit-coverage integration-coverage coverage-html all-coverage
+.PHONY: unit-test integration-test integration-test-no-build all-test
+.PHONY: unit-coverage integration-coverage integration-coverage-no-build coverage-html all-coverage
 .PHONY: build-devnet deploy-devnet
 
 # Install dependencies
@@ -44,10 +44,13 @@ unit-test:
 	pnpm test:unit
 	@cd program && cargo test
 
-# Run integration tests (includes build)
-integration-test: build
+# Run integration tests without build (for CI composition)
+integration-test-no-build:
 	@echo "Running integration tests for escrow program..."
 	@cd tests/integration-tests && cargo test -- --nocapture
+
+# Run integration tests (includes build)
+integration-test: build integration-test-no-build
 
 all-test: unit-test integration-test
 
@@ -56,10 +59,13 @@ unit-coverage:
 	@echo "Running unit tests with coverage..."
 	@cd program && cargo llvm-cov --lib --tests --lcov --output-path ../../coverage-escrow-unit.lcov
 
-# Run integration tests with coverage
-integration-coverage: build
+# Run integration tests with coverage without build (for CI composition)
+integration-coverage-no-build:
 	@echo "Running integration tests with coverage..."
 	@cd tests/integration-tests && cargo llvm-cov --lcov --output-path ../../../coverage-escrow-integration.lcov -- --nocapture
+
+# Run integration tests with coverage
+integration-coverage: build integration-coverage-no-build
 
 # Generate HTML coverage report
 coverage-html:
@@ -108,4 +114,3 @@ deploy-devnet: build-devnet
 		--program-id ../target/deploy/contra_escrow_program-keypair.json \
 		--keypair $(DEPLOYER_KEY) \
 		--url devnet
-

--- a/contra-withdraw-program/Makefile
+++ b/contra-withdraw-program/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install build fmt generate-idl generate-clients
-.PHONY: unit-test integration-test all-test
-.PHONY: unit-coverage integration-coverage coverage-html all-coverage
+.PHONY: unit-test integration-test integration-test-no-build all-test
+.PHONY: unit-coverage integration-coverage integration-coverage-no-build coverage-html all-coverage
 .PHONY: build-devnet deploy-devnet
 
 # Install dependencies
@@ -38,10 +38,13 @@ unit-test:
 	pnpm test:unit
 	@cd program && cargo test
 
-# Run integration tests (includes build)
-integration-test: build
+# Run integration tests without build (for CI composition)
+integration-test-no-build:
 	@echo "Running integration tests for withdraw program..."
 	@cd tests/integration-tests && cargo test -- --nocapture
+
+# Run integration tests (includes build)
+integration-test: build integration-test-no-build
 
 all-test: unit-test integration-test
 
@@ -50,10 +53,13 @@ unit-coverage:
 	@echo "Running unit tests with coverage..."
 	@cd program && cargo llvm-cov --lib --tests --lcov --output-path ../../coverage-withdraw-unit.lcov
 
-# Run integration tests with coverage
-integration-coverage: build
+# Run integration tests with coverage without build (for CI composition)
+integration-coverage-no-build:
 	@echo "Running integration tests with coverage..."
 	@cd tests/integration-tests && cargo llvm-cov --lcov --output-path ../../../coverage-withdraw-integration.lcov -- --nocapture
+
+# Run integration tests with coverage
+integration-coverage: build integration-coverage-no-build
 
 # Generate HTML coverage report
 coverage-html:


### PR DESCRIPTION
Cherry-picks `b6ab457` from `main` to bring the optimized hosted-runner workflow and CI targets into `hardening/pre-release-audit`.

This ensures PRs targeting the hardening branch (e.g. #26) run with the latest CI configuration.