### PR TITLE
feat(operator): fire-and-forget mint sender with batch confirmation polling

### DIFF
--- a/.github/workflows/program-integration.yml
+++ b/.github/workflows/program-integration.yml
@@ -39,6 +39,7 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           install-base-cargo-tools: "false"
+          install-system-dependencies: "false"
           build-programs: "false"
 
       - name: Build programs

--- a/bench-tps/.env.sample
+++ b/bench-tps/.env.sample
@@ -90,10 +90,10 @@ BENCH_ADMIN_KEYPAIR=
 BENCH_DURATION=60
 
 # Concurrent sender threads per flow
-BENCH_THREADS=4
+BENCH_THREADS=3
 
 # Milliseconds each sender thread sleeps between batches; 0 = maximum throughput
-BENCH_SENDER_SLEEP_MS=0
+BENCH_SENDER_SLEEP_MS=5
 
 # Raw token units minted to each account's ATA during setup; 1 unit consumed per tx
 BENCH_INITIAL_BALANCE=1000000

--- a/bench-tps/.env.sample.devnet
+++ b/bench-tps/.env.sample.devnet
@@ -106,10 +106,10 @@ BENCH_ADMIN_KEYPAIR=
 BENCH_DURATION=60
 
 # Concurrent sender threads per flow
-BENCH_THREADS=4
+BENCH_THREADS=3
 
 # Milliseconds each sender thread sleeps between batches; 0 = maximum throughput
-BENCH_SENDER_SLEEP_MS=0
+BENCH_SENDER_SLEEP_MS=5
 
 # Raw token units minted to each account's ATA during setup; 1 unit consumed per tx
 BENCH_INITIAL_BALANCE=1000000

--- a/bench-tps/src/args.rs
+++ b/bench-tps/src/args.rs
@@ -186,6 +186,17 @@ pub struct DepositArgs {
     #[arg(long, env = "BENCH_INSTANCE_SEED_KEYPAIR")]
     pub instance_seed_keypair: Option<PathBuf>,
 
+    /// JSON-RPC endpoint of the Contra write-node (or gateway).
+    ///
+    /// Used during setup to initialise the SPL mint on Contra so the operator
+    /// can mint immediately without JIT initialisation.
+    #[arg(
+        long,
+        default_value = "http://localhost:8898",
+        env = "BENCH_RPC_URL"
+    )]
+    pub contra_rpc_url: String,
+
     /// Tracing log level.
     #[arg(long, default_value = "info", env = "BENCH_LOG_LEVEL")]
     pub log_level: String,

