### PR TITLE
chore(build): normalize make targets and extract env helper scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,284 +1,263 @@
 # Master Makefile for Contra Programs
 # Delegates to subdirectory Makefiles
 
-.PHONY: install build fmt generate-idl generate-clients
-.PHONY: unit-test unit-test-ci integration-test integration-test-ci integration-test-ci-build-test-tree integration-test-ci-prebuilt integration-test-ci-no-build all-test
-.PHONY: unit-coverage integration-coverage coverage-html all-coverage
-.PHONY: build-devnet deploy-devnet
-.PHONY: download-yellowstone-grpc build-geyser-plugin clean-geyser
-.PHONY: profile help
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -euo pipefail -c
+.DEFAULT_GOAL := build
 
-# Default target
+PROGRAM_DIRS := contra-escrow-program contra-withdraw-program
+RUST_DIRS := core indexer
+FMT_DIRS := $(PROGRAM_DIRS) $(RUST_DIRS) integration
+
+.PHONY: all help
+.PHONY: install build fmt generate-idl generate-clients
+.PHONY: unit-test integration-test all-test
+.PHONY: ci-unit-test ci-integration-test ci-integration-test-prebuilt ci-integration-test-build-test-tree
+.PHONY: unit-test-ci integration-test-ci integration-test-ci-prebuilt integration-test-ci-build-test-tree integration-test-ci-no-build
+.PHONY: unit-coverage integration-coverage coverage-html all-coverage
+.PHONY: yellowstone-prepare yellowstone-build-plugin yellowstone-clean
+.PHONY: download-yellowstone-grpc build-geyser-plugin clean-geyser
+.PHONY: generate-operator-keypair build-localnet build-devnet deploy-devnet
+.PHONY: profile
+
 all: build
 
-# Common targets that run on all projects (escrow + withdraw + indexer)
 install:
-	@echo "📦 Installing dependencies for all projects..."
-	@$(MAKE) -C contra-escrow-program install
-	@$(MAKE) -C contra-withdraw-program install
+	@echo "Installing dependencies for all projects..."
+	@for dir in $(PROGRAM_DIRS); do \
+		$(MAKE) -C $$dir install; \
+	done
 
 build:
-	@echo "🔨 Building all projects..."
-	@$(MAKE) -C contra-escrow-program build
-	@$(MAKE) -C contra-withdraw-program build
-	@$(MAKE) -C core build
-	@$(MAKE) -C indexer build
+	@echo "Building all projects..."
+	@for dir in $(PROGRAM_DIRS) $(RUST_DIRS); do \
+		$(MAKE) -C $$dir build; \
+	done
 
 fmt:
-	@echo "✨ Formatting all projects..."
-	@$(MAKE) -C contra-escrow-program fmt
-	@$(MAKE) -C contra-withdraw-program fmt
-	@$(MAKE) -C core fmt
-	@$(MAKE) -C indexer fmt
-	@$(MAKE) -C integration fmt
+	@echo "Formatting all projects..."
+	@for dir in $(FMT_DIRS); do \
+		$(MAKE) -C $$dir fmt; \
+	done
 	@cd scripts/devnet && cargo fmt
 
 generate-idl:
-	@echo "📝 Generating IDL for all programs..."
-	@$(MAKE) -C contra-escrow-program generate-idl
-	@$(MAKE) -C contra-withdraw-program generate-idl
+	@echo "Generating IDL for all programs..."
+	@for dir in $(PROGRAM_DIRS); do \
+		$(MAKE) -C $$dir generate-idl; \
+	done
 
 generate-clients:
-	@echo "🔧 Generating clients for all programs..."
-	@$(MAKE) -C contra-escrow-program generate-clients
-	@$(MAKE) -C contra-withdraw-program generate-clients
+	@echo "Generating clients for all programs..."
+	@for dir in $(PROGRAM_DIRS); do \
+		$(MAKE) -C $$dir generate-clients; \
+	done
 
 unit-test:
