### PR TITLE
fix(rpc): getAccountInfo returns data for user accounts

### DIFF
--- a/contra-escrow-program/tests/trident-tests/README.md
+++ b/contra-escrow-program/tests/trident-tests/README.md
@@ -8,10 +8,10 @@ Stateful fuzz tests for the escrow program using [Trident](https://github.com/Ac
 
 Tests the core escrow lifecycle in a single tree generation.
 
-| Flow | Description |
-|------|-------------|
-| `fuzz_deposit` | Deposits a random amount. Asserts exact ATA balance movement. |
-| `fuzz_release` | 50% valid proof release / 50% garbage proof. Asserts success/failure and balance invariants. |
+| Flow                | Description                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| `fuzz_deposit`      | Deposits a random amount. Asserts exact ATA balance movement.                                |
+| `fuzz_release`      | 50% valid proof release / 50% garbage proof. Asserts success/failure and balance invariants. |
 | `fuzz_double_spend` | Replays a previously successful release with the exact same proof — must always be rejected. |
 
 **Final invariant:** `escrow_balance == total_deposited - total_released`
@@ -20,12 +20,12 @@ Tests the core escrow lifecycle in a single tree generation.
 
 Tests the SMT reset lifecycle across multiple tree generations.
 
-| Flow | Description |
-|------|-------------|
-| `fuzz_deposit` | Deposits a random amount. |
-| `fuzz_release` | Valid release within the current tree generation. Skipped silently if preconditions aren't met. |
+| Flow                  | Description                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| `fuzz_deposit`        | Deposits a random amount.                                                                           |
+| `fuzz_release`        | Valid release within the current tree generation. Skipped silently if preconditions aren't met.     |
 | `fuzz_reset_smt_root` | Resets the on-chain SMT root, advancing the tree generation index. Asserts balances are unaffected. |
-| `fuzz_stale_nonce` | Attempts a release with a nonce from the previous generation — must always be rejected. |
+| `fuzz_stale_nonce`    | Attempts a release with a nonce from the previous generation — must always be rejected.             |
 
 **Final invariant:** `escrow_balance == total_deposited - total_released`
 

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -29,13 +29,12 @@
 /// evict less frequently accessed accounts.
 use {
     crate::{
-        accounts::{bpf_loader_program_account, AccountsDB},
+        accounts::{precompiles::PRECOMPILES, AccountsDB},
         stages::AccountSettlement,
     },
     solana_sdk::{
-        account::{Account, AccountSharedData, ReadableAccount},
+        account::{AccountSharedData, ReadableAccount},
         pubkey::Pubkey,
-        rent::Rent,
         transaction::SanitizedTransaction,
     },
     solana_svm::{
@@ -49,7 +48,7 @@ use {
         time::{SystemTime, UNIX_EPOCH},
     },
     tokio::sync::mpsc,
-    tracing::{debug, info, warn},
+    tracing::{debug, warn},
 };
 
 // TODO: Make this a config parameter
@@ -88,90 +87,12 @@ impl BOB {
         accounts_db: AccountsDB,
         settled_accounts_rx: mpsc::UnboundedReceiver<Vec<(Pubkey, AccountSettlement)>>,
     ) -> Self {
-        // Initialize precompiles that are always kept in memory
-        let mut precompiles = HashMap::new();
-
-        // Use zero rent for gasless operation
-        let rent = Rent {
-            lamports_per_byte_year: 0,
-            exemption_threshold: 0.0,
-            burn_percent: 0,
-        };
-
-        // Load system program.
-        //
-        // lamports=1 (not 0): the SVM's AccountLoader caches loaded accounts
-        // across transactions within a single batch, and if a cached entry has
-        // `lamports == 0` it is treated as "previously deallocated" and
-        // returned as `None` on subsequent loads. A zero-lamport precompile
-        // therefore becomes invisible to the second transaction in a batch,
-        // breaking any CPI into system_program (e.g. ATA account creation).
-        // Same applies to the rent sysvar below.
-        let system_account = Account {
-            lamports: 1,
-            data: b"solana_system_program".to_vec(),
-            owner: solana_sdk_ids::native_loader::ID,
-            executable: true,
-            rent_epoch: u64::MAX,
-        };
-        precompiles.insert(
-            solana_sdk_ids::system_program::ID,
-            AccountSharedData::from(system_account),
-        );
-        info!("Loaded system program");
-
-        // Load SPL Token program
-        let spl_token_elf = include_bytes!("../../precompiles/spl_token-8.0.0.so");
-        let (spl_token_id, spl_token_account) =
-            bpf_loader_program_account(&spl_token::ID, spl_token_elf, &rent);
-        precompiles.insert(spl_token_id, AccountSharedData::from(spl_token_account));
-        info!("Loaded SPL Token program");
-
-        // Load Associated Token Account program
-        let ata_elf = include_bytes!("../../precompiles/spl_associated_token_account-1.1.1.so");
-        let (ata_id, ata_account) =
-            bpf_loader_program_account(&spl_associated_token_account::ID, ata_elf, &rent);
-        precompiles.insert(ata_id, AccountSharedData::from(ata_account));
-        info!("Loaded Associated Token Account program");
-
-        // Load rent sysvar. lamports=1 for the same reason as system_program above.
-        let rent_account = Account {
-            lamports: 1,
-            data: bincode::serialize(&rent).unwrap(),
-            owner: solana_sdk_ids::sysvar::ID,
-            executable: false,
-            rent_epoch: u64::MAX,
-        };
-        precompiles.insert(
-            solana_sdk_ids::sysvar::rent::ID,
-            AccountSharedData::from(rent_account),
-        );
-        info!("Loaded rent sysvar");
-
-        // Load SPL Memo v3 program
-        let memo_v3_elf = include_bytes!("../../precompiles/spl_memo-3.0.0.so");
-        let (memo_v3_id, memo_v3_account) =
-            bpf_loader_program_account(&spl_memo::id(), memo_v3_elf, &rent);
-        precompiles.insert(memo_v3_id, AccountSharedData::from(memo_v3_account));
-        info!("Loaded SPL Memo v3 program");
-
-        // Load Contra Withdraw program
-        let withdraw_elf = include_bytes!("../../precompiles/contra_withdraw_program.so");
-        // Convert from solana_pubkey::Pubkey to solana_sdk::pubkey::Pubkey
-        let (_, withdraw_account) = bpf_loader_program_account(
-            &contra_withdraw_program_client::CONTRA_WITHDRAW_PROGRAM_ID,
-            withdraw_elf,
-            &rent,
-        );
-        precompiles.insert(
-            contra_withdraw_program_client::CONTRA_WITHDRAW_PROGRAM_ID,
-            AccountSharedData::from(withdraw_account),
-        );
-        info!("Loaded Contra Withdraw program");
-
+        // Precompile ELFs are parsed once process-wide; see
+        // `crate::accounts::precompiles`. Cloning the map is cheap, the
+        // heavy work of parsing BPF bytes happens at first LazyLock access.
         Self {
             accounts: HashMap::new(),
-            precompiles,
+            precompiles: PRECOMPILES.clone(),
             settled_accounts_rx,
             accounts_db,
             batches_since_eviction: 0,
@@ -411,7 +332,9 @@ impl TransactionProcessingCallback for BOB {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_svm_callback::TransactionProcessingCallback};
+    use {
+        super::*, solana_sdk::account::Account, solana_svm_callback::TransactionProcessingCallback,
+    };
 
     fn create_test_bob() -> (BOB, mpsc::UnboundedSender<Vec<(Pubkey, AccountSettlement)>>) {
         crate::test_helpers::create_test_bob()

--- a/core/src/accounts/mod.rs
+++ b/core/src/accounts/mod.rs
@@ -16,6 +16,7 @@ pub mod get_recent_performance_samples;
 pub mod get_transaction;
 pub mod get_transaction_count;
 pub mod postgres;
+pub mod precompiles;
 pub mod redis;
 pub mod set_account;
 pub mod set_latest_slot;

--- a/core/src/accounts/precompiles.rs
+++ b/core/src/accounts/precompiles.rs
@@ -1,0 +1,158 @@
+//! Shared precompile account map.
+//!
+//! Built once process-wide from the embedded ELF blobs and served from a
+//! `LazyLock`. Both the write-side `BOB` and read-side RPC handlers consume
+//! this same map so precompile construction cost is paid exactly once.
+
+use {
+    crate::accounts::bpf_loader_program_account,
+    solana_sdk::{
+        account::{Account, AccountSharedData},
+        pubkey::Pubkey,
+        rent::Rent,
+    },
+    std::{collections::HashMap, sync::LazyLock},
+};
+
+pub static PRECOMPILES: LazyLock<HashMap<Pubkey, AccountSharedData>> =
+    LazyLock::new(build_precompiles);
+
+/// Returns the precompile account for `pubkey`, if any.
+///
+/// Read-only RPC handlers should prefer this plus a direct `AccountsDB`
+/// lookup over constructing a `BOB`.
+pub fn get(pubkey: &Pubkey) -> Option<AccountSharedData> {
+    PRECOMPILES.get(pubkey).cloned()
+}
+
+fn build_precompiles() -> HashMap<Pubkey, AccountSharedData> {
+    let mut precompiles = HashMap::new();
+
+    // Zero rent for gasless operation.
+    let rent = Rent {
+        lamports_per_byte_year: 0,
+        exemption_threshold: 0.0,
+        burn_percent: 0,
+    };
+
+    // System program. lamports=1 (not 0): the SVM's AccountLoader caches
+    // loaded accounts across transactions within a batch, and a cached entry
+    // with lamports=0 is treated as "previously deallocated" and returned
+    // as None on subsequent loads — breaking any CPI into system_program.
+    // Same sentinel applies to the rent sysvar below.
+    let system_account = Account {
+        lamports: 1,
+        data: b"solana_system_program".to_vec(),
+        owner: solana_sdk_ids::native_loader::ID,
+        executable: true,
+        rent_epoch: u64::MAX,
+    };
+    precompiles.insert(
+        solana_sdk_ids::system_program::ID,
+        AccountSharedData::from(system_account),
+    );
+
+    // SPL Token v8.
+    let spl_token_elf = include_bytes!("../../precompiles/spl_token-8.0.0.so");
+    let (spl_token_id, spl_token_account) =
+        bpf_loader_program_account(&spl_token::ID, spl_token_elf, &rent);
+    precompiles.insert(spl_token_id, AccountSharedData::from(spl_token_account));
+
+    // Associated Token Account v1.1.1.
+    let ata_elf = include_bytes!("../../precompiles/spl_associated_token_account-1.1.1.so");
+    let (ata_id, ata_account) =
+        bpf_loader_program_account(&spl_associated_token_account::ID, ata_elf, &rent);
+    precompiles.insert(ata_id, AccountSharedData::from(ata_account));
+
+    // Rent sysvar. lamports=1 sentinel for the same reason as system_program.
+    let rent_account = Account {
+        lamports: 1,
+        data: bincode::serialize(&rent).unwrap(),
+        owner: solana_sdk_ids::sysvar::ID,
+        executable: false,
+        rent_epoch: u64::MAX,
+    };
+    precompiles.insert(
+        solana_sdk_ids::sysvar::rent::ID,
+        AccountSharedData::from(rent_account),
+    );
+
+    // SPL Memo v3.
+    let memo_v3_elf = include_bytes!("../../precompiles/spl_memo-3.0.0.so");
+    let (memo_v3_id, memo_v3_account) =
+        bpf_loader_program_account(&spl_memo::id(), memo_v3_elf, &rent);
+    precompiles.insert(memo_v3_id, AccountSharedData::from(memo_v3_account));
+
+    // Contra Withdraw program.
+    let withdraw_elf = include_bytes!("../../precompiles/contra_withdraw_program.so");
+    let (_, withdraw_account) = bpf_loader_program_account(
+        &contra_withdraw_program_client::CONTRA_WITHDRAW_PROGRAM_ID,
+        withdraw_elf,
+        &rent,
+    );
+    precompiles.insert(
+        contra_withdraw_program_client::CONTRA_WITHDRAW_PROGRAM_ID,
+        AccountSharedData::from(withdraw_account),
+    );
+
+    precompiles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::account::ReadableAccount;
+
+    #[test]
+    fn precompiles_contains_expected_entries() {
+        assert!(PRECOMPILES.contains_key(&solana_sdk_ids::system_program::ID));
+        assert!(PRECOMPILES.contains_key(&spl_token::ID));
+        assert!(PRECOMPILES.contains_key(&spl_associated_token_account::ID));
+        assert!(PRECOMPILES.contains_key(&solana_sdk_ids::sysvar::rent::ID));
+        assert!(PRECOMPILES.contains_key(&spl_memo::id()));
+        assert!(
+            PRECOMPILES.contains_key(&contra_withdraw_program_client::CONTRA_WITHDRAW_PROGRAM_ID)
+        );
+        assert_eq!(PRECOMPILES.len(), 6);
+    }
+
+    #[test]
+    fn precompile_programs_are_executable_with_elf_data() {
+        for program_id in [
+            spl_token::ID,
+            spl_associated_token_account::ID,
+            spl_memo::id(),
+            contra_withdraw_program_client::CONTRA_WITHDRAW_PROGRAM_ID,
+        ] {
+            let account = PRECOMPILES.get(&program_id).expect("missing precompile");
+            assert!(account.executable(), "{} should be executable", program_id);
+            assert!(!account.data().is_empty());
+        }
+    }
+
+    #[test]
+    fn system_program_and_rent_use_sentinel_lamports() {
+        // lamports=1 sentinel prevents the SVM AccountLoader from treating
+        // these as deallocated on re-read within a batch.
+        let system = PRECOMPILES
+            .get(&solana_sdk_ids::system_program::ID)
+            .unwrap();
+        assert_eq!(system.lamports(), 1);
+        assert!(system.executable());
+
+        let rent = PRECOMPILES.get(&solana_sdk_ids::sysvar::rent::ID).unwrap();
+        assert_eq!(rent.lamports(), 1);
+        assert!(!rent.executable());
+    }
+
+    #[test]
+    fn get_returns_none_for_unknown() {
+        assert!(get(&Pubkey::new_unique()).is_none());
+    }
+
+    #[test]
+    fn get_returns_cloned_precompile() {
+        let account = get(&spl_token::ID).expect("spl_token missing");
+        assert!(account.executable());
+    }
+}

--- a/core/src/rpc/get_account_info_impl.rs
+++ b/core/src/rpc/get_account_info_impl.rs
@@ -1,5 +1,5 @@
 use crate::{
-    accounts::bob::BOB,
+    accounts::precompiles,
     rpc::{
         error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
         ReadDeps,
@@ -13,10 +13,8 @@ use solana_client::{
     rpc_response::{Response, RpcResponseContext},
 };
 use solana_sdk::pubkey::Pubkey;
-use solana_svm_callback::TransactionProcessingCallback;
 use std::str::FromStr;
-use tokio::sync::mpsc;
-use tracing::info;
+use tracing::debug;
 
 pub async fn get_account_info_impl(
     read_deps: &ReadDeps,
@@ -35,18 +33,18 @@ pub async fn get_account_info_impl(
         .map_err(|e| custom_error(JSON_RPC_SERVER_ERROR, format!("Failed to get slot: {}", e)))?
         .unwrap_or(0);
 
-    // Get account from database
-    let (_settled_accounts_tx, settled_accounts_rx) = mpsc::unbounded_channel();
-    let bob = BOB::new(read_deps.accounts_db.clone(), settled_accounts_rx).await;
-    let account_data = bob.get_account_shared_data(&pubkey);
-    let encoding = config.encoding.unwrap_or(UiAccountEncoding::Base64);
-    let value = account_data.map(|account| {
-        // Encode data based on requested encoding
-        encode_ui_account(&pubkey, &account, encoding, None, config.data_slice)
-    });
-    info!("Account info: {:?}", value);
+    // Precompiles short-circuit the DB; everything else reads from AccountsDB.
+    let account_data = match precompiles::get(&pubkey) {
+        Some(account) => Some(account),
+        None => read_deps.accounts_db.get_account_shared_data(&pubkey).await,
+    };
 
-    // TODO: Get actual slot from the read node's state
+    let encoding = config.encoding.unwrap_or(UiAccountEncoding::Base64);
+    let value = account_data
+        .map(|account| encode_ui_account(&pubkey, &account, encoding, None, config.data_slice));
+
+    debug!("get_account_info pubkey={} hit={}", pubkey, value.is_some());
+
     Ok(Response {
         context: RpcResponseContext::new(slot),
         value,

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -377,21 +377,25 @@ pub async fn execute_batch(
             accounts_to_preload.insert(*account);
         }
 
-        if tx
-            .message()
-            .program_instructions_iter()
-            .any(|(program_id, instruction)| {
-                program_id == &spl_token::id()
-                    && instruction
-                        .data
-                        .first()
-                        .is_some_and(|t| is_admin_instruction(program_id, *t))
-            })
-        {
-            // Admin SPL transactions
+        // Router contract: a tx is admin-routed only when EVERY instruction is
+        // listed in ADMIN_INSTRUCTIONS_MAP. A mixed tx is routed to
+        // the regular SVM where the admin instruction will fail naturally
+        let mut has_any_admin = false;
+        let mut all_admin = true;
+        for (program_id, instruction) in tx.message().program_instructions_iter() {
+            let is_admin = instruction
+                .data
+                .first()
+                .is_some_and(|t| is_admin_instruction(program_id, *t));
+            has_any_admin |= is_admin;
+            all_admin &= is_admin;
+        }
+
+        if has_any_admin && all_admin {
+            // Pure admin tx, Admin VM.
             admin_transactions.push(tx);
         } else {
-            // Regular transactions
+            // Pure regular OR mixed, real SVM.
             regular_transactions.push(tx);
         }
     }
@@ -674,6 +678,61 @@ mod tests {
         assert_eq!(results.processing_results.len(), n);
     }
 
+    /// Build a well-formed admin InitializeMint tx (single SPL Token ix, type=0).
+    fn create_admin_initialize_mint_tx() -> SanitizedTransaction {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+
+        let payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let mut data = vec![0u8; 35];
+        data[1] = 6; // decimals
+        data[2..34].copy_from_slice(&authority.to_bytes());
+        data[34] = 0; // no freeze authority
+        let ix = Instruction {
+            program_id: spl_token::id(),
+            accounts: vec![
+                AccountMeta::new(mint, false),
+                AccountMeta::new(payer.pubkey(), true),
+            ],
+            data,
+        };
+        let msg = Message::new(&[ix], Some(&payer.pubkey()));
+        let tx = Transaction::new(&[&payer], msg, Hash::default());
+        SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new())
+            .expect("failed to create admin init-mint tx")
+    }
+
+    /// Build a mixed tx: one admin instruction (InitializeMint) + one
+    /// non-admin instruction (system transfer). Router must NOT send this to
+    /// the Admin VM.
+    fn create_mixed_admin_and_regular_tx() -> SanitizedTransaction {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+
+        let payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let mut data = vec![0u8; 35];
+        data[1] = 6;
+        data[2..34].copy_from_slice(&authority.to_bytes());
+        let init_mint_ix = Instruction {
+            program_id: spl_token::id(),
+            accounts: vec![
+                AccountMeta::new(mint, false),
+                AccountMeta::new(payer.pubkey(), true),
+            ],
+            data,
+        };
+        let transfer_ix =
+            solana_system_interface::instruction::transfer(&payer.pubkey(), &recipient, 100);
+        let msg = Message::new(&[init_mint_ix, transfer_ix], Some(&payer.pubkey()));
+        let tx = Transaction::new(&[&payer], msg, Hash::default());
+        SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new())
+            .expect("failed to create mixed tx")
+    }
+
+    // An empty batch yields empty partitions and no VM invocations.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_execute_batch_empty_batch() {
         let (accounts_db, _pg) = start_test_postgres().await;
@@ -1105,5 +1164,87 @@ mod tests {
             result.is_ok(),
             "worker should exit when input channel is closed"
         );
+    }
+
+    // ─── Router tests (admin routing must be all-or-nothing) ───
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_execute_batch_routes_pure_admin_tx_to_admin_vm() {
+        // A tx whose only instruction is an admin instruction routes to the Admin VM.
+        let (accounts_db, _pg) = start_test_postgres().await;
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx).await;
+
+        let tx = create_admin_initialize_mint_tx();
+        let batch = ConflictFreeBatch {
+            transactions: vec![crate::scheduler::TransactionWithIndex {
+                transaction: Arc::new(tx),
+                index: 0,
+            }],
+        };
+
+        let result = execute_batch(batch, &mut deps).await;
+        assert_eq!(result.admin_transactions.len(), 1);
+        assert!(result.regular_transactions.is_empty());
+        assert!(result.admin_results.is_some());
+        assert!(result.regular_results.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_execute_batch_routes_mixed_admin_regular_to_real_svm() {
+        // A tx that mixes one admin instruction (InitializeMint) with one
+        // non-admin instruction (system transfer) must NOT be sent to the
+        // Admin VM. The router sends it to the regular SVM path; the admin
+        // path stays strictly single-purpose.
+        let (accounts_db, _pg) = start_test_postgres().await;
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx).await;
+
+        let tx = create_mixed_admin_and_regular_tx();
+        let batch = ConflictFreeBatch {
+            transactions: vec![crate::scheduler::TransactionWithIndex {
+                transaction: Arc::new(tx),
+                index: 0,
+            }],
+        };
+
+        let result = execute_batch(batch, &mut deps).await;
+        assert!(
+            result.admin_transactions.is_empty(),
+            "mixed tx must not be admin-routed"
+        );
+        assert_eq!(result.regular_transactions.len(), 1);
+        assert!(result.admin_results.is_none());
+        assert!(result.regular_results.is_some());
+    }
+
+    // In a batch with one pure-admin tx and one pure-regular tx, each routes
+    // to the correct VM and both partitions produce results.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_execute_batch_partitions_admin_and_regular_separately() {
+        let (accounts_db, _pg) = start_test_postgres().await;
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx).await;
+
+        let admin_tx = create_admin_initialize_mint_tx();
+        let regular_tx = create_test_transaction();
+        let batch = ConflictFreeBatch {
+            transactions: vec![
+                crate::scheduler::TransactionWithIndex {
+                    transaction: Arc::new(admin_tx),
+                    index: 0,
+                },
+                crate::scheduler::TransactionWithIndex {
+                    transaction: Arc::new(regular_tx),
+                    index: 1,
+                },
+            ],
+        };
+
+        let result = execute_batch(batch, &mut deps).await;
+        assert_eq!(result.admin_transactions.len(), 1);
+        assert_eq!(result.regular_transactions.len(), 1);
+        assert!(result.admin_results.is_some());
+        assert!(result.regular_results.is_some());
     }
 }

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -1173,7 +1173,7 @@ mod tests {
         // A tx whose only instruction is an admin instruction routes to the Admin VM.
         let (accounts_db, _pg) = start_test_postgres().await;
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut deps = get_execution_deps(accounts_db, rx).await;
+        let mut deps = get_execution_deps(accounts_db, rx, 4).await;
 
         let tx = create_admin_initialize_mint_tx();
         let batch = ConflictFreeBatch {
@@ -1183,7 +1183,8 @@ mod tests {
             }],
         };
 
-        let result = execute_batch(batch, &mut deps).await;
+        let noop: SharedMetrics = Arc::new(NoopMetrics);
+        let result = execute_batch(batch, &mut deps, &noop).await;
         assert_eq!(result.admin_transactions.len(), 1);
         assert!(result.regular_transactions.is_empty());
         assert!(result.admin_results.is_some());
@@ -1198,7 +1199,7 @@ mod tests {
         // path stays strictly single-purpose.
         let (accounts_db, _pg) = start_test_postgres().await;
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut deps = get_execution_deps(accounts_db, rx).await;
+        let mut deps = get_execution_deps(accounts_db, rx, 4).await;
 
         let tx = create_mixed_admin_and_regular_tx();
         let batch = ConflictFreeBatch {
@@ -1208,7 +1209,8 @@ mod tests {
             }],
         };
 
-        let result = execute_batch(batch, &mut deps).await;
+        let noop: SharedMetrics = Arc::new(NoopMetrics);
+        let result = execute_batch(batch, &mut deps, &noop).await;
         assert!(
             result.admin_transactions.is_empty(),
             "mixed tx must not be admin-routed"
@@ -1224,7 +1226,7 @@ mod tests {
     async fn test_execute_batch_partitions_admin_and_regular_separately() {
         let (accounts_db, _pg) = start_test_postgres().await;
         let (_tx, rx) = mpsc::unbounded_channel();
-        let mut deps = get_execution_deps(accounts_db, rx).await;
+        let mut deps = get_execution_deps(accounts_db, rx, 4).await;
 
         let admin_tx = create_admin_initialize_mint_tx();
         let regular_tx = create_test_transaction();
@@ -1241,7 +1243,8 @@ mod tests {
             ],
         };
 
-        let result = execute_batch(batch, &mut deps).await;
+        let noop: SharedMetrics = Arc::new(NoopMetrics);
+        let result = execute_batch(batch, &mut deps, &noop).await;
         assert_eq!(result.admin_transactions.len(), 1);
         assert_eq!(result.regular_transactions.len(), 1);
         assert!(result.admin_results.is_some());

--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -1,6 +1,11 @@
 use std::collections::HashMap;
 
-use solana_sdk::{account::AccountSharedData, pubkey::Pubkey};
+use solana_sdk::{
+    account::{AccountSharedData, ReadableAccount},
+    instruction::InstructionError,
+    pubkey::Pubkey,
+    transaction::TransactionError,
+};
 use solana_svm::{
     account_loader::{LoadedTransaction, TransactionCheckResult},
     transaction_error_metrics::TransactionErrorMetrics,
@@ -17,7 +22,7 @@ use solana_timings::ExecuteTimings;
 use spl_token::solana_program::program_option::COption;
 use spl_token::solana_program::program_pack::Pack;
 use spl_token::state::Mint;
-use tracing::warn;
+use tracing::{debug, warn};
 
 const SPL_TOKEN_ID: Pubkey = spl_token::id();
 
@@ -66,8 +71,11 @@ impl AdminVm {
         account
     }
 
-    /// Creates an ExecutedTransaction result
+    /// Creates an ExecutedTransaction result carrying the given status.
+    /// On failure (`status.is_err()`), callers pass `vec![]` so nothing persists —
+    /// this matches real-SVM atomicity.
     fn create_executed_transaction(
+        status: Result<(), TransactionError>,
         accounts: Vec<(Pubkey, AccountSharedData)>,
     ) -> ExecutedTransaction {
         ExecutedTransaction {
@@ -76,7 +84,7 @@ impl AdminVm {
                 ..Default::default()
             },
             execution_details: TransactionExecutionDetails {
-                status: Ok(()),
+                status,
                 log_messages: None,
                 inner_instructions: None,
                 return_data: None,
@@ -87,9 +95,21 @@ impl AdminVm {
         }
     }
 
+    /// Process each tx's instructions in order. On the first failing instruction,
+    /// short-circuit via `break 'tx` with a failed `ExecutedTransaction`
+    ///
+    /// Failure mapping:
+    /// - non-`spl_token` program id             -> InvalidInstructionData
+    /// - empty instruction data                 -> InvalidInstructionData
+    /// - unsupported SPL instruction type       -> InvalidInstructionData
+    /// - InitializeMint data < 34 bytes         -> InvalidAccountData
+    /// - InitializeMint empty accounts          -> InvalidAccountData
+    /// - freeze authority tag=1, <32 trailing   -> InvalidAccountData
+    /// - mint index out of `account_keys`       -> NotEnoughAccountKeys
+    /// - mint already initialized               -> AccountAlreadyInitialized
     pub fn load_and_execute_sanitized_transactions<CB: TransactionProcessingCallback>(
         &self,
-        _callbacks: &CB,
+        callbacks: &CB,
         sanitized_txs: &[impl SVMTransaction],
         _check_results: Vec<TransactionCheckResult>,
         _environment: &TransactionProcessingEnvironment,
@@ -98,65 +118,65 @@ impl AdminVm {
         let mut processing_results: Vec<TransactionProcessingResult> = vec![];
         for tx in sanitized_txs {
             let mut accounts = vec![];
-            for (program_id, instruction) in tx.program_instructions_iter() {
-                match *program_id {
-                    SPL_TOKEN_ID => {
-                        let Some(instruction_type) = instruction.data.first() else {
-                            warn!("[admin-vm] SPL Token instruction has empty data, skipping");
-                            continue;
-                        };
-                        match *instruction_type {
-                            INSTRUCTION_INITIALIZE_MINT => {
-                                // Parse InitializeMint instruction
-                                if !instruction.accounts.is_empty() && instruction.data.len() >= 34
-                                {
-                                    // Parse instruction data
-                                    // TODO: Instruction data could be invalid,
-                                    // so we need to handle it without causing a
-                                    // panic
-                                    let account_keys = tx.account_keys();
-                                    let mint_index = instruction.accounts[0] as usize;
-                                    let mint_pubkey = account_keys.get(mint_index).unwrap();
+            let executed: ExecutedTransaction = 'tx: {
+                for (ix_index, (program_id, instruction)) in
+                    tx.program_instructions_iter().enumerate()
+                {
+                    // Solana's InstructionError index is a u8;
+                    let ix_idx_u8 = u8::try_from(ix_index).unwrap_or(u8::MAX);
 
-                                    // Extract parameters from instruction data
-                                    let decimals = instruction.data[1];
-                                    let mint_authority = &instruction.data[2..34];
+                    if *program_id != SPL_TOKEN_ID {
+                        warn!("[admin-vm] Unsupported program ID: {}", program_id);
+                        break 'tx Self::create_executed_transaction(
+                            Err(TransactionError::InstructionError(
+                                ix_idx_u8,
+                                InstructionError::InvalidInstructionData,
+                            )),
+                            vec![],
+                        );
+                    }
 
-                                    // Check for optional freeze authority
-                                    let freeze_authority = if instruction.data.len() > 34
-                                        && instruction.data[34] == 1
-                                    {
-                                        Some(&instruction.data[35..67])
-                                    } else {
-                                        None
-                                    };
+                    let Some(&instruction_type) = instruction.data.first() else {
+                        warn!("[admin-vm] SPL Token instruction has empty data");
+                        break 'tx Self::create_executed_transaction(
+                            Err(TransactionError::InstructionError(
+                                ix_idx_u8,
+                                InstructionError::InvalidInstructionData,
+                            )),
+                            vec![],
+                        );
+                    };
 
-                                    // Create the mint account
-                                    let mint_account = Self::create_mint_account(
-                                        decimals,
-                                        mint_authority,
-                                        freeze_authority,
+                    match instruction_type {
+                        INSTRUCTION_INITIALIZE_MINT => {
+                            match Self::process_initialize_mint(callbacks, tx, instruction) {
+                                Ok((pubkey, account)) => accounts.push((pubkey, account)),
+                                Err(err) => {
+                                    break 'tx Self::create_executed_transaction(
+                                        Err(TransactionError::InstructionError(ix_idx_u8, err)),
+                                        vec![],
                                     );
-
-                                    accounts.push((*mint_pubkey, mint_account));
                                 }
                             }
-                            _ => {
-                                warn!(
-                                    "[admin-vm] Unsupported SPL token instruction type: {}",
-                                    instruction_type
-                                );
-                            }
+                        }
+                        _ => {
+                            warn!(
+                                "[admin-vm] Unsupported SPL token instruction type: {}",
+                                instruction_type
+                            );
+                            break 'tx Self::create_executed_transaction(
+                                Err(TransactionError::InstructionError(
+                                    ix_idx_u8,
+                                    InstructionError::InvalidInstructionData,
+                                )),
+                                vec![],
+                            );
                         }
                     }
-                    _ => {
-                        warn!("[admin-vm] Unsupported program ID: {}", program_id);
-                    }
                 }
-            }
-            // Create successful processing result
-            let executed_tx = Self::create_executed_transaction(accounts);
-            processing_results.push(Ok(ProcessedTransaction::Executed(Box::new(executed_tx))))
+                Self::create_executed_transaction(Ok(()), accounts)
+            };
+            processing_results.push(Ok(ProcessedTransaction::Executed(Box::new(executed))));
         }
 
         LoadAndExecuteSanitizedTransactionsOutput {
@@ -169,6 +189,78 @@ impl AdminVm {
             processing_results,
         }
     }
+
+    /// Validate and process a single SPL Token `InitializeMint` instruction.
+    /// Returns the (pubkey, Mint account) on success, or the
+    /// appropriate `InstructionError` on any validation failure.
+    ///
+    /// SPL Token `InitializeMint` wire layout
+    /// (see `spl_token::instruction::TokenInstruction::pack`):
+    ///
+    /// ```text
+    /// byte  0       : discriminator = 0   (already checked by caller)
+    /// byte  1       : decimals (u8)
+    /// bytes 2..34   : mint_authority      (Pubkey, 32 bytes)
+    /// byte  34      : freeze_authority COption tag: 0 = None, 1 = Some
+    /// bytes 35..67  : freeze_authority    (present only when tag = 1)
+    /// ```
+    ///
+    /// All byte indices below refer to this layout.
+    fn process_initialize_mint<CB: TransactionProcessingCallback>(
+        callbacks: &CB,
+        tx: &impl SVMTransaction,
+        instruction: solana_svm_transaction::instruction::SVMInstruction,
+    ) -> Result<(Pubkey, AccountSharedData), InstructionError> {
+        // Minimum payload: instruction must reference the mint as an account,
+        // and data must span discriminator + decimals + mint_authority (up to
+        // byte 34). The COption tag at byte 34 is inspected separately below.
+        if instruction.accounts.is_empty() || instruction.data.len() < 34 {
+            debug!("[admin-vm] InitializeMint: malformed (len or accounts)");
+            return Err(InstructionError::InvalidAccountData);
+        }
+
+        // Freeze-authority COption: byte 34 is the tag (0 = None, 1 = Some).
+        // When Some, bytes 35..67 carry the 32-byte pubkey; reject if truncated.
+        let freeze_authority = if instruction.data.len() > 34 && instruction.data[34] == 1 {
+            if instruction.data.len() < 67 {
+                debug!("[admin-vm] InitializeMint: truncated freeze authority");
+                return Err(InstructionError::InvalidAccountData);
+            }
+            Some(&instruction.data[35..67])
+        } else {
+            None
+        };
+
+        // Resolve the mint pubkey: InitializeMint places the mint at
+        // `instruction.accounts[0]`
+        let account_keys = tx.account_keys();
+        let mint_index = instruction.accounts[0] as usize;
+        let Some(mint_pubkey) = account_keys.get(mint_index).copied() else {
+            return Err(InstructionError::NotEnoughAccountKeys);
+        };
+
+        // Refuse re-init on a live mint: if an account already exists at
+        // `mint_pubkey` and unpacks as an initialized Mint, a second
+        // InitializeMint would silently overwrite supply / decimals / authority.
+        // Zero-initialized allocations (is_initialized = false) still proceed.
+        if let Some(existing) = callbacks.get_account_shared_data(&mint_pubkey) {
+            if Mint::unpack(existing.data())
+                .map(|m| m.is_initialized)
+                .unwrap_or(false)
+            {
+                debug!(
+                    "[admin-vm] InitializeMint: {} already initialized",
+                    mint_pubkey
+                );
+                return Err(InstructionError::AccountAlreadyInitialized);
+            }
+        }
+
+        let decimals = instruction.data[1];
+        let mint_authority = &instruction.data[2..34];
+        let mint_account = Self::create_mint_account(decimals, mint_authority, freeze_authority);
+        Ok((mint_pubkey, mint_account))
+    }
 }
 
 #[cfg(test)]
@@ -178,6 +270,9 @@ mod tests {
     use spl_token::solana_program::program_pack::Pack;
     use spl_token::state::Mint;
 
+    /// `create_mint_account` packs a Mint with the given decimals + authority
+    /// and no freeze authority; the packed bytes round-trip through
+    /// `Mint::unpack` to the same values.
     #[test]
     fn test_create_mint_account_roundtrip() {
         let authority = Pubkey::new_unique();
@@ -191,6 +286,8 @@ mod tests {
         assert_eq!(mint.freeze_authority, COption::None);
     }
 
+    /// `create_mint_account` sets `freeze_authority` to `Some` when one is
+    /// supplied, and the packed bytes round-trip to the same pubkey.
     #[test]
     fn test_initialize_mint_with_freeze_authority() {
         let authority = Pubkey::new_unique();
@@ -203,7 +300,14 @@ mod tests {
         assert_eq!(mint.freeze_authority, COption::Some(freeze));
     }
 
-    // Shared dummy callback for all admin VM tests
+    // ─── Test callbacks ─────────────────────────────────────────────────────
+    //
+    // DummyCb: account lookups always return None → "fresh" state, good for the
+    // happy path and most malformed-input cases.
+    //
+    // StubCbWithInitializedMint / StubCbWithUninitialized: return a specific
+    // account for a specific pubkey so the AlreadyInUse + "pre-existing but
+    // uninitialized account" paths are exercisable.
     struct DummyCb;
     impl solana_svm_callback::TransactionProcessingCallback for DummyCb {
         fn get_account_shared_data(&self, _pubkey: &Pubkey) -> Option<AccountSharedData> {
@@ -215,23 +319,107 @@ mod tests {
     }
     impl solana_svm_callback::InvokeContextCallback for DummyCb {}
 
+    /// Returns a pre-initialized SPL Mint for the configured pubkey, None for anything else.
+    struct StubCbWithInitializedMint {
+        mint: Pubkey,
+    }
+    impl solana_svm_callback::TransactionProcessingCallback for StubCbWithInitializedMint {
+        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+            if *pubkey == self.mint {
+                Some(AdminVm::create_mint_account(
+                    6,
+                    &Pubkey::new_unique().to_bytes(),
+                    None,
+                ))
+            } else {
+                None
+            }
+        }
+        fn account_matches_owners(&self, _account: &Pubkey, _owners: &[Pubkey]) -> Option<usize> {
+            None
+        }
+    }
+    impl solana_svm_callback::InvokeContextCallback for StubCbWithInitializedMint {}
+
+    /// Returns an allocated but NOT-initialized account for the configured pubkey.
+    /// Simulates the real-Solana case where `create_account` ran but `initialize_mint`
+    /// has not — we should still let InitializeMint succeed in that case.
+    struct StubCbWithUninitialized {
+        mint: Pubkey,
+    }
+    impl solana_svm_callback::TransactionProcessingCallback for StubCbWithUninitialized {
+        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+            if *pubkey == self.mint {
+                // Zeroed data of Mint::LEN → is_initialized = false
+                let mut acct = AccountSharedData::new(0, Mint::LEN, &spl_token::id());
+                acct.set_data_from_slice(&vec![0u8; Mint::LEN]);
+                Some(acct)
+            } else {
+                None
+            }
+        }
+        fn account_matches_owners(&self, _account: &Pubkey, _owners: &[Pubkey]) -> Option<usize> {
+            None
+        }
+    }
+    impl solana_svm_callback::InvokeContextCallback for StubCbWithUninitialized {}
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
     fn run_admin_vm(
         txs: &[solana_sdk::transaction::SanitizedTransaction],
+    ) -> LoadAndExecuteSanitizedTransactionsOutput {
+        run_admin_vm_with_cb(txs, &DummyCb)
+    }
+
+    fn run_admin_vm_with_cb<CB: solana_svm_callback::TransactionProcessingCallback>(
+        txs: &[solana_sdk::transaction::SanitizedTransaction],
+        cb: &CB,
     ) -> LoadAndExecuteSanitizedTransactionsOutput {
         let vm = AdminVm::default();
         let check_results = crate::processor::get_transaction_check_results(txs.len());
         let env = solana_svm::transaction_processor::TransactionProcessingEnvironment::default();
         let config = solana_svm::transaction_processor::TransactionProcessingConfig::default();
-        vm.load_and_execute_sanitized_transactions(&DummyCb, txs, check_results, &env, &config)
+        vm.load_and_execute_sanitized_transactions(cb, txs, check_results, &env, &config)
+    }
+
+    /// Unwrap a single `ProcessedTransaction::Executed` from the VM output and
+    /// assert that its `execution_details.status` matches `expected`. Returns
+    /// the `ExecutedTransaction` so callers can inspect `accounts` afterwards.
+    ///
+    /// Every test in this module asserts on `execution_details.status` via
+    /// this helper; asserting only on `accounts` contents is not sufficient.
+    fn assert_executed_with_status(
+        output: LoadAndExecuteSanitizedTransactionsOutput,
+        expected: Result<(), TransactionError>,
+    ) -> Box<ExecutedTransaction> {
+        assert_eq!(output.processing_results.len(), 1);
+        let result = output
+            .processing_results
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
+        match result {
+            ProcessedTransaction::Executed(executed) => {
+                assert_eq!(
+                    executed.execution_details.status, expected,
+                    "status mismatch"
+                );
+                executed
+            }
+            _ => panic!("Expected Executed variant"),
+        }
     }
 
     /// Build a SanitizedTransaction with a single instruction targeting the given
-    /// program_id, with the given accounts and data.
-    fn make_spl_tx(
+    /// program_id, with the mint as the FIRST account meta (as SPL Token
+    /// `InitializeMint` expects). Returns both the tx and the mint pubkey so
+    /// tests can stub the callback keyed on the same pubkey the VM will query.
+    fn make_spl_tx_with_mint(
         program_id: Pubkey,
-        accounts_indices: &[u8],
         data: Vec<u8>,
-    ) -> solana_sdk::transaction::SanitizedTransaction {
+    ) -> (solana_sdk::transaction::SanitizedTransaction, Pubkey) {
         use solana_sdk::{
             instruction::{AccountMeta, Instruction},
             message::Message,
@@ -242,17 +430,11 @@ mod tests {
 
         let payer = Keypair::new();
         let mint = Pubkey::new_unique();
-
-        // Build account metas: payer (signer), mint, program
-        let mut account_metas = vec![
-            AccountMeta::new(payer.pubkey(), true),
+        // Mint first — SPL Token InitializeMint semantics: accounts[0] is the mint.
+        let account_metas = vec![
             AccountMeta::new(mint, false),
+            AccountMeta::new(payer.pubkey(), true),
         ];
-        // If test wants more accounts, add dummies
-        for _ in 2..accounts_indices.iter().copied().max().unwrap_or(0) as usize + 1 {
-            account_metas.push(AccountMeta::new(Pubkey::new_unique(), false));
-        }
-
         let ix = Instruction {
             program_id,
             accounts: account_metas,
@@ -260,67 +442,37 @@ mod tests {
         };
         let msg = Message::new(&[ix], Some(&payer.pubkey()));
         let tx = Transaction::new(&[&payer], msg, solana_sdk::hash::Hash::default());
-        solana_sdk::transaction::SanitizedTransaction::try_from_legacy_transaction(
+        let sanitized = solana_sdk::transaction::SanitizedTransaction::try_from_legacy_transaction(
             tx,
             &HashSet::new(),
         )
-        .unwrap()
+        .unwrap();
+        (sanitized, mint)
     }
 
-    #[test]
-    fn test_load_and_execute_unsupported_program() {
-        let from = solana_sdk::signature::Keypair::new();
-        let to = Pubkey::new_unique();
-        let tx = crate::test_helpers::create_test_sanitized_transaction(&from, &to, 100);
-
-        let output = run_admin_vm(&[tx]);
-
-        // Should still produce a result (with empty accounts since program is unsupported)
-        assert_eq!(output.processing_results.len(), 1);
-        let result = output
-            .processing_results
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
-        match result {
-            ProcessedTransaction::Executed(executed) => {
-                assert!(executed.loaded_transaction.accounts.is_empty());
-            }
-            _ => panic!("Expected Executed variant"),
-        }
+    fn make_spl_tx(
+        program_id: Pubkey,
+        _accounts_indices: &[u8],
+        data: Vec<u8>,
+    ) -> solana_sdk::transaction::SanitizedTransaction {
+        make_spl_tx_with_mint(program_id, data).0
     }
 
-    #[test]
-    fn test_spl_empty_data_skips_gracefully() {
-        // SPL Token instruction with empty data → skips without panic
-        let tx = make_spl_tx(spl_token::id(), &[1], vec![]);
-        let output = run_admin_vm(&[tx]);
-        assert_eq!(output.processing_results.len(), 1);
-        let result = output
-            .processing_results
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
-        match result {
-            ProcessedTransaction::Executed(executed) => {
-                assert!(executed.loaded_transaction.accounts.is_empty());
-            }
-            _ => panic!("Expected Executed variant"),
-        }
+    /// Build a valid-looking 35-byte InitializeMint instruction data blob.
+    fn valid_init_mint_data(decimals: u8, authority: Pubkey) -> Vec<u8> {
+        let mut data = vec![0u8; 35];
+        data[1] = decimals;
+        data[2..34].copy_from_slice(&authority.to_bytes());
+        data[34] = 0; // COption::None for freeze authority
+        data
     }
 
-    #[test]
-    fn test_spl_compiled_indices_prevent_oob() {
-        // InitializeMint instruction where accounts[0] = 255 (way out of bounds)
-        // data: [0 (InitializeMint), decimals, 32 bytes mint_authority]
-        let mut data = vec![0u8; 34]; // type=0, decimals=6, then 32 bytes authority
-        data[1] = 6;
-        data[2..34].copy_from_slice(&Pubkey::new_unique().to_bytes());
-
-        // Build tx with program_id = spl_token, but the instruction's account index
-        // points beyond the transaction's account_keys
+    /// Build a SanitizedTransaction carrying TWO instructions so we can prove
+    /// multi-instruction atomicity (real-SVM semantics: fails at first bad ix).
+    fn make_two_instruction_spl_tx(
+        ix1_data: Vec<u8>,
+        ix2_data: Vec<u8>,
+    ) -> solana_sdk::transaction::SanitizedTransaction {
         use solana_sdk::{
             instruction::{AccountMeta, Instruction},
             message::Message,
@@ -330,9 +482,242 @@ mod tests {
         use std::collections::HashSet;
 
         let payer = Keypair::new();
-        // Only 2 account keys total (payer + program), but instruction.accounts[0] = 1
-        // which is valid. Let's use accounts[0] = 200 to trigger OOB.
-        // We need raw control: create instruction with accounts = [200]
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let ix1 = Instruction {
+            program_id: spl_token::id(),
+            accounts: vec![
+                AccountMeta::new(mint_a, false),
+                AccountMeta::new(payer.pubkey(), true),
+            ],
+            data: ix1_data,
+        };
+        let ix2 = Instruction {
+            program_id: spl_token::id(),
+            accounts: vec![
+                AccountMeta::new(mint_b, false),
+                AccountMeta::new(payer.pubkey(), true),
+            ],
+            data: ix2_data,
+        };
+        let msg = Message::new(&[ix1, ix2], Some(&payer.pubkey()));
+        let tx = Transaction::new(&[&payer], msg, solana_sdk::hash::Hash::default());
+        solana_sdk::transaction::SanitizedTransaction::try_from_legacy_transaction(
+            tx,
+            &HashSet::new(),
+        )
+        .unwrap()
+    }
+
+    // ─── Happy path ─────────────────────────────────────────────────────────
+
+    /// A well-formed InitializeMint tx succeeds and produces a Mint account
+    /// whose packed bytes carry the declared decimals and mint authority.
+    #[test]
+    fn test_spl_valid_initialize_mint() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(9, authority);
+        let tx = make_spl_tx(spl_token::id(), &[1], data);
+
+        let executed = assert_executed_with_status(run_admin_vm(&[tx]), Ok(()));
+
+        assert_eq!(executed.loaded_transaction.accounts.len(), 1);
+        let (_, account) = &executed.loaded_transaction.accounts[0];
+        let mint = Mint::unpack(account.data()).unwrap();
+        assert_eq!(mint.decimals, 9);
+        assert_eq!(mint.mint_authority, COption::Some(authority));
+    }
+
+    // ─── Failure paths ──────────────────────────────────────────────────────
+
+    /// An admin-routed tx whose program is not spl_token surfaces
+    /// `InstructionError(0, InvalidInstructionData)` and persists no accounts.
+    #[test]
+    fn test_load_and_execute_unsupported_program_returns_invalid_instruction_data() {
+        let from = solana_sdk::signature::Keypair::new();
+        let to = Pubkey::new_unique();
+        let tx = crate::test_helpers::create_test_sanitized_transaction(&from, &to, 100);
+
+        let executed = assert_executed_with_status(
+            run_admin_vm(&[tx]),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::InvalidInstructionData,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
+    /// An spl_token instruction with empty `data` surfaces
+    /// `InvalidInstructionData` at ix index 0.
+    #[test]
+    fn test_spl_empty_data_returns_invalid_instruction_data() {
+        let tx = make_spl_tx(spl_token::id(), &[1], vec![]);
+        let executed = assert_executed_with_status(
+            run_admin_vm(&[tx]),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::InvalidInstructionData,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
+    /// InitializeMint (type byte 0) with data shorter than the minimum
+    /// required payload surfaces `InvalidAccountData`.
+    #[test]
+    fn test_spl_short_data_returns_invalid_account_data() {
+        let data = vec![0u8; 10];
+        let tx = make_spl_tx(spl_token::id(), &[1], data);
+
+        let executed = assert_executed_with_status(
+            run_admin_vm(&[tx]),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::InvalidAccountData,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
+    /// An spl_token instruction whose first byte is a non-InitializeMint
+    /// discriminator (here Transfer = 3) surfaces `InvalidInstructionData`.
+    #[test]
+    fn test_spl_unsupported_instruction_type_returns_invalid_instruction_data() {
+        let data = vec![3u8; 10];
+        let tx = make_spl_tx(spl_token::id(), &[1], data);
+
+        let executed = assert_executed_with_status(
+            run_admin_vm(&[tx]),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::InvalidInstructionData,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
+    /// When the callback reports an already-initialized Mint at the target
+    /// pubkey, InitializeMint is rejected with `AccountAlreadyInitialized`
+    /// and no accounts are persisted (preventing overwrite of the live mint).
+    #[test]
+    fn test_already_initialized_mint_returns_already_in_use() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(6, authority);
+        let (tx, mint_pubkey) = make_spl_tx_with_mint(spl_token::id(), data);
+        let cb = StubCbWithInitializedMint { mint: mint_pubkey };
+
+        let executed = assert_executed_with_status(
+            run_admin_vm_with_cb(&[tx], &cb),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::AccountAlreadyInitialized,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
+    /// A pre-existing but zero-initialized account (allocated, never
+    /// initialized) does not block InitializeMint — the VM still succeeds
+    /// and produces the fresh Mint.
+    #[test]
+    fn test_uninitialized_existing_account_still_initializes() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(6, authority);
+        let (tx, mint_pubkey) = make_spl_tx_with_mint(spl_token::id(), data);
+        let cb = StubCbWithUninitialized { mint: mint_pubkey };
+
+        let executed = assert_executed_with_status(run_admin_vm_with_cb(&[tx], &cb), Ok(()));
+        assert_eq!(executed.loaded_transaction.accounts.len(), 1);
+    }
+
+    /// InitializeMint data with the freeze-authority COption tag set to 1
+    /// (Some) but missing the trailing 32-byte pubkey surfaces
+    /// `InvalidAccountData` rather than panicking on the slice.
+    #[test]
+    fn test_short_freeze_authority_data_errors() {
+        let mut data = vec![0u8; 35];
+        data[1] = 6;
+        data[2..34].copy_from_slice(&Pubkey::new_unique().to_bytes());
+        data[34] = 1; // COption::Some but no trailing 32 bytes
+
+        let tx = make_spl_tx(spl_token::id(), &[1], data);
+        let executed = assert_executed_with_status(
+            run_admin_vm(&[tx]),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::InvalidAccountData,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
+    // ─── Multi-instruction atomicity ───────────────────────────────────────
+
+    /// A two-instruction tx with a valid ix followed by a bad ix fails at
+    /// the bad ix's index, and no accounts from the earlier valid ix are
+    /// persisted (atomicity: all-or-nothing).
+    #[test]
+    fn test_multi_instruction_first_bad_fails_at_correct_index() {
+        let authority = Pubkey::new_unique();
+        let valid = valid_init_mint_data(6, authority);
+        // Second instruction: unsupported SPL Token type 3 (Transfer).
+        let bad = vec![3u8; 10];
+
+        let tx = make_two_instruction_spl_tx(valid, bad);
+        let executed = assert_executed_with_status(
+            run_admin_vm(&[tx]),
+            Err(TransactionError::InstructionError(
+                1,
+                InstructionError::InvalidInstructionData,
+            )),
+        );
+        assert!(
+            executed.loaded_transaction.accounts.is_empty(),
+            "multi-instruction atomicity violated: partial accounts leaked"
+        );
+    }
+
+    /// If the first instruction fails, subsequent instructions are not
+    /// processed — the reported error index is 0 and no accounts persist.
+    #[test]
+    fn test_multi_instruction_second_valid_not_reached() {
+        let authority = Pubkey::new_unique();
+        let bad = vec![3u8; 10];
+        let valid = valid_init_mint_data(6, authority);
+
+        let tx = make_two_instruction_spl_tx(bad, valid);
+        let executed = assert_executed_with_status(
+            run_admin_vm(&[tx]),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::InvalidInstructionData,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
+    // ─── Low-level invariants ───────────────────────────────────────────────
+
+    /// `SanitizedTransaction` guarantees that compiled
+    /// `instruction.accounts` indices are in-range for `account_keys`, so
+    /// the VM's index lookups are safe. This test exercises a minimal valid
+    /// InitializeMint that relies on that invariant.
+    #[test]
+    fn test_spl_compiled_indices_prevent_oob() {
+        let mut data = vec![0u8; 34];
+        data[1] = 6;
+        data[2..34].copy_from_slice(&Pubkey::new_unique().to_bytes());
+
+        use solana_sdk::{
+            instruction::{AccountMeta, Instruction},
+            message::Message,
+            signature::{Keypair, Signer},
+            transaction::Transaction,
+        };
+        use std::collections::HashSet;
+
+        let payer = Keypair::new();
         let ix = Instruction {
             program_id: spl_token::id(),
             accounts: vec![AccountMeta::new(payer.pubkey(), true)],
@@ -346,89 +731,9 @@ mod tests {
         )
         .unwrap();
 
-        // The instruction.accounts[0] in the compiled instruction will be a valid
-        // index since Message compilation maps AccountMeta → indices. So OOB via
-        // SanitizedTransaction is hard to achieve. Instead, verify the short-data
-        // path handles correctly (data.len() >= 34 but accounts is empty).
-        // This is the more realistic attack vector.
+        // accounts[0] is the payer (valid index). The ix is a valid InitializeMint
+        // targeting the payer pubkey as the mint → VM succeeds.
         let output = run_admin_vm(&[sanitized]);
-        // With valid compiled indices this won't panic — the accounts[0] maps correctly.
         assert_eq!(output.processing_results.len(), 1);
-    }
-
-    #[test]
-    fn test_spl_short_data_skips_mint_creation() {
-        // InitializeMint type byte (0) but data too short (< 34 bytes)
-        let data = vec![0u8; 10]; // type=0, but only 10 bytes total
-        let tx = make_spl_tx(spl_token::id(), &[1], data);
-
-        let output = run_admin_vm(&[tx]);
-        assert_eq!(output.processing_results.len(), 1);
-        let result = output
-            .processing_results
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
-        match result {
-            ProcessedTransaction::Executed(executed) => {
-                // Short data → guard clause skips mint creation → empty accounts
-                assert!(executed.loaded_transaction.accounts.is_empty());
-            }
-            _ => panic!("Expected Executed variant"),
-        }
-    }
-
-    #[test]
-    fn test_spl_unsupported_instruction_type() {
-        // SPL Token Transfer instruction (type = 3) → logs warning, empty accounts
-        let data = vec![3u8; 10]; // type=3 (Transfer)
-        let tx = make_spl_tx(spl_token::id(), &[1], data);
-
-        let output = run_admin_vm(&[tx]);
-        assert_eq!(output.processing_results.len(), 1);
-        let result = output
-            .processing_results
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
-        match result {
-            ProcessedTransaction::Executed(executed) => {
-                assert!(executed.loaded_transaction.accounts.is_empty());
-            }
-            _ => panic!("Expected Executed variant"),
-        }
-    }
-
-    #[test]
-    fn test_spl_valid_initialize_mint() {
-        // Valid InitializeMint: type=0, decimals=9, 32-byte authority
-        let authority = Pubkey::new_unique();
-        let mut data = vec![0u8; 34];
-        data[1] = 9; // decimals
-        data[2..34].copy_from_slice(&authority.to_bytes());
-
-        let tx = make_spl_tx(spl_token::id(), &[1], data);
-        let output = run_admin_vm(&[tx]);
-
-        assert_eq!(output.processing_results.len(), 1);
-        let result = output
-            .processing_results
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
-        match result {
-            ProcessedTransaction::Executed(executed) => {
-                // Should have created one mint account
-                assert_eq!(executed.loaded_transaction.accounts.len(), 1);
-                let (_, account) = &executed.loaded_transaction.accounts[0];
-                let mint = Mint::unpack(account.data()).unwrap();
-                assert_eq!(mint.decimals, 9);
-                assert_eq!(mint.mint_authority, COption::Some(authority));
-            }
-            _ => panic!("Expected Executed variant"),
-        }
     }
 }

--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -352,7 +352,7 @@ mod tests {
             if *pubkey == self.mint {
                 // Zeroed data of Mint::LEN → is_initialized = false
                 let mut acct = AccountSharedData::new(0, Mint::LEN, &spl_token::id());
-                acct.set_data_from_slice(&vec![0u8; Mint::LEN]);
+                acct.set_data_from_slice(&[0u8; Mint::LEN]);
                 Some(acct)
             } else {
                 None

--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -102,7 +102,7 @@ impl AdminVm {
     /// - non-`spl_token` program id             -> InvalidInstructionData
     /// - empty instruction data                 -> InvalidInstructionData
     /// - unsupported SPL instruction type       -> InvalidInstructionData
-    /// - InitializeMint data < 34 bytes         -> InvalidAccountData
+    /// - InitializeMint data < 35 bytes         -> InvalidAccountData
     /// - InitializeMint empty accounts          -> InvalidAccountData
     /// - freeze authority tag=1, <32 trailing   -> InvalidAccountData
     /// - mint index out of `account_keys`       -> NotEnoughAccountKeys
@@ -212,16 +212,17 @@ impl AdminVm {
         instruction: solana_svm_transaction::instruction::SVMInstruction,
     ) -> Result<(Pubkey, AccountSharedData), InstructionError> {
         // Minimum payload: instruction must reference the mint as an account,
-        // and data must span discriminator + decimals + mint_authority (up to
-        // byte 34). The COption tag at byte 34 is inspected separately below.
-        if instruction.accounts.is_empty() || instruction.data.len() < 34 {
+        // and data must span discriminator + decimals + mint_authority + the
+        // freeze_authority COption tag at byte 34. `TokenInstruction::pack`
+        // always emits the tag, so any shorter payload is malformed.
+        if instruction.accounts.is_empty() || instruction.data.len() < 35 {
             debug!("[admin-vm] InitializeMint: malformed (len or accounts)");
             return Err(InstructionError::InvalidAccountData);
         }
 
         // Freeze-authority COption: byte 34 is the tag (0 = None, 1 = Some).
         // When Some, bytes 35..67 carry the 32-byte pubkey; reject if truncated.
-        let freeze_authority = if instruction.data.len() > 34 && instruction.data[34] == 1 {
+        let freeze_authority = if instruction.data[34] == 1 {
             if instruction.data.len() < 67 {
                 debug!("[admin-vm] InitializeMint: truncated freeze authority");
                 return Err(InstructionError::InvalidAccountData);
@@ -705,9 +706,10 @@ mod tests {
     /// InitializeMint that relies on that invariant.
     #[test]
     fn test_spl_compiled_indices_prevent_oob() {
-        let mut data = vec![0u8; 34];
+        let mut data = vec![0u8; 35];
         data[1] = 6;
         data[2..34].copy_from_slice(&Pubkey::new_unique().to_bytes());
+        data[34] = 0; // COption::None for freeze authority
 
         use solana_sdk::{
             instruction::{AccountMeta, Instruction},

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -139,13 +139,15 @@ pub(super) async fn try_jit_mint_initialization(
 
     match result {
         ConfirmationResult::Confirmed => {
+            // `Confirmed` covers both a successful InitializeMint and the
+            // `AccountAlreadyInitialized` race, which the extra error check
+            // on this builder remaps to `Confirmed` without an RPC re-check.
             info!("InitializeMint transaction confirmed: {}", sig);
             Some(instruction)
         }
         _ => {
-            // Non-`Confirmed` may just mean the mint was already initialized (stale existence
-            // check or RPC-error fail-safe above raced the InitializeMint). Re-read on-chain;
-            // if initialized, JIT is effectively done.
+            // Fallback for unknown failures (network blips, timeouts): re-read
+            // the mint on-chain with backoff in case it was initialized out-of-band.
             if mint_is_initialized_on_chain(&state.rpc_client, &mint).await {
                 info!(
                     "InitializeMint tx {} not confirmed (result={:?}), but mint {} is already \

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -47,12 +47,16 @@ pub(super) async fn try_jit_mint_initialization(
     // 2. Extract mint pubkey
     let mint = builder.get_mint()?;
 
-    // 3. Check if mint exists on Contra
+    // 3. Check if mint is initialized on Contra. An account may exist at the
+    // mint address (allocated via `create_account`) with non-empty zeroed data
+    // and `is_initialized = false`; treating that as "present" skips JIT and
+    // the subsequent `mint_to` fails with `UninitializedAccount`. Gate on
+    // initialization, matching the `mint_is_initialized_on_chain` fallback.
     match state.rpc_client.get_account_data(&mint).await {
-        Ok(data) if !data.is_empty() => return Some(instruction),
+        Ok(data) if is_initialized_mint_data(&data) => return Some(instruction),
         Ok(_) => {
             info!(
-                "Mint {} not found on Contra - attempting JIT initialization",
+                "Mint {} not initialized on Contra - attempting JIT initialization",
                 mint
             );
         }

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -18,6 +18,8 @@ use solana_transaction_status::{
     EncodedTransaction, UiCompiledInstruction, UiInstruction, UiMessage, UiParsedInstruction,
     UiParsedMessage, UiPartiallyDecodedInstruction, UiRawMessage,
 };
+use spl_token::solana_program::program_pack::Pack;
+use spl_token::state::Mint;
 use std::str::FromStr;
 use tracing::{error, info, warn};
 
@@ -137,11 +139,46 @@ pub(super) async fn try_jit_mint_initialization(
             Some(instruction)
         }
         _ => {
+            // Non-`Confirmed` may just mean the mint was already initialized (stale existence
+            // check or RPC-error fail-safe above raced the InitializeMint). Re-read on-chain;
+            // if initialized, JIT is effectively done.
+            if mint_is_initialized_on_chain(&state.rpc_client, &mint).await {
+                info!(
+                    "InitializeMint tx {} not confirmed (result={:?}), but mint {} is already \
+                     initialized on-chain — treating JIT as success",
+                    sig, result, mint
+                );
+                return Some(instruction);
+            }
             error!(
                 "InitializeMint transaction could not be confirmed: {:?}",
                 result
             );
             None
+        }
+    }
+}
+
+/// returns true if `data` decodes as an initialized SPL `Mint`.
+/// Non-Mint-length or malformed data → false. Zeroed Mint::LEN data → false.
+fn is_initialized_mint_data(data: &[u8]) -> bool {
+    Mint::unpack(data)
+        .map(|m| m.is_initialized)
+        .unwrap_or(false)
+}
+
+/// Re-queries the mint account on Contra and reports whether it is initialized.
+/// RPC errors and missing/empty accounts are treated as "not initialized" so the
+/// caller falls through to the original error path.
+async fn mint_is_initialized_on_chain(rpc_client: &RpcClientWithRetry, mint: &Pubkey) -> bool {
+    match rpc_client.get_account_data(mint).await {
+        Ok(data) => is_initialized_mint_data(&data),
+        Err(e) => {
+            warn!(
+                "RPC error re-checking mint {} after failed JIT init: {}",
+                mint, e
+            );
+            false
         }
     }
 }
@@ -604,7 +641,7 @@ pub(super) fn cleanup_mint_builder(state: &mut SenderState, transaction_id: Opti
 mod tests {
     use super::{
         accounts_and_amount_match, expected_mint_instruction, instruction_has_expected_mint,
-        instruction_has_memo, is_method_not_found_error, memo_matches,
+        instruction_has_memo, is_initialized_mint_data, is_method_not_found_error, memo_matches,
         parse_token_instruction_mint_amount, partially_decoded_instruction_has_expected_mint,
         raw_instruction_has_expected_mint, strip_memo_length_prefix,
         transaction_matches_expected_mint, ExpectedMintInstruction,
@@ -623,6 +660,9 @@ mod tests {
         UiParsedInstruction, UiParsedMessage, UiPartiallyDecodedInstruction, UiRawMessage,
         UiTransaction, UiTransactionStatusMeta,
     };
+    use spl_token::solana_program::program_option::COption;
+    use spl_token::solana_program::program_pack::Pack;
+    use spl_token::state::Mint;
 
     fn make_expected() -> (Pubkey, Pubkey, Pubkey, ExpectedMintInstruction) {
         let mint = Pubkey::new_unique();
@@ -1459,5 +1499,65 @@ mod tests {
     #[test]
     fn strip_memo_length_prefix_no_space_after_bracket() {
         assert_eq!(strip_memo_length_prefix("[123]no-space"), "[123]no-space");
+    }
+
+    // Tests for the pure `is_initialized_mint_data` helper that drives the
+    // on-chain re-check in `try_jit_mint_initialization`. The async
+    // `mint_is_initialized_on_chain` wrapper is exercised indirectly via this
+    // helper plus the RPC boundary.
+
+    fn pack_mint(is_initialized: bool) -> Vec<u8> {
+        let mint = Mint {
+            mint_authority: COption::Some(Pubkey::new_unique()),
+            supply: 0,
+            decimals: 6,
+            is_initialized,
+            freeze_authority: COption::None,
+        };
+        let mut data = vec![0u8; Mint::LEN];
+        Mint::pack(mint, &mut data).expect("pack mint");
+        data
+    }
+
+    // Empty account data means the mint account was never created.
+    #[test]
+    fn is_initialized_mint_data_empty_is_false() {
+        assert!(!is_initialized_mint_data(&[]));
+    }
+
+    // Data of the wrong length (too short or too long) cannot be a valid mint.
+    #[test]
+    fn is_initialized_mint_data_wrong_length_is_false() {
+        assert!(!is_initialized_mint_data(&[0u8; 10]));
+        assert!(!is_initialized_mint_data(&[0xFFu8; Mint::LEN + 1]));
+    }
+
+    // A rent-exempt-but-uninitialized mint account (correct length, all zeros)
+    // is rejected by `Mint::unpack` because `is_initialized` is 0.
+    #[test]
+    fn is_initialized_mint_data_zeroed_mint_len_is_false() {
+        assert!(!is_initialized_mint_data(&vec![0u8; Mint::LEN]));
+    }
+
+    // Properly packed, initialized mint data is recognized as initialized.
+    #[test]
+    fn is_initialized_mint_data_packed_initialized_mint_is_true() {
+        let data = pack_mint(true);
+        assert!(is_initialized_mint_data(&data));
+    }
+
+    // `Mint::pack` with `is_initialized = false` produces data that
+    // `Mint::unpack` rejects, so the helper reports "not initialized".
+    #[test]
+    fn is_initialized_mint_data_packed_uninitialized_mint_is_false() {
+        let data = pack_mint(false);
+        assert!(!is_initialized_mint_data(&data));
+    }
+
+    // Arbitrary bytes of the correct length are not a valid mint layout.
+    #[test]
+    fn is_initialized_mint_data_random_bytes_is_false() {
+        let data: Vec<u8> = (0u8..Mint::LEN as u8).collect();
+        assert!(!is_initialized_mint_data(&data));
     }
 }

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -1536,7 +1536,7 @@ mod tests {
     // is rejected by `Mint::unpack` because `is_initialized` is 0.
     #[test]
     fn is_initialized_mint_data_zeroed_mint_len_is_false() {
-        assert!(!is_initialized_mint_data(&vec![0u8; Mint::LEN]));
+        assert!(!is_initialized_mint_data(&[0u8; Mint::LEN]));
     }
 
     // Properly packed, initialized mint data is recognized as initialized.

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -171,20 +171,31 @@ fn is_initialized_mint_data(data: &[u8]) -> bool {
         .unwrap_or(false)
 }
 
-/// Re-queries the mint account on Contra and reports whether it is initialized.
-/// RPC errors and missing/empty accounts are treated as "not initialized" so the
-/// caller falls through to the original error path.
+/// Returns whether the mint is initialized on Contra, retrying with backoff
+/// to absorb read-RPC lag after a racing InitializeMint. Any error or
+/// uninitialized result on the final attempt is reported as `false`.
 async fn mint_is_initialized_on_chain(rpc_client: &RpcClientWithRetry, mint: &Pubkey) -> bool {
-    match rpc_client.get_account_data(mint).await {
-        Ok(data) => is_initialized_mint_data(&data),
-        Err(e) => {
-            warn!(
-                "RPC error re-checking mint {} after failed JIT init: {}",
-                mint, e
-            );
-            false
+    const ATTEMPTS: u32 = 4;
+    const BACKOFF_MS: u64 = 250;
+
+    for attempt in 0..ATTEMPTS {
+        match rpc_client.get_account_data(mint).await {
+            Ok(data) if is_initialized_mint_data(&data) => return true,
+            Ok(_) => {}
+            Err(e) => {
+                if attempt + 1 == ATTEMPTS {
+                    warn!(
+                        "RPC error re-checking mint {} after failed JIT init: {}",
+                        mint, e
+                    );
+                }
+            }
+        }
+        if attempt + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_millis(BACKOFF_MS)).await;
         }
     }
+    false
 }
 
 /// Check recent ATA signatures for an already-confirmed mint carrying this transaction's

--- a/indexer/src/operator/utils/instruction_util.rs
+++ b/indexer/src/operator/utils/instruction_util.rs
@@ -1,7 +1,7 @@
 use crate::error::ProgramError;
 use crate::operator::{
-    is_mint_not_initialized_error, ConfirmationResult, SignerUtil, DEFAULT_CU_MINT,
-    DEFAULT_CU_RELEASE_FUNDS, MINT_IDEMPOTENCY_MEMO_PREFIX,
+    is_mint_already_initialized_error, is_mint_not_initialized_error, ConfirmationResult,
+    SignerUtil, DEFAULT_CU_MINT, DEFAULT_CU_RELEASE_FUNDS, MINT_IDEMPOTENCY_MEMO_PREFIX,
 };
 use contra_escrow_program_client::instructions::{ReleaseFundsBuilder, ResetSmtRootBuilder};
 use solana_keychain::Signer;
@@ -165,9 +165,10 @@ impl TransactionBuilder {
             Self::Mint(_) => {
                 ExtraErrorCheckPolicy::Extra(vec![Box::new(is_mint_not_initialized_error)])
             }
-            Self::ReleaseFunds(_) | Self::InitializeMint(_) | Self::ResetSmtRoot(_) => {
-                ExtraErrorCheckPolicy::None
+            Self::InitializeMint(_) => {
+                ExtraErrorCheckPolicy::Extra(vec![Box::new(is_mint_already_initialized_error)])
             }
+            Self::ReleaseFunds(_) | Self::ResetSmtRoot(_) => ExtraErrorCheckPolicy::None,
         }
     }
 }
@@ -639,7 +640,7 @@ mod tests {
         ));
         assert!(matches!(
             make_init_mint_builder().extra_error_checks_policy(),
-            ExtraErrorCheckPolicy::None
+            ExtraErrorCheckPolicy::Extra(_)
         ));
         assert!(matches!(
             make_mint_builder().extra_error_checks_policy(),

--- a/indexer/src/operator/utils/transaction_util.rs
+++ b/indexer/src/operator/utils/transaction_util.rs
@@ -165,6 +165,26 @@ pub fn is_mint_not_initialized_error(
     None
 }
 
+/// Treat `AccountAlreadyInitialized` as a confirmed `InitializeMint`: another
+/// caller (or a racing retry) initialized the same mint first, which is the
+/// desired end state. Returning `Confirmed` avoids a read-RPC re-check that
+/// can lose to replication lag.
+pub fn is_mint_already_initialized_error(
+    err: &solana_sdk::transaction::TransactionError,
+) -> Option<ConfirmationResult> {
+    if matches!(
+        err,
+        solana_sdk::transaction::TransactionError::InstructionError(
+            _,
+            InstructionError::AccountAlreadyInitialized
+        )
+    ) {
+        return Some(ConfirmationResult::Confirmed);
+    }
+
+    None
+}
+
 /// Parse program error code from transaction error
 ///
 /// Extracts ContraEscrowProgramError from Solana transaction errors.
@@ -236,6 +256,32 @@ mod tests {
     fn mint_not_init_non_instruction_error_returns_none() {
         let err = TransactionError::InsufficientFundsForFee;
         assert!(is_mint_not_initialized_error(&err).is_none());
+    }
+
+    // ====================================================================
+    // is_mint_already_initialized_error
+    // ====================================================================
+
+    #[test]
+    fn mint_already_init_maps_to_confirmed() {
+        let err =
+            TransactionError::InstructionError(0, InstructionError::AccountAlreadyInitialized);
+        assert!(matches!(
+            is_mint_already_initialized_error(&err),
+            Some(ConfirmationResult::Confirmed)
+        ));
+    }
+
+    #[test]
+    fn mint_already_init_other_instruction_error_returns_none() {
+        let err = TransactionError::InstructionError(0, InstructionError::InvalidAccountData);
+        assert!(is_mint_already_initialized_error(&err).is_none());
+    }
+
+    #[test]
+    fn mint_already_init_non_instruction_error_returns_none() {
+        let err = TransactionError::InsufficientFundsForFee;
+        assert!(is_mint_already_initialized_error(&err).is_none());
     }
 
     // ====================================================================


### PR DESCRIPTION
## Summary

`getAccountInfo` built a throwaway `BOB` per request whose in-memory map
was always empty and never fell back to `AccountsDB`. Every non-precompile
pubkey returned `null` regardless of DB state.

## Changes

- **`core/src/rpc/get_account_info_impl.rs`** — rewritten: precompile
  short-circuit, then direct `accounts_db.get_account_shared_data` call.
  No more throwaway BOB, no dangling `mpsc` channel. Verbose `info!`
  that leaked account contents dropped in favor of a `debug!` hit/miss.
- **`core/src/accounts/precompiles.rs`** (new) — shared
  `LazyLock<HashMap<Pubkey, AccountSharedData>>` + `get()` accessor. ELF
  blobs parsed once process-wide.
- **`core/src/accounts/bob.rs`** — `BOB::new` clones the shared map instead
  of re-parsing ELFs. Public signature, field layout, and write-path
  behavior unchanged.


**No read-side cache added**: BOB's coherence depends on the settlement
  channel; a read cache needs its own invalidation design and is out of
  scope.


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 8,321 | 9,760 | 85.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24721643407) |
| Indexer | 13,524 | 15,800 | 85.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24721643407) |
| Gateway | 952 | 1,076 | 88.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24721643407) |
| Auth | 541 | 596 | 90.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24721643407) |
| Withdraw Program | 118 | 230 | 51.3% | [unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24721643439) |
| Escrow Program | 1,170 | 1,951 | 60.0% | [unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24721643439) |
| E2E Integration | 8,064 | 11,933 | 67.6% | [e2e-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24721643407) |
| **Total** | **32,690** | **41,346** | **79.1%** | |

> Last updated: 2026-04-21 12:37:24 UTC by E2E Integration