### PR TITLE
fix(operator): configurable confirmation poll interval and permanent RPC error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ RUN touch contra-escrow-program/program/src/lib.rs contra-escrow-program/tests/i
     test_utils/src/lib.rs scripts/devnet/src/lib.rs \
     contra-escrow-program/clients/rust/src/lib.rs contra-withdraw-program/clients/rust/src/lib.rs \
     core/src/lib.rs metrics/src/lib.rs auth/src/lib.rs && \
-    printf 'fn main() {}\n' > bench-tps/src/main.rs
+    printf 'fn main() {}\n' > bench-tps/src/main.rs && \
+    printf 'fn main() {}\n' > auth/src/main.rs
 
 # Build the project with the dummy files. We can cache this layer.
 RUN cargo build --release

--- a/indexer/config/local/operator-contra.toml
+++ b/indexer/config/local/operator-contra.toml
@@ -20,8 +20,10 @@ type = "postgres"
 max_connections = 10
 
 [operator]
-poll_interval_secs = 5
+poll_interval_secs = 1
 batch_size = 10
 retry_max_attempts = 3
 retry_base_delay_secs = 1
 channel_buffer_size = 100
+# Solana block time is ~400 ms
+confirmation_poll_interval_ms = 400

--- a/indexer/config/local/operator-solana.toml
+++ b/indexer/config/local/operator-solana.toml
@@ -20,8 +20,11 @@ type = "postgres"
 max_connections = 10
 
 [operator]
-poll_interval_secs = 5
-batch_size = 10
+# Faster poll/batch settings suited to higher-throughput
+poll_interval_secs = 1
+batch_size = 100
 retry_max_attempts = 3
 retry_base_delay_secs = 1
-channel_buffer_size = 100
+channel_buffer_size = 1000
+# Contra block time is 100 ms so poll quickly
+confirmation_poll_interval_ms = 100

--- a/indexer/config/railway/operator-contra.toml
+++ b/indexer/config/railway/operator-contra.toml
@@ -18,8 +18,10 @@ type = "postgres"
 max_connections = 10
 
 [operator]
-poll_interval_secs = 5
+poll_interval_secs = 1
 batch_size = 10
 retry_max_attempts = 3
 retry_base_delay_secs = 1
 channel_buffer_size = 100
+# Solana mainnet block time is ~400 ms
+confirmation_poll_interval_ms = 400

--- a/indexer/config/railway/operator-solana.toml
+++ b/indexer/config/railway/operator-solana.toml
@@ -19,8 +19,10 @@ type = "postgres"
 max_connections = 10
 
 [operator]
-poll_interval_secs = 5
-batch_size = 10
+poll_interval_secs = 1
+batch_size = 100
 retry_max_attempts = 3
 retry_base_delay_secs = 1
-channel_buffer_size = 100
+channel_buffer_size = 1000
+# Contra block time is ~100 ms; poll faster than the 400 ms default
+confirmation_poll_interval_ms = 100