-	@echo "🧪 Running unit tests for all projects..."
-	@$(MAKE) -C contra-escrow-program unit-test
-	@$(MAKE) -C contra-withdraw-program unit-test
-	@$(MAKE) -C core unit-test
-	@$(MAKE) -C indexer unit-test
-
-# CI-focused unit tests for non-program crates.
-# Program unit tests run in a dedicated workflow.
-unit-test-ci:
-	@echo "🧪 Running CI unit tests for core + indexer..."
-	@$(MAKE) -C core unit-test
-	@$(MAKE) -C indexer unit-test
+	@echo "Running unit tests for all projects..."
+	@for dir in $(PROGRAM_DIRS) $(RUST_DIRS); do \
+		$(MAKE) -C $$dir unit-test; \
+	done
 
 integration-test:
-	@echo "🔗 Running integration tests for all projects..."
+	@echo "Running integration tests for all projects..."
 	@$(MAKE) -C contra-escrow-program integration-test
 	@$(MAKE) -C contra-withdraw-program integration-test
-	@echo "🔗 Running contra integration test (with production build)..."
+	@echo "Running contra integration test (with production build)..."
 	@cd integration && cargo test --test contra_integration -- --nocapture
-	@echo "🔗 Building escrow with test-tree for indexer tests..."
+	@echo "Building escrow with test-tree for indexer tests..."
 	@$(MAKE) -C contra-escrow-program build-test
-	@echo "🔗 Running indexer integration test (with test-tree build)..."
+	@echo "Running indexer integration test (with test-tree build)..."
 	@cd integration && cargo test --features test-tree --test indexer_integration -- --nocapture
 
-# CI-focused integration target that avoids running program integration
-# suites already covered in the dedicated program workflow.
-integration-test-ci:
-	@echo "🔗 Running CI integration tests (non-program suites)..."
-	@echo "🔨 Building program artifacts once for integration crate tests..."
+ci-unit-test:
+	@echo "Running CI unit tests for core + indexer..."
+	@$(MAKE) -C core unit-test
+	@$(MAKE) -C indexer unit-test
+
+ci-integration-test:
+	@echo "Running CI integration tests (non-program suites)..."
+	@echo "Building program artifacts once for integration crate tests..."
 	@$(MAKE) -C contra-escrow-program build
 	@$(MAKE) -C contra-withdraw-program build
-	@$(MAKE) integration-test-ci-build-test-tree
+	@$(MAKE) ci-integration-test-build-test-tree
 
-# CI-focused integration target that assumes production program artifacts
-# and generated clients are already available.
-integration-test-ci-build-test-tree:
-	@$(MAKE) integration-test-ci-prebuilt
-	@echo "🔗 Building escrow with test-tree for indexer tests..."
+ci-integration-test-build-test-tree:
+	@$(MAKE) ci-integration-test-prebuilt
+	@echo "Building escrow with test-tree for indexer tests..."
 	@$(MAKE) -C contra-escrow-program build-test
-	@echo "🔗 Running indexer integration test (with test-tree build)..."
+	@echo "Running indexer integration test (with test-tree build)..."
 	@cd integration && cargo test --features test-tree --test indexer_integration -- --nocapture
 
-# CI-focused integration target that runs production-artifact integration tests only.
-integration-test-ci-prebuilt:
-	@echo "🔗 Running contra integration test (with production build)..."
+ci-integration-test-prebuilt:
+	@echo "Running contra integration test (with production build)..."
 	@cd integration && cargo test --test contra_integration -- --nocapture
 
-# Backward-compatible alias for historical target name.
+# Backward-compatible aliases.
+unit-test-ci: ci-unit-test
+integration-test-ci: ci-integration-test
+integration-test-ci-build-test-tree: ci-integration-test-build-test-tree
+integration-test-ci-prebuilt: ci-integration-test-prebuilt
 integration-test-ci-no-build:
-	@echo "⚠️  Deprecated: use integration-test-ci-build-test-tree"
-	@$(MAKE) integration-test-ci-build-test-tree
+	@echo "Deprecated: use integration-test-ci-build-test-tree"
+	@$(MAKE) ci-integration-test-build-test-tree
 
 all-test: unit-test integration-test
 
 unit-coverage:
