### PR TITLE
fix(core): use mode-independent RPC method for health checks [PRO-978]

### DIFF
--- a/core/src/bin/streamer.rs
+++ b/core/src/bin/streamer.rs
@@ -69,7 +69,7 @@ struct StreamedTransaction {
 )]
 struct Args {
     /// Port to listen on
-    #[arg(short, long, env = "PORT")]
+    #[arg(short, long, env = "STREAMER_PORT")]
     port: Option<u16>,
 
     /// PostgreSQL connection URL (Contra read replica — for mint/burn/transfer)

--- a/core/src/rpc/handler.rs
+++ b/core/src/rpc/handler.rs
@@ -30,40 +30,35 @@ pub async fn handle_request(
 
     let response = match (req.method(), req.uri().path()) {
         (&Method::GET, "/health") => {
-            // Health check endpoint for monitoring and load balancers.
-            // Returns 200 with slot when the node is responsive, 503 otherwise.
-            let slot_request = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot"}"#;
-            match rpc_module.raw_json_request(slot_request, 1024).await {
+            let health_request = r#"{"jsonrpc":"2.0","id":1,"method":"getEpochSchedule"}"#;
+            match rpc_module.raw_json_request(health_request, 1024).await {
                 Ok((resp, _)) => {
-                    match serde_json::from_str::<serde_json::Value>(&resp)
+                    if serde_json::from_str::<serde_json::Value>(&resp)
                         .ok()
-                        .and_then(|v| v.get("result").and_then(|r| r.as_u64()))
+                        .and_then(|v| v.get("result").cloned())
+                        .is_some()
                     {
-                        Some(slot) => Response::builder()
+                        Response::builder()
                             .status(StatusCode::OK)
                             .header("Content-Type", "application/json")
-                            .body(Full::new(Bytes::from(format!(
-                                r#"{{"status":"ok","slot":{}}}"#,
-                                slot
-                            ))))
-                            .unwrap(),
-                        None => {
-                            tracing::warn!(
-                                "Health check: getSlot returned unexpected response: {}",
-                                resp
-                            );
-                            Response::builder()
-                                .status(StatusCode::SERVICE_UNAVAILABLE)
-                                .header("Content-Type", "application/json")
-                                .body(Full::new(Bytes::from(
-                                    r#"{"status":"degraded","error":"unexpected getSlot response"}"#,
-                                )))
-                                .unwrap()
-                        }
+                            .body(Full::new(Bytes::from(r#"{"status":"ok"}"#)))
+                            .unwrap()
+                    } else {
+                        tracing::warn!(
+                            "Health check: getEpochSchedule returned unexpected response: {}",
+                            resp
+                        );
+                        Response::builder()
+                            .status(StatusCode::SERVICE_UNAVAILABLE)
+                            .header("Content-Type", "application/json")
+                            .body(Full::new(Bytes::from(
+                                r#"{"status":"degraded","error":"unexpected getEpochSchedule response"}"#,
+                            )))
+                            .unwrap()
                     }
                 }
                 Err(e) => {
-                    tracing::error!("Health check: getSlot RPC call failed: {}", e);
+                    tracing::error!("Health check: getEpochSchedule RPC call failed: {}", e);
                     Response::builder()
                         .status(StatusCode::SERVICE_UNAVAILABLE)
                         .header("Content-Type", "application/json")

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -320,6 +320,14 @@ services:
     networks:
       - contra-network
 
+  # Blackbox Exporter for HTTP health probing
+  blackbox-exporter:
+    image: prom/blackbox-exporter:latest
+    container_name: contra-blackbox-exporter
+    restart: unless-stopped
+    networks:
+      - contra-network
+
   # cAdvisor for container metrics
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.49.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -416,6 +416,14 @@ services:
     networks:
       - contra-network
 
+  # Blackbox Exporter for HTTP health probing
+  blackbox-exporter:
+    image: prom/blackbox-exporter:latest
+    container_name: contra-blackbox-exporter
+    restart: unless-stopped
+    networks:
+      - contra-network
+
   # cAdvisor for container metrics
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.49.1

--- a/docs/RAILWAY.md
+++ b/docs/RAILWAY.md
@@ -65,7 +65,10 @@ railway add --service operator-solana
 railway add --service operator-contra
 railway add --service streamer
 railway add --service admin-ui
+railway add --service blackbox-exporter
 ```
+
+The `blackbox-exporter` service uses the Docker image `prom/blackbox-exporter:latest` directly (not the repo Dockerfile). In Railway, set **Settings > Build > Docker Image** to `prom/blackbox-exporter:latest`. No env vars, start command, or volumes needed -- it listens on port 9115.
 
 ## Start Commands
 
@@ -408,12 +411,23 @@ The grafana service needs these env vars to resolve datasource provisioning:
 | Contra Operator | Infrastructure, operator metrics (fetched, backlog, sent, errors, DB updates), Solana RPC, withdrawal status breakdown, pending withdrawals over time | Prometheus, Postgres |
 | Contra RPC | Gateway request rates, latency, errors | Prometheus |
 
+### Alerting
+
+Grafana alert rules fire when any Contra service becomes unreachable:
+
+- **Scrape-based** (`service-down-scrape`) -- alerts when `up` metric drops to 0 for gateway, indexer-solana, indexer-contra, operator-solana, or operator-contra (services that expose Prometheus metrics).
+- **Probe-based** (`service-down-probe`) -- alerts when blackbox-exporter's HTTP probe fails for write-node, read-node, or streamer `/health` endpoints.
+
+Both rules use a 30s pending period. Worst-case detection is ~55s (15s scrape + 10s eval + 30s pending). Alerts auto-resolve when services recover. The existing webhook contact point (`ALERT_WEBHOOK_URL`) handles all alerts.
+
 ### Deploying Observability Services
 
 ```bash
 railway up --service prometheus
 railway up --service grafana
 ```
+
+The `blackbox-exporter` service uses a stock Docker image -- no code deploy needed. Create it in the Railway dashboard with image `prom/blackbox-exporter:latest`.
 
 Prometheus uses `Dockerfile.prometheus` which runs `envsubst` at startup to interpolate `${HOST_SUFFIX}` into the config. Set `HOST_SUFFIX=.railway.internal` on the Railway prometheus service. No custom start command is needed — the Dockerfile handles it.
 
@@ -434,6 +448,7 @@ Prometheus uses `Dockerfile.prometheus` which runs `envsubst` at startup to inte
 | `grafana/dashboards/contra-indexer.json` | Indexer dashboard (infrastructure + indexer metrics + lag) |
 | `grafana/dashboards/contra-operator.json` | Operator dashboard (operator metrics + withdrawals) |
 | `grafana/dashboards/contra-rpc.json` | RPC/Gateway dashboard |
+| `grafana/provisioning/alerting/alert-rules.yml` | Grafana alert rules (indexer lag + service-down) |
 
 ## Dockerfile Changes for Railway
 

--- a/grafana/provisioning/alerting/alert-rules.yml
+++ b/grafana/provisioning/alerting/alert-rules.yml
@@ -38,3 +38,76 @@ groups:
                     type: gt
                     params: [10]
               refId: C
+
+  - orgId: 1
+    name: service-down-alerts
+    folder: Contra Alerts
+    interval: 10s
+    rules:
+      - uid: service-down-scrape
+        title: "Contra service down (scrape target unreachable)"
+        condition: C
+        for: 30s
+        noDataState: Alerting
+        execErrState: Error
+        annotations:
+          summary: "Service {{ $labels.job }} is down (Prometheus scrape failed)"
+        labels:
+          severity: critical
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: up{job=~"gateway|indexer-solana|indexer-contra|operator-solana|operator-contra"}
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params: [1]
+              refId: C
+
+      - uid: service-down-probe
+        title: "Contra service down (health probe failed)"
+        condition: C
+        for: 30s
+        noDataState: Alerting
+        execErrState: Error
+        annotations:
+          summary: "Service {{ $labels.instance }} is down (health check failed)"
+        labels:
+          severity: critical
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: probe_success{job="blackbox-http"}
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params: [1]
+              refId: C

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -34,6 +34,23 @@ scrape_configs:
     static_configs:
       - targets: ['gateway${HOST_SUFFIX}:9101']
 
+  - job_name: 'blackbox-http'
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - http://write-node${HOST_SUFFIX}:8900/health
+          - http://read-node${HOST_SUFFIX}:8901/health
+          - http://streamer${HOST_SUFFIX}:8902/health
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter${HOST_SUFFIX}:9115
+
   # Prometheus self-monitoring
   - job_name: 'prometheus'
     static_configs:


### PR DESCRIPTION
## Summary

- Switch `/health` endpoint from `getSlot` to `getEpochSchedule` — a pure function with no DB access or mode dependency, fixing 503s on the write-node where `CONTRA_ENABLE_READ=false`
- Fix streamer port binding: clap's `env = "PORT"` picked up Railway's injected `PORT=8080` instead of `STREAMER_PORT=8902`, causing blackbox probe failures
- Add Prometheus blackbox-exporter scrape config and Grafana alert rules for service-down detection

## Test plan

- [x] `cargo test -p contra-core health_returns_503` — existing test passes (empty RPC module still returns 503)
- [ ] Write-node `/health` returns 200 on Railway (deployed, pending build)
- [ ] Streamer `/health` reachable on port 8902 on Railway (deployed, pending build)
- [ ] Blackbox probe shows `probe_success=1` for all three targets
- [ ] Grafana `service-down-probe` alert auto-resolves

Closes PRO-978