--- a/bench-tps/src/args.rs
+++ b/bench-tps/src/args.rs
@@ -193,7 +193,7 @@ pub struct DepositArgs {
     #[arg(
         long,
         default_value = "http://localhost:8898",
-        env = "BENCH_RPC_URL"
+        env = "BENCH_CONTRA_RPC_URL"
     )]
     pub contra_rpc_url: String,
 

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -247,6 +247,7 @@ async fn run_deposit(args: args::DepositArgs) -> Result<()> {
 
     let deposit_config = setup_deposit::run_setup_deposit_phase(
         &args.solana_rpc_url,
+        &args.contra_rpc_url,
         &args.admin_keypair,
         args.instance_seed_keypair.as_deref(),
         args.accounts,

--- a/bench-tps/src/setup_deposit.rs
+++ b/bench-tps/src/setup_deposit.rs
@@ -6,9 +6,9 @@
 //!   3. Creates the escrow instance on Solana (CreateInstance instruction).
 //!   4. Generates N fresh depositor keypairs.
 //!   5. Funds each depositor with SOL (via transfer from admin).
-//!   6. Creates a fresh Solana SPL mint (admin is mint authority).
-//!  6b. Initialises the same mint on **Contra** so the operator can mint
-//!      immediately without JIT initialisation.
+//!   6. Creates a fresh Solana SPL mint (admin is mint authority) and
+//!      initialises it on **Contra** so the operator can mint immediately
+//!      without JIT initialisation.
 //!   7. Calls AllowMint — registers the mint with the instance, creating both
 //!      the allowed_mint PDA and the instance ATA on Solana.
 //!   8. Creates Solana ATAs for each depositor.

--- a/bench-tps/src/setup_deposit.rs
+++ b/bench-tps/src/setup_deposit.rs
@@ -1,12 +1,14 @@
-//! Deposit setup phase — Solana escrow preparation.
+//! Deposit setup phase — Solana escrow + Contra mint preparation.
 //!
-//! Prepares all Solana on-chain state the deposit load phase needs:
+//! Prepares all on-chain state the deposit load phase needs:
 //!   1. Loads the admin keypair from disk.
 //!   2. Generates a fresh instance-seed keypair and derives the escrow instance PDA.
 //!   3. Creates the escrow instance on Solana (CreateInstance instruction).
 //!   4. Generates N fresh depositor keypairs.
 //!   5. Funds each depositor with SOL (via transfer from admin).
 //!   6. Creates a fresh Solana SPL mint (admin is mint authority).
+//!  6b. Initialises the same mint on **Contra** so the operator can mint
+//!      immediately without JIT initialisation.
 //!   7. Calls AllowMint — registers the mint with the instance, creating both
 //!      the allowed_mint PDA and the instance ATA on Solana.
 //!   8. Creates Solana ATAs for each depositor.
@@ -22,7 +24,9 @@ use {
         types::{BenchState, DepositConfig, MINT_DECIMALS, SETUP_BATCH_SIZE},
     },
     anyhow::{Context, Result},
-    contra_core::client::{create_admin_mint_to, create_ata_transaction},
+    contra_core::client::{
+        create_admin_initialize_mint, create_admin_mint_to, create_ata_transaction,
+    },
     contra_escrow_program_client::{
         instructions::{
             AllowMint, AllowMintInstructionArgs, CreateInstance, CreateInstanceInstructionArgs,
@@ -78,18 +82,20 @@ fn find_event_authority() -> (Pubkey, u8) {
     Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], &CONTRA_ESCROW_PROGRAM_ID)
 }
 
-/// Run all Solana deposit setup tasks and return the `DepositConfig` needed by
-/// the deposit load phase.
+/// Run all deposit setup tasks and return the `DepositConfig` needed by the
+/// deposit load phase.
 ///
-/// `solana_rpc_url`         — Solana validator RPC endpoint
-/// `admin_path`            — path to the admin keypair JSON file
-/// `instance_seed_path`    — optional path to save/load the instance-seed keypair;
-///                           when `Some`, the keypair (and thus instance PDA) is
-///                           reused across runs so the indexer can track it.
-/// `num_accounts`          — number of depositor accounts to create
-/// `initial_balance`       — raw token units minted to each depositor ATA
+/// `solana_rpc_url`  — Solana validator RPC endpoint
+/// `contra_rpc_url`  — Contra gateway / write-node RPC endpoint
+/// `admin_path`      — path to the admin keypair JSON file
+/// `instance_seed_path` — optional path to save/load the instance-seed keypair;
+///                        when `Some`, the keypair (and thus instance PDA) is
+///                        reused across runs so the indexer can track it.
+/// `num_accounts`    — number of depositor accounts to create
+/// `initial_balance` — raw token units minted to each depositor ATA
 pub async fn run_setup_deposit_phase(
     solana_rpc_url: &str,
+    contra_rpc_url: &str,
     admin_path: &Path,
     instance_seed_path: Option<&Path>,
     num_accounts: usize,
@@ -340,11 +346,9 @@ pub async fn run_setup_deposit_phase(
     // ------------------------------------------------------------------
     // Task 6: Create and initialise Solana SPL mint
     //
-    // On a real Solana validator (Solana) the mint account must be explicitly
-    // allocated via system_program::create_account before SPL token's
-    // initialize_mint can write into it.  The Contra write-node creates
-    // accounts implicitly (gasless), so create_admin_initialize_mint in
-    // core only sends initialize_mint and works on Contra but not Solana.
+    // On Solana the mint account must be explicitly allocated via
+    // system_program::create_account before SPL token's initialize_mint
+    // can write into it.
     // ------------------------------------------------------------------
     let t6 = Instant::now();
     let mint_keypair = Keypair::new();
@@ -407,6 +411,68 @@ pub async fn run_setup_deposit_phase(
         ));
     }
     info!(%mint, elapsed_ms = t6.elapsed().as_millis(), "Solana mint initialized");
+
+    // ------------------------------------------------------------------
+    // Task 6b: Initialise the same mint on Contra
+    //
+    // The Contra write-node creates accounts implicitly (gasless), so
+    // create_admin_initialize_mint only sends the initialize_mint
+    // instruction — no preceding create_account is needed.
+    //
+    // Without this step the operator would attempt JIT initialisation for
+    // every first deposit, blocking the sender loop ~200 ms each time.
+    // ------------------------------------------------------------------
+    let t6b = Instant::now();
+    let contra_rpc =
+        RpcClient::new_with_commitment(contra_rpc_url.to_string(), CommitmentConfig::confirmed());
+    let contra_mint_sig = 'send: {
+        let mut last_err = String::new();
+        for (attempt, &delay_secs) in send_retry_delays.iter().enumerate() {
+            match contra_rpc.get_latest_blockhash().await {
+                Err(e) => {
+                    warn!(attempt, err = %e,
+                        "get_latest_blockhash failed (Contra mint init), retrying in {delay_secs}s");
+                    last_err = e.to_string();
+                }
+                Ok(blockhash) => {
+                    let init_tx = create_admin_initialize_mint(
+                        &admin_keypair,
+                        &mint,
+                        MINT_DECIMALS,
+                        blockhash,
+                    );
+                    match contra_rpc.send_transaction(&init_tx).await {
+                        Ok(sig) => break 'send sig,
+                        Err(e) => {
+                            warn!(attempt, err = %e,
+                                "Contra initialize_mint send failed, retrying in {delay_secs}s");
+                            last_err = e.to_string();
+                        }
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+        }
+        return Err(anyhow::anyhow!(
+            "Contra initialize_mint: all retries exhausted: {last_err}"
+        ));
+    };
+    let retry = poll_confirmations(
+        &contra_rpc,
+        &[Some(contra_mint_sig)],
+        "initialize_mint(contra)",
+        0,
+        1,
+    )
+    .await?;
+    if !retry.is_empty() {
+        return Err(anyhow::anyhow!("Contra initialize_mint failed to confirm"));
+    }
+    info!(
+        %mint,
+        elapsed_ms = t6b.elapsed().as_millis(),
+        "Contra mint initialized",
+    );
 
     // ------------------------------------------------------------------
     // Task 7: AllowMint — register the mint with the escrow instance

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -70,6 +70,7 @@ rustls = { workspace = true, optional = true }
 solana-keychain = { version = "0.1.0", features = ["all"] }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 spl-associated-token-account = { workspace = true }
 
 solana-system-interface = { workspace = true }

--- a/indexer/config/local/operator-solana.toml
+++ b/indexer/config/local/operator-solana.toml
@@ -22,7 +22,7 @@ max_connections = 10
 [operator]
 # Faster poll/batch settings suited to higher-throughput
 poll_interval_secs = 1
-batch_size = 100
+batch_size = 1000
 retry_max_attempts = 3
 retry_base_delay_secs = 1
 channel_buffer_size = 1000

--- a/indexer/config/railway/operator-solana.toml
+++ b/indexer/config/railway/operator-solana.toml
@@ -20,7 +20,7 @@ max_connections = 10
 
 [operator]
 poll_interval_secs = 1
-batch_size = 100
+batch_size = 1000
 retry_max_attempts = 3
 retry_base_delay_secs = 1
 channel_buffer_size = 1000

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -21,6 +21,9 @@ pub async fn run(
     info!("Starting Contra Operator");
     info!("Program: {:?}", common_config.program_type);
     info!("Poll interval: {:?}", config.db_poll_interval);
+    info!("Batch size: {}", config.batch_size);
+    info!("Channel buffer size: {}", config.channel_buffer_size);
+    info!("Confirmation poll interval: {}ms", config.confirmation_poll_interval_ms);
     info!("Retry max attempts: {}", config.retry_max_attempts);
 
     let cancellation_token = CancellationToken::new();

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -23,7 +23,10 @@ pub async fn run(
     info!("Poll interval: {:?}", config.db_poll_interval);
     info!("Batch size: {}", config.batch_size);
     info!("Channel buffer size: {}", config.channel_buffer_size);
-    info!("Confirmation poll interval: {}ms", config.confirmation_poll_interval_ms);
+    info!(
+        "Confirmation poll interval: {}ms",
+        config.confirmation_poll_interval_ms
+    );
     info!("Retry max attempts: {}", config.retry_max_attempts);
 
     let cancellation_token = CancellationToken::new();

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{info, info_span, Instrument};
+use tracing::{debug, info, info_span, Instrument};
 
 pub struct ProcessorState {
     pub admin_pubkey: Pubkey,
@@ -275,6 +275,7 @@ pub async fn process_deposit_funds(
         let span = info_span!("process", trace_id = %transaction.trace_id, txn_id = transaction.id);
 
         async {
+            let proc_t0 = tokio::time::Instant::now();
             let mint =
                 Pubkey::from_str(&transaction.mint).map_err(|e| OperatorError::InvalidPubkey {
                     pubkey: transaction.mint.clone(),
@@ -303,7 +304,8 @@ pub async fn process_deposit_funds(
                 .amount(transaction.amount as u64)
                 .idempotency_memo(mint_idempotency_memo(transaction.id));
 
-            info!("Processing deposit");
+            let proc_elapsed_ms = proc_t0.elapsed().as_millis();
+            info!(proc_elapsed_ms, "Processing deposit");
 
             let wrapped = TransactionBuilder::Mint(Box::new(MintToBuilderWithTxnId {
                 builder,
@@ -311,9 +313,19 @@ pub async fn process_deposit_funds(
                 trace_id: transaction.trace_id.clone(),
             }));
 
+            let send_t0 = tokio::time::Instant::now();
             send_guaranteed(&sender_tx, wrapped, "processed deposit")
                 .await
                 .map_err(OperatorError::ChannelSend)?;
+            let send_elapsed_ms = send_t0.elapsed().as_millis();
+            // Any wait >1ms means the sender channel is full — sender is the bottleneck.
+            if send_elapsed_ms > 1 {
+                debug!(
+                    send_elapsed_ms,
+                    sender_capacity = sender_tx.capacity(),
+                    "Processor blocked sending to sender (sender back-pressure)"
+                );
+            }
 
             Ok::<(), OperatorError>(())
         }

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -19,11 +19,13 @@ use solana_sdk::commitment_config::CommitmentLevel;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::time::{interval, Duration};
-use tracing::{error, info};
+use tracing::{debug, error, info, warn};
 
 use proof::take_pending_rotation_if_ready;
-use transaction::handle_transaction_submission;
-use types::SenderState;
+use transaction::{
+    handle_transaction_submission, poll_in_flight, route_poll_results, run_poll_task,
+};
+use types::{PollTaskResult, SenderState, MAX_IN_FLIGHT};
 
 /// Sends transactions to the blockchain and updates their status
 ///
@@ -66,20 +68,80 @@ pub async fn run_sender(
     // Periodic check for pending rotation (every 500ms)
     let mut rotation_check_interval = interval(Duration::from_millis(500));
 
+    // Channel for the poll task to deliver batched confirmation results back to the sender loop.
+    let (poll_result_tx, mut poll_result_rx) = mpsc::channel(32);
+
+    // Separate shutdown token for the poll task
+    let poll_shutdown = tokio_util::sync::CancellationToken::new();
+
+    // Spawn the dedicated poll task.
+    //
+    // The task handles confirmed-success entirely in-task (fires storage update +
+    // metric) and pushes unconfirmed entries straight back to `in_flight`.  Only
+    // on-chain errors and confirmation timeouts — rare events — come back via
+    // `poll_result_rx` as `PollTaskResult::NeedsRouting`.
+    // The task blocks on `in_flight.notify` when the queue is empty — zero CPU idle.
+    let poll_task_handle = tokio::spawn(run_poll_task(
+        state.in_flight.clone(),
+        poll_result_tx,
+        state.rpc_client.clone(),
+        storage_tx.clone(),
+        config.program_type,
+        state.confirmation_poll_interval_ms,
+        poll_shutdown.clone(),
+    ));
+
     loop {
         tokio::select! {
             _ = cancellation_token.cancelled() => {
                 info!("Sender received cancellation signal, draining pipeline...");
-                // Continue processing until processor closes the channel
-                // This ensures all messages sent by processor before shutdown are handled
+                // Drain processor channel so all pending txs are submitted.
                 let mut drained_count = 0;
                 while let Some(tx_builder) = processor_rx.recv().await {
                     handle_transaction_submission(&mut state, tx_builder, &storage_tx).await;
                     drained_count += 1;
                 }
-                info!("Sender drained {} remaining transactions", drained_count);
+                info!("Sender drained {} new transactions from channel", drained_count);
+                // Wait for any fire-and-forget txs to confirm before exiting.
+                // The poll task has already been cancelled; drain_in_flight calls
+                // poll_in_flight directly (single-cycle, no dedicated task needed).
+                drain_in_flight(&mut state, &storage_tx).await;
                 break;
             }
+
+            // Receive results from the dedicated poll task.
+            //
+            // In the common case this arm carries only `ConfirmedSuccess` items
+            // (O(1) mint_builders cleanup each).  `NeedsRouting` items — on-chain
+            // errors and confirmation timeouts — are rare and go through the full
+            // route_poll_results path.
+            Some(results) = poll_result_rx.recv() => {
+                let mut to_route = Vec::new();
+                let mut confirmed_count = 0usize;
+                for result in results {
+                    match result {
+                        PollTaskResult::ConfirmedSuccess(txn_id) => {
+                            confirmed_count += 1;
+                            if let Some(id) = txn_id {
+                                state.mint_builders.remove(&id);
+                            }
+                        }
+                        PollTaskResult::NeedsRouting(tx, status) => {
+                            to_route.push((tx, status));
+                        }
+                    }
+                }
+                debug!(
+                    confirmed = confirmed_count,
+                    needs_routing = to_route.len(),
+                    in_flight = state.in_flight.len(),
+                    "Poll results received from poll task"
+                );
+                if !to_route.is_empty() {
+                    route_poll_results(&mut state, to_route, &storage_tx).await;
+                }
+            }
+
             _ = rotation_check_interval.tick() => {
                 // Check if pending rotation can now be executed
                 if let Some(rotation_builder) = take_pending_rotation_if_ready(&mut state) {
@@ -107,19 +169,82 @@ pub async fn run_sender(
                     handle_transaction_submission(&mut state, tx_builder, &storage_tx).await;
                 }
             }
-            tx_builder = processor_rx.recv() => {
+
+            // Back-pressure: stop consuming new transactions when in_flight is full.
+            // The channel fills up → processor blocks → fetcher stops polling the DB.
+            // Resumes automatically once the poll task confirms entries and drains the queue.
+            tx_builder = processor_rx.recv(), if state.in_flight.len() < MAX_IN_FLIGHT => {
                 if let Some(tx_builder) = tx_builder {
+                    let in_flight_len = state.in_flight.len();
+                    debug!(
+                        in_flight = in_flight_len,
+                        processor_channel_capacity = processor_rx.len(),
+                        "Sender received transaction from processor"
+                    );
                     handle_transaction_submission(&mut state, tx_builder, &storage_tx).await;
                 } else {
                     info!("Sender channel closed");
+                    // Wait for any fire-and-forget txs to confirm before exiting.
+                    drain_in_flight(&mut state, &storage_tx).await;
                     break;
                 }
             }
         }
     }
 
+    // Shut down the poll task regardless of which exit path fired.
+    poll_shutdown.cancel();
+    drop(poll_result_rx);
+    let _ = poll_task_handle.await;
+
     info!("Sender stopped gracefully");
     Ok(())
+}
+
+/// Wait for all in-flight fire-and-forget transactions to reach a terminal state.
+///
+/// Polls at state.confirmation_poll_interval_ms intervals with a 30-second wall-clock timeout.  Called on both
+/// graceful shutdown paths (cancellation and channel close) so no confirmed Mint
+/// transactions are orphaned at process exit.
+///
+/// If the timeout expires with entries still in-flight, a warning is logged and
+/// the operator exits anyway — on restart the processor will re-emit any transactions
+/// that lack a terminal DB status, and the idempotency memo check will prevent
+/// duplicate mints if the original tx did land.
+async fn drain_in_flight(
+    state: &mut SenderState,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) {
+    if state.in_flight.is_empty() {
+        return;
+    }
+
+    info!(
+        count = state.in_flight.len(),
+        "Draining in-flight transactions before shutdown"
+    );
+
+    let timeout_at = tokio::time::Instant::now() + Duration::from_secs(30);
+
+    while !state.in_flight.is_empty() {
+        if tokio::time::Instant::now() >= timeout_at {
+            warn!(
+                count = state.in_flight.len(),
+                "Shutdown drain timeout — {} in-flight transactions unresolved; \
+                 they will be re-processed on restart",
+                state.in_flight.len(),
+            );
+            return;
+        }
+
+        poll_in_flight(state, storage_tx).await;
+
+        if !state.in_flight.is_empty() {
+            tokio::time::sleep(Duration::from_millis(state.confirmation_poll_interval_ms)).await;
+        }
+    }
+
+    info!("All in-flight transactions resolved");
 }
 
 #[cfg(test)]
@@ -127,12 +252,76 @@ mod tests {
     use super::*;
     use crate::config::DEFAULT_CONFIRMATION_POLL_INTERVAL_MS;
     use crate::config::{PostgresConfig, ProgramType, StorageType};
+    use crate::operator::sender::types::{
+        InFlightQueue, InFlightTx, InstructionWithSigners, SenderState, TransactionContext,
+    };
+    use crate::operator::utils::instruction_util::{ExtraErrorCheckPolicy, RetryPolicy};
+    use crate::operator::utils::rpc_util::{RetryConfig, RpcClientWithRetry};
+    use crate::operator::MintCache;
     use crate::storage::common::storage::mock::MockStorage;
     use crate::ContraIndexerConfig;
-    use solana_sdk::commitment_config::CommitmentLevel;
+    use solana_keychain::Signer;
+    use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
+    use solana_sdk::pubkey::Pubkey;
+    use solana_sdk::signature::Signature;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
+
+    fn make_sender_state(rpc_url: &str) -> SenderState {
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let rpc_client = Arc::new(RpcClientWithRetry::with_retry_config(
+            rpc_url.to_string(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: std::time::Duration::from_millis(1),
+                max_delay: std::time::Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        ));
+        SenderState {
+            rpc_client: rpc_client.clone(),
+            storage: storage.clone(),
+            instance_pda: None,
+            smt_state: None,
+            retry_counts: HashMap::new(),
+            mint_builders: HashMap::new(),
+            mint_cache: MintCache::new(storage),
+            retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 1,
+            rotation_retry_queue: Vec::new(),
+            pending_rotation: None,
+            program_type: ProgramType::Escrow,
+            remint_cache: HashMap::new(),
+            pending_signatures: HashMap::new(),
+            pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
+        }
+    }
+
+    fn make_in_flight_tx(txn_id: i64) -> InFlightTx {
+        InFlightTx {
+            signature: Signature::new_unique(),
+            ctx: TransactionContext {
+                transaction_id: Some(txn_id),
+                withdrawal_nonce: None,
+                trace_id: None,
+            },
+            instruction: InstructionWithSigners {
+                instructions: vec![],
+                fee_payer: Pubkey::default(),
+                signers: Vec::<&'static Signer>::new(),
+                compute_unit_price: None,
+                compute_budget: None,
+            },
+            compute_unit_price: None,
+            retry_policy: RetryPolicy::None,
+            extra_error_checks_policy: ExtraErrorCheckPolicy::None,
+            poll_attempts: 0,
+            resend_count: 0,
+        }
+    }
 
     fn minimal_config() -> ContraIndexerConfig {
         ContraIndexerConfig {
@@ -210,5 +399,76 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
+    }
+
+    // ── drain_in_flight ───────────────────────────────────────────────
+
+    /// An empty in-flight queue must return immediately without any RPC calls or
+    /// storage updates.
+    #[tokio::test]
+    async fn drain_in_flight_empty_queue_returns_immediately() {
+        let mut state = make_sender_state("http://localhost:8899");
+        assert!(state.in_flight.is_empty());
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        drain_in_flight(&mut state, &storage_tx).await;
+
+        assert!(state.in_flight.is_empty());
+        assert!(storage_rx.try_recv().is_err(), "no storage update expected");
+    }
+
+    /// When in-flight entries never confirm, drain_in_flight must stop after the
+    /// 30-second wall-clock timeout and log a warning rather than hanging forever.
+    #[tokio::test(start_paused = true)]
+    async fn drain_in_flight_timeout_exits_with_unresolved_entries() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Always return null — entry never confirms.
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": { "context": {"slot": 1}, "value": [null] }
+                })
+                .to_string(),
+            )
+            .expect_at_least(1)
+            .create();
+
+        let mut state = make_sender_state(&server.url());
+        state.confirmation_poll_interval_ms = 100;
+        state.in_flight.push(make_in_flight_tx(1));
+
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        let drain = tokio::spawn(async move {
+            drain_in_flight(&mut state, &storage_tx).await;
+            state.in_flight.len() // return remaining count to assert on
+        });
+
+        // Yield once so the spawned task starts and computes `timeout_at` based on
+        // time=0 (before we advance).  After this yield drain is blocked inside
+        // poll_in_flight awaiting the RPC response.
+        tokio::task::yield_now().await;
+
+        // Advance the mock clock past the 30-second timeout.  The pending 100ms
+        // sleep inside drain_in_flight will also be resolved by this advance.
+        tokio::time::advance(Duration::from_secs(31)).await;
+
+        let remaining = tokio::time::timeout(Duration::from_secs(5), drain)
+            .await
+            .expect("drain must complete after timeout advance")
+            .expect("task must not panic");
+
+        assert_eq!(
+            remaining, 1,
+            "unresolved entry must still be in in_flight after timeout"
+        );
     }
 }

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -25,7 +25,7 @@ use proof::take_pending_rotation_if_ready;
 use transaction::{
     handle_transaction_submission, poll_in_flight, route_poll_results, run_poll_task,
 };
-use types::{PollTaskResult, SenderState, MAX_IN_FLIGHT};
+use types::{PollTaskResult, SenderState};
 
 /// Sends transactions to the blockchain and updates their status
 ///
@@ -102,9 +102,13 @@ pub async fn run_sender(
                     drained_count += 1;
                 }
                 info!("Sender drained {} new transactions from channel", drained_count);
-                // Wait for any fire-and-forget txs to confirm before exiting.
-                // The poll task has already been cancelled; drain_in_flight calls
-                // poll_in_flight directly (single-cycle, no dedicated task needed).
+                // Stop the poll task before draining so it no longer races with
+                // drain_in_flight over state.in_flight entries.  Any NeedsRouting
+                // results it may have queued in poll_result_rx are discarded — those
+                // transactions remain in Processing and are recovered on restart.
+                poll_shutdown.cancel();
+                drop(poll_result_rx);
+                let _ = poll_task_handle.await;
                 drain_in_flight(&mut state, &storage_tx).await;
                 break;
             }
@@ -127,7 +131,7 @@ pub async fn run_sender(
                             }
                         }
                         PollTaskResult::NeedsRouting(tx, status) => {
-                            to_route.push((tx, status));
+                            to_route.push((*tx, status));
                         }
                     }
                 }
@@ -171,31 +175,32 @@ pub async fn run_sender(
             }
 
             // Back-pressure: stop consuming new transactions when in_flight is full.
+            // `available_permits()` reflects both in-flight entries AND spawned send
+            // tasks that have not yet pushed to the queue, so this guard is tight.
             // The channel fills up → processor blocks → fetcher stops polling the DB.
-            // Resumes automatically once the poll task confirms entries and drains the queue.
-            tx_builder = processor_rx.recv(), if state.in_flight.len() < MAX_IN_FLIGHT => {
+            // Resumes automatically once the poll task confirms entries and permits are returned.
+            tx_builder = processor_rx.recv(), if state.semaphore.available_permits() > 0 => {
                 if let Some(tx_builder) = tx_builder {
-                    let in_flight_len = state.in_flight.len();
                     debug!(
-                        in_flight = in_flight_len,
+                        in_flight = state.in_flight.len(),
+                        available_permits = state.semaphore.available_permits(),
                         processor_channel_capacity = processor_rx.len(),
                         "Sender received transaction from processor"
                     );
                     handle_transaction_submission(&mut state, tx_builder, &storage_tx).await;
                 } else {
                     info!("Sender channel closed");
-                    // Wait for any fire-and-forget txs to confirm before exiting.
+                    // Stop the poll task before draining (same reasoning as the
+                    // cancellation path above — prevent races over in_flight).
+                    poll_shutdown.cancel();
+                    drop(poll_result_rx);
+                    let _ = poll_task_handle.await;
                     drain_in_flight(&mut state, &storage_tx).await;
                     break;
                 }
             }
         }
     }
-
-    // Shut down the poll task regardless of which exit path fired.
-    poll_shutdown.cancel();
-    drop(poll_result_rx);
-    let _ = poll_task_handle.await;
 
     info!("Sender stopped gracefully");
     Ok(())
@@ -254,6 +259,7 @@ mod tests {
     use crate::config::{PostgresConfig, ProgramType, StorageType};
     use crate::operator::sender::types::{
         InFlightQueue, InFlightTx, InstructionWithSigners, SenderState, TransactionContext,
+        MAX_IN_FLIGHT,
     };
     use crate::operator::utils::instruction_util::{ExtraErrorCheckPolicy, RetryPolicy};
     use crate::operator::utils::rpc_util::{RetryConfig, RpcClientWithRetry};
@@ -266,7 +272,7 @@ mod tests {
     use solana_sdk::signature::Signature;
     use std::collections::HashMap;
     use std::sync::Arc;
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, Semaphore};
     use tokio_util::sync::CancellationToken;
 
     fn make_sender_state(rpc_url: &str) -> SenderState {
@@ -297,6 +303,7 @@ mod tests {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 
@@ -320,6 +327,9 @@ mod tests {
             extra_error_checks_policy: ExtraErrorCheckPolicy::None,
             poll_attempts: 0,
             resend_count: 0,
+            permit: Arc::new(Semaphore::new(MAX_IN_FLIGHT))
+                .try_acquire_owned()
+                .unwrap(),
         }
     }
 

--- a/indexer/src/operator/sender/proof.rs
+++ b/indexer/src/operator/sender/proof.rs
@@ -7,6 +7,8 @@ use solana_keychain::Signer;
 use solana_sdk::pubkey::Pubkey;
 use tracing::{error, info, warn};
 
+#[cfg(test)]
+use super::types::InFlightQueue;
 use super::types::{InstructionWithSigners, SenderSMTState, SenderState, TransactionContext};
 
 impl SenderSMTState {
@@ -236,6 +238,7 @@ mod tests {
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
         }
     }
 

--- a/indexer/src/operator/sender/proof.rs
+++ b/indexer/src/operator/sender/proof.rs
@@ -211,7 +211,9 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use crate::operator::sender::types::MAX_IN_FLIGHT;
     use crate::operator::utils::instruction_util::WithdrawalRemintInfo;
+    use tokio::sync::Semaphore;
 
     /// Build a minimal SenderState for testing (no RPC needed)
     fn make_sender_state() -> SenderState {
@@ -239,6 +241,7 @@ mod tests {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -1,4 +1,6 @@
 use super::types::SenderState;
+#[cfg(test)]
+use super::types::InFlightQueue;
 use crate::{
     channel_utils::send_guaranteed,
     operator::{
@@ -350,6 +352,7 @@ mod tests {
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
         }
     }
 
@@ -393,6 +396,7 @@ mod tests {
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
         }
     }
 

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -1,6 +1,6 @@
-use super::types::SenderState;
 #[cfg(test)]
 use super::types::InFlightQueue;
+use super::types::SenderState;
 use crate::{
     channel_utils::send_guaranteed,
     operator::{
@@ -308,7 +308,9 @@ pub async fn process_pending_remints(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::operator::sender::types::{PendingRemint, SenderState, TransactionContext};
+    use crate::operator::sender::types::{
+        PendingRemint, SenderState, TransactionContext, MAX_IN_FLIGHT,
+    };
     use crate::operator::utils::instruction_util::WithdrawalRemintInfo;
     use crate::operator::MintCache;
     use crate::storage::common::storage::mock::MockStorage;
@@ -316,7 +318,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::Once;
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, Semaphore};
 
     static INIT_TEST_SIGNER: Once = Once::new();
     fn ensure_test_signer() {
@@ -353,6 +355,7 @@ mod tests {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 
@@ -397,6 +400,7 @@ mod tests {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -17,10 +17,10 @@ use spl_associated_token_account::get_associated_token_address_with_program_id;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Semaphore};
 use tracing::{error, info};
 
-use super::types::{InFlightQueue, SenderSMTState, SenderState};
+use super::types::{InFlightQueue, SenderSMTState, SenderState, MAX_IN_FLIGHT};
 
 impl SenderState {
     pub(super) fn new(
@@ -61,6 +61,7 @@ impl SenderState {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         })
     }
 
@@ -322,7 +323,6 @@ impl SenderState {
 
         Ok(())
     }
-
 }
 
 #[cfg(test)]
@@ -361,6 +361,7 @@ mod tests {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 
@@ -815,6 +816,7 @@ mod tests {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 
@@ -900,4 +902,3 @@ mod tests {
         assert_eq!(state.retry_max_attempts, 5);
     }
 }
-

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{error, info};
 
-use super::types::{SenderSMTState, SenderState};
+use super::types::{InFlightQueue, SenderSMTState, SenderState};
 
 impl SenderState {
     pub(super) fn new(
@@ -60,6 +60,7 @@ impl SenderState {
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
         })
     }
 
@@ -291,7 +292,7 @@ impl SenderState {
 
             let remint_info = WithdrawalRemintInfo {
                 transaction_id: tx.id,
-                trace_id: tx.trace_id,
+                trace_id: tx.trace_id.clone(),
                 mint,
                 user,
                 user_ata,
@@ -321,6 +322,7 @@ impl SenderState {
 
         Ok(())
     }
+
 }
 
 #[cfg(test)]
@@ -358,6 +360,7 @@ mod tests {
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
         }
     }
 
@@ -811,6 +814,7 @@ mod tests {
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
         }
     }
 
@@ -896,3 +900,4 @@ mod tests {
         assert_eq!(state.retry_max_attempts, 5);
     }
 }
+

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -17,7 +17,7 @@ use contra_metrics::MetricLabel;
 use solana_keychain::SolanaSigner;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::signature::Signature;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tracing::{error, info, info_span, warn, Instrument};
 
 use super::mint::{
@@ -191,17 +191,15 @@ pub async fn handle_transaction_submission(
                 // proof ordering requires at-most-one in-flight withdrawal at a time.
                 match &tx_builder {
                     TransactionBuilder::Mint(_) | TransactionBuilder::InitializeMint(_) => {
-                        fire_and_store(
+                        spawn_fire_and_store(
                             state,
                             instruction,
                             compute_unit_price,
                             ctx.clone(),
                             retry_policy,
                             extra_error_checks_policy,
-                            storage_tx,
-                            0,
-                        )
-                        .await;
+                            storage_tx.clone(),
+                        );
                     }
                     _ => {
                         send_and_confirm(
@@ -727,12 +725,13 @@ pub(super) async fn handle_permanent_failure(
 
 /// Sign, send, and store a Mint or InitializeMint tx in `state.in_flight`.
 ///
-/// The confirmation step is deferred: `poll_in_flight` checks all in-flight signatures
-/// on each timer tick via one batched `getSignatureStatuses` call, so the sender loop
-/// can accept new transactions immediately without waiting for confirmation.
+/// Called from the `route_poll_results` retry path where the caller already holds a
+/// semaphore permit (carried inside the timed-out `InFlightTx`).  The permit transfers
+/// to the new `InFlightTx` on success, or is dropped (slot released) on send failure.
 ///
-/// On send failure the tx routes directly to `handle_permanent_failure` — no signature
-/// means we can't safely check idempotency later, so the failure is declared permanent.
+/// New incoming transactions use `spawn_fire_and_store` instead, which acquires the
+/// permit and offloads the blocking send to a background task.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn fire_and_store(
     state: &mut SenderState,
     instruction: InstructionWithSigners,
@@ -742,24 +741,8 @@ pub(super) async fn fire_and_store(
     extra_error_checks_policy: ExtraErrorCheckPolicy,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     resend_count: u32,
+    permit: OwnedSemaphorePermit,
 ) {
-    // Safety net: in normal operation the select! guard in run_sender prevents this
-    // branch from being reached for new incoming transactions.  It can still fire for
-    // idempotent retries emitted by route_poll_results.  Leave the DB status unchanged
-    // so the fetcher can re-emit the transaction on the next poll cycle — permanent
-    // failure here would silently lose deposits.
-    if state.in_flight.len() >= MAX_IN_FLIGHT {
-        metrics::OPERATOR_TRANSACTION_ERRORS
-            .with_label_values(&[state.program_type.as_label(), "in_flight_cap_exceeded"])
-            .inc();
-        warn!(
-            "In-flight cap ({MAX_IN_FLIGHT}) reached — skipping send for txn {:?}; \
-             DB status unchanged, will be re-fetched",
-            ctx.transaction_id,
-        );
-        return;
-    }
-
     let pt = state.program_type.as_label();
     let send_start = std::time::Instant::now();
 
@@ -781,9 +764,11 @@ pub(super) async fn fire_and_store(
                 extra_error_checks_policy,
                 poll_attempts: 0,
                 resend_count,
+                permit,
             });
         }
         Err(e) => {
+            drop(permit);
             metrics::OPERATOR_RPC_SEND_DURATION
                 .with_label_values(&[pt, "error"])
                 .observe(send_start.elapsed().as_secs_f64());
@@ -794,6 +779,82 @@ pub(super) async fn fire_and_store(
             handle_permanent_failure(state, &ctx, storage_tx, &e.to_string()).await;
         }
     }
+}
+
+/// Acquire a semaphore permit and spawn a background task that signs and sends
+/// the transaction without blocking the sender loop's `recv` arm.
+///
+/// The permit is held from acquisition until the entry reaches a terminal state:
+///  - **Success**: permit moves into `InFlightTx` in `in_flight`; dropped when the
+///    poll task (or drain loop) confirms the tx.
+///  - **Send error**: permit dropped before reporting the failure to storage.
+///
+/// Returns `false` if the semaphore is already at `MAX_IN_FLIGHT` capacity.  The DB
+/// status is left unchanged so the fetcher re-emits the transaction on the next poll
+/// cycle.
+pub(super) fn spawn_fire_and_store(
+    state: &SenderState,
+    instruction: InstructionWithSigners,
+    compute_unit_price: Option<u64>,
+    ctx: TransactionContext,
+    retry_policy: RetryPolicy,
+    extra_error_checks_policy: ExtraErrorCheckPolicy,
+    storage_tx: mpsc::Sender<TransactionStatusUpdate>,
+) -> bool {
+    let permit = match Arc::clone(&state.semaphore).try_acquire_owned() {
+        Ok(p) => p,
+        Err(_) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[state.program_type.as_label(), "in_flight_cap_exceeded"])
+                .inc();
+            warn!(
+                "In-flight cap ({MAX_IN_FLIGHT}) reached — skipping send for txn {:?}; \
+                 DB status unchanged, will be re-fetched",
+                ctx.transaction_id,
+            );
+            return false;
+        }
+    };
+
+    let rpc_client = state.rpc_client.clone();
+    let in_flight = state.in_flight.clone();
+    let program_type = state.program_type;
+
+    tokio::spawn(async move {
+        let send_start = std::time::Instant::now();
+        match sign_and_send_transaction(rpc_client, instruction.clone(), retry_policy).await {
+            Ok(signature) => {
+                metrics::OPERATOR_RPC_SEND_DURATION
+                    .with_label_values(&[program_type.as_label(), "in_flight"])
+                    .observe(send_start.elapsed().as_secs_f64());
+                info!("Transaction sent: {}", signature);
+                in_flight.push(InFlightTx {
+                    signature,
+                    ctx,
+                    instruction,
+                    compute_unit_price,
+                    retry_policy,
+                    extra_error_checks_policy,
+                    poll_attempts: 0,
+                    resend_count: 0,
+                    permit,
+                });
+            }
+            Err(e) => {
+                drop(permit);
+                metrics::OPERATOR_RPC_SEND_DURATION
+                    .with_label_values(&[program_type.as_label(), "error"])
+                    .observe(send_start.elapsed().as_secs_f64());
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[program_type.as_label(), "rpc_send_error"])
+                    .inc();
+                error!("Failed to send transaction (fire-and-forget): {}", e);
+                send_fatal_error(&storage_tx, &ctx, &e.to_string()).await;
+            }
+        }
+    });
+
+    true
 }
 
 /// Route a batch of `(InFlightTx, Option<TransactionStatus>)` pairs returned by a
@@ -908,6 +969,7 @@ pub(super) async fn route_poll_results(
                                     tx.extra_error_checks_policy,
                                     storage_tx,
                                     next_resend,
+                                    tx.permit, // transfer permit to new InFlightTx
                                 )
                                 .await;
                             }
@@ -1080,7 +1142,7 @@ pub(super) async fn run_poll_task(
                     } else {
                         // ── Confirmed with on-chain error ─────────────────────────────
                         // Needs SenderState for error routing (cleanup, remint, etc.).
-                        results.push(PollTaskResult::NeedsRouting(tx, Some(status)));
+                        results.push(PollTaskResult::NeedsRouting(Box::new(tx), Some(status)));
                     }
                 }
                 _ => {
@@ -1091,7 +1153,7 @@ pub(super) async fn run_poll_task(
                     if tx.poll_attempts + 1 >= MAX_POLL_ATTEMPTS_CONFIRMATION {
                         // Do NOT increment here; route_poll_results will increment it
                         // to MAX and fire the timeout branch.
-                        results.push(PollTaskResult::NeedsRouting(tx, None));
+                        results.push(PollTaskResult::NeedsRouting(Box::new(tx), None));
                     } else {
                         tx.poll_attempts += 1;
                         in_flight.push(tx);
@@ -1151,6 +1213,7 @@ mod tests {
     use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
     use std::sync::Arc;
+    use tokio::sync::Semaphore;
 
     fn dummy_instruction() -> InstructionWithSigners {
         InstructionWithSigners {
@@ -1187,6 +1250,7 @@ mod tests {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 
@@ -1219,6 +1283,7 @@ mod tests {
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 
@@ -2062,6 +2127,7 @@ mod tests {
                 pending_signatures: HashMap::new(),
                 pending_remints: Vec::new(),
                 in_flight: InFlightQueue::new(),
+                semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
             }
         };
 
@@ -2081,6 +2147,9 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             &storage_tx,
             0,
+            Arc::new(Semaphore::new(MAX_IN_FLIGHT))
+                .try_acquire_owned()
+                .unwrap(),
         )
         .await;
 
@@ -2172,6 +2241,7 @@ mod tests {
                 pending_signatures: HashMap::new(),
                 pending_remints: Vec::new(),
                 in_flight: InFlightQueue::new(),
+                semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
             }
         };
 
@@ -2191,6 +2261,9 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             &storage_tx,
             0,
+            Arc::new(Semaphore::new(MAX_IN_FLIGHT))
+                .try_acquire_owned()
+                .unwrap(),
         )
         .await;
 
@@ -2224,6 +2297,9 @@ mod tests {
             extra_error_checks_policy: ExtraErrorCheckPolicy::None,
             poll_attempts: 0,
             resend_count: 0,
+            permit: Arc::new(Semaphore::new(MAX_IN_FLIGHT))
+                .try_acquire_owned()
+                .unwrap(),
         }
     }
 
@@ -2290,6 +2366,7 @@ mod tests {
                 q.push(make_in_flight_tx(sig, 77));
                 q
             },
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         };
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
@@ -2365,6 +2442,7 @@ mod tests {
                 q.push(make_in_flight_tx(sig, 88));
                 q
             },
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         };
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
@@ -2436,6 +2514,7 @@ mod tests {
                 q.push(make_in_flight_tx(sig, 99));
                 q
             },
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         };
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
@@ -2518,6 +2597,7 @@ mod tests {
                 q.push(tx);
                 q
             },
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         };
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
@@ -2630,6 +2710,7 @@ mod tests {
                 q.push(make_in_flight_tx(sig2, 202));
                 q
             },
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         };
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
@@ -2775,23 +2856,21 @@ mod tests {
         );
     }
 
-    // ── fire_and_store: cap exceeded ──────────────────────────────────
+    // ── spawn_fire_and_store: cap enforcement ─────────────────────────
 
-    /// When the in-flight queue is at MAX_IN_FLIGHT, fire_and_store must return
-    /// without emitting any storage update — DB stays unchanged so the fetcher
-    /// can re-emit the transaction on the next poll cycle.
+    /// When the semaphore is exhausted (all MAX_IN_FLIGHT slots occupied),
+    /// `spawn_fire_and_store` must return `false` without spawning any task
+    /// or emitting any storage update. DB status stays unchanged so the
+    /// fetcher can re-emit the transaction on the next poll cycle.
     #[tokio::test]
-    async fn fire_and_store_cap_exceeded_emits_no_storage_update() {
-        let mut state = make_sender_state();
+    async fn spawn_fire_and_store_cap_exhausted_returns_false() {
+        let state = make_sender_state();
 
-        // Fill the queue to the cap.
-        {
-            let mut entries = state.in_flight.entries.lock().unwrap();
-            for i in 0..MAX_IN_FLIGHT {
-                entries.push(make_in_flight_tx(Signature::new_unique(), i as i64));
-            }
-        }
-        assert_eq!(state.in_flight.len(), MAX_IN_FLIGHT);
+        // Hold all permits — simulates MAX_IN_FLIGHT tasks in-flight.
+        let _permits: Vec<_> = (0..MAX_IN_FLIGHT)
+            .map(|_| state.semaphore.clone().try_acquire_owned().unwrap())
+            .collect();
+        assert_eq!(state.semaphore.available_permits(), 0);
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
         let ctx = TransactionContext {
@@ -2800,22 +2879,56 @@ mod tests {
             trace_id: None,
         };
 
-        fire_and_store(
-            &mut state,
+        let result = spawn_fire_and_store(
+            &state,
             dummy_instruction(),
             None,
             ctx,
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
-            &storage_tx,
-            0,
-        )
-        .await;
+            storage_tx,
+        );
 
-        // Queue must be unchanged — no new entry pushed.
-        assert_eq!(state.in_flight.len(), MAX_IN_FLIGHT);
-        // No storage update must have been emitted.
+        assert!(!result, "must return false when at capacity");
+        // Yield to ensure any erroneously spawned tasks have time to run.
+        tokio::task::yield_now().await;
         assert!(storage_rx.try_recv().is_err(), "no storage update expected");
+        // Queue stays empty — no entry pushed.
+        assert!(state.in_flight.is_empty());
+    }
+
+    /// When capacity is available, `spawn_fire_and_store` must return `true` and
+    /// the permit must be consumed immediately (before the RPC call completes),
+    /// so back-pressure is applied as soon as the task starts, not after it finishes.
+    #[tokio::test]
+    async fn spawn_fire_and_store_available_capacity_returns_true_and_consumes_permit() {
+        let state = make_sender_state();
+        assert_eq!(state.semaphore.available_permits(), MAX_IN_FLIGHT);
+
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        let result = spawn_fire_and_store(
+            &state,
+            dummy_instruction(),
+            None,
+            TransactionContext {
+                transaction_id: Some(1),
+                withdrawal_nonce: None,
+                trace_id: None,
+            },
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+        );
+
+        assert!(result, "must return true when capacity is available");
+        // Permit must be consumed before spawn returns — regardless of whether
+        // the RPC call has completed yet.
+        assert_eq!(
+            state.semaphore.available_permits(),
+            MAX_IN_FLIGHT - 1,
+            "one permit must be held by the spawned task"
+        );
     }
 
     // ── run_poll_task: cancellation ───────────────────────────────────

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1,9 +1,15 @@
 use crate::channel_utils::send_guaranteed;
+use crate::config::ProgramType;
 use crate::error::{OperatorError, ProgramError};
 use crate::metrics;
 use crate::operator::utils::instruction_util::TransactionBuilder;
-use crate::operator::utils::transaction_util::{check_transaction_status, ConfirmationResult};
-use crate::operator::{sign_and_send_transaction, ExtraErrorCheckPolicy, RetryPolicy};
+use crate::operator::utils::transaction_util::parse_program_error;
+use crate::operator::utils::transaction_util::{
+    check_transaction_status, ConfirmationResult, MAX_POLL_ATTEMPTS_CONFIRMATION,
+};
+use crate::operator::{
+    sign_and_send_transaction, ExtraErrorCheckPolicy, RetryPolicy, RpcClientWithRetry,
+};
 use crate::storage::common::models::TransactionStatus;
 use chrono::Utc;
 use contra_escrow_program_client::errors::ContraEscrowProgramError;
@@ -19,14 +25,19 @@ use super::mint::{
 };
 use super::proof::{cleanup_failed_transaction, rebuild_with_regenerated_proof};
 use super::types::{
-    InstructionWithSigners, PendingRemint, SenderState, TransactionContext, TransactionStatusUpdate,
+    InFlightQueue, InFlightTx, InstructionWithSigners, PendingRemint, PollTaskResult, SenderState,
+    TransactionContext, TransactionStatusUpdate, MAX_IN_FLIGHT,
 };
+
+use std::sync::Arc;
 
 use std::time::Duration;
 
 /// Safety delay before checking finality and reminting.
 /// Solana finalized ≈ 32 slots × 400ms = ~12.8s. We use 2.5× safety factor.
 pub const FINALITY_SAFETY_DELAY: Duration = Duration::from_secs(32);
+
+const MAX_SIGS_PER_CALL: usize = 256;
 
 impl SenderState {
     /// Handle incoming transaction builder (either ReleaseFunds or Mint)
@@ -143,7 +154,8 @@ pub async fn handle_transaction_submission(
     };
     let retry_policy = tx_builder.retry_policy();
     let compute_unit_price = tx_builder.compute_unit_price();
-    let extra_error_checks_policy = &tx_builder.extra_error_checks_policy();
+    // Owned so it can be moved into InFlightTx
+    let extra_error_checks_policy = tx_builder.extra_error_checks_policy();
 
     let span = info_span!(
         "tx",
@@ -173,16 +185,37 @@ pub async fn handle_transaction_submission(
         match state.handle_transaction_builder(tx_builder.clone()).await {
             Ok(instruction) => {
                 info!("Transaction instruction ready for submission");
-                send_and_confirm(
-                    state,
-                    instruction,
-                    compute_unit_price,
-                    &ctx,
-                    retry_policy,
-                    extra_error_checks_policy,
-                    storage_tx,
-                )
-                .await;
+                // Mint and InitializeMint use fire-and-forget: send immediately,
+                // defer confirmation to the batch timer poll in `poll_in_flight`.
+                // ReleaseFunds and ResetSmtRoot use the blocking path because SMT
+                // proof ordering requires at-most-one in-flight withdrawal at a time.
+                match &tx_builder {
+                    TransactionBuilder::Mint(_) | TransactionBuilder::InitializeMint(_) => {
+                        fire_and_store(
+                            state,
+                            instruction,
+                            compute_unit_price,
+                            ctx.clone(),
+                            retry_policy,
+                            extra_error_checks_policy,
+                            storage_tx,
+                            0,
+                        )
+                        .await;
+                    }
+                    _ => {
+                        send_and_confirm(
+                            state,
+                            instruction,
+                            compute_unit_price,
+                            &ctx,
+                            retry_policy,
+                            &extra_error_checks_policy,
+                            storage_tx,
+                        )
+                        .await;
+                    }
+                }
             }
             Err(OperatorError::Program(ProgramError::RotationPending { in_flight_count })) => {
                 info!(
@@ -692,6 +725,387 @@ pub(super) async fn handle_permanent_failure(
     });
 }
 
+/// Sign, send, and store a Mint or InitializeMint tx in `state.in_flight`.
+///
+/// The confirmation step is deferred: `poll_in_flight` checks all in-flight signatures
+/// on each timer tick via one batched `getSignatureStatuses` call, so the sender loop
+/// can accept new transactions immediately without waiting for confirmation.
+///
+/// On send failure the tx routes directly to `handle_permanent_failure` — no signature
+/// means we can't safely check idempotency later, so the failure is declared permanent.
+pub(super) async fn fire_and_store(
+    state: &mut SenderState,
+    instruction: InstructionWithSigners,
+    compute_unit_price: Option<u64>,
+    ctx: TransactionContext,
+    retry_policy: RetryPolicy,
+    extra_error_checks_policy: ExtraErrorCheckPolicy,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    resend_count: u32,
+) {
+    // Safety net: in normal operation the select! guard in run_sender prevents this
+    // branch from being reached for new incoming transactions.  It can still fire for
+    // idempotent retries emitted by route_poll_results.  Leave the DB status unchanged
+    // so the fetcher can re-emit the transaction on the next poll cycle — permanent
+    // failure here would silently lose deposits.
+    if state.in_flight.len() >= MAX_IN_FLIGHT {
+        metrics::OPERATOR_TRANSACTION_ERRORS
+            .with_label_values(&[state.program_type.as_label(), "in_flight_cap_exceeded"])
+            .inc();
+        warn!(
+            "In-flight cap ({MAX_IN_FLIGHT}) reached — skipping send for txn {:?}; \
+             DB status unchanged, will be re-fetched",
+            ctx.transaction_id,
+        );
+        return;
+    }
+
+    let pt = state.program_type.as_label();
+    let send_start = std::time::Instant::now();
+
+    match sign_and_send_transaction(state.rpc_client.clone(), instruction.clone(), retry_policy)
+        .await
+    {
+        Ok(signature) => {
+            metrics::OPERATOR_RPC_SEND_DURATION
+                .with_label_values(&[pt, "in_flight"])
+                .observe(send_start.elapsed().as_secs_f64());
+            info!("Transaction sent: {}", signature);
+            // push() also notifies the poll task if it is waiting on an empty queue.
+            state.in_flight.push(InFlightTx {
+                signature,
+                ctx,
+                instruction,
+                compute_unit_price,
+                retry_policy,
+                extra_error_checks_policy,
+                poll_attempts: 0,
+                resend_count,
+            });
+        }
+        Err(e) => {
+            metrics::OPERATOR_RPC_SEND_DURATION
+                .with_label_values(&[pt, "error"])
+                .observe(send_start.elapsed().as_secs_f64());
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "rpc_send_error"])
+                .inc();
+            error!("Failed to send transaction (fire-and-forget): {}", e);
+            handle_permanent_failure(state, &ctx, storage_tx, &e.to_string()).await;
+        }
+    }
+}
+
+/// Route a batch of `(InFlightTx, Option<TransactionStatus>)` pairs returned by a
+/// `getSignatureStatuses` call.
+///
+/// Called from both `poll_in_flight` (test / shutdown drain path) and the sender
+/// loop's `poll_result_rx` arm (normal production path).
+///
+/// Unconfirmed entries are pushed back into `state.in_flight`, which automatically
+/// re-arms the poll task's `Notify` for the next cycle.
+pub(super) async fn route_poll_results(
+    state: &mut SenderState,
+    results: Vec<(
+        InFlightTx,
+        Option<solana_transaction_status::TransactionStatus>,
+    )>,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) {
+    for (mut tx, status_opt) in results {
+        match status_opt {
+            Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
+                let result = if let Some(err) = &status.err {
+                    let mut extra_result = None;
+                    if let ExtraErrorCheckPolicy::Extra(ref checks) = tx.extra_error_checks_policy {
+                        for check in checks.iter() {
+                            if let Some(r) = check(err) {
+                                extra_result = Some(Ok(r));
+                                break;
+                            }
+                        }
+                    }
+                    extra_result
+                        .unwrap_or_else(|| Ok(ConfirmationResult::Failed(parse_program_error(err))))
+                } else {
+                    Ok(ConfirmationResult::Confirmed)
+                };
+
+                handle_confirmation_result(
+                    state,
+                    result,
+                    tx.signature,
+                    tx.compute_unit_price,
+                    &tx.ctx,
+                    tx.instruction,
+                    tx.retry_policy,
+                    &tx.extra_error_checks_policy,
+                    storage_tx,
+                )
+                .await;
+            }
+            _ => {
+                tx.poll_attempts += 1;
+                if tx.poll_attempts >= MAX_POLL_ATTEMPTS_CONFIRMATION {
+                    match tx.retry_policy {
+                        RetryPolicy::None => {
+                            metrics::OPERATOR_TRANSACTION_ERRORS
+                                .with_label_values(&[
+                                    state.program_type.as_label(),
+                                    "confirmation_timeout_non_idempotent",
+                                ])
+                                .inc();
+                            warn!(
+                                "Confirmation timeout for non-idempotent tx {} after {} polls — permanent failure",
+                                tx.signature, tx.poll_attempts,
+                            );
+                            handle_permanent_failure(
+                                state,
+                                &tx.ctx,
+                                storage_tx,
+                                "Confirmation failed - transaction status unknown, unsafe to retry",
+                            )
+                            .await;
+                        }
+                        RetryPolicy::Idempotent => {
+                            metrics::OPERATOR_TRANSACTION_ERRORS
+                                .with_label_values(&[
+                                    state.program_type.as_label(),
+                                    "confirmation_timeout",
+                                ])
+                                .inc();
+
+                            let next_resend = tx.resend_count + 1;
+                            if next_resend > state.retry_max_attempts {
+                                metrics::OPERATOR_TRANSACTION_ERRORS
+                                    .with_label_values(&[
+                                        state.program_type.as_label(),
+                                        "confirmation_timeout_resend_limit",
+                                    ])
+                                    .inc();
+                                warn!(
+                                    "Confirmation timeout for idempotent tx {} — resend limit ({}) reached, permanent failure",
+                                    tx.signature, state.retry_max_attempts,
+                                );
+                                handle_permanent_failure(
+                                    state,
+                                    &tx.ctx,
+                                    storage_tx,
+                                    "Confirmation timeout: resend limit exceeded",
+                                )
+                                .await;
+                            } else {
+                                warn!(
+                                    "Confirmation timeout for idempotent tx {} after {} polls — re-sending (attempt {}/{})",
+                                    tx.signature, tx.poll_attempts, next_resend, state.retry_max_attempts,
+                                );
+                                fire_and_store(
+                                    state,
+                                    tx.instruction,
+                                    tx.compute_unit_price,
+                                    tx.ctx,
+                                    tx.retry_policy,
+                                    tx.extra_error_checks_policy,
+                                    storage_tx,
+                                    next_resend,
+                                )
+                                .await;
+                            }
+                        }
+                    }
+                } else {
+                    // Still pending — push back into the shared queue.
+                    // push() notifies the poll task so it wakes on the next cycle.
+                    state.in_flight.push(tx);
+                }
+            }
+        }
+    }
+}
+
+/// Single-cycle poll: drain the shared queue, call `getSignatureStatuses`, then
+/// route results via `route_poll_results`.
+///
+/// Used by `drain_in_flight` (shutdown) and by tests.  Normal production polling
+/// is handled by the dedicated `run_poll_task` task so it doesn't block the send loop.
+pub(super) async fn poll_in_flight(
+    state: &mut SenderState,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) {
+    if state.in_flight.is_empty() {
+        return;
+    }
+    let batch = state.in_flight.drain_all();
+    let signatures: Vec<Signature> = batch.iter().map(|t| t.signature).collect();
+    let mut statuses: Vec<Option<_>> = Vec::with_capacity(signatures.len());
+
+    for chunk in signatures.chunks(MAX_SIGS_PER_CALL) {
+        match state.rpc_client.get_signature_statuses(chunk).await {
+            Ok(resp) => statuses.extend(resp.value),
+            Err(e) => {
+                warn!(
+                    "getSignatureStatuses failed ({} in-flight) — will retry next tick: {}",
+                    batch.len(),
+                    e
+                );
+                // Put everything back so the next drain_in_flight iteration retries.
+                for tx in batch {
+                    state.in_flight.push(tx);
+                }
+                return;
+            }
+        }
+    }
+
+    let results: Vec<_> = batch.into_iter().zip(statuses).collect();
+    route_poll_results(state, results, storage_tx).await;
+}
+
+/// Dedicated poll task: sleeps until entries arrive, then batches
+/// `getSignatureStatuses` calls and forwards raw results to the sender loop.
+///
+/// Running in a separate task means `getSignatureStatuses` RPC latency (~50–200 ms)
+/// never blocks the sender from processing new incoming transactions.
+///
+/// # No busy loop
+/// The task waits on `in_flight.notify` (a `tokio::sync::Notify`) before each cycle.
+/// Every `InFlightQueue::push` call fires `notify_one`, which stores at most one permit,
+/// so the task wakes exactly once per "there is work" event even if many entries are
+/// added simultaneously.  When the queue drains to zero and no new entries arrive the
+/// task blocks indefinitely — zero CPU while idle.
+/// Dedicated async task that owns the confirmation polling loop.
+///
+/// Confirmed-success entries are handled entirely within this task:
+/// the `Completed` storage update is sent and `OPERATOR_MINTS_SENT` is
+/// incremented without touching `SenderState`.  Only on-chain errors and
+/// confirmation timeouts — rare events — are forwarded to the sender loop
+/// via `result_tx` as `PollTaskResult::NeedsRouting`.  Unconfirmed entries
+/// are pushed straight back into `in_flight`.
+///
+/// This means the `Some(results) = poll_result_rx.recv()` arm in the main
+/// `select!` loop fires only for exceptions, keeping the common path off the
+/// main task entirely.
+pub(super) async fn run_poll_task(
+    in_flight: Arc<InFlightQueue>,
+    result_tx: mpsc::Sender<Vec<PollTaskResult>>,
+    rpc_client: Arc<RpcClientWithRetry>,
+    storage_tx: mpsc::Sender<TransactionStatusUpdate>,
+    program_type: ProgramType,
+    poll_interval_ms: u64,
+    cancellation_token: tokio_util::sync::CancellationToken,
+) {
+    // Reused across poll cycles to avoid per-cycle heap allocation.
+    // Signature is Copy ([u8; 64]) so extend() is a plain memcopy.
+    let mut signatures: Vec<Signature> = Vec::with_capacity(MAX_IN_FLIGHT);
+
+    loop {
+        // Block until at least one entry is present (no busy loop when idle).
+        tokio::select! {
+            _ = cancellation_token.cancelled() => break,
+            _ = in_flight.notify.notified() => {},
+        }
+
+        // Sleep the poll interval to batch entries that arrive in quick succession.
+        tokio::select! {
+            _ = cancellation_token.cancelled() => break,
+            _ = tokio::time::sleep(tokio::time::Duration::from_millis(poll_interval_ms)) => {},
+        }
+
+        let batch = in_flight.drain_all();
+        if batch.is_empty() {
+            continue;
+        }
+
+        signatures.clear();
+        signatures.extend(batch.iter().map(|t| t.signature));
+        let mut statuses: Vec<Option<_>> = Vec::with_capacity(signatures.len());
+        let mut rpc_ok = true;
+
+        for chunk in signatures.chunks(MAX_SIGS_PER_CALL) {
+            match rpc_client.get_signature_statuses(chunk).await {
+                Ok(resp) => statuses.extend(resp.value),
+                Err(e) => {
+                    warn!(
+                        "getSignatureStatuses failed ({} in-flight) — will retry next tick: {}",
+                        batch.len(),
+                        e
+                    );
+                    rpc_ok = false;
+                    break;
+                }
+            }
+        }
+
+        if !rpc_ok {
+            // Put everything back in one lock acquisition.
+            in_flight.push_all(batch);
+            continue;
+        }
+
+        let mut results: Vec<PollTaskResult> = Vec::with_capacity(batch.len());
+
+        for (mut tx, status_opt) in batch.into_iter().zip(statuses) {
+            match status_opt {
+                Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
+                    if status.err.is_none() {
+                        // ── Confirmed success (hot path) ──────────────────────────────
+                        // Handle entirely here — no need to wake the sender loop.
+                        metrics::OPERATOR_MINTS_SENT
+                            .with_label_values(&[program_type.as_label()])
+                            .inc();
+
+                        if let Some(txn_id) = tx.ctx.transaction_id {
+                            if storage_tx
+                                .send(TransactionStatusUpdate {
+                                    transaction_id: txn_id,
+                                    trace_id: tx.ctx.trace_id,
+                                    status: TransactionStatus::Completed,
+                                    counterpart_signature: Some(tx.signature.to_string()),
+                                    processed_at: Some(Utc::now()),
+                                    error_message: None,
+                                    remint_signature: None,
+                                    remint_attempted: false,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                warn!(
+                                    "Storage channel closed — Completed update lost for txn {}",
+                                    txn_id
+                                );
+                            }
+                        }
+                        // Notify sender loop to clean up mint_builders (O(1) HashMap remove).
+                        results.push(PollTaskResult::ConfirmedSuccess(tx.ctx.transaction_id));
+                    } else {
+                        // ── Confirmed with on-chain error ─────────────────────────────
+                        // Needs SenderState for error routing (cleanup, remint, etc.).
+                        results.push(PollTaskResult::NeedsRouting(tx, Some(status)));
+                    }
+                }
+                _ => {
+                    // ── Not yet confirmed ─────────────────────────────────────────────
+                    // If we're one poll away from MAX, hand to the sender loop so it can
+                    // run the timeout branch (which needs SenderState).  Otherwise push
+                    // straight back — no result channel traffic needed.
+                    if tx.poll_attempts + 1 >= MAX_POLL_ATTEMPTS_CONFIRMATION {
+                        // Do NOT increment here; route_poll_results will increment it
+                        // to MAX and fire the timeout branch.
+                        results.push(PollTaskResult::NeedsRouting(tx, None));
+                    } else {
+                        tx.poll_attempts += 1;
+                        in_flight.push(tx);
+                    }
+                }
+            }
+        }
+
+        if !results.is_empty() && result_tx.send(results).await.is_err() {
+            break; // Sender loop gone — clean up and exit.
+        }
+    }
+}
+
 /// Helper for fatal errors (Failed status, no signature)
 pub(super) async fn send_fatal_error(
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
@@ -772,6 +1186,39 @@ mod tests {
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
+        }
+    }
+
+    fn make_sender_state_with_server(url: &str) -> SenderState {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        let rpc_client = Arc::new(RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: std::time::Duration::from_millis(1),
+                max_delay: std::time::Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        ));
+        SenderState {
+            rpc_client: rpc_client.clone(),
+            storage: storage.clone(),
+            instance_pda: None,
+            smt_state: None,
+            retry_counts: HashMap::new(),
+            mint_builders: HashMap::new(),
+            mint_cache: MintCache::new(storage),
+            retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
+            rotation_retry_queue: Vec::new(),
+            pending_rotation: None,
+            program_type: ProgramType::Escrow,
+            remint_cache: HashMap::new(),
+            pending_signatures: HashMap::new(),
+            pending_remints: Vec::new(),
+            in_flight: InFlightQueue::new(),
         }
     }
 
@@ -1538,5 +1985,975 @@ mod tests {
         let update = rx.recv().await.unwrap();
         assert_eq!(update.transaction_id, 15);
         assert_eq!(update.status, TransactionStatus::Failed);
+    }
+
+    // ── fire_and_store ────────────────────────────────────────────────
+
+    /// A successful send must push exactly one InFlightTx with poll_attempts=0
+    /// and the returned signature; no storage update must be emitted yet.
+    #[tokio::test]
+    async fn fire_and_store_success_pushes_to_in_flight() {
+        let mut server = mockito::Server::new_async().await;
+
+        let expected_sig = Signature::default().to_string();
+
+        let _m_hash = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getLatestBlockhash"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 1},
+                        "value": {
+                            "blockhash": "GHtXQBsoZHjzkAm2Sdm6FTyFHBCqBnLanJJhZFCFJXoe",
+                            "lastValidBlockHeight": 100
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        let _m_send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": expected_sig
+                })
+                .to_string(),
+            )
+            .create();
+
+        let mut state = {
+            let storage = Arc::new(Storage::Mock(MockStorage::new()));
+            SenderState {
+                rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                    server.url(),
+                    crate::operator::utils::rpc_util::RetryConfig {
+                        max_attempts: 1,
+                        base_delay: std::time::Duration::from_millis(1),
+                        max_delay: std::time::Duration::from_millis(1),
+                    },
+                    CommitmentConfig::confirmed(),
+                )),
+                storage: storage.clone(),
+                instance_pda: None,
+                smt_state: None,
+                retry_counts: HashMap::new(),
+                mint_builders: HashMap::new(),
+                mint_cache: crate::operator::MintCache::new(storage),
+                retry_max_attempts: 3,
+                confirmation_poll_interval_ms: 400,
+                rotation_retry_queue: Vec::new(),
+                pending_rotation: None,
+                program_type: ProgramType::Escrow,
+                remint_cache: HashMap::new(),
+                pending_signatures: HashMap::new(),
+                pending_remints: Vec::new(),
+                in_flight: InFlightQueue::new(),
+            }
+        };
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        let ctx = TransactionContext {
+            transaction_id: Some(42),
+            withdrawal_nonce: None,
+            trace_id: Some("trace-fire".to_string()),
+        };
+
+        fire_and_store(
+            &mut state,
+            dummy_instruction(),
+            None,
+            ctx.clone(),
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            &storage_tx,
+            0,
+        )
+        .await;
+
+        // No storage update yet — confirmation is deferred.
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "fire_and_store must not emit a status update immediately"
+        );
+
+        // Exactly one in-flight entry with the expected signature.
+        assert_eq!(state.in_flight.len(), 1);
+        let guard = state.in_flight.entries.lock().unwrap();
+        let entry = &guard[0];
+        assert_eq!(entry.signature.to_string(), expected_sig);
+        assert_eq!(entry.ctx.transaction_id, Some(42));
+        assert_eq!(entry.poll_attempts, 0);
+    }
+
+    /// When sendTransaction fails, fire_and_store must route to permanent failure
+    /// and emit a Failed status — no in-flight entry should be added.
+    #[tokio::test]
+    async fn fire_and_store_send_failure_routes_to_permanent_failure() {
+        let mut server = mockito::Server::new_async().await;
+
+        // getLatestBlockhash succeeds
+        let _m_hash = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getLatestBlockhash"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 1},
+                        "value": {
+                            "blockhash": "GHtXQBsoZHjzkAm2Sdm6FTyFHBCqBnLanJJhZFCFJXoe",
+                            "lastValidBlockHeight": 100
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        // sendTransaction returns an RPC error
+        let _m_send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32600, "message": "Internal error"}
+                })
+                .to_string(),
+            )
+            .create();
+
+        let mut state = {
+            let storage = Arc::new(Storage::Mock(MockStorage::new()));
+            SenderState {
+                rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                    server.url(),
+                    crate::operator::utils::rpc_util::RetryConfig {
+                        max_attempts: 1,
+                        base_delay: std::time::Duration::from_millis(1),
+                        max_delay: std::time::Duration::from_millis(1),
+                    },
+                    CommitmentConfig::confirmed(),
+                )),
+                storage: storage.clone(),
+                instance_pda: None,
+                smt_state: None,
+                retry_counts: HashMap::new(),
+                mint_builders: HashMap::new(),
+                mint_cache: crate::operator::MintCache::new(storage),
+                retry_max_attempts: 3,
+                confirmation_poll_interval_ms: 400,
+                rotation_retry_queue: Vec::new(),
+                pending_rotation: None,
+                program_type: ProgramType::Escrow,
+                remint_cache: HashMap::new(),
+                pending_signatures: HashMap::new(),
+                pending_remints: Vec::new(),
+                in_flight: InFlightQueue::new(),
+            }
+        };
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        let ctx = TransactionContext {
+            transaction_id: Some(55),
+            withdrawal_nonce: None,
+            trace_id: None,
+        };
+
+        fire_and_store(
+            &mut state,
+            dummy_instruction(),
+            None,
+            ctx,
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            &storage_tx,
+            0,
+        )
+        .await;
+
+        // Failed status must be emitted immediately.
+        let update = storage_rx
+            .try_recv()
+            .expect("expected Failed status update");
+        assert_eq!(update.transaction_id, 55);
+        assert_eq!(update.status, TransactionStatus::Failed);
+
+        // Nothing pushed to in_flight.
+        assert!(
+            state.in_flight.is_empty(),
+            "in_flight must stay empty on send failure"
+        );
+    }
+
+    // ── poll_in_flight ────────────────────────────────────────────────
+
+    fn make_in_flight_tx(sig: Signature, txn_id: i64) -> super::super::types::InFlightTx {
+        super::super::types::InFlightTx {
+            signature: sig,
+            ctx: TransactionContext {
+                transaction_id: Some(txn_id),
+                withdrawal_nonce: None,
+                trace_id: Some(format!("trace-{txn_id}")),
+            },
+            instruction: dummy_instruction(),
+            compute_unit_price: None,
+            retry_policy: RetryPolicy::None,
+            extra_error_checks_policy: ExtraErrorCheckPolicy::None,
+            poll_attempts: 0,
+            resend_count: 0,
+        }
+    }
+
+    /// A confirmed signature in the batch must route to handle_success, emitting
+    /// a Completed status and removing the entry from in_flight.
+    #[tokio::test]
+    async fn poll_in_flight_confirmed_tx_emits_completed() {
+        let mut server = mockito::Server::new_async().await;
+
+        let sig = Signature::new_unique();
+
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 100},
+                        "value": [{
+                            "confirmationStatus": "confirmed",
+                            "confirmations": 1,
+                            "err": null,
+                            "slot": 100,
+                            "status": {"Ok": null}
+                        }]
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut state = SenderState {
+            rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                server.url(),
+                crate::operator::utils::rpc_util::RetryConfig {
+                    max_attempts: 1,
+                    base_delay: std::time::Duration::from_millis(1),
+                    max_delay: std::time::Duration::from_millis(1),
+                },
+                CommitmentConfig::confirmed(),
+            )),
+            storage: storage.clone(),
+            instance_pda: None,
+            smt_state: None,
+            retry_counts: HashMap::new(),
+            mint_builders: HashMap::new(),
+            mint_cache: crate::operator::MintCache::new(storage),
+            retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
+            rotation_retry_queue: Vec::new(),
+            pending_rotation: None,
+            program_type: ProgramType::Escrow,
+            remint_cache: HashMap::new(),
+            pending_signatures: HashMap::new(),
+            pending_remints: Vec::new(),
+            in_flight: {
+                let q = InFlightQueue::new();
+                q.push(make_in_flight_tx(sig, 77));
+                q
+            },
+        };
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        // Entry removed from in_flight after confirmation.
+        assert!(
+            state.in_flight.is_empty(),
+            "in_flight must be empty after confirmation"
+        );
+
+        // Completed status emitted.
+        let update = storage_rx.try_recv().expect("expected Completed status");
+        assert_eq!(update.transaction_id, 77);
+        assert_eq!(update.status, TransactionStatus::Completed);
+    }
+
+    /// A not-yet-confirmed tx should stay in in_flight with an incremented poll_attempts counter
+    /// and no storage update must be emitted.
+    #[tokio::test]
+    async fn poll_in_flight_unconfirmed_tx_stays_in_flight() {
+        let mut server = mockito::Server::new_async().await;
+
+        let sig = Signature::new_unique();
+
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 10},
+                        "value": [null]   // not yet seen by RPC
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut state = SenderState {
+            rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                server.url(),
+                crate::operator::utils::rpc_util::RetryConfig {
+                    max_attempts: 1,
+                    base_delay: std::time::Duration::from_millis(1),
+                    max_delay: std::time::Duration::from_millis(1),
+                },
+                CommitmentConfig::confirmed(),
+            )),
+            storage: storage.clone(),
+            instance_pda: None,
+            smt_state: None,
+            retry_counts: HashMap::new(),
+            mint_builders: HashMap::new(),
+            mint_cache: crate::operator::MintCache::new(storage),
+            retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
+            rotation_retry_queue: Vec::new(),
+            pending_rotation: None,
+            program_type: ProgramType::Escrow,
+            remint_cache: HashMap::new(),
+            pending_signatures: HashMap::new(),
+            pending_remints: Vec::new(),
+            in_flight: {
+                let q = InFlightQueue::new();
+                q.push(make_in_flight_tx(sig, 88));
+                q
+            },
+        };
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        // Still in-flight with incremented counter.
+        assert_eq!(state.in_flight.len(), 1);
+        assert_eq!(state.in_flight.entries.lock().unwrap()[0].poll_attempts, 1);
+
+        // No storage update.
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update for pending tx"
+        );
+    }
+
+    /// On RPC error, the entire batch must be kept in-flight untouched for retry on the
+    /// next tick — poll_attempts must NOT be incremented (the RPC call did not count).
+    #[tokio::test]
+    async fn poll_in_flight_rpc_error_keeps_batch_unchanged() {
+        let mut server = mockito::Server::new_async().await;
+
+        let sig = Signature::new_unique();
+
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32600, "message": "Internal error"}
+                })
+                .to_string(),
+            )
+            .create();
+
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut state = SenderState {
+            rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                server.url(),
+                crate::operator::utils::rpc_util::RetryConfig {
+                    max_attempts: 1,
+                    base_delay: std::time::Duration::from_millis(1),
+                    max_delay: std::time::Duration::from_millis(1),
+                },
+                CommitmentConfig::confirmed(),
+            )),
+            storage: storage.clone(),
+            instance_pda: None,
+            smt_state: None,
+            retry_counts: HashMap::new(),
+            mint_builders: HashMap::new(),
+            mint_cache: crate::operator::MintCache::new(storage),
+            retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
+            rotation_retry_queue: Vec::new(),
+            pending_rotation: None,
+            program_type: ProgramType::Escrow,
+            remint_cache: HashMap::new(),
+            pending_signatures: HashMap::new(),
+            pending_remints: Vec::new(),
+            in_flight: {
+                let q = InFlightQueue::new();
+                q.push(make_in_flight_tx(sig, 99));
+                q
+            },
+        };
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        // Batch unchanged — RPC error is transient.
+        assert_eq!(
+            state.in_flight.len(),
+            1,
+            "in_flight must be unchanged on RPC error"
+        );
+        assert_eq!(
+            state.in_flight.entries.lock().unwrap()[0].poll_attempts,
+            0,
+            "poll_attempts must not increment on RPC error"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no storage update on RPC error"
+        );
+    }
+
+    /// When poll_attempts reaches MAX_POLL_ATTEMPTS_CONFIRMATION for a RetryPolicy::None tx,
+    /// it must be declared a permanent failure and removed from in_flight.
+    #[tokio::test]
+    async fn poll_in_flight_timeout_none_policy_permanent_failure() {
+        let mut server = mockito::Server::new_async().await;
+
+        let sig = Signature::new_unique();
+
+        // Return "not confirmed" enough times to trigger timeout
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"context": {"slot": 10}, "value": [null]}
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create();
+
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut state = SenderState {
+            rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                server.url(),
+                crate::operator::utils::rpc_util::RetryConfig {
+                    max_attempts: 1,
+                    base_delay: std::time::Duration::from_millis(1),
+                    max_delay: std::time::Duration::from_millis(1),
+                },
+                CommitmentConfig::confirmed(),
+            )),
+            storage: storage.clone(),
+            instance_pda: None,
+            smt_state: None,
+            retry_counts: HashMap::new(),
+            mint_builders: HashMap::new(),
+            mint_cache: crate::operator::MintCache::new(storage),
+            retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
+            rotation_retry_queue: Vec::new(),
+            pending_rotation: None,
+            program_type: ProgramType::Escrow,
+            remint_cache: HashMap::new(),
+            pending_signatures: HashMap::new(),
+            pending_remints: Vec::new(),
+            in_flight: {
+                let q = InFlightQueue::new();
+                let mut tx = make_in_flight_tx(sig, 101);
+                // Pre-fill poll_attempts to one below MAX so this poll tips it over.
+                tx.poll_attempts = MAX_POLL_ATTEMPTS_CONFIRMATION - 1;
+                q.push(tx);
+                q
+            },
+        };
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        // Entry removed from in_flight.
+        assert!(
+            state.in_flight.is_empty(),
+            "timed-out tx must leave in_flight"
+        );
+
+        // Failed status emitted.
+        let update = storage_rx
+            .try_recv()
+            .expect("expected Failed status for non-idempotent timeout");
+        assert_eq!(update.transaction_id, 101);
+        assert_eq!(update.status, TransactionStatus::Failed);
+        assert!(
+            update
+                .error_message
+                .as_deref()
+                .unwrap_or("")
+                .contains("unknown"),
+            "error should mention unknown status: {:?}",
+            update.error_message,
+        );
+    }
+
+    /// poll_in_flight with an empty in_flight must be a no-op (no RPC call, no storage update).
+    #[tokio::test]
+    async fn poll_in_flight_empty_is_noop() {
+        let mut state = make_sender_state();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // No mock server needed — should not make any RPC call.
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        assert!(state.in_flight.is_empty());
+        assert!(storage_rx.try_recv().is_err());
+    }
+
+    /// A mixed batch (one confirmed, one pending) must resolve the confirmed entry while
+    /// keeping the pending entry in in_flight with an incremented poll_attempts.
+    #[tokio::test]
+    async fn poll_in_flight_mixed_batch_partial_resolution() {
+        let mut server = mockito::Server::new_async().await;
+
+        let sig1 = Signature::new_unique();
+        let sig2 = Signature::new_unique();
+
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 200},
+                        "value": [
+                            // sig1 confirmed
+                            {
+                                "confirmationStatus": "confirmed",
+                                "confirmations": 1,
+                                "err": null,
+                                "slot": 200,
+                                "status": {"Ok": null}
+                            },
+                            // sig2 not yet confirmed
+                            null
+                        ]
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut state = SenderState {
+            rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                server.url(),
+                crate::operator::utils::rpc_util::RetryConfig {
+                    max_attempts: 1,
+                    base_delay: std::time::Duration::from_millis(1),
+                    max_delay: std::time::Duration::from_millis(1),
+                },
+                CommitmentConfig::confirmed(),
+            )),
+            storage: storage.clone(),
+            instance_pda: None,
+            smt_state: None,
+            retry_counts: HashMap::new(),
+            mint_builders: HashMap::new(),
+            mint_cache: crate::operator::MintCache::new(storage),
+            retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
+            rotation_retry_queue: Vec::new(),
+            pending_rotation: None,
+            program_type: ProgramType::Escrow,
+            remint_cache: HashMap::new(),
+            pending_signatures: HashMap::new(),
+            pending_remints: Vec::new(),
+            in_flight: {
+                let q = InFlightQueue::new();
+                q.push(make_in_flight_tx(sig1, 201));
+                q.push(make_in_flight_tx(sig2, 202));
+                q
+            },
+        };
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        // sig1 resolved — only sig2 remains.
+        assert_eq!(state.in_flight.len(), 1, "only pending tx remains");
+        {
+            let guard = state.in_flight.entries.lock().unwrap();
+            assert_eq!(guard[0].ctx.transaction_id, Some(202));
+            assert_eq!(guard[0].poll_attempts, 1);
+        }
+
+        // Completed for sig1, nothing for sig2 yet.
+        let update = storage_rx.try_recv().expect("expected Completed for sig1");
+        assert_eq!(update.transaction_id, 201);
+        assert_eq!(update.status, TransactionStatus::Completed);
+        assert!(storage_rx.try_recv().is_err(), "no update for pending sig2");
+    }
+
+    // ── poll_in_flight: chunking ──────────────────────────────────────
+
+    /// When in_flight exceeds 256 entries (the getSignatureStatuses limit), poll_in_flight
+    /// must issue multiple RPC calls — one per 256-sig chunk — and merge the results.
+    ///
+    /// Strategy: mock returns all-null statuses (not yet confirmed) so every entry stays
+    /// in `remaining` after the call.  We seed 300 entries and assert the mock was hit
+    /// at least twice (≥ 2 chunks: 256 + 44), and that all 300 entries are still in-flight.
+    #[tokio::test]
+    async fn poll_in_flight_chunks_large_batch() {
+        // Build a response body with 256 null slots — enough for the largest chunk.
+        // The zip in poll_in_flight stops at the shorter of (batch, statuses), so
+        // returning 256 nulls for both the 256-sig chunk and the 44-sig chunk is fine:
+        // extra slots are ignored, missing slots cause zip to stop early (entries stay).
+        let null_statuses: Vec<serde_json::Value> = vec![serde_json::Value::Null; 256];
+        let response_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "context": {"slot": 1},
+                "value": null_statuses
+            }
+        })
+        .to_string();
+
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(response_body)
+            .expect_at_least(2) // 256 sigs → chunk 1; 44 sigs → chunk 2
+            .create();
+
+        let total = 300usize;
+        let mut state = make_sender_state_with_server(&server.url());
+        for i in 0..total {
+            state
+                .in_flight
+                .push(make_in_flight_tx(Signature::new_unique(), i as i64 + 1));
+        }
+
+        let (storage_tx, _rx) = mpsc::channel(10);
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        // All entries stay in-flight (all statuses were null → not confirmed).
+        assert_eq!(
+            state.in_flight.len(),
+            total,
+            "all entries must stay in-flight"
+        );
+        _m.assert(); // verifies ≥ 2 RPC calls were made
+    }
+
+    /// An idempotent tx that exhausts its resend_count budget must be declared a
+    /// permanent failure rather than re-queued indefinitely (infinite loop guard).
+    #[tokio::test]
+    async fn poll_in_flight_idempotent_resend_limit_triggers_permanent_failure() {
+        let mut server = mockito::Server::new_async().await;
+
+        let sig = Signature::new_unique();
+
+        // RPC returns null (not confirmed) — triggering the timeout arm.
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 10},
+                        "value": [null]
+                    }
+                })
+                .to_string(),
+            )
+            .expect_at_least(1)
+            .create();
+
+        let retry_max = 2u32;
+        let mut state = make_sender_state_with_server(&server.url());
+        state.retry_max_attempts = retry_max;
+        {
+            let mut tx = make_in_flight_tx(sig, 77);
+            tx.retry_policy = RetryPolicy::Idempotent;
+            // Already at the cap — next_resend (3) > retry_max (2).
+            tx.resend_count = retry_max;
+            tx.poll_attempts = MAX_POLL_ATTEMPTS_CONFIRMATION; // trigger timeout arm
+            *state.in_flight.entries.lock().unwrap() = vec![tx];
+        }
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        // Must have been removed from in_flight.
+        assert!(
+            state.in_flight.is_empty(),
+            "exhausted tx must leave in_flight"
+        );
+
+        // Permanent failure status must be emitted.
+        let update = storage_rx
+            .try_recv()
+            .expect("expected permanent-failure status update");
+        assert_eq!(update.transaction_id, 77);
+        assert_eq!(update.status, TransactionStatus::Failed);
+        assert!(
+            update
+                .error_message
+                .as_deref()
+                .unwrap_or("")
+                .contains("resend limit"),
+            "error message should mention resend limit: {:?}",
+            update.error_message
+        );
+    }
+
+    // ── fire_and_store: cap exceeded ──────────────────────────────────
+
+    /// When the in-flight queue is at MAX_IN_FLIGHT, fire_and_store must return
+    /// without emitting any storage update — DB stays unchanged so the fetcher
+    /// can re-emit the transaction on the next poll cycle.
+    #[tokio::test]
+    async fn fire_and_store_cap_exceeded_emits_no_storage_update() {
+        let mut state = make_sender_state();
+
+        // Fill the queue to the cap.
+        {
+            let mut entries = state.in_flight.entries.lock().unwrap();
+            for i in 0..MAX_IN_FLIGHT {
+                entries.push(make_in_flight_tx(Signature::new_unique(), i as i64));
+            }
+        }
+        assert_eq!(state.in_flight.len(), MAX_IN_FLIGHT);
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        let ctx = TransactionContext {
+            transaction_id: Some(9999),
+            withdrawal_nonce: None,
+            trace_id: None,
+        };
+
+        fire_and_store(
+            &mut state,
+            dummy_instruction(),
+            None,
+            ctx,
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            &storage_tx,
+            0,
+        )
+        .await;
+
+        // Queue must be unchanged — no new entry pushed.
+        assert_eq!(state.in_flight.len(), MAX_IN_FLIGHT);
+        // No storage update must have been emitted.
+        assert!(storage_rx.try_recv().is_err(), "no storage update expected");
+    }
+
+    // ── run_poll_task: cancellation ───────────────────────────────────
+
+    /// Cancelling while the task is blocked waiting for entries (idle queue) must
+    /// cause it to exit cleanly without hanging.
+    #[tokio::test]
+    async fn run_poll_task_cancels_while_waiting_for_entries() {
+        let in_flight = InFlightQueue::new();
+        let (result_tx, _result_rx) = mpsc::channel(8);
+        let (storage_tx, _storage_rx) = mpsc::channel(8);
+        let rpc = Arc::new(RpcClientWithRetry::with_retry_config(
+            "http://localhost:8899".to_string(),
+            RetryConfig::default(),
+            CommitmentConfig::confirmed(),
+        ));
+        let token = tokio_util::sync::CancellationToken::new();
+
+        let handle = tokio::spawn(run_poll_task(
+            in_flight.clone(),
+            result_tx,
+            rpc,
+            storage_tx,
+            ProgramType::Escrow,
+            50,
+            token.clone(),
+        ));
+
+        // Cancel immediately — task is blocked on notified(), must wake and exit.
+        token.cancel();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("task must exit within 2s after cancellation")
+            .expect("task must not panic");
+    }
+
+    /// Cancelling while the task is sleeping between notify and drain must cause
+    /// it to exit without processing any entries.
+    #[tokio::test]
+    async fn run_poll_task_cancels_during_poll_interval_sleep() {
+        let in_flight = InFlightQueue::new();
+        let (result_tx, _result_rx) = mpsc::channel(8);
+        let (storage_tx, _storage_rx) = mpsc::channel(8);
+        let rpc = Arc::new(RpcClientWithRetry::with_retry_config(
+            "http://localhost:8899".to_string(),
+            RetryConfig::default(),
+            CommitmentConfig::confirmed(),
+        ));
+        let token = tokio_util::sync::CancellationToken::new();
+
+        let handle = tokio::spawn(run_poll_task(
+            in_flight.clone(),
+            result_tx,
+            rpc,
+            storage_tx,
+            ProgramType::Escrow,
+            60_000, // very long interval — task will be sleeping here when we cancel
+            token.clone(),
+        ));
+
+        // Push an entry to unblock the first select (notified), then cancel
+        // while the task is in the poll_interval sleep.
+        in_flight.push(make_in_flight_tx(Signature::new_unique(), 1));
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        token.cancel();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("task must exit within 2s after cancellation")
+            .expect("task must not panic");
+    }
+
+    /// When the result_tx receiver is dropped (sender loop gone), the task must
+    /// detect the closed channel and exit cleanly rather than looping forever.
+    #[tokio::test]
+    async fn run_poll_task_exits_when_result_channel_closed() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Return a confirmed-with-error status so a NeedsRouting result is produced,
+        // which forces a send on result_tx (the closed channel) → task must exit.
+        let sig = Signature::new_unique();
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 5},
+                        "value": [{
+                            "slot": 5,
+                            "confirmations": null,
+                            "confirmationStatus": "finalized",
+                            "err": {"InstructionError": [0, "GenericError"]},
+                            "status": {"Err": {"InstructionError": [0, "GenericError"]}}
+                        }]
+                    }
+                })
+                .to_string(),
+            )
+            .expect_at_least(1)
+            .create();
+
+        let in_flight = InFlightQueue::new();
+        // Drop result_rx immediately to close the channel from the receiver side.
+        let (result_tx, result_rx) = mpsc::channel::<Vec<PollTaskResult>>(8);
+        drop(result_rx);
+        let (storage_tx, _storage_rx) = mpsc::channel(8);
+        let rpc = Arc::new(RpcClientWithRetry::with_retry_config(
+            server.url(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: std::time::Duration::from_millis(1),
+                max_delay: std::time::Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        ));
+        let token = tokio_util::sync::CancellationToken::new();
+
+        in_flight.push(make_in_flight_tx(sig, 42));
+
+        let handle = tokio::spawn(run_poll_task(
+            in_flight.clone(),
+            result_tx,
+            rpc,
+            storage_tx,
+            ProgramType::Escrow,
+            1, // minimal sleep
+            token.clone(),
+        ));
+
+        tokio::time::timeout(std::time::Duration::from_secs(3), handle)
+            .await
+            .expect("task must exit within 3s when result channel is closed")
+            .expect("task must not panic");
     }
 }