-	@echo "📊 Running unit tests with coverage..."
-	@$(MAKE) -C contra-escrow-program unit-coverage
-	@$(MAKE) -C contra-withdraw-program unit-coverage
+	@echo "Running unit tests with coverage..."
+	@for dir in $(PROGRAM_DIRS); do \
+		$(MAKE) -C $$dir unit-coverage; \
+	done
 
 integration-coverage:
-	@echo "📊 Running integration tests with coverage..."
-	@$(MAKE) -C contra-escrow-program integration-coverage
-	@$(MAKE) -C contra-withdraw-program integration-coverage
+	@echo "Running integration tests with coverage..."
+	@for dir in $(PROGRAM_DIRS); do \
+		$(MAKE) -C $$dir integration-coverage; \
+	done
 
 coverage-html:
-	@echo "📊 Generating HTML coverage reports..."
-	@$(MAKE) -C contra-escrow-program coverage-html
-	@$(MAKE) -C contra-withdraw-program coverage-html
+	@echo "Generating HTML coverage reports..."
+	@for dir in $(PROGRAM_DIRS); do \
+		$(MAKE) -C $$dir coverage-html; \
+	done
 
 all-coverage:
-	@echo "📊 Running all coverage tasks..."
-	@$(MAKE) -C contra-escrow-program all-coverage
-	@$(MAKE) -C contra-withdraw-program all-coverage
+	@echo "Running all coverage tasks..."
+	@for dir in $(PROGRAM_DIRS); do \
+		$(MAKE) -C $$dir all-coverage; \
+	done
 
 #############
 # Integration Test Setup
 #############
-download-yellowstone-grpc:
-	@echo "🔧 Building Yellowstone Geyser plugin for Agave 3.0..."
+yellowstone-prepare:
+	@echo "Building Yellowstone Geyser plugin for Agave 3.0..."
 	@mkdir -p integration/.yellowstone-grpc
 	@if [ ! -d "integration/.yellowstone-grpc/.git" ]; then \
-		echo "📦 Cloning yellowstone-grpc repository..."; \
+		echo "Cloning yellowstone-grpc repository..."; \
 		git clone https://github.com/rpcpool/yellowstone-grpc.git integration/.yellowstone-grpc; \
 	fi
-	@echo "🔀 Checking out Agave 3.0 compatible commit..."
+	@echo "Checking out Agave 3.0 compatible commit..."
 	@cd integration/.yellowstone-grpc && \
 		git fetch origin && \
 		git checkout f3d5e041c427f0f383b520c44b231c851d324ddc
