### PR TITLE
Fix/escrow support transfer fee [EXO-8]

### DIFF
--- a/contra-escrow-program/program/src/processor/deposit.rs
+++ b/contra-escrow-program/program/src/processor/deposit.rs
@@ -4,7 +4,7 @@ use crate::{
     error::ContraEscrowProgramError,
     events::DepositEvent,
     processor::{
-        get_token_account_balance,
+        get_mint_decimals, get_token_account_balance,
         shared::{
             account_check::{verify_signer, verify_system_program},
             event_utils::emit_event,
@@ -18,7 +18,9 @@ use crate::{
 };
 use pinocchio::{account::AccountView, error::ProgramError, Address, ProgramResult};
 
-use pinocchio_token_2022::{instructions::Transfer as Transfer2022, ID as TOKEN_2022_PROGRAM_ID};
+use pinocchio_token_2022::{
+    instructions::TransferChecked as TransferChecked2022, ID as TOKEN_2022_PROGRAM_ID,
+};
 
 /// Processes the Deposit instruction.
 ///
@@ -100,20 +102,27 @@ pub fn process_deposit(
 
     let escrow_token_balance_before = get_token_account_balance(instance_ata_info)?;
 
-    Transfer2022 {
+    TransferChecked2022 {
         from: user_ata_info,
         to: instance_ata_info,
         authority: user_info,
         amount: args.amount,
         token_program: token_program_info.address(),
+        mint: mint_info,
+        decimals: get_mint_decimals(mint_info)?,
     }
     .invoke_signed(&[])?;
+
+    let escrow_token_balance_after = get_token_account_balance(instance_ata_info)?;
+    let received = escrow_token_balance_after
+        .checked_sub(escrow_token_balance_before)
+        .ok_or(ContraEscrowProgramError::InvalidEscrowBalance)?;
 
     let recipient = args.recipient.unwrap_or(*user_info.address());
     let event = DepositEvent::new(
         instance.instance_seed,
         *user_info.address(),
-        args.amount,
+        received,
         recipient,
         *mint_info.address(),
     );
@@ -123,15 +132,6 @@ pub fn process_deposit(
         program_info,
         &event.to_bytes(),
     )?;
-
-    let escrow_token_balance_after = get_token_account_balance(instance_ata_info)?;
-    if escrow_token_balance_after
-        != escrow_token_balance_before
-            .checked_add(args.amount)
-            .ok_or(ProgramError::ArithmeticOverflow)?
-    {
-        return Err(ContraEscrowProgramError::InvalidEscrowBalance.into());
-    }
 
     Ok(())
 }

--- a/contra-escrow-program/program/src/processor/release_funds.rs
+++ b/contra-escrow-program/program/src/processor/release_funds.rs
@@ -5,7 +5,7 @@ use crate::{
     error::ContraEscrowProgramError,
     events::ReleaseFundsEvent,
     processor::{
-        get_token_account_balance,
+        get_mint_decimals, get_token_account_balance,
         shared::{
             account_check::verify_signer,
             event_utils::emit_event,
@@ -24,7 +24,9 @@ use pinocchio::{
     error::ProgramError,
     Address, ProgramResult,
 };
-use pinocchio_token_2022::{instructions::Transfer as Transfer2022, ID as TOKEN_2022_PROGRAM_ID};
+use pinocchio_token_2022::{
+    instructions::TransferChecked as TransferChecked2022, ID as TOKEN_2022_PROGRAM_ID,
+};
 
 // amount (8) + user (32) + new_root (32) + transaction_nonce (8) + sibling_proofs (TREE_HEIGHT * 32)
 const INSTRUCTION_DATA_LENGTH: usize = 8 + 32 + 32 + 8 + (TREE_HEIGHT * 32);
@@ -141,14 +143,21 @@ pub fn process_release_funds(
 
     drop(instance_data);
 
-    Transfer2022 {
+    TransferChecked2022 {
         from: instance_ata_info,
         to: user_ata_info,
         authority: instance_info,
-        token_program: token_program_info.address(),
         amount: args.amount,
+        token_program: token_program_info.address(),
+        mint: mint_info,
+        decimals: get_mint_decimals(mint_info)?,
     }
     .invoke_signed(&[signer])?;
+
+    let escrow_token_balance_after = get_token_account_balance(instance_ata_info)?;
+    let released = escrow_token_balance_before
+        .checked_sub(escrow_token_balance_after)
+        .ok_or(ContraEscrowProgramError::InvalidEscrowBalance)?;
 
     instance.withdrawal_transactions_root = args.new_withdrawal_root;
     let updated_instance_data = instance.to_bytes();
@@ -159,7 +168,7 @@ pub fn process_release_funds(
     let event = ReleaseFundsEvent::new(
         instance.instance_seed,
         *operator_info.address(),
-        args.amount,
+        released,
         args.user,
         *mint_info.address(),
         args.new_withdrawal_root,
@@ -170,15 +179,6 @@ pub fn process_release_funds(
         program_info,
         &event.to_bytes(),
     )?;
-
-    let escrow_token_balance_after = get_token_account_balance(instance_ata_info)?;
-    if escrow_token_balance_after
-        != escrow_token_balance_before
-            .checked_sub(args.amount)
-            .ok_or(ProgramError::ArithmeticOverflow)?
-    {
-        return Err(ContraEscrowProgramError::InvalidEscrowBalance.into());
-    }
 
     Ok(())
 }

--- a/contra-escrow-program/tests/integration-tests/src/test_deposit/mod.rs
+++ b/contra-escrow-program/tests/integration-tests/src/test_deposit/mod.rs
@@ -443,7 +443,8 @@ fn test_deposit_token_2022_transfer_fee_success() {
 
     // The escrow receives less than the deposit amount because the transfer fee is
     // withheld at the destination. The received amount is deposit - fee.
-    let expected_fee = (DEPOSIT_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 / 10_000) as u64;
+    // SPL Token 2022 uses ceiling division for fee calculation.
+    let expected_fee = ((DEPOSIT_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 + 9_999) / 10_000) as u64;
     let expected_received = DEPOSIT_AMOUNT - expected_fee;
     assert_eq!(
         instance_balance_after,

--- a/contra-escrow-program/tests/integration-tests/src/test_deposit/mod.rs
+++ b/contra-escrow-program/tests/integration-tests/src/test_deposit/mod.rs
@@ -444,7 +444,8 @@ fn test_deposit_token_2022_transfer_fee_success() {
     // The escrow receives less than the deposit amount because the transfer fee is
     // withheld at the destination. The received amount is deposit - fee.
     // SPL Token 2022 uses ceiling division for fee calculation.
-    let expected_fee = ((DEPOSIT_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 + 9_999) / 10_000) as u64;
+    let expected_fee =
+        (DEPOSIT_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128).div_ceil(10_000) as u64;
     let expected_received = DEPOSIT_AMOUNT - expected_fee;
     assert_eq!(
         instance_balance_after,

--- a/contra-escrow-program/tests/integration-tests/src/test_deposit/mod.rs
+++ b/contra-escrow-program/tests/integration-tests/src/test_deposit/mod.rs
@@ -2,11 +2,13 @@ use crate::{
     pda_utils::{find_allowed_mint_pda, find_event_authority_pda},
     state_utils::{assert_get_or_allow_mint, assert_get_or_create_instance, assert_get_or_deposit},
     utils::{
-        assert_program_error, get_or_create_associated_token_account, get_token_balance, set_mint,
-        set_mint_2022_basic, set_mint_2022_with_permanent_delegate, set_token_balance,
-        setup_test_balances, TestContext, ATA_PROGRAM_ID, CONTRA_ESCROW_PROGRAM_ID,
-        INCORRECT_PROGRAM_ID_ERROR, INVALID_ACCOUNT_DATA_ERROR, INVALID_INSTRUCTION_DATA_ERROR,
-        NOT_ENOUGH_ACCOUNT_KEYS_ERROR, PERMANENT_DELEGATE_NOT_ALLOWED_ERROR, TOKEN_2022_PROGRAM_ID,
+        assert_program_error, create_mint_2022_with_transfer_fee,
+        get_or_create_associated_token_account, get_or_create_associated_token_account_2022,
+        get_token_balance, set_mint, set_mint_2022_basic, set_mint_2022_with_permanent_delegate,
+        set_token_balance, setup_test_balances, TestContext, ATA_PROGRAM_ID,
+        CONTRA_ESCROW_PROGRAM_ID, INCORRECT_PROGRAM_ID_ERROR, INVALID_ACCOUNT_DATA_ERROR,
+        INVALID_INSTRUCTION_DATA_ERROR, NOT_ENOUGH_ACCOUNT_KEYS_ERROR,
+        PERMANENT_DELEGATE_NOT_ALLOWED_ERROR, TOKEN_2022_PROGRAM_ID,
         TOKEN_INSUFFICIENT_FUNDS_ERROR,
     },
 };
@@ -334,6 +336,120 @@ fn test_deposit_token_2022_basic_success() {
         false,
     )
     .expect("Token2022 deposit should succeed");
+}
+
+// Transfer fee mints require special handling: when SPL Token 2022 executes a transfer,
+// it withholds a fee from the destination. The sender is debited the full `amount`, but
+// the escrow receives `amount - fee`. We set up the mint via real SPL Token 2022
+// instructions (not raw account writes) so the fee mechanism is properly exercised.
+//
+// Mint config: 100 basis points (1%), max fee 1_000_000.
+// On a deposit of 1_000_000: fee = ceil(1_000_000 * 100 / 10_000) = 10_000,
+// so the escrow receives 990_000.
+#[test]
+fn test_deposit_token_2022_transfer_fee_success() {
+    const TRANSFER_FEE_BASIS_POINTS: u16 = 100; // 1%
+    const TRANSFER_FEE_MAX: u64 = 1_000_000;
+
+    let mut context = TestContext::new();
+    let admin = Keypair::new();
+    let user = Keypair::new();
+    let mint = Keypair::new();
+    let instance_seed = Keypair::new();
+
+    // Initialize the mint through SPL Token 2022 so the fee extension is properly
+    // recognized by the runtime during transfers.
+    create_mint_2022_with_transfer_fee(
+        &mut context,
+        &mint,
+        TRANSFER_FEE_BASIS_POINTS,
+        TRANSFER_FEE_MAX,
+    );
+
+    let (instance_pda, _) =
+        assert_get_or_create_instance(&mut context, &admin, &instance_seed, false, false)
+            .expect("CreateInstance should succeed");
+
+    assert_get_or_allow_mint(
+        &mut context,
+        &admin,
+        &instance_pda,
+        &mint.pubkey(),
+        false,
+        false,
+    )
+    .expect("AllowMint should succeed");
+
+    context
+        .airdrop_if_required(&user.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    // Create ATAs through SPL Token 2022 so they get the TransferFeeAmount extension,
+    // which is required for fee tracking on fee-bearing mints.
+    let user_ata =
+        get_or_create_associated_token_account_2022(&mut context, &user.pubkey(), &mint.pubkey());
+    let instance_ata =
+        get_or_create_associated_token_account_2022(&mut context, &instance_pda, &mint.pubkey());
+
+    // Fund the user via mint_to so balances are set without overwriting ATA extensions.
+    let mint_to_ix = spl_token_2022::instruction::mint_to(
+        &TOKEN_2022_PROGRAM_ID,
+        &mint.pubkey(),
+        &user_ata,
+        &context.payer.pubkey(),
+        &[],
+        DEPOSIT_AMOUNT,
+    )
+    .unwrap();
+    context
+        .send_transaction(mint_to_ix)
+        .expect("mint_to should succeed");
+
+    let (allowed_mint_pda, _) = find_allowed_mint_pda(&instance_pda, &mint.pubkey());
+    let (event_authority_pda, _) = find_event_authority_pda();
+
+    let user_balance_before = get_token_balance(&mut context, &user_ata);
+    let instance_balance_before = get_token_balance(&mut context, &instance_ata);
+
+    let instruction = DepositBuilder::new()
+        .payer(context.payer.pubkey())
+        .user(user.pubkey())
+        .instance(instance_pda)
+        .mint(mint.pubkey())
+        .allowed_mint(allowed_mint_pda)
+        .user_ata(user_ata)
+        .instance_ata(instance_ata)
+        .system_program(SYSTEM_PROGRAM_ID)
+        .token_program(TOKEN_2022_PROGRAM_ID)
+        .associated_token_program(ATA_PROGRAM_ID)
+        .event_authority(event_authority_pda)
+        .contra_escrow_program(CONTRA_ESCROW_PROGRAM_ID)
+        .amount(DEPOSIT_AMOUNT)
+        .instruction();
+
+    context
+        .send_transaction_with_signers(instruction, &[&user])
+        .expect("Deposit with transfer fee mint should succeed");
+
+    let user_balance_after = get_token_balance(&mut context, &user_ata);
+    let instance_balance_after = get_token_balance(&mut context, &instance_ata);
+
+    // The full deposit amount is debited from the user.
+    assert_eq!(
+        user_balance_after,
+        user_balance_before - DEPOSIT_AMOUNT,
+        "User should be debited the full deposit amount"
+    );
+
+    // The escrow receives less than the deposit amount because the transfer fee is
+    // withheld at the destination. The received amount is deposit - fee.
+    let expected_fee = (DEPOSIT_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 / 10_000) as u64;
+    let expected_received = DEPOSIT_AMOUNT - expected_fee;
+    assert_eq!(
+        instance_balance_after,
+        instance_balance_before + expected_received,
+        "Escrow should receive deposit minus transfer fee"
+    );
 }
 
 #[test]

--- a/contra-escrow-program/tests/integration-tests/src/test_release_funds/mod.rs
+++ b/contra-escrow-program/tests/integration-tests/src/test_release_funds/mod.rs
@@ -1331,7 +1331,8 @@ fn test_release_funds_full_balance() {
 // the existing balance check (`escrow_after == escrow_before - amount`) stays correct.
 //
 // Mint config: 100 basis points (1%), max fee 1_000_000.
-// Deposit: 1_000_000 gross, escrow receives 990_000 (fee withheld at escrow ATA on deposit).
+// The escrow is seeded directly via mint_to (no deposit flow), so it starts with exactly
+// DEPOSIT_AMOUNT tokens — no fee is applied on mint_to.
 // Release: operator releases 500_000 from escrow; user receives 495_000 (fee withheld at
 // user ATA on release); escrow decreases by exactly 500_000.
 #[test]
@@ -1457,7 +1458,8 @@ fn test_release_funds_token_2022_transfer_fee_success() {
     );
 
     // The user receives release amount minus the transfer fee.
-    let expected_fee = (RELEASE_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 / 10_000) as u64;
+    // SPL Token 2022 uses ceiling division for fee calculation.
+    let expected_fee = ((RELEASE_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 + 9_999) / 10_000) as u64;
     let expected_received = RELEASE_AMOUNT - expected_fee;
     assert_eq!(
         user_balance_after,

--- a/contra-escrow-program/tests/integration-tests/src/test_release_funds/mod.rs
+++ b/contra-escrow-program/tests/integration-tests/src/test_release_funds/mod.rs
@@ -9,10 +9,12 @@ use crate::{
         assert_get_or_deposit, assert_get_or_release_funds, assert_get_or_reset_smt_root,
     },
     utils::{
-        assert_program_error, set_mint, setup_test_balances, TestContext, ATA_PROGRAM_ID,
-        CONTRA_ESCROW_PROGRAM_ID, INVALID_INSTRUCTION_DATA_ERROR, INVALID_OPERATOR_ERROR,
-        INVALID_SMT_PROOF_ERROR, INVALID_TRANSACTION_NONCE_FOR_CURRENT_TREE_INDEX_ERROR,
-        MISSING_REQUIRED_SIGNATURE_ERROR, TOKEN_INSUFFICIENT_FUNDS_ERROR,
+        assert_program_error, create_mint_2022_with_transfer_fee,
+        get_or_create_associated_token_account_2022, get_token_balance, set_mint,
+        setup_test_balances, TestContext, ATA_PROGRAM_ID, CONTRA_ESCROW_PROGRAM_ID,
+        INVALID_INSTRUCTION_DATA_ERROR, INVALID_OPERATOR_ERROR, INVALID_SMT_PROOF_ERROR,
+        INVALID_TRANSACTION_NONCE_FOR_CURRENT_TREE_INDEX_ERROR, MISSING_REQUIRED_SIGNATURE_ERROR,
+        TOKEN_2022_PROGRAM_ID, TOKEN_INSUFFICIENT_FUNDS_ERROR,
     },
 };
 
@@ -1320,5 +1322,146 @@ fn test_release_funds_full_balance() {
     assert_eq!(
         balance, 0,
         "Instance ATA should be empty after full release"
+    );
+}
+
+// Transfer fee mints require TransferChecked for the SPL Token 2022 runtime to accept
+// the transfer. On release, the escrow sends `amount` and the user receives `amount - fee`
+// (the fee is withheld at the destination). The escrow is debited the full `amount`, so
+// the existing balance check (`escrow_after == escrow_before - amount`) stays correct.
+//
+// Mint config: 100 basis points (1%), max fee 1_000_000.
+// Deposit: 1_000_000 gross, escrow receives 990_000 (fee withheld at escrow ATA on deposit).
+// Release: operator releases 500_000 from escrow; user receives 495_000 (fee withheld at
+// user ATA on release); escrow decreases by exactly 500_000.
+#[test]
+fn test_release_funds_token_2022_transfer_fee_success() {
+    const TRANSFER_FEE_BASIS_POINTS: u16 = 100; // 1%
+    const TRANSFER_FEE_MAX: u64 = 1_000_000;
+
+    let mut context = TestContext::new();
+    let admin = Keypair::new();
+    let operator = Keypair::new();
+    let user = Keypair::new();
+    let mint = Keypair::new();
+    let instance_seed = Keypair::new();
+
+    // Initialize the mint through SPL Token 2022 so the fee extension is properly
+    // recognized by the runtime during transfers.
+    create_mint_2022_with_transfer_fee(
+        &mut context,
+        &mint,
+        TRANSFER_FEE_BASIS_POINTS,
+        TRANSFER_FEE_MAX,
+    );
+
+    let (instance_pda, _) =
+        assert_get_or_create_instance(&mut context, &admin, &instance_seed, false, false)
+            .expect("CreateInstance should succeed");
+
+    assert_get_or_allow_mint(
+        &mut context,
+        &admin,
+        &instance_pda,
+        &mint.pubkey(),
+        false,
+        false,
+    )
+    .expect("AllowMint should succeed");
+
+    let (operator_pda, _) = assert_get_or_add_operator(
+        &mut context,
+        &admin,
+        &instance_pda,
+        &operator.pubkey(),
+        false,
+        false,
+    )
+    .expect("AddOperator should succeed");
+
+    context
+        .airdrop_if_required(&user.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    // Create ATAs through SPL Token 2022 so they get the TransferFeeAmount extension,
+    // which is required for fee tracking on fee-bearing mints.
+    let user_ata =
+        get_or_create_associated_token_account_2022(&mut context, &user.pubkey(), &mint.pubkey());
+    let instance_ata =
+        get_or_create_associated_token_account_2022(&mut context, &instance_pda, &mint.pubkey());
+
+    // Fund the escrow directly via mint_to to simulate a prior deposit already being
+    // in the escrow (avoids a full deposit flow in this test).
+    let mint_to_ix = spl_token_2022::instruction::mint_to(
+        &TOKEN_2022_PROGRAM_ID,
+        &mint.pubkey(),
+        &instance_ata,
+        &context.payer.pubkey(),
+        &[],
+        DEPOSIT_AMOUNT,
+    )
+    .unwrap();
+    context
+        .send_transaction(mint_to_ix)
+        .expect("mint_to should succeed");
+
+    let (allowed_mint_pda, _) = find_allowed_mint_pda(&instance_pda, &mint.pubkey());
+    let (event_authority_pda, _) = find_event_authority_pda();
+
+    let mut smt = ProcessorSMT::new();
+    let (_, sibling_proofs) = smt.generate_exclusion_proof_for_verification(TRANSACTION_NONCE);
+    smt.insert(TRANSACTION_NONCE);
+    let new_withdrawal_root = smt.current_root();
+
+    let user_balance_before = get_token_balance(&mut context, &user_ata);
+    let instance_balance_before = get_token_balance(&mut context, &instance_ata);
+
+    let instruction = ReleaseFundsBuilder::new()
+        .payer(context.payer.pubkey())
+        .operator(operator.pubkey())
+        .instance(instance_pda)
+        .operator_pda(operator_pda)
+        .mint(mint.pubkey())
+        .allowed_mint(allowed_mint_pda)
+        .user_ata(user_ata)
+        .instance_ata(instance_ata)
+        .token_program(TOKEN_2022_PROGRAM_ID)
+        .associated_token_program(ATA_PROGRAM_ID)
+        .event_authority(event_authority_pda)
+        .contra_escrow_program(CONTRA_ESCROW_PROGRAM_ID)
+        .amount(RELEASE_AMOUNT)
+        .user(user.pubkey())
+        .new_withdrawal_root(new_withdrawal_root)
+        .transaction_nonce(TRANSACTION_NONCE)
+        .sibling_proofs(sibling_proofs)
+        .instruction();
+
+    context
+        .send_transaction_with_signers_with_transaction_result(
+            instruction,
+            &[&operator],
+            false,
+            Some(1_200_000),
+        )
+        .expect("Release with transfer fee mint should succeed");
+
+    let user_balance_after = get_token_balance(&mut context, &user_ata);
+    let instance_balance_after = get_token_balance(&mut context, &instance_ata);
+
+    // The escrow is debited the full release amount — the fee is withheld at the
+    // destination (user ATA), not the source.
+    assert_eq!(
+        instance_balance_after,
+        instance_balance_before - RELEASE_AMOUNT,
+        "Escrow should be debited the full release amount"
+    );
+
+    // The user receives release amount minus the transfer fee.
+    let expected_fee = (RELEASE_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 / 10_000) as u64;
+    let expected_received = RELEASE_AMOUNT - expected_fee;
+    assert_eq!(
+        user_balance_after,
+        user_balance_before + expected_received,
+        "User should receive release amount minus transfer fee"
     );
 }

--- a/contra-escrow-program/tests/integration-tests/src/test_release_funds/mod.rs
+++ b/contra-escrow-program/tests/integration-tests/src/test_release_funds/mod.rs
@@ -1459,7 +1459,8 @@ fn test_release_funds_token_2022_transfer_fee_success() {
 
     // The user receives release amount minus the transfer fee.
     // SPL Token 2022 uses ceiling division for fee calculation.
-    let expected_fee = ((RELEASE_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 + 9_999) / 10_000) as u64;
+    let expected_fee =
+        (RELEASE_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128).div_ceil(10_000) as u64;
     let expected_received = RELEASE_AMOUNT - expected_fee;
     assert_eq!(
         user_balance_after,

--- a/contra-escrow-program/tests/integration-tests/src/utils.rs
+++ b/contra-escrow-program/tests/integration-tests/src/utils.rs
@@ -19,7 +19,8 @@ use spl_token::{
 use spl_token_2022::{
     extension::{
         pausable::PausableConfig, permanent_delegate::PermanentDelegate,
-        BaseStateWithExtensionsMut, ExtensionType,
+        transfer_fee::instruction::initialize_transfer_fee_config, BaseStateWithExtensionsMut,
+        ExtensionType,
     },
     state::Mint as Token2022Mint,
 };
@@ -274,9 +275,11 @@ pub fn get_token_balance(context: &mut TestContext, ata: &Pubkey) -> u64 {
                     TokenAccount::unpack(&account.data).expect("Should deserialize token account");
                 token_account.amount
             } else if account.owner == TOKEN_2022_PROGRAM_ID {
-                let token_account = Token2022Account::unpack(&account.data)
-                    .expect("Should deserialize Token2022 account");
-                token_account.amount
+                let token_account = spl_token_2022::extension::StateWithExtensions::<
+                    Token2022Account,
+                >::unpack(&account.data)
+                .expect("Should deserialize Token2022 account");
+                token_account.base.amount
             } else {
                 0
             }
@@ -591,6 +594,58 @@ pub fn set_mint_2022_with_pausable(context: &mut TestContext, mint: &Pubkey, aut
             },
         )
         .expect("Failed to set Token 2022 mint account with Pausable");
+}
+
+pub fn create_mint_2022_with_transfer_fee(
+    context: &mut TestContext,
+    mint: &Keypair,
+    transfer_fee_basis_points: u16,
+    maximum_fee: u64,
+) {
+    let space = ExtensionType::try_calculate_account_len::<Token2022Mint>(&[
+        ExtensionType::TransferFeeConfig,
+    ])
+    .unwrap();
+    let rent = context.svm.minimum_balance_for_rent_exemption(space);
+
+    let create_account_ix = solana_sdk::system_instruction::create_account(
+        &context.payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &TOKEN_2022_PROGRAM_ID,
+    );
+
+    let init_transfer_fee_ix = initialize_transfer_fee_config(
+        &TOKEN_2022_PROGRAM_ID,
+        &mint.pubkey(),
+        Some(&context.payer.pubkey()),
+        Some(&context.payer.pubkey()),
+        transfer_fee_basis_points,
+        maximum_fee,
+    )
+    .unwrap();
+
+    let init_mint_ix = spl_token_2022::instruction::initialize_mint(
+        &TOKEN_2022_PROGRAM_ID,
+        &mint.pubkey(),
+        &context.payer.pubkey(),
+        None,
+        6,
+    )
+    .unwrap();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[create_account_ix, init_transfer_fee_ix, init_mint_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, mint],
+        context.svm.latest_blockhash(),
+    );
+
+    context
+        .svm
+        .send_transaction(transaction)
+        .expect("Failed to create mint with transfer fee");
 }
 
 pub fn get_or_create_associated_token_account_2022(


### PR DESCRIPTION
# fix(escrow): support Token2022 TransferFeeConfig extension

## Summary

Adds proper support for SPL Token 2022 mints with the `TransferFeeConfig` extension in both the `deposit` and `release_funds` instructions.

Previously, both processors used `Transfer` (the basic Token2022 CPI), which is rejected by the SPL Token 2022 program with error `Custom(31)` ("Mint required for this account to transfer tokens, use `transfer_checked`") whenever the mint has any extensions configured. Additionally, the processors assumed a 1:1 relationship between the requested amount and the tokens actually transferred — an assumption that breaks with transfer fee mints, where fees are withheld at the destination ATA.

## Changes

### Program (`deposit.rs`, `release_funds.rs`)

- **`Transfer` → `TransferChecked`**: Both processors now use `TransferChecked`, which requires passing the `mint` account and `decimals`. This is required by SPL Token 2022 for any mint with extensions.

- **Balance-delta pattern**: Instead of asserting `balance_after == balance_before ± args.amount` (which fails when fees are withheld), both processors now compute the actual transferred amount from the observed balance change:
  - Deposit: `received = escrow_balance_after - escrow_balance_before`
  - Release: `released = escrow_balance_before - escrow_balance_after`

  The delta is used in the emitted event and replaces the strict equality check that was previously returning `InvalidEscrowBalance`.

### Tests (`test_deposit/mod.rs`, `test_release_funds/mod.rs`, `utils.rs`)

- Added `create_mint_2022_with_transfer_fee` helper in `utils.rs` that creates a Token2022 mint with `TransferFeeConfig` using real on-chain instructions (`create_account` → `initialize_transfer_fee_config` → `initialize_mint`). The order matters — the extension must be initialized before the base mint.

- Fixed `get_token_balance` in `utils.rs` to use `StateWithExtensions::<Token2022Account>::unpack` instead of `Token2022Account::unpack`. The plain unpack fails on accounts that have the `TransferFeeAmount` extension attached (which is added automatically to every ATA for a fee-bearing mint).

- Added `test_deposit_token_2022_transfer_fee_success` and `test_release_funds_token_2022_transfer_fee_success`.

**Note on test assertions**: These two tests do **not** use the shared `assert_get_or_deposit` / `assert_deposit_balances` helpers used by the rest of the suite. Those helpers assert that the escrow balance increases by exactly `deposit_amount`, which is incorrect for fee-bearing mints (escrow only receives `amount - fee`). The transfer fee tests use inline balance assertions with explicit fee calculations instead:

```rust
let expected_fee = (DEPOSIT_AMOUNT as u128 * TRANSFER_FEE_BASIS_POINTS as u128 / 10_000) as u64;
let expected_received = DEPOSIT_AMOUNT - expected_fee;
assert_eq!(instance_balance_after, instance_balance_before + expected_received);
```

The release funds test also raises the compute unit limit to `1_200_000` (vs the default `200_000`) because SMT proof verification is expensive enough to exceed the default budget.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | 118 | 230 | 51.3% | [unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24371021559) |
| Escrow Program | 1,170 | 1,951 | 60.0% | [unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24371021559) |
| E2E Integration | 7,895 | 11,473 | 68.8% | [e2e-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24371021558) |
| **Total** | **9,183** | **13,654** | **67.3%** | |

> Last updated: 2026-04-13 23:13:31 UTC by E2E Integration