### PR TITLE
fix(indexer): use body matchers in RPC batch test to prevent flake

### DIFF
--- a/indexer/src/indexer/datasource/rpc_polling/rpc.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/rpc.rs
@@ -310,32 +310,69 @@ mod tests {
     async fn test_get_blocks_batch_multiple_blocks() {
         let mut server = Server::new_async().await;
 
-        // Mock expects 3 requests - mockito will match them in order
-        let _m1 = mock_rpc_success(
-            &mut server,
-            r#"{
-                "blockhash": "Block100",
-                "parentSlot": 99,
-                "transactions": []
-            }"#,
-        )
-        .await
-        .expect(1);
+        // Use body matchers so each mock responds to its specific slot,
+        // regardless of the order concurrent requests arrive.
+        let _m1 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [100]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "blockhash": "Block100",
+                        "parentSlot": 99,
+                        "transactions": []
+                    },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
 
-        let _m2 = mock_rpc_error(&mut server, -32009, "Slot was skipped")
-            .await
-            .expect(1);
+        let _m2 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [101]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32009, "message": "Slot was skipped" },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
 
-        let _m3 = mock_rpc_success(
-            &mut server,
-            r#"{
-                "blockhash": "Block102",
-                "parentSlot": 101,
-                "transactions": []
-            }"#,
-        )
-        .await
-        .expect(1);
+        let _m3 = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [102]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "blockhash": "Block102",
+                        "parentSlot": 101,
+                        "transactions": []
+                    },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
 
         let poller = RpcPoller::new(
             server.url(),


### PR DESCRIPTION
## Summary
- \`test_get_blocks_batch_multiple_blocks\` used FIFO-ordered generic mocks, but \`get_blocks_batch\` fires all requests concurrently via \`join_all\`
- When requests arrived out of order, mockito returned the wrong response for each slot, causing intermittent assertion failures
- Replace the three generic \`mock_rpc_success\`/\`mock_rpc_error\` calls with \`PartialJson\` body matchers keyed on the slot number in \`params\`
- Each mock now only responds to its specific slot regardless of request arrival order — verified stable across 10 consecutive runs