-	@echo "🔧 Applying macOS compatibility fixes..."
+	@echo "Applying macOS compatibility fixes..."
 	@if [ "$$(uname)" = "Darwin" ]; then \
 		echo "Copying macOS-fixed files from test_utils/geyser/mac-files-fix/..."; \
 		cp -rf test_utils/geyser/mac-files-fix/yellowstone-grpc-geyser/* \
 			integration/.yellowstone-grpc/yellowstone-grpc-geyser/; \
 		cp -f test_utils/geyser/mac-files-fix/Cargo.toml \
 			integration/.yellowstone-grpc/; \
-		echo "✅ macOS fixes applied (affinity → core_affinity)"; \
+		echo "macOS fixes applied (affinity -> core_affinity)"; \
 	else \
-		echo "⏭️  Skipping macOS fixes (not on macOS)"; \
+		echo "Skipping macOS fixes (not on macOS)"; \
 	fi
 
-build-geyser-plugin:
-	@echo "🔨 Building plugin (this may take a few minutes)..."
+yellowstone-build-plugin: yellowstone-prepare
+	@echo "Building plugin (this may take a few minutes)..."
 	@cd integration/.yellowstone-grpc/yellowstone-grpc-geyser && \
 		cargo build --release --no-default-features
-	@echo "📋 Copying plugin to test_utils/geyser/..."
+	@echo "Copying plugin to test_utils/geyser/..."
 	@mkdir -p test_utils/geyser
 	@if [ -f integration/.yellowstone-grpc/target/release/libyellowstone_grpc_geyser.dylib ]; then \
 		cp integration/.yellowstone-grpc/target/release/libyellowstone_grpc_geyser.dylib \
 			test_utils/geyser/libyellowstone_grpc_geyser.dylib; \
-		echo "✅ Geyser plugin built: test_utils/geyser/libyellowstone_grpc_geyser.dylib"; \
+		echo "Geyser plugin built: test_utils/geyser/libyellowstone_grpc_geyser.dylib"; \
 	elif [ -f integration/.yellowstone-grpc/target/release/libyellowstone_grpc_geyser.so ]; then \
 		cp integration/.yellowstone-grpc/target/release/libyellowstone_grpc_geyser.so \
 			test_utils/geyser/libyellowstone_grpc_geyser.so; \
-		echo "✅ Geyser plugin built: test_utils/geyser/libyellowstone_grpc_geyser.so"; \
+		echo "Geyser plugin built: test_utils/geyser/libyellowstone_grpc_geyser.so"; \
 	else \
-		echo "❌ Error: Plugin binary not found after build"; \
+		echo "Error: Plugin binary not found after build"; \
 		exit 1; \
 	fi
 
-clean-geyser:
-	@echo "🧹 Cleaning Yellowstone Geyser build artifacts..."
+yellowstone-clean:
+	@echo "Cleaning Yellowstone Geyser build artifacts..."
 	@rm -rf integration/.yellowstone-grpc
 	@rm -f test_utils/geyser/libyellowstone_grpc_geyser.dylib
 	@rm -f test_utils/geyser/libyellowstone_grpc_geyser.so
-	@echo "✅ Geyser artifacts cleaned"
+	@echo "Geyser artifacts cleaned"
+
+# Backward-compatible aliases.
+download-yellowstone-grpc: yellowstone-prepare
+build-geyser-plugin: yellowstone-build-plugin
+clean-geyser: yellowstone-clean
 
 #############
 # Common
 #############
 generate-operator-keypair:
-	@if [ ! -f keypairs/operator-keypair.json ]; then \
-		echo "🔑 Generating operator keypair..."; \
-		mkdir -p keypairs; \
-		solana-keygen new -o keypairs/operator-keypair.json -s --no-bip39-passphrase; \
-		echo "✅ Operator keypair generated at keypairs/operator-keypair.json"; \
-	else \
-		echo "✅ Operator keypair already exists at keypairs/operator-keypair.json"; \
-	fi
+	@./scripts/ensure-operator-keypair.sh keypairs/operator-keypair.json
 
 #############
 # Localnet
 #############
 build-localnet:
-	@echo "🚀 Building all programs for localnet..."
+	@echo "Building all programs for localnet..."
 	@$(MAKE) -C contra-escrow-program build-localnet
 	@$(MAKE) -C contra-withdraw-program build-localnet
 	@$(MAKE) generate-operator-keypair
-	@echo "📝 Updating .env.local with operator pubkey and private key..."
-	@OPERATOR_PUBKEY=$$(solana-keygen pubkey keypairs/operator-keypair.json); \
-	OPERATOR_PRIVATE_KEY=$$(cat keypairs/operator-keypair.json); \
-	if [ -f .env.local ]; then \
-		sed -i.bak "s/^CONTRA_ADMIN_KEYS=.*/CONTRA_ADMIN_KEYS=$$OPERATOR_PUBKEY/" .env.local && \
-		sed -i.bak "s|^ADMIN_PRIVATE_KEY=.*|ADMIN_PRIVATE_KEY=$$OPERATOR_PRIVATE_KEY|" .env.local && \
-		rm .env.local.bak; \
-		echo "✅ Updated .env.local with CONTRA_ADMIN_KEYS=$$OPERATOR_PUBKEY"; \
-		echo "✅ Updated .env.local with ADMIN_PRIVATE_KEY"; \
-	else \
-		echo "CONTRA_ADMIN_KEYS=$$OPERATOR_PUBKEY" >> .env.local; \
-		echo "ADMIN_PRIVATE_KEY=$$OPERATOR_PRIVATE_KEY" >> .env.local; \
-		echo "✅ Created .env.local with CONTRA_ADMIN_KEYS=$$OPERATOR_PUBKEY"; \
-		echo "✅ Created .env.local with ADMIN_PRIVATE_KEY"; \
-	fi
+	@./scripts/update-admin-env.sh .env.local keypairs/operator-keypair.json
 
 #############
 # Devnet
 #############
 build-devnet:
-	@echo "🚀 Building all programs for devnet..."
+	@echo "Building all programs for devnet..."
 	@$(MAKE) -C contra-escrow-program build-devnet
 	@$(MAKE) -C contra-withdraw-program build-devnet
 	@$(MAKE) generate-operator-keypair
-	@echo "📝 Updating .env.devnet with operator pubkey and private key..."
-	@OPERATOR_PUBKEY=$$(solana-keygen pubkey keypairs/operator-keypair.json); \
-	OPERATOR_PRIVATE_KEY=$$(cat keypairs/operator-keypair.json); \
-	if [ -f .env.devnet ]; then \
-		sed -i.bak "s/^CONTRA_ADMIN_KEYS=.*/CONTRA_ADMIN_KEYS=$$OPERATOR_PUBKEY/" .env.devnet && \
-		sed -i.bak "s|^ADMIN_PRIVATE_KEY=.*|ADMIN_PRIVATE_KEY=$$OPERATOR_PRIVATE_KEY|" .env.devnet && \
-		rm .env.devnet.bak; \
-		echo "✅ Updated .env.devnet with CONTRA_ADMIN_KEYS=$$OPERATOR_PUBKEY"; \
-		echo "✅ Updated .env.devnet with ADMIN_PRIVATE_KEY"; \
-	else \
-		echo "CONTRA_ADMIN_KEYS=$$OPERATOR_PUBKEY" >> .env.devnet; \
-		echo "ADMIN_PRIVATE_KEY=$$OPERATOR_PRIVATE_KEY" >> .env.devnet; \
-		echo "✅ Created .env.devnet with CONTRA_ADMIN_KEYS=$$OPERATOR_PUBKEY"; \
-		echo "✅ Created .env.devnet with ADMIN_PRIVATE_KEY"; \
-	fi
+	@./scripts/update-admin-env.sh .env.devnet keypairs/operator-keypair.json
 
 deploy-devnet:
-	@echo "🚀 Deploying all programs to devnet..."
+	@echo "Deploying all programs to devnet..."
 	@$(MAKE) -C contra-escrow-program deploy-devnet DEPLOYER_KEY=$(DEPLOYER_KEY)
 	@$(MAKE) -C contra-withdraw-program deploy-devnet DEPLOYER_KEY=$(DEPLOYER_KEY)
 
 profile:
-	@echo "🔥 Generating CU profiling report..."
-	python3 generate_profiling.py
-	@echo "✅ CU profiling report generated: profiling_report.md"
+	@echo "Generating CU profiling report..."
+	@python3 generate_profiling.py
+	@echo "CU profiling report generated: profiling_report.md"
 
 help:
 	@echo "Contra Programs - Available targets:"
 	@echo ""
-	@echo "📦 Dependencies:"
+	@echo "Dependencies:"
 	@echo "  install              - Install dependencies for all projects"
 	@echo ""
-	@echo "🔨 Build:"
-	@echo "  build                - Build all programs"
+	@echo "Build:"
+	@echo "  build                - Build all projects"
 	@echo "  generate-idl         - Generate IDL for all programs"
 	@echo "  generate-clients     - Generate clients for all programs"
 	@echo ""
-	@echo "✨ Code Quality:"
+	@echo "Code Quality:"
 	@echo "  fmt                  - Format all code"
 	@echo ""
-	@echo "🧪 Testing:"
+	@echo "Testing:"
 	@echo "  unit-test            - Run unit tests for all projects"
-	@echo "  unit-test-ci         - Run CI unit tests for core + indexer"
+	@echo "  ci-unit-test         - Run CI unit tests for core + indexer"
 	@echo "  integration-test     - Run integration tests for all projects"
