### PR TITLE
DO NOT MERGE — test coverage table output

### DIFF
--- a/contra-escrow-program/program/src/lib.rs
+++ b/contra-escrow-program/program/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-
+// ci: test coverage table
 pub mod constants;
 pub mod error;
 pub mod events;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
 // Library modules that other binaries and tests can use
+// ci: test coverage table
 pub mod accounts;
 pub mod client;
 pub mod nodes;


### PR DESCRIPTION
Test PR to verify the progressive coverage table works.

Dummy comment changes to `core/src/lib.rs` and `contra-escrow-program/program/src/lib.rs` to trigger both `rust.yml` and `program-unit.yml` workflows.

Expected: a coverage table should appear below this text as jobs finish.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 4,473 | 6,849 | 65.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/22769923613) |
| Indexer | 6,945 | 18,190 | 38.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/22769923613) |
| Gateway | 265 | 434 | 61.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/22769923613) |
| Withdraw Program | 118 | 230 | 51.3% | [unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/22769923611) |
| Escrow Program | 692 | 1,688 | 41.0% | [unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/22769923611) |
| E2E Integration | 6,946 | 13,883 | 50.0% | [e2e-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/22769923613) |
| **Total** | **19,439** | **41,274** | **47.1%** | |

> Last updated: 2026-03-06 15:48:54 UTC by Withdraw Program