--- a/indexer/src/operator/sender/types.rs
+++ b/indexer/src/operator/sender/types.rs
@@ -1,4 +1,7 @@
 use crate::config::ProgramType;
+use crate::operator::utils::instruction_util::{
+    ExtraErrorCheckPolicy, MintToBuilder, RetryPolicy, WithdrawalRemintInfo,
+};
 use crate::operator::RpcClientWithRetry;
 use crate::storage::common::models::TransactionStatus;
 use crate::storage::common::storage::Storage;
@@ -11,7 +14,62 @@ use solana_sdk::signature::Signature;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::operator::utils::instruction_util::{MintToBuilder, WithdrawalRemintInfo};
+/// Maximum number of fire-and-forget transactions allowed in-flight simultaneously.
+/// New sends are rejected with a permanent failure once this cap is reached,
+/// preventing unbounded memory growth under sustained load.
+pub const MAX_IN_FLIGHT: usize = 1000;
+
+/// Shared queue of in-flight fire-and-forget transactions.
+///
+/// Owned jointly by the sender loop (pushes new entries, reads routing results)
+/// and the poll task (drains entries for `getSignatureStatuses`, puts unconfirmed
+/// back).  The `notify` wakes the poll task whenever a new entry is pushed so it
+/// never busy-loops when the queue is empty.
+pub struct InFlightQueue {
+    pub entries: std::sync::Mutex<Vec<InFlightTx>>,
+    pub notify:  tokio::sync::Notify,
+}
+
+impl InFlightQueue {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            entries: std::sync::Mutex::new(Vec::with_capacity(MAX_IN_FLIGHT)),
+            notify:  tokio::sync::Notify::new(),
+        })
+    }
+
+    /// Push an entry and wake the poll task.
+    pub fn push(&self, tx: InFlightTx) {
+        self.entries.lock().unwrap().push(tx);
+        self.notify.notify_one();
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.lock().unwrap().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.lock().unwrap().is_empty()
+    }
+
+    /// Take all entries out atomically, leaving a pre-allocated buffer in place
+    /// so the next cycle does not need to reallocate.
+    pub fn drain_all(&self) -> Vec<InFlightTx> {
+        let mut guard = self.entries.lock().unwrap();
+        let mut out = Vec::with_capacity(guard.capacity());
+        std::mem::swap(&mut *guard, &mut out);
+        out
+    }
+
+    /// Re-insert a batch of entries with a single mutex lock and one notify.
+    pub fn push_all(&self, txs: Vec<InFlightTx>) {
+        if txs.is_empty() {
+            return;
+        }
+        self.entries.lock().unwrap().extend(txs);
+        self.notify.notify_one();
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct TransactionContext {
@@ -34,6 +92,40 @@ pub struct TransactionStatusUpdate {
     /// True when a remint was attempted but failed (ManualReview). Lets consumers
     /// distinguish "remint tried and failed" from "remint never attempted".
     pub remint_attempted: bool,
+}
+
+/// A Mint or InitializeMint transaction that has been sent but not yet confirmed.
+///
+/// Stored in `SenderState::in_flight` and checked in batch on each confirmation timer
+/// tick via a single `getSignatureStatuses` RPC call.  Decoupling send from confirm
+/// allows the sender to process new transactions while waiting for on-chain confirmation.
+///
+/// Only Mint and InitializeMint are eligible — ReleaseFunds and ResetSmtRoot still use
+/// the blocking `send_and_confirm` path because SMT proof ordering makes concurrent
+/// in-flight withdrawals unsafe.
+pub struct InFlightTx {
+    /// Signature returned by `sendTransaction`. Used as the polling key.
+    pub signature: Signature,
+    /// Routing context for storage updates on success or failure.
+    pub ctx: TransactionContext,
+    /// Original instruction kept for re-sign + re-send on confirmation timeout.
+    pub instruction: InstructionWithSigners,
+    /// Compute unit price forwarded to the re-send path unchanged.
+    pub compute_unit_price: Option<u64>,
+    /// Whether this tx can be safely re-sent (Idempotent) or must fail (None).
+    pub retry_policy: RetryPolicy,
+    /// On-chain error checks applied when the tx is confirmed with an error
+    /// (e.g. MintNotInitialized detection for Mint transactions).
+    pub extra_error_checks_policy: ExtraErrorCheckPolicy,
+    /// Number of timer ticks elapsed since the send without a confirmed status.
+    /// When this reaches `MAX_POLL_ATTEMPTS_CONFIRMATION` the tx is either re-sent
+    /// (Idempotent) or declared a permanent failure (None).
+    pub poll_attempts: u32,
+    /// Number of times this transaction has been re-signed and re-sent after a
+    /// confirmation timeout.  Compared against `SenderState::retry_max_attempts`
+    /// before each re-send; once the cap is reached even an Idempotent tx is
+    /// declared a permanent failure rather than looping forever.
+    pub resend_count: u32,
 }
 
 /// Sender state tracking SMT and pending transactions
@@ -59,6 +151,9 @@ pub struct SenderState {
     pub pending_signatures: HashMap<u64, Vec<Signature>>,
     /// Deferred remint queue — entries are processed after their deadline matures.
     pub pending_remints: Vec<PendingRemint>,
+    /// Mint/InitializeMint transactions sent but awaiting on-chain confirmation.
+    /// Shared with the dedicated poll task via `Arc`; capped at `MAX_IN_FLIGHT`.
+    pub in_flight: Arc<InFlightQueue>,
 }
 
 /// A remint deferred until Solana finality window passes, allowing us to verify
@@ -75,6 +170,23 @@ pub struct PendingRemint {
     pub deadline: DateTime<Utc>,
     /// Number of times the finality check has been retried (e.g. due to RPC errors).
     pub finality_check_attempts: u32,
+}
+
+/// Result item sent from the dedicated poll task back to the sender loop.
+///
+/// The poll task handles confirmed-success entries directly — it fires the storage
+/// update and increments the metric — so the common path never wakes the main
+/// select loop.  Only rare outcomes (on-chain errors, confirmation timeouts) are
+/// sent back for routing through `SenderState`.
+pub enum PollTaskResult {
+    /// Mint/InitializeMint confirmed with no error.  The poll task already sent the
+    /// `Completed` status update and incremented `OPERATOR_MINTS_SENT`.
+    /// The sender loop removes the builder from `SenderState::mint_builders`.
+    /// `None` for `InitializeMint` which has no `transaction_id`.
+    ConfirmedSuccess(Option<i64>),
+    /// Needs routing via `SenderState` — either an on-chain error was returned
+    /// or the entry timed out.  `None` status means timeout (not an RPC null).
+    NeedsRouting(InFlightTx, Option<solana_transaction_status::TransactionStatus>),
 }
 
 pub struct SenderSMTState {

--- a/indexer/src/operator/sender/types.rs
+++ b/indexer/src/operator/sender/types.rs
@@ -13,6 +13,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 /// Maximum number of fire-and-forget transactions allowed in-flight simultaneously.
 /// New sends are rejected with a permanent failure once this cap is reached,
@@ -27,14 +28,14 @@ pub const MAX_IN_FLIGHT: usize = 1000;
 /// never busy-loops when the queue is empty.
 pub struct InFlightQueue {
     pub entries: std::sync::Mutex<Vec<InFlightTx>>,
-    pub notify:  tokio::sync::Notify,
+    pub notify: tokio::sync::Notify,
 }
 
 impl InFlightQueue {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             entries: std::sync::Mutex::new(Vec::with_capacity(MAX_IN_FLIGHT)),
-            notify:  tokio::sync::Notify::new(),
+            notify: tokio::sync::Notify::new(),
         })
     }
 
@@ -126,6 +127,13 @@ pub struct InFlightTx {
     /// before each re-send; once the cap is reached even an Idempotent tx is
     /// declared a permanent failure rather than looping forever.
     pub resend_count: u32,
+    /// Semaphore permit held for the lifetime of this entry.
+    ///
+    /// Acquired before spawning the send task; dropped when the entry is removed
+    /// from the queue (on confirmation, permanent failure, or transfer to a retry).
+    /// This is the sole mechanism that enforces `MAX_IN_FLIGHT` across both
+    /// in-flight entries and send tasks that have not yet pushed to the queue.
+    pub permit: OwnedSemaphorePermit,
 }
 
 /// Sender state tracking SMT and pending transactions
@@ -154,6 +162,12 @@ pub struct SenderState {
     /// Mint/InitializeMint transactions sent but awaiting on-chain confirmation.
     /// Shared with the dedicated poll task via `Arc`; capped at `MAX_IN_FLIGHT`.
     pub in_flight: Arc<InFlightQueue>,
+    /// Enforces the `MAX_IN_FLIGHT` cap across both entries in `in_flight` and
+    /// in-progress spawned send tasks.  A permit is acquired before spawning a
+    /// send task and released only when the entry reaches a terminal state
+    /// (confirmed, permanent failure, or transfer to a retry), so
+    /// `available_permits()` accurately reflects remaining capacity at all times.
+    pub semaphore: Arc<Semaphore>,
 }
 
 /// A remint deferred until Solana finality window passes, allowing us to verify
@@ -186,7 +200,10 @@ pub enum PollTaskResult {
     ConfirmedSuccess(Option<i64>),
     /// Needs routing via `SenderState` — either an on-chain error was returned
     /// or the entry timed out.  `None` status means timeout (not an RPC null).
-    NeedsRouting(InFlightTx, Option<solana_transaction_status::TransactionStatus>),
+    NeedsRouting(
+        Box<InFlightTx>,
+        Option<solana_transaction_status::TransactionStatus>,
+    ),
 }
 
 pub struct SenderSMTState {

--- a/indexer/src/operator/utils/rpc_util.rs
+++ b/indexer/src/operator/utils/rpc_util.rs
@@ -42,15 +42,18 @@ impl Default for RetryConfig {
 }
 
 /// Returns `true` for errors that will never succeed on retry.
-///
-/// `-32601` (Method not found) is a permanent protocol-level rejection; retrying
-/// wastes the full backoff budget without any chance of recovery.
-// TODO: remove once the RPC endpoint implements all required methods.
+// TODO: remove -32601 check once the RPC endpoint implements all required methods.
 fn is_permanent_rpc_error(e: &client_error::Error) -> bool {
-    matches!(
-        e.kind(),
-        ErrorKind::RpcError(RpcError::RpcResponseError { code: -32601, .. })
-    )
+    let ErrorKind::RpcError(rpc_err) = e.kind() else {
+        return false;
+    };
+    match rpc_err {
+        // Method not supported by this RPC endpoint — protocol-level rejection.
+        RpcError::RpcResponseError { code: -32601, .. } => true,
+        // "AccountNotFound" is a definitive answer, not a transient failure.
+        RpcError::ForUser(msg) => msg.contains("AccountNotFound"),
+        _ => false,
+    }
 }
 
 pub struct RpcClientWithRetry {
@@ -404,5 +407,151 @@ mod tests {
         // Should complete quickly because max_delay clamps the large base_delay
         assert!(start.elapsed() < Duration::from_secs(1));
         assert_eq!(call_count.load(Ordering::SeqCst), 3);
+    }
+
+    fn make_client_fast() -> RpcClientWithRetry {
+        RpcClientWithRetry::with_retry_config(
+            "http://localhost:8899".to_string(),
+            RetryConfig {
+                max_attempts: 5,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        )
+    }
+
+    fn rpc_method_not_found() -> client_error::Error {
+        client_error::Error::new_with_request(
+            client_error::ErrorKind::RpcError(RpcError::RpcResponseError {
+                code: -32601,
+                message: "Method not found".to_string(),
+                data: solana_rpc_client_api::request::RpcResponseErrorData::Empty,
+            }),
+            solana_rpc_client_api::request::RpcRequest::GetBalance,
+        )
+    }
+
+    fn rpc_account_not_found() -> client_error::Error {
+        client_error::Error::new_with_request(
+            client_error::ErrorKind::RpcError(RpcError::ForUser(
+                "AccountNotFound: pubkey=So11111111111111111111111111111111111111112".to_string(),
+            )),
+            solana_rpc_client_api::request::RpcRequest::GetAccountInfo,
+        )
+    }
+
+    fn rpc_transient() -> client_error::Error {
+        client_error::Error::new_with_request(
+            client_error::ErrorKind::RpcError(RpcError::ForUser("NodeUnhealthy".to_string())),
+            solana_rpc_client_api::request::RpcRequest::GetBalance,
+        )
+    }
+
+    /// -32601 (Method not found) must abort on the first attempt — no retries.
+    #[tokio::test]
+    async fn permanent_error_method_not_found_stops_immediately() {
+        let client = make_client_fast();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+
+        let result: Result<u32, Box<client_error::Error>> = client
+            .with_retry("op", RetryPolicy::Idempotent, || {
+                let cc = cc.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Err::<u32, client_error::Error>(rpc_method_not_found())
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "-32601 must not be retried"
+        );
+    }
+
+    /// AccountNotFound is a definitive answer — must abort on the first attempt.
+    #[tokio::test]
+    async fn permanent_error_account_not_found_stops_immediately() {
+        let client = make_client_fast();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+
+        let result: Result<u32, Box<client_error::Error>> = client
+            .with_retry("op", RetryPolicy::Idempotent, || {
+                let cc = cc.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Err::<u32, client_error::Error>(rpc_account_not_found())
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "AccountNotFound must not be retried"
+        );
+    }
+
+    /// Transient RPC errors (e.g. NodeUnhealthy) must be retried up to max_attempts.
+    #[tokio::test]
+    async fn transient_rpc_error_is_retried() {
+        let client = make_client_fast();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+
+        let result: Result<u32, Box<client_error::Error>> = client
+            .with_retry("op", RetryPolicy::Idempotent, || {
+                let cc = cc.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Err::<u32, client_error::Error>(rpc_transient())
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            5,
+            "transient error must be retried to max_attempts"
+        );
+    }
+
+    /// ForUser message that mentions AccountNotFound only as a substring of a larger word
+    /// must NOT be treated as permanent — only exact "AccountNotFound" prefix matches.
+    #[tokio::test]
+    async fn for_user_error_unrelated_message_is_retried() {
+        let client = make_client_fast();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+
+        // Message does not contain "AccountNotFound"
+        let result: Result<u32, Box<client_error::Error>> = client
+            .with_retry("op", RetryPolicy::Idempotent, || {
+                let cc = cc.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Err::<u32, client_error::Error>(client_error::Error::new_with_request(
+                        client_error::ErrorKind::RpcError(RpcError::ForUser(
+                            "BlockNotFound".to_string(),
+                        )),
+                        solana_rpc_client_api::request::RpcRequest::GetBalance,
+                    ))
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            5,
+            "unrelated ForUser error must be retried"
+        );
     }
 }

--- a/indexer/src/operator/utils/transaction_util.rs
+++ b/indexer/src/operator/utils/transaction_util.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
 };
 use tracing::{debug, warn};
 
-const MAX_POLL_ATTEMPTS_CONFIRMATION: u32 = 5;
+pub const MAX_POLL_ATTEMPTS_CONFIRMATION: u32 = 5;
 
 /// Result of transaction confirmation
 #[derive(Debug, Clone)]

--- a/scripts/devnet/config/operator-solana.toml
+++ b/scripts/devnet/config/operator-solana.toml
@@ -15,7 +15,7 @@ max_connections = 10
 
 [operator]
 poll_interval_secs = 1
-batch_size = 100
+batch_size = 1000
 retry_max_attempts = 3
 retry_base_delay_secs = 1
 channel_buffer_size = 1000

--- a/test_utils/src/validator_helper.rs
+++ b/test_utils/src/validator_helper.rs
@@ -7,11 +7,7 @@ use {
     solana_sdk::signature::Keypair,
     solana_sdk_ids::bpf_loader_upgradeable,
     solana_test_validator::{TestValidator, TestValidatorGenesis, UpgradeableProgramInfo},
-    std::{
-        io::Write,
-        net::TcpListener,
-        path::PathBuf,
-    },
+    std::{io::Write, net::TcpListener, path::PathBuf},
 };
 
 fn get_free_port() -> u16 {

--- a/test_utils/src/validator_helper.rs
+++ b/test_utils/src/validator_helper.rs
@@ -3,14 +3,13 @@ use {
     contra_withdraw_program_client::CONTRA_WITHDRAW_PROGRAM_ID,
     solana_address::Address,
     solana_client::rpc_client::RpcClient,
-    solana_net_utils::{find_available_port_in_range, sockets::unique_port_range_for_tests},
     solana_rpc::rpc::JsonRpcConfig,
     solana_sdk::signature::Keypair,
     solana_sdk_ids::bpf_loader_upgradeable,
     solana_test_validator::{TestValidator, TestValidatorGenesis, UpgradeableProgramInfo},
     std::{
         io::Write,
-        net::{IpAddr, Ipv4Addr, TcpListener},
+        net::TcpListener,
         path::PathBuf,
     },
 };
@@ -59,24 +58,11 @@ fn make_program_info(program_id_bytes: [u8; 32], program_path: &str) -> Upgradea
 /// Start the solana-test-validator on free ports with geyser plugin enabled.
 /// Returns the test validator instance, the mint keypair, and the geyser port.
 pub async fn start_test_validator() -> (TestValidator, Keypair, u16) {
-    // `unique_port_range_for_tests` uses a process-global AtomicU16 to hand out
-    // non-overlapping 200-port blocks.  Under nextest each test is its own process
-    // so the atomic always starts at 0 and the NEXTEST_TEST_GLOBAL_SLOT env var
-    // (set by nextest) provides per-worker isolation.  Under plain `cargo test`
-    // all tests share one process; the non-nextest path of the function simply
-    // increments the atomic, giving each concurrent test a distinct block
-    // (2000–2200, 2200–2400, …) without any per-slot cap.  Do NOT force-set
-    // NEXTEST_TEST_GLOBAL_SLOT here: doing so switches the function into the
-    // nextest path which has a 990-port-per-process cap, causing the
-    // "Overrunning into the port range" panic when more than ~4 tests run in
-    // parallel within the same process.
-    let port_range = unique_port_range_for_tests(200);
-    let port_range = (port_range.start, port_range.end);
-    // Find the first available TCP port within our allocated range for the RPC server.
-    let rpc_port = find_available_port_in_range(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range)
-        .expect("Failed to find available RPC port in range");
-    // gossip_port=0 lets the OS pick a port; port_range below constrains all other validator
-    // sockets (TPU, TVU, …) to the same allocated block, keeping them off other tests' ranges.
+    // Bind to port 0 and let the OS pick a free port for RPC and geyser.
+    // Concurrent validators (nextest runs each test in its own process) never
+    // collide: the kernel assigns OS-level sockets atomically.
+    // All other validator sockets (gossip, TPU, TVU) use port=0 as well.
+    let rpc_port = get_free_port();
     let gossip_port = 0u16;
     let geyser_port = get_free_port();
 
@@ -118,9 +104,6 @@ pub async fn start_test_validator() -> (TestValidator, Keypair, u16) {
             .rpc_config(rpc_config)
             .rpc_port(rpc_port)
             .gossip_port(gossip_port)
-            // Constrain all validator sockets to the allocated range so parallel validators
-            // stay within their own non-overlapping port blocks.
-            .port_range(port_range)
             .add_upgradeable_programs_with_path(&[escrow_program, withdraw_program])
             .start()
     })
@@ -152,11 +135,8 @@ pub async fn start_test_validator() -> (TestValidator, Keypair, u16) {
 /// Start the solana-test-validator without the geyser plugin enabled.
 /// Returns the test validator instance and the mint keypair.
 pub async fn start_test_validator_no_geyser() -> (TestValidator, Keypair) {
-    // Same port-isolation strategy as start_test_validator — see the comment there.
-    let port_range = unique_port_range_for_tests(200);
-    let port_range = (port_range.start, port_range.end);
-    let rpc_port = find_available_port_in_range(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range)
-        .expect("Failed to find available RPC port in range");
+    // Same port strategy as start_test_validator — see the comment there.
+    let rpc_port = get_free_port();
     let gossip_port = 0u16;
 
     let rpc_config = JsonRpcConfig {
@@ -180,9 +160,6 @@ pub async fn start_test_validator_no_geyser() -> (TestValidator, Keypair) {
             .rpc_config(rpc_config)
             .rpc_port(rpc_port)
             .gossip_port(gossip_port)
-            // Constrain all validator sockets to the allocated range so parallel validators
-            // stay within their own non-overlapping port blocks.
-            .port_range(port_range)
             .add_upgradeable_programs_with_path(&[escrow_program, withdraw_program])
             .start()
     })


### PR DESCRIPTION
## Summary

Decouples `sendTransaction` latency from the sender loop for Mint/InitializeMint transactions. Instead of blocking until each tx confirms, the sender signs and sends immediately, stores the signature, and moves on. A dedicated poll task batches all in-flight signatures into a single `getSignatureStatuses` call per interval.

- **Fire-and-forget send**: Mint/InitializeMint only. 
- **Batched confirmation**: dedicated tokio task wakes on `Notify`, accumulates one poll interval, resolves all N signatures in one RPC call. Confirmed-success is handled entirely in the poll task; only errors and timeouts wake the sender loop.
- **Semaphore back-pressure**: `MAX_IN_FLIGHT = 1000` permits. `select!` recv arm guarded by `available_permits() > 0`; when exhausted, the processor channel backs up and the fetcher stops.
- **`AccountNotFound` now permanent**: previously retried 5× with backoff (~1.5 s wasted per JIT mint lookup).
- **bench-tps setup**: `setup_deposit` now initialises the Contra-side SPL mint upfront so the operator doesn't hit JIT init on the first deposit.

## Files changed

| File | Change |
|------|--------|
| `sender/types.rs` | `InFlightTx`, `InFlightQueue` (`Arc<Mutex<Vec>>` + `Notify`), `PollTaskResult` |
| `sender/transaction.rs` | `spawn_fire_and_store`, `fire_and_store`, `run_poll_task`, `poll_in_flight`; branches in `handle_transaction_submission` |
| `sender/mod.rs` | Wires poll task; both exit paths stop poll task before `drain_in_flight` |
| `sender/state.rs` | `semaphore: Arc<Semaphore>` added to `SenderState` |
| `rpc_util.rs` | `AccountNotFound` → permanent error |
| `bench-tps/` | Contra-side mint init in setup; dedicated `BENCH_CONTRA_RPC_URL` env var |

## Tests

- `spawn_fire_and_store`: cap exhausted returns false, permit consumed on success
- `run_poll_task`: cancellation (idle + mid-sleep), closed result channel exit
- `drain_in_flight`: empty queue no-op, 30 s timeout
- `InFlightQueue`: push/drain roundtrip, capacity preserved across `drain_all`
- `is_permanent_rpc_error`: `Method not Found` and `AccountNotFound` exit immediately

## Impact
Deposit TPS: ~9 -> ~500 
<img width="1545" height="636" alt="Screenshot from 2026-04-09 21-17-22" src="https://github.com/user-attachments/assets/0831fb2d-811f-40a4-a611-1ea73576db03" />


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 7,103 | 8,411 | 84.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24204810648) |
| Indexer | 13,471 | 15,715 | 85.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24204810648) |
| Gateway | 952 | 1,076 | 88.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24204810648) |
| Auth | 541 | 596 | 90.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24204810648) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | 7,909 | 11,473 | 68.9% | [e2e-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24204810648) |
| **Total** | **29,976** | **37,271** | **80.4%** | |

> Last updated: 2026-04-09 18:06:27 UTC by E2E Integration