-	@echo "  integration-test-ci  - Build prod artifacts, build test-tree, and run CI integration suites"
-	@echo "  integration-test-ci-build-test-tree - Run contra integration, then build test-tree artifact and run indexer integration"
-	@echo "  integration-test-ci-prebuilt - Run contra integration using prebuilt production artifacts only"
-	@echo "  integration-test-ci-no-build - Deprecated alias to integration-test-ci-build-test-tree"
+	@echo "  ci-integration-test  - Build prod artifacts, build test-tree, run CI integration suites"
+	@echo "  ci-integration-test-build-test-tree - Run prebuilt test, then test-tree indexer integration"
+	@echo "  ci-integration-test-prebuilt - Run contra integration using prebuilt production artifacts"
 	@echo "  all-test             - Run all tests for all projects"
 	@echo ""
-	@echo "📊 Coverage:"
+	@echo "Coverage:"
 	@echo "  unit-coverage        - Unit test coverage"
 	@echo "  integration-coverage - Integration test coverage"
 	@echo "  coverage-html        - Generate HTML coverage reports"
 	@echo "  all-coverage         - Run all coverage tasks"
 	@echo ""
-	@echo "🔧 Integration Test Setup:"
-	@echo "  download-yellowstone-grpc - Download & patch Yellowstone for Agave 3.0"
-	@echo "  build-geyser-plugin       - Build Yellowstone Geyser plugin"
-	@echo "  clean-geyser              - Clean Geyser build artifacts"
+	@echo "Integration Test Setup:"
+	@echo "  yellowstone-prepare      - Download & patch Yellowstone for Agave 3.0"
+	@echo "  yellowstone-build-plugin - Build Yellowstone Geyser plugin"
+	@echo "  yellowstone-clean        - Clean Geyser build artifacts"
 	@echo ""
-	@echo "🚀 Devnet:"
+	@echo "Devnet:"
 	@echo "  build-devnet         - Build programs for devnet"
 	@echo "  deploy-devnet        - Deploy programs to devnet (requires DEPLOYER_KEY)"
 	@echo ""
-	@echo "🔥 Profiling:"
+	@echo "Profiling:"
 	@echo "  profile              - Generate CU profiling report"

--- a/contra-escrow-program/Makefile
+++ b/contra-escrow-program/Makefile
@@ -1,7 +1,15 @@
-.PHONY: install build fmt generate-idl generate-clients
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -euo pipefail -c
+.DEFAULT_GOAL := build
+
+PROGRAM_SO := ../target/deploy/contra_escrow_program.so
+PROGRAM_KEYPAIR := ../target/deploy/contra_escrow_program-keypair.json
+PROGRAM_ENV_KEY := ESCROW_PROGRAM_ID
+
+.PHONY: install build build-test fmt generate-idl generate-clients
 .PHONY: unit-test integration-test integration-test-no-build all-test
 .PHONY: unit-coverage integration-coverage integration-coverage-no-build coverage-html all-coverage
-.PHONY: build-devnet deploy-devnet
+.PHONY: build-localnet build-devnet deploy-devnet
 
 # Install dependencies
 install:
@@ -9,14 +17,12 @@ install:
 
 # Build the program
 build:
-	make generate-idl
-	make generate-clients
+	$(MAKE) generate-clients
 	cargo-build-sbf
 
 # Build the program with test-tree feature for integration tests
 build-test:
-	make generate-idl
-	make generate-clients
+	$(MAKE) generate-clients
 	cd program && cargo-build-sbf --features test-tree
 
 # Format / lint code
@@ -79,19 +85,10 @@ all-coverage: unit-coverage integration-coverage coverage-html
 # Localnet
 #############
 build-localnet:
-	make generate-idl
-	make generate-clients
+	$(MAKE) generate-clients
 	cargo-build-sbf
 	@echo "Updating .env.local with program IDs..."
