### PR TITLE
fix(ci): resolve broken caches and invalid workflow inputs

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -108,6 +108,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
+        cache-bin: false
 
     # install-dependencies implies Node.js + pnpm prerequisites.
     - name: Setup Node.js
@@ -121,13 +122,19 @@ runs:
       if: inputs.setup-pnpm == 'true' || inputs.install-dependencies == 'true'
       uses: pnpm/action-setup@v2
       with:
-        version: 10.14.0
+        version: 10.15.1
+
+    - name: Get pnpm store directory
+      if: inputs.setup-pnpm == 'true' || inputs.install-dependencies == 'true'
+      id: pnpm-store
+      shell: bash
+      run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
       if: inputs.setup-pnpm == 'true' || inputs.install-dependencies == 'true'
       uses: actions/cache@v4
       with:
-        path: ~/.pnpm-store
+        path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-

--- a/.github/workflows/program-integration.yml
+++ b/.github/workflows/program-integration.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
-          rust-toolchain: stable
           rust-components: llvm-tools-preview
 
       - name: Run integration tests with coverage

--- a/.github/workflows/program-unit.yml
+++ b/.github/workflows/program-unit.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
         with:
-          rust-toolchain: stable
           rust-components: llvm-tools-preview
 
       - name: Run unit tests with coverage

--- a/.github/workflows/sdk-unit.yml
+++ b/.github/workflows/sdk-unit.yml
@@ -38,10 +38,15 @@ jobs:
         with:
           version: 10.15.1
 
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
-          path: ~/.pnpm-store
+          path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-
 


### PR DESCRIPTION
## Summary

- Fix pnpm cache path: dynamically resolve via `pnpm store path --silent` instead of hardcoding `~/.pnpm-store` (pnpm 10.x stores at `~/.local/share/pnpm/store`). Applied in both `setup-environment` action and `sdk-unit.yml`.
- Fix cargo binaries cache conflict: set `cache-bin: false` on `Swatinem/rust-cache@v2` so it doesn't manage `~/.cargo/bin/`, which was conflicting with the dedicated `actions/cache@v4` step for shank/cargo-llvm-cov.
- Remove invalid `rust-toolchain: stable` input from `program-unit.yml` and `program-integration.yml` (not a declared input on the composite action).
- Align pnpm version in `setup-environment` from `10.14.0` to `10.15.1` to match `package.json`.

## Test plan

- [ ] CI runs without `Unexpected input(s) 'rust-toolchain'` warnings
- [ ] pnpm cache saves successfully (no Path Validation Error)
- [ ] Cargo binaries cache saves successfully (no Path Validation Error)
- [ ] Subsequent runs hit the pnpm and cargo binaries caches