### PR TITLE
fix(rpc): query accounts database directly in getAccountInfo

### DIFF
--- a/core/src/rpc/get_account_info_impl.rs
+++ b/core/src/rpc/get_account_info_impl.rs
@@ -1,9 +1,6 @@
-use crate::{
-    accounts::bob::BOB,
-    rpc::{
-        error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
-        ReadDeps,
-    },
+use crate::rpc::{
+    error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
+    ReadDeps,
 };
 use jsonrpsee::core::RpcResult;
 use solana_account_decoder::encode_ui_account;
@@ -13,10 +10,7 @@ use solana_client::{
     rpc_response::{Response, RpcResponseContext},
 };
 use solana_sdk::pubkey::Pubkey;
-use solana_svm_callback::TransactionProcessingCallback;
 use std::str::FromStr;
-use tokio::sync::mpsc;
-use tracing::info;
 
 pub async fn get_account_info_impl(
     read_deps: &ReadDeps,
@@ -36,15 +30,11 @@ pub async fn get_account_info_impl(
         .unwrap_or(0);
 
     // Get account from database
-    let (_settled_accounts_tx, settled_accounts_rx) = mpsc::unbounded_channel();
-    let bob = BOB::new(read_deps.accounts_db.clone(), settled_accounts_rx).await;
-    let account_data = bob.get_account_shared_data(&pubkey);
+    let account_data = read_deps.accounts_db.get_account_shared_data(&pubkey).await;
     let encoding = config.encoding.unwrap_or(UiAccountEncoding::Base64);
     let value = account_data.map(|account| {
-        // Encode data based on requested encoding
         encode_ui_account(&pubkey, &account, encoding, None, config.data_slice)
     });
-    info!("Account info: {:?}", value);
 
     // TODO: Get actual slot from the read node's state
     Ok(Response {


### PR DESCRIPTION
## Summary

`getAccountInfo` always returned `null` for user accounts because it constructed a fresh `BOB` instance with an empty in-memory cache instead of querying the accounts database directly.

- `BOB` is the write-node's execution-time account cache. A newly created `BOB` only contains precompile accounts (system program, SPL Token, etc.), never user data.
- `getTokenAccountBalance` already uses the correct pattern: `read_deps.accounts_db.get_account_shared_data()`.
- This fix aligns `getAccountInfo` with that same pattern.

**Root cause:** `BOB::get_account_shared_data()` (via `TransactionProcessingCallback` trait) checks only its in-memory HashMap — it has no database fallback. When called from a fresh instance on the read-node, it always returns `None` for any non-precompile account.

## Changes

- Replace `BOB` instantiation with direct `AccountsDB` query (1 line)
- Remove unused imports (`BOB`, `TransactionProcessingCallback`, `mpsc`, `tracing::info`)
- Remove verbose per-request account data logging

## Test plan

- [x] Verified `getAccountInfo` returns account data (base64 + jsonParsed encoding) for both mint and token accounts on devnet
- [x] Verified `getTokenAccountBalance` still works correctly
- [x] Verified non-existent accounts still return `null`