### PR TITLE
fix(ci): create program placeholder for check and clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,6 +118,11 @@ jobs:
           setup-solana: "false"
           build-programs: "false"
 
+      - name: Create program placeholder for type checking
+        run: |
+          mkdir -p target/deploy
+          touch target/deploy/contra_withdraw_program.so
+
       - name: Generate clients
         run: make generate-clients
 
@@ -175,6 +180,11 @@ jobs:
           rust-components: clippy,rustfmt
           setup-solana: "false"
           build-programs: "false"
+
+      - name: Create program placeholder for type checking
+        run: |
+          mkdir -p target/deploy
+          touch target/deploy/contra_withdraw_program.so
 
       - name: Generate clients
         run: make generate-clients


### PR DESCRIPTION
## Summary

- `core/precompiles/contra_withdraw_program.so` is a git symlink pointing to `target/deploy/contra_withdraw_program.so`
- The `check` and `clippy` jobs skip program builds (`build-programs: "false"`), leaving the symlink dangling
- `contra-indexer` depends on `contra-core`, so `contra-core` compiles as a dependency even with `--exclude contra-core`
- `include_bytes!` in `core/src/accounts/bob.rs:137` fails at compile time with `No such file or directory`

**Fix:** touch an empty placeholder before running `cargo check`/`clippy`. Since `cargo check` is type-check only and `contra-core` has no `build.rs`, an empty file fully satisfies `include_bytes!` — zero latency impact.

## Why it passed on `main`

PR #30 only changed `.github/` files. `Swatinem/rust-cache` restored a compiled `contra-core` from a prior run where the `.so` existed. On hardening, PRO-907 source changes invalidated the cache and forced a fresh compile.