-	@ESCROW_ID=$$(solana-keygen pubkey ../target/deploy/contra_escrow_program-keypair.json); \
-	if [ -f ../.env.local ]; then \
-		sed -i.bak "s/^ESCROW_PROGRAM_ID=.*/ESCROW_PROGRAM_ID=$$ESCROW_ID/" ../.env.local && \
-		rm ../.env.local.bak; \
-		echo "✅ Updated .env.local with ESCROW_PROGRAM_ID=$$ESCROW_ID"; \
-	else \
-		echo "ESCROW_PROGRAM_ID=$$ESCROW_ID" > ../.env.local; \
-		echo "✅ Created .env.local with ESCROW_PROGRAM_ID=$$ESCROW_ID"; \
-	fi
+	@../scripts/update-program-env.sh ../.env.local $(PROGRAM_ENV_KEY) $(PROGRAM_KEYPAIR)
 
 #############
 # Devnet
@@ -99,8 +96,7 @@ build-localnet:
 
 # Build the program with devnet feature
 build-devnet:
-	make generate-idl
-	make generate-clients
+	$(MAKE) generate-clients
 	cargo-build-sbf
 
 # Deploy to devnet
@@ -110,7 +106,7 @@ deploy-devnet: build-devnet
 		echo "Error: DEPLOYER_KEY parameter is required. Usage: make deploy-devnet DEPLOYER_KEY=/path/to/deployer-keypair.json"; \
 		exit 1; \
 	fi
-	solana program deploy ../target/deploy/contra_escrow_program.so \
-		--program-id ../target/deploy/contra_escrow_program-keypair.json \
+	solana program deploy $(PROGRAM_SO) \
+		--program-id $(PROGRAM_KEYPAIR) \
 		--keypair $(DEPLOYER_KEY) \
 		--url devnet

--- a/contra-withdraw-program/Makefile
+++ b/contra-withdraw-program/Makefile
@@ -1,7 +1,15 @@
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -euo pipefail -c
+.DEFAULT_GOAL := build
+
+PROGRAM_SO := ../target/deploy/contra_withdraw_program.so
+PROGRAM_KEYPAIR := ../target/deploy/contra_withdraw_program-keypair.json
+PROGRAM_ENV_KEY := WITHDRAW_PROGRAM_ID
+
 .PHONY: install build fmt generate-idl generate-clients
 .PHONY: unit-test integration-test integration-test-no-build all-test
 .PHONY: unit-coverage integration-coverage integration-coverage-no-build coverage-html all-coverage
-.PHONY: build-devnet deploy-devnet
+.PHONY: build-localnet build-devnet deploy-devnet
 
 # Install dependencies
 install:
@@ -9,8 +17,7 @@ install:
 
 # Build the program
 build:
-	make generate-idl
-	make generate-clients
+	$(MAKE) generate-clients
 	cargo-build-sbf
 
 # Format / lint code
@@ -73,19 +80,10 @@ all-coverage: unit-coverage integration-coverage coverage-html
 # Localnet
 #############
 build-localnet:
-	make generate-idl
-	make generate-clients
+	$(MAKE) generate-clients
 	cargo-build-sbf
 	@echo "Updating .env.local with program IDs..."
-	@WITHDRAW_ID=$$(solana-keygen pubkey ../target/deploy/contra_withdraw_program-keypair.json); \
-	if [ -f ../.env.local ]; then \
-		sed -i.bak "s/^WITHDRAW_PROGRAM_ID=.*/WITHDRAW_PROGRAM_ID=$$WITHDRAW_ID/" ../.env.local && \
-		rm ../.env.local.bak; \
-		echo "✅ Updated .env.local with WITHDRAW_PROGRAM_ID=$$WITHDRAW_ID"; \
-	else \
-		echo "WITHDRAW_PROGRAM_ID=$$WITHDRAW_ID" >> ../.env.local; \
-		echo "✅ Created .env.local with WITHDRAW_PROGRAM_ID=$$WITHDRAW_ID"; \
-	fi
+	@../scripts/update-program-env.sh ../.env.local $(PROGRAM_ENV_KEY) $(PROGRAM_KEYPAIR)
 
 #############
 # Devnet
@@ -93,8 +91,7 @@ build-localnet:
 
 # Build the program with devnet feature
 build-devnet:
-	make generate-idl
-	make generate-clients
+	$(MAKE) generate-clients
 	cargo-build-sbf
 
 # Deploy to devnet