--- a/indexer/src/bin/indexer.rs
+++ b/indexer/src/bin/indexer.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use contra_indexer::config::DEFAULT_CONFIRMATION_POLL_INTERVAL_MS;
 use contra_indexer::{
     BackfillConfig, ContraIndexerConfig, DatasourceType, IndexerConfig, OperatorConfig,
     PostgresConfig, ProgramType, ReconciliationConfig, RpcPollingConfig, StorageType,
@@ -96,6 +97,8 @@ struct OperatorSection {
     reconciliation_webhook_url: Option<String>,
     #[serde(default = "default_feepayer_monitor_interval_secs")]
     feepayer_monitor_interval_secs: u64,
+    #[serde(default = "default_confirmation_poll_interval_ms")]
+    confirmation_poll_interval_ms: u64,
 }
 
 fn default_reconciliation_interval_secs() -> u64 {
@@ -108,6 +111,10 @@ fn default_reconciliation_tolerance_bps() -> u16 {
 
 fn default_feepayer_monitor_interval_secs() -> u64 {
     60
+}
+
+fn default_confirmation_poll_interval_ms() -> u64 {
+    DEFAULT_CONFIRMATION_POLL_INTERVAL_MS
 }
 
 #[derive(Parser, Debug)]
@@ -401,6 +408,7 @@ async fn run_operator(figment: Figment, verbose: bool) -> Result<(), Box<dyn std
         reconciliation_tolerance_bps: operator.reconciliation_tolerance_bps,
         reconciliation_webhook_url: operator.reconciliation_webhook_url,
         feepayer_monitor_interval: Duration::from_secs(operator.feepayer_monitor_interval_secs),
+        confirmation_poll_interval_ms: operator.confirmation_poll_interval_ms,
     };
 
     // Validate signer configuration early (from environment variables)

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -270,7 +270,16 @@ pub struct OperatorConfig {
     /// How often to check the feepayer SOL balance (escrow operators only)
     #[serde(default = "default_feepayer_monitor_interval")]
     pub feepayer_monitor_interval: std::time::Duration,
+    /// Milliseconds between `getSignatureStatuses` polls when confirming a sent transaction.
+    /// Lower values reduce per-tx latency on Contra (~100 ms); higher values suit Solana
+    /// (~400 ms block time). Defaults to `DEFAULT_CONFIRMATION_POLL_INTERVAL_MS`.
+    #[serde(default = "default_confirmation_poll_interval_ms")]
+    pub confirmation_poll_interval_ms: u64,
 }
+
+/// Default poll interval for `confirmation_poll_interval_ms`, matching Solana's ~400 ms block time.
+/// operator-solana overrides this to 100 ms since Contra confirms faster.
+pub const DEFAULT_CONFIRMATION_POLL_INTERVAL_MS: u64 = 400;
 
 fn default_reconciliation_interval() -> std::time::Duration {
     std::time::Duration::from_secs(5 * 60) // 5 minutes
@@ -282,6 +291,10 @@ fn default_reconciliation_tolerance() -> u16 {
 
 fn default_feepayer_monitor_interval() -> std::time::Duration {
     std::time::Duration::from_secs(60)
+}
+
+fn default_confirmation_poll_interval_ms() -> u64 {
+    DEFAULT_CONFIRMATION_POLL_INTERVAL_MS
 }
 
 impl OperatorConfig {

--- a/indexer/src/operator/fetcher.rs
+++ b/indexer/src/operator/fetcher.rs
@@ -116,6 +116,7 @@ mod tests {
             reconciliation_tolerance_bps: 10,
             reconciliation_webhook_url: None,
             feepayer_monitor_interval: Duration::from_secs(60),
+            confirmation_poll_interval_ms: 400,
         }
     }
 

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -115,6 +115,7 @@ pub async fn run(
             sender_token,
             sender_storage,
             config.retry_max_attempts,
+            config.confirmation_poll_interval_ms,
             sender_source_rpc,
         )
         .await

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -738,6 +738,7 @@ mod tests {
             reconciliation_tolerance_bps: 10,
             reconciliation_webhook_url: None,
             feepayer_monitor_interval: std::time::Duration::from_secs(60),
+            confirmation_poll_interval_ms: 400,
         }
     }
 

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -120,6 +120,7 @@ pub(super) async fn try_jit_mint_initialization(
         &sig,
         CommitmentConfig::confirmed(),
         &init_tx_builder.extra_error_checks_policy(),
+        state.confirmation_poll_interval_ms,
     )
     .await
     {

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -38,6 +38,7 @@ pub async fn run_sender(
     cancellation_token: tokio_util::sync::CancellationToken,
     storage: Arc<Storage>,
     retry_max_attempts: u32,
+    confirmation_poll_interval_ms: u64,
     source_rpc_client: Option<Arc<RpcClientWithRetry>>,
 ) -> Result<(), OperatorError> {
     info!("Starting sender");
@@ -53,6 +54,7 @@ pub async fn run_sender(
         instance_pda,
         storage,
         retry_max_attempts,
+        confirmation_poll_interval_ms,
         source_rpc_client,
     )?;
 
@@ -168,6 +170,7 @@ mod tests {
             cancellation_token,
             storage,
             3,
+            1000,
             None,
         )
         .await;
@@ -200,6 +203,7 @@ mod tests {
             cancellation_token,
             storage,
             3,
+            1000,
             None,
         )
         .await;

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -125,6 +125,7 @@ pub async fn run_sender(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::DEFAULT_CONFIRMATION_POLL_INTERVAL_MS;
     use crate::config::{PostgresConfig, ProgramType, StorageType};
     use crate::storage::common::storage::mock::MockStorage;
     use crate::ContraIndexerConfig;
@@ -170,7 +171,7 @@ mod tests {
             cancellation_token,
             storage,
             3,
-            1000,
+            DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
             None,
         )
         .await;
@@ -203,7 +204,7 @@ mod tests {
             cancellation_token,
             storage,
             3,
-            1000,
+            DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
             None,
         )
         .await;

--- a/indexer/src/operator/sender/proof.rs
+++ b/indexer/src/operator/sender/proof.rs
@@ -229,6 +229,7 @@ mod tests {
             mint_builders: HashMap::new(),
             mint_cache: MintCache::new(storage),
             retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
             rotation_retry_queue: Vec::new(),
             pending_rotation: None,
             program_type: crate::config::ProgramType::Escrow,

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -94,6 +94,7 @@ async fn attempt_remint(
         &signature,
         CommitmentConfig::confirmed(),
         &ExtraErrorCheckPolicy::None,
+        state.confirmation_poll_interval_ms,
     )
     .await
     .map_err(|e| format!("Failed to confirm remint transaction: {}", e))?;
@@ -342,6 +343,7 @@ mod tests {
             mint_builders: HashMap::new(),
             mint_cache: MintCache::new(storage),
             retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
             rotation_retry_queue: Vec::new(),
             pending_rotation: None,
             program_type: crate::config::ProgramType::Escrow,
@@ -384,6 +386,7 @@ mod tests {
             mint_builders: HashMap::new(),
             mint_cache: MintCache::new(storage),
             retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
             rotation_retry_queue: Vec::new(),
             pending_rotation: None,
             program_type: crate::config::ProgramType::Escrow,

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -29,6 +29,7 @@ impl SenderState {
         instance_pda: Option<Pubkey>,
         storage: Arc<Storage>,
         retry_max_attempts: u32,
+        confirmation_poll_interval_ms: u64,
         source_rpc_client: Option<Arc<RpcClientWithRetry>>,
     ) -> Result<Self, OperatorError> {
         // Initialize global RPC client with retry
@@ -52,6 +53,7 @@ impl SenderState {
             mint_cache,
             mint_builders: HashMap::new(),
             retry_max_attempts,
+            confirmation_poll_interval_ms,
             rotation_retry_queue: Vec::new(),
             pending_rotation: None,
             program_type: config.program_type,
@@ -349,6 +351,7 @@ mod tests {
             mint_builders: HashMap::new(),
             mint_cache: MintCache::new(storage),
             retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
             rotation_retry_queue: Vec::new(),
             pending_rotation: None,
             program_type: crate::config::ProgramType::Escrow,
@@ -801,6 +804,7 @@ mod tests {
             mint_builders: HashMap::new(),
             mint_cache: MintCache::new(storage),
             retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
             rotation_retry_queue: Vec::new(),
             pending_rotation: None,
             program_type: ProgramType::Escrow,
@@ -849,7 +853,15 @@ mod tests {
         let storage = Arc::new(Storage::Mock(mock));
         let config = make_config();
 
-        let result = SenderState::new(&config, CommitmentLevel::Confirmed, None, storage, 3, None);
+        let result = SenderState::new(
+            &config,
+            CommitmentLevel::Confirmed,
+            None,
+            storage,
+            3,
+            400,
+            None,
+        );
 
         assert!(result.is_ok());
         let state = result.unwrap();
@@ -874,6 +886,7 @@ mod tests {
             Some(instance_pda),
             storage,
             5,
+            400,
             None,
         );
 

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -290,6 +290,7 @@ pub(super) async fn send_and_confirm(
                 &signature,
                 commitment_config,
                 extra_error_checks_policy,
+                state.confirmation_poll_interval_ms,
             )
             .await;
 
@@ -764,6 +765,7 @@ mod tests {
             mint_builders: HashMap::new(),
             mint_cache: MintCache::new(storage),
             retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
             rotation_retry_queue: Vec::new(),
             pending_rotation: None,
             program_type: ProgramType::Escrow,

--- a/indexer/src/operator/sender/types.rs
+++ b/indexer/src/operator/sender/types.rs
@@ -46,6 +46,8 @@ pub struct SenderState {
     pub mint_builders: HashMap<i64, MintToBuilder>,
     pub mint_cache: MintCache,
     pub retry_max_attempts: u32,
+    /// Milliseconds between `getSignatureStatuses` polls. Populated from `OperatorConfig`.
+    pub confirmation_poll_interval_ms: u64,
     pub rotation_retry_queue: Vec<(TransactionContext, ReleaseFundsBuilder)>,
     /// Pending ResetSmtRoot transaction waiting for in-flight txs to settle
     pub pending_rotation: Option<Box<ResetSmtRootBuilder>>,

--- a/indexer/src/operator/utils/rpc_util.rs
+++ b/indexer/src/operator/utils/rpc_util.rs
@@ -1,7 +1,9 @@
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
 use solana_rpc_client_api::client_error;
+use solana_rpc_client_api::client_error::ErrorKind;
 use solana_rpc_client_api::config::RpcTransactionConfig;
+use solana_rpc_client_api::request::RpcError;
 use solana_sdk::account::Account;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::hash::Hash;
@@ -37,6 +39,18 @@ impl Default for RetryConfig {
             max_delay: DEFAULT_MAX_DELAY,
         }
     }
+}
+
+/// Returns `true` for errors that will never succeed on retry.
+///
+/// `-32601` (Method not found) is a permanent protocol-level rejection; retrying
+/// wastes the full backoff budget without any chance of recovery.
+// TODO: remove once the RPC endpoint implements all required methods.
+fn is_permanent_rpc_error(e: &client_error::Error) -> bool {
+    matches!(
+        e.kind(),
+        ErrorKind::RpcError(RpcError::RpcResponseError { code: -32601, .. })
+    )
 }
 
 pub struct RpcClientWithRetry {
@@ -91,12 +105,15 @@ impl RpcClientWithRetry {
                     match f().await {
                         Ok(result) => return Ok(result),
                         Err(e) => {
-                            if attempts >= self.retry_config.max_attempts {
+                            let err: Box<client_error::Error> = e.into();
+                            if attempts >= self.retry_config.max_attempts
+                                || is_permanent_rpc_error(&err)
+                            {
                                 warn!(
                                     "{} failed after {} attempts: {}",
-                                    operation_name, attempts, e
+                                    operation_name, attempts, err
                                 );
-                                return Err(e.into());
+                                return Err(err);
                             }
 
                             let delay = self.retry_config.base_delay * 2_u32.pow(attempts - 1);

--- a/indexer/src/operator/utils/transaction_util.rs
+++ b/indexer/src/operator/utils/transaction_util.rs
@@ -15,7 +15,6 @@ use solana_sdk::{
 use tracing::{debug, warn};
 
 const MAX_POLL_ATTEMPTS_CONFIRMATION: u32 = 5;
-const POLL_INTERVAL_MS_CONFIRMATION: u64 = 1000;
 
 /// Result of transaction confirmation
 #[derive(Debug, Clone)]
@@ -85,14 +84,16 @@ pub async fn sign_and_send_transaction(
     Ok(signature)
 }
 
-/// Check transaction status WITH polling
+/// Check transaction status with polling.
 ///
-/// Polls up to MAX_POLL_ATTEMPTS_CONFIRMATION times for transaction to land on-chain
+/// Polls up to `MAX_POLL_ATTEMPTS_CONFIRMATION` times, sleeping `poll_interval_ms` between
+/// each attempt. Pass `OperatorConfig::confirmation_poll_interval_ms` as the interval.
 pub async fn check_transaction_status(
     rpc_client: Arc<RpcClientWithRetry>,
     signature: &Signature,
     commitment_config: CommitmentConfig,
     extra_error_checks_policy: &ExtraErrorCheckPolicy,
+    poll_interval_ms: u64,
 ) -> Result<ConfirmationResult, TransactionError> {
     debug!("Checking transaction status: {}", signature);
 
@@ -133,10 +134,7 @@ pub async fn check_transaction_status(
 
         attempts += 1;
         if attempts < MAX_POLL_ATTEMPTS_CONFIRMATION {
-            tokio::time::sleep(tokio::time::Duration::from_millis(
-                POLL_INTERVAL_MS_CONFIRMATION,
-            ))
-            .await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(poll_interval_ms)).await;
         }
     }
 
@@ -338,6 +336,7 @@ mod tests {
             &sig,
             CommitmentConfig::confirmed(),
             &ExtraErrorCheckPolicy::None,
+            400,
         )
         .await;
 
@@ -382,6 +381,7 @@ mod tests {
             &sig,
             CommitmentConfig::confirmed(),
             &ExtraErrorCheckPolicy::None,
+            400,
         )
         .await;
 
@@ -422,6 +422,7 @@ mod tests {
             &sig,
             CommitmentConfig::confirmed(),
             &ExtraErrorCheckPolicy::None,
+            400,
         )
         .await;
 

--- a/indexer/tests/reconciliation_e2e_test.rs
+++ b/indexer/tests/reconciliation_e2e_test.rs
@@ -119,6 +119,7 @@ fn create_test_config(tolerance_bps: u16, webhook_url: Option<String>) -> Operat
         reconciliation_tolerance_bps: tolerance_bps,
         reconciliation_webhook_url: webhook_url,
         feepayer_monitor_interval: Duration::from_secs(60),
+        confirmation_poll_interval_ms: 400,
     }
 }
 

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -61,6 +61,7 @@ fn default_operator_config(alert_url: Option<String>) -> OperatorConfig {
         reconciliation_tolerance_bps: 10,
         reconciliation_webhook_url: None,
         feepayer_monitor_interval: Duration::from_secs(60),
+        confirmation_poll_interval_ms: 400,
     }
 }
 

--- a/scripts/devnet/config/operator-contra.toml
+++ b/scripts/devnet/config/operator-contra.toml
@@ -16,8 +16,10 @@ type = "postgres"
 max_connections = 10
 
 [operator]
-poll_interval_secs = 5
+poll_interval_secs = 1
 batch_size = 10
 retry_max_attempts = 3
 retry_base_delay_secs = 1
 channel_buffer_size = 100
+# Solana devnet block time is ~400 ms
+confirmation_poll_interval_ms = 400

--- a/scripts/devnet/config/operator-solana.toml
+++ b/scripts/devnet/config/operator-solana.toml
@@ -14,8 +14,10 @@ type = "postgres"
 max_connections = 10
 
 [operator]
-poll_interval_secs = 5
-batch_size = 10
+poll_interval_secs = 1
+batch_size = 100
 retry_max_attempts = 3
 retry_base_delay_secs = 1
-channel_buffer_size = 100
+channel_buffer_size = 1000
+# Contra block time is ~100 ms; poll quickly to reduce per-mint latency
+confirmation_poll_interval_ms = 100

--- a/test_utils/src/operator_helper.rs
+++ b/test_utils/src/operator_helper.rs
@@ -32,6 +32,7 @@ fn default_operator_config() -> OperatorConfig {
         reconciliation_tolerance_bps: 10,
         reconciliation_webhook_url: None,
         feepayer_monitor_interval: Duration::from_secs(60),
+        confirmation_poll_interval_ms: 400,
     }
 }
 


### PR DESCRIPTION
## Problem

Two hardcoded assumptions in the per-transaction hot path for deposit/withdraw were capping the throughput:

1. `check_transaction_status` used a fixed 1000 ms poll interval. Contra's block time is ~100 ms, so the operator waited 10× longer than necessary to detect confirmation.
2. The mint idempotency check (`getSignaturesForAddress`) retried 5 times with exponential backoff, burning ~1500 ms per transaction — even though the Contra RPC node returns `-32601 Method not found`, a response that will never change between attempts.

## Changes

- **Configurable poll interval:** replaces the hardcoded `POLL_INTERVAL_MS_CONFIRMATION = 1000` with `confirmation_poll_interval_ms` in `OperatorConfig` (default: 400 ms, matching Solana's block time). All deployment configs are updated: `operator-solana` uses 100 ms; `operator-contra` uses 400 ms.

- **Permanent RPC error short-circuit:** `with_retry` now exits immediately on `-32601 Method not found` rather than exhausting the backoff budget. The check is scoped to this specific JSON-RPC error code so all other errors continue to retry as before. A `TODO` marks the guard for removal once `getSignaturesForAddress` is implemented on the RPC node.

## Impact

| TPS | Before | After | improvement |
|---|---|---|---|
| Deposit | ~0.4 | ~9 | 22x |
| Withdraw | ~1 | ~2.5 | 2.5x |

## Results

### Deposit
<img width="1517" height="651" alt="Screenshot from 2026-04-07 00-42-04" src="https://github.com/user-attachments/assets/7708168c-8ed8-4314-8ec3-889a4e0c885d" />

### Withdraw
<img width="1517" height="651" alt="Screenshot from 2026-04-07 00-44-05" src="https://github.com/user-attachments/assets/c45bffff-8fa4-47bc-822e-c39a5a6943c8" />


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 7,103 | 8,411 | 84.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24046697295) |
| Indexer | 12,135 | 14,212 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24046697295) |
| Gateway | 952 | 1,076 | 88.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24046697295) |
| Auth | 541 | 596 | 90.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24046697295) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | 7,687 | 11,041 | 69.6% | [e2e-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24046697295) |
| **Total** | **28,418** | **35,336** | **80.4%** | |

> Last updated: 2026-04-06 19:32:36 UTC by E2E Integration