@@ -104,7 +101,7 @@ deploy-devnet: build-devnet
 		echo "Error: DEPLOYER_KEY parameter is required. Usage: make deploy-devnet DEPLOYER_KEY=/path/to/deployer-keypair.json"; \
 		exit 1; \
 	fi
-	solana program deploy ../target/deploy/contra_withdraw_program.so \
-		--program-id ../target/deploy/contra_withdraw_program-keypair.json \
+	solana program deploy $(PROGRAM_SO) \
+		--program-id $(PROGRAM_KEYPAIR) \
 		--keypair $(DEPLOYER_KEY) \
 		--url devnet

--- a/scripts/ensure-operator-keypair.sh
+++ b/scripts/ensure-operator-keypair.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <operator-keypair-path>" >&2
+  exit 1
+fi
+
+operator_keypair="$1"
+
+if [[ -f "$operator_keypair" ]]; then
+  echo "Operator keypair already exists at $operator_keypair"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$operator_keypair")"
+solana-keygen new -o "$operator_keypair" -s --no-bip39-passphrase
+echo "Operator keypair generated at $operator_keypair"

--- a/scripts/update-admin-env.sh
+++ b/scripts/update-admin-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <env-file> <operator-keypair-path>" >&2
+  exit 1
+fi
+
+env_file="$1"
+operator_keypair="$2"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+operator_pubkey="$(solana-keygen pubkey "$operator_keypair")"
+operator_private_key="$(tr -d '\n' < "$operator_keypair")"
+
+"$script_dir/upsert-env.sh" "$env_file" "CONTRA_ADMIN_KEYS" "$operator_pubkey"
+"$script_dir/upsert-env.sh" "$env_file" "ADMIN_PRIVATE_KEY" "$operator_private_key"
+
+echo "Updated $env_file with CONTRA_ADMIN_KEYS=$operator_pubkey"
+echo "Updated $env_file with ADMIN_PRIVATE_KEY"

--- a/scripts/update-program-env.sh
+++ b/scripts/update-program-env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <env-file> <env-key> <program-keypair-path>" >&2
+  exit 1
+fi
+
+env_file="$1"
+env_key="$2"
+program_keypair="$3"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+program_id="$(solana-keygen pubkey "$program_keypair")"
+"$script_dir/upsert-env.sh" "$env_file" "$env_key" "$program_id"
+
+echo "Updated $env_file with $env_key=$program_id"

--- a/scripts/upsert-env.sh
+++ b/scripts/upsert-env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <env-file> <key> <value>" >&2
+  exit 1
+fi
+
+env_file="$1"
+key="$2"
+value="$3"
+line="${key}=${value}"
+
+dirname="$(dirname "$env_file")"
+if [[ "$dirname" != "." ]]; then
+  mkdir -p "$dirname"
+fi
+
+if [[ ! -f "$env_file" ]]; then
+  printf '%s\n' "$line" > "$env_file"
+  exit 0
+fi
+
+if grep -q "^${key}=" "$env_file"; then
+  tmp_file="$(mktemp)"
+  awk -v key="$key" -v value="$value" '
+    $0 ~ "^" key "=" {
+      print key "=" value
+      next
+    }
+    { print }
+  ' "$env_file" > "$tmp_file"
+  mv "$tmp_file" "$env_file"
+else
+  printf '%s\n' "$line" >> "$env_file"
+fi


### PR DESCRIPTION
## Summary
- normalize root and program Makefiles with strict shell settings and consistent recursive invocations using `$(MAKE)`
- add canonical CI targets (`ci-*`) while keeping backward-compatible aliases for existing workflow commands
- extract repeated env/keypair mutation logic into reusable scripts under `scripts/`
- keep existing external make entrypoints working while reducing duplication and drift

## Validation
- make help
- make -n ci-unit-test
- make -n integration-test-ci
- make -n integration-test-ci-build-test-tree
- make -n build-localnet
- make -n build-devnet
- bash -n scripts/upsert-env.sh scripts/update-admin-env.sh scripts/update-program-env.sh scripts/ensure-operator-keypair.sh