### PR TITLE
fix(operator): prevent operator crash on malformed transaction

### DIFF
--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -134,6 +134,28 @@ gauge_vec!(
     &["program_type"]
 );
 
+// Poison-pill: a single transaction that could not be sent on-chain was
+// quarantined to ManualReview so the pipeline could keep moving.  The `reason`
+// label mirrors the error classification (`invalid_pubkey`, `invalid_builder`,
+// `missing_nonce`, ...) so dashboards can distinguish systemic bugs from
+// one-off bad rows.
+counter_vec!(
+    OPERATOR_TRANSACTION_QUARANTINED,
+    "contra_operator_transaction_quarantined_total",
+    "Transactions quarantined to ManualReview by the processor",
+    &["program_type", "reason"]
+);
+
+// Supervision: a critical task inside the operator exited.  The supervisor
+// aborts the process immediately when this increments; the counter exists
+// so dashboards can alert even if the restart is fast.
+counter_vec!(
+    OPERATOR_TASK_EXIT,
+    "contra_operator_task_exit_total",
+    "Critical operator task exits observed by the supervisor",
+    &["program_type", "task"]
+);
+
 pub fn init_labels(program_type: &str) {
     INDEXER_MINTS_SAVED.with_label_values(&[program_type]);
     INDEXER_TRANSACTIONS_SAVED.with_label_values(&[program_type]);
@@ -179,6 +201,29 @@ pub fn init_labels(program_type: &str) {
 
     OPERATOR_BACKLOG_DEPTH.with_label_values(&[program_type]);
     FEEPAYER_BALANCE_LAMPORTS.with_label_values(&[program_type]);
+
+    // Quarantine reasons roughly track the OperatorError variants the processor
+    // classifies as deterministic (see classify_processor_error).
+    for reason in &[
+        "invalid_pubkey",
+        "invalid_builder",
+        "missing_nonce",
+        "program_error",
+        "other",
+    ] {
+        OPERATOR_TRANSACTION_QUARANTINED.with_label_values(&[program_type, reason]);
+    }
+
+    for task in &[
+        "fetcher",
+        "processor",
+        "sender",
+        "storage_writer",
+        "reconciliation",
+        "feepayer_monitor",
+    ] {
+        OPERATOR_TASK_EXIT.with_label_values(&[program_type, task]);
+    }
 }
 
 pub fn init() {
@@ -201,6 +246,8 @@ pub fn init() {
         OPERATOR_MINTS_SENT,
         OPERATOR_BACKLOG_DEPTH,
         FEEPAYER_BALANCE_LAMPORTS,
+        OPERATOR_TRANSACTION_QUARANTINED,
+        OPERATOR_TASK_EXIT,
     );
 }
 
@@ -285,6 +332,8 @@ mod tests {
             "contra_operator_mints_sent_total",
             "contra_operator_backlog_depth",
             "contra_feepayer_balance_lamports",
+            "contra_operator_transaction_quarantined_total",
+            "contra_operator_task_exit_total",
         ];
 
         let families = prometheus::gather();

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -136,9 +136,9 @@ gauge_vec!(
 
 // Poison-pill: a single transaction that could not be sent on-chain was
 // quarantined to ManualReview so the pipeline could keep moving.  The `reason`
-// label mirrors the error classification (`invalid_pubkey`, `invalid_builder`,
-// `missing_nonce`, ...) so dashboards can distinguish systemic bugs from
-// one-off bad rows.
+// label mirrors `classify_processor_error` (`invalid_pubkey`, `invalid_builder`,
+// `program_error`) so dashboards can distinguish systemic bugs from one-off
+// bad rows.  Keep `init_labels` in sync when adding a new variant.
 counter_vec!(
     OPERATOR_TRANSACTION_QUARANTINED,
     "contra_operator_transaction_quarantined_total",
@@ -202,15 +202,10 @@ pub fn init_labels(program_type: &str) {
     OPERATOR_BACKLOG_DEPTH.with_label_values(&[program_type]);
     FEEPAYER_BALANCE_LAMPORTS.with_label_values(&[program_type]);
 
-    // Quarantine reasons roughly track the OperatorError variants the processor
-    // classifies as deterministic (see classify_processor_error).
-    for reason in &[
-        "invalid_pubkey",
-        "invalid_builder",
-        "missing_nonce",
-        "program_error",
-        "other",
-    ] {
+    // Quarantine reasons must match the string constants returned by
+    // `classify_processor_error` in processor.rs — any mismatch is a dead
+    // label (visible in Prometheus, never incremented).
+    for reason in &["invalid_pubkey", "invalid_builder", "program_error"] {
         OPERATOR_TRANSACTION_QUARANTINED.with_label_values(&[program_type, reason]);
     }
 

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -217,7 +217,10 @@ pub async fn run(
     let mut storage_writer_handle = storage_writer_handle;
     let pt_label = program_type.as_label();
 
+    // `biased;` makes ctrl-c win on concurrent readiness — avoids a
+    // false-positive `critical_exit` when a task ends at the same instant.
     tokio::select! {
+        biased;
         result = tokio::signal::ctrl_c() => {
             result.map_err(|_| OperatorError::ShutdownChannelSend)?;
             info!("Shutdown signal received, initiating graceful shutdown...");

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -1,5 +1,6 @@
 use crate::config::OperatorConfig;
 use crate::error::OperatorError;
+use crate::metrics;
 use crate::operator::{
     feepayer_monitor, fetcher, processor, reconciliation, sender, DbTransactionWriter, RetryConfig,
     RpcClientWithRetry,
@@ -7,11 +8,12 @@ use crate::operator::{
 use crate::shutdown_utils::shutdown_operator;
 use crate::storage::Storage;
 use crate::ContraIndexerConfig;
+use contra_metrics::MetricLabel;
 use solana_sdk::commitment_config::CommitmentConfig;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 pub async fn run(
     storage: Arc<Storage>,
@@ -74,15 +76,21 @@ pub async fn run(
     });
 
     // Start processor task
+    //
+    // storage_tx is cloned into the processor so per-transaction quarantine
+    // updates (ManualReview) flow through the same DbTransactionWriter path
+    // the sender uses for status updates.
     let program_type = common_config.program_type;
     let instance_pda = common_config.escrow_instance_id;
     let processor_storage = storage.clone();
     let processor_rpc = rpc_client.clone();
     let processor_source_rpc = source_rpc_client.clone();
+    let processor_storage_tx = storage_tx.clone();
     let processor_handle = tokio::spawn(async move {
         processor::run_processor(
             processor_rx,
             sender_tx,
+            processor_storage_tx,
             program_type,
             instance_pda,
             processor_storage,
@@ -92,7 +100,7 @@ pub async fn run(
         .await;
     });
 
-    // Start storage writer task (receives updates from sender)
+    // Start storage writer task (receives updates from sender + processor)
     let writer_storage = storage.clone();
     let storage_writer = DbTransactionWriter::new(
         writer_storage,
@@ -188,15 +196,49 @@ pub async fn run(
             tokio::spawn(async {})
         };
 
-    info!("Operator started, waiting for shutdown signal...");
+    info!("Operator started, waiting for shutdown signal or task exit...");
 
-    // Wait for shutdown signal
-    tokio::signal::ctrl_c()
-        .await
-        .map_err(|_| OperatorError::ShutdownChannelSend)?;
-    info!("Shutdown signal received, initiating graceful shutdown...");
+    // Task supervision.
+    //
+    // We race ctrl-c against each critical task's JoinHandle — whichever
+    // fires first wins — and fall through to the shutdown path either way.
+    // A task exit increments the OPERATOR_TASK_EXIT metric with a task
+    // label so dashboards can tell which one failed without tailing logs.
+    //
+    // Non-critical tasks (reconciliation, feepayer monitor) are not watched
+    // here.
+    //
+    // Handles are polled by mutable reference so ownership stays here and
+    // they can still be moved into `shutdown_operator` below — awaiting an
+    // already-completed JoinHandle is a no-op.
+    let mut fetcher_handle = fetcher_handle;
+    let mut processor_handle = processor_handle;
+    let mut sender_handle = sender_handle;
+    let mut storage_writer_handle = storage_writer_handle;
+    let pt_label = program_type.as_label();
 
-    // Graceful shutdown
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            result.map_err(|_| OperatorError::ShutdownChannelSend)?;
+            info!("Shutdown signal received, initiating graceful shutdown...");
+        }
+        _ = &mut fetcher_handle => {
+            critical_exit(pt_label, "fetcher");
+        }
+        _ = &mut processor_handle => {
+            critical_exit(pt_label, "processor");
+        }
+        _ = &mut sender_handle => {
+            critical_exit(pt_label, "sender");
+        }
+        _ = &mut storage_writer_handle => {
+            critical_exit(pt_label, "storage_writer");
+        }
+    }
+
+    // Graceful shutdown — runs on both the ctrl-c path and the critical-task-
+    // exit path.  On the exit path, the handle that tripped the select is
+    // already completed; shutdown_operator will wait on the others.
     shutdown_operator(
         cancellation_token,
         storage,
@@ -214,4 +256,20 @@ pub async fn run(
 
     info!("Operator shutdown complete");
     Ok(())
+}
+
+/// Log + metric for a critical task that exited before cancellation.
+///
+/// We don't abort the process here — the caller falls through to
+/// `shutdown_operator` so the remaining tasks get the usual graceful-shutdown
+/// treatment.  The process will exit naturally once `shutdown_operator`
+/// returns, and the supervisor will restart the operator.
+fn critical_exit(program_type_label: &str, task_name: &str) {
+    error!(
+        task = task_name,
+        "Critical operator task exited unexpectedly — triggering shutdown",
+    );
+    metrics::OPERATOR_TASK_EXIT
+        .with_label_values(&[program_type_label, task_name])
+        .inc();
 }

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -189,12 +189,18 @@ async fn quarantine_single(
 ///   2. Flip every other `Pending`/`Processing` withdrawal in the DB to
 ///      `ManualReview` so the fetcher has nothing left to pull.
 ///
+/// `poison_id` is the row the caller has already individually quarantined
+/// via `storage_tx`; it is excluded from the DB sweep so we don't fire a
+/// second `ManualReview` webhook for the same transaction if the async
+/// status update has not yet committed.
+///
 /// Recovery is manual — see the
 /// runbook `withdrawal_pipeline_halt_runbook.md`.
 async fn halt_withdrawal_pipeline(
     storage: &Storage,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     fetcher_rx: &mut mpsc::Receiver<DbTransaction>,
+    poison_id: Option<i64>,
 ) {
     // Drain anything already delivered by the fetcher.  These rows were
     // flipped to `Processing` by `get_and_lock_pending_transactions` but
@@ -214,7 +220,7 @@ async fn halt_withdrawal_pipeline(
     // Sweep the rest of the pipeline: any row still `Pending` (never
     // fetched) or `Processing` (locked but unsent, e.g. a sibling was mid-
     // flight in another instance) is flipped to `ManualReview`.
-    match storage.quarantine_all_active_withdrawals().await {
+    match storage.quarantine_all_active_withdrawals(poison_id).await {
         Ok(affected) => {
             warn!(
                 drained_from_channel = drained,
@@ -489,7 +495,13 @@ pub async fn process_release_funds(
                         .with_label_values(&[pt_label, reason])
                         .inc();
                     quarantine_single(&storage_tx, &transaction, err.to_string()).await;
-                    halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx).await;
+                    halt_withdrawal_pipeline(
+                        &storage,
+                        &storage_tx,
+                        &mut fetcher_rx,
+                        Some(transaction.id),
+                    )
+                    .await;
                     return Ok(());
                 }
                 ErrorDisposition::Transient => {
@@ -1380,7 +1392,7 @@ mod tests {
         let (storage_tx, mut storage_rx) = mpsc::channel(4);
         let (_fetcher_tx, mut fetcher_rx) = mpsc::channel::<DbTransaction>(4);
 
-        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx).await;
+        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx, None).await;
 
         // No in-flight rows were buffered — no channel-side quarantines.
         assert!(storage_rx.try_recv().is_err());
@@ -1416,7 +1428,7 @@ mod tests {
         }
         drop(fetcher_tx);
 
-        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx).await;
+        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx, None).await;
 
         let mut ids = Vec::new();
         while let Ok(update) = storage_rx.try_recv() {
@@ -1452,7 +1464,7 @@ mod tests {
         drop(fetcher_tx);
 
         // Must not panic; must complete.
-        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx).await;
+        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx, None).await;
 
         let update = storage_rx.recv().await.expect("buffered row quarantined");
         assert_eq!(update.transaction_id, 42);

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -1,25 +1,29 @@
 use crate::channel_utils::send_guaranteed;
 use crate::error::{OperatorError, ProgramError};
+use crate::metrics;
 use crate::operator::instruction_util::{
     mint_idempotency_memo, MintToBuilder, TransactionBuilder, WithdrawalRemintInfo,
 };
+use crate::operator::sender::TransactionStatusUpdate;
 use crate::operator::utils::mint_util::MintCache;
 use crate::operator::{
     find_allowed_mint_pda, find_event_authority_pda, find_operator_pda,
     tree_constants::MAX_TREE_LEAVES, MintToBuilderWithTxnId, ReleaseFundsBuilderWithNonce,
     SignerUtil,
 };
-use crate::storage::common::models::DbTransaction;
+use crate::storage::common::models::{DbTransaction, TransactionStatus};
 use crate::storage::Storage;
 use crate::ProgramType;
+use chrono::Utc;
 use contra_escrow_program_client::instructions::{ReleaseFundsBuilder, ResetSmtRootBuilder};
+use contra_metrics::MetricLabel;
 use solana_sdk::pubkey::Pubkey;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{debug, info, info_span, Instrument};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 
 pub struct ProcessorState {
     pub admin_pubkey: Pubkey,
@@ -95,12 +99,153 @@ impl ReleaseFundsState {
     }
 }
 
+/// Error classification for per-transaction handling.
+///
+/// `Quarantine` errors are deterministic — the row itself is bad and will keep
+/// failing if retried.  The processor marks the row `ManualReview`, emits a
+/// webhook (via the DbTransactionWriter path), and moves on so the pipeline
+/// keeps flowing.
+///
+/// `Transient` errors are infrastructure issues that should heal on their
+/// own — we bubble them up so the task exits and the supervisor restarts us.
+/// This is deliberately conservative: on restart the row is re-locked and
+/// re-attempted from `Pending` by the fetcher.
+///
+/// `Fatal` errors mean the processor itself is misconfigured (missing
+/// builder, dead downstream channel) — letting the task exit fast surfaces
+/// the problem at the supervisor instead of silently dropping work.
+enum ErrorDisposition {
+    Quarantine(&'static str),
+    Transient,
+    Fatal,
+}
+
+/// Classify an `OperatorError` surfaced inside the per-transaction body.
+/// The reason string is used as a metric label
+fn classify_processor_error(err: &OperatorError) -> ErrorDisposition {
+    match err {
+        OperatorError::InvalidPubkey { .. } => ErrorDisposition::Quarantine("invalid_pubkey"),
+        OperatorError::Program(ProgramError::InvalidBuilder { .. }) => {
+            ErrorDisposition::Quarantine("invalid_builder")
+        }
+        // Other Program(_) variants are from the sender-side proof/root checks and
+        // cannot originate in the processor today — label them generically if they
+        // ever surface here.
+        OperatorError::Program(_) => ErrorDisposition::Quarantine("program_error"),
+        // MissingBuilder means the processor was constructed without the state it
+        // needs — configuration bug, not a row problem.  Exit to surface it.
+        OperatorError::MissingBuilder => ErrorDisposition::Fatal,
+        // A dead downstream channel means the sender or storage writer died; the
+        // supervisor handles this by aborting the whole operator.
+        OperatorError::ChannelSend(_)
+        | OperatorError::ChannelClosed { .. }
+        | OperatorError::ShutdownChannelSend => ErrorDisposition::Fatal,
+        // DB + RPC + webhook errors are treated as infrastructure — retry on restart.
+        OperatorError::Storage(_)
+        | OperatorError::RpcError(_)
+        | OperatorError::WebhookError(_)
+        | OperatorError::Account(_)
+        | OperatorError::Transaction(_) => ErrorDisposition::Transient,
+    }
+}
+
+/// Emit a `ManualReview` status update for a single row via the shared storage
+/// writer channel.  Reuses `TransactionStatusUpdate` so the existing
+/// DbTransactionWriter path handles both the DB write and the alert webhook.
+async fn quarantine_single(
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    transaction: &DbTransaction,
+    error_message: String,
+) {
+    let update = TransactionStatusUpdate {
+        transaction_id: transaction.id,
+        trace_id: Some(transaction.trace_id.clone()),
+        status: TransactionStatus::ManualReview,
+        counterpart_signature: None,
+        processed_at: Some(Utc::now()),
+        error_message: Some(error_message),
+        remint_signature: None,
+        remint_attempted: false,
+    };
+    // send_guaranteed: losing a quarantine update is worse than blocking briefly —
+    // the DB row would stay `Processing` and never alert.
+    if let Err(e) = send_guaranteed(storage_tx, update, "quarantine status update").await {
+        // The only way this can fail is a closed channel, which means the storage
+        // writer is already gone and the supervisor is about to restart us anyway.
+        error!(
+            txn_id = transaction.id,
+            trace_id = %transaction.trace_id,
+            "Failed to send quarantine update (storage writer down): {}", e
+        );
+    }
+}
+
+/// Halt the withdrawal pipeline after a poison-pill is detected.
+///
+/// A quarantined withdrawal leaves a permanent nonce gap that the on-chain
+/// program rejects for every subsequent nonce in the same tree. Rather
+/// than bleed errors downstream, we stop cleanly:
+///   1. Quarantine any rows the fetcher already handed us (drain the rx).
+///   2. Flip every other `Pending`/`Processing` withdrawal in the DB to
+///      `ManualReview` so the fetcher has nothing left to pull.
+///
+/// Recovery is manual — see the
+/// runbook `withdrawal_pipeline_halt_runbook.md`.
+async fn halt_withdrawal_pipeline(
+    storage: &Storage,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    fetcher_rx: &mut mpsc::Receiver<DbTransaction>,
+) {
+    // Drain anything already delivered by the fetcher.  These rows were
+    // flipped to `Processing` by `get_and_lock_pending_transactions` but
+    // have not yet been handed to the sender, so they would otherwise be
+    // stranded in `Processing`.
+    let mut drained = 0u64;
+    while let Ok(buffered) = fetcher_rx.try_recv() {
+        quarantine_single(
+            storage_tx,
+            &buffered,
+            "withdrawal pipeline halted after poison-pill".to_string(),
+        )
+        .await;
+        drained += 1;
+    }
+
+    // Sweep the rest of the pipeline: any row still `Pending` (never
+    // fetched) or `Processing` (locked but unsent, e.g. a sibling was mid-
+    // flight in another instance) is flipped to `ManualReview`.
+    match storage.quarantine_all_active_withdrawals().await {
+        Ok(affected) => {
+            warn!(
+                drained_from_channel = drained,
+                db_rows_quarantined = affected,
+                "Halted withdrawal pipeline; all active rows moved to ManualReview"
+            );
+        }
+        Err(e) => {
+            // Even on DB failure we have already quarantined the poison row
+            // plus anything buffered in the channel, so the offending leaf is
+            // visible in the alert stream. Log and continue to shutdown —
+            // the supervisor restart path will re-attempt on next boot via
+            // the runbook.
+            error!(
+                drained_from_channel = drained,
+                "quarantine_all_active_withdrawals failed: {}", e
+            );
+        }
+    }
+}
+
 /// Processes and validates transactions before sending to blockchain
 ///
-/// Receives transactions from fetcher, validates them, and forwards to sender
+/// Receives transactions from fetcher, validates them, and forwards to sender.
+/// Per-transaction errors are classified and handled locally so a single bad
+/// row does not propagate out of the task.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_processor(
     fetcher_rx: mpsc::Receiver<DbTransaction>,
     sender_tx: mpsc::Sender<TransactionBuilder>,
+    storage_tx: mpsc::Sender<TransactionStatusUpdate>,
     program_type: ProgramType,
     instance_pda: Option<Pubkey>,
     storage: Arc<Storage>,
@@ -111,13 +256,28 @@ pub async fn run_processor(
 
     match program_type {
         ProgramType::Withdraw => {
+            // A withdrawal operator without an instance_pda is misconfigured.
+            let Some(instance_pda) = instance_pda else {
+                error!(
+                    "Withdraw operator missing escrow_instance_id, cannot build ReleaseFunds instructions; processor exiting"
+                );
+                return;
+            };
             let mut processor_state = ProcessorState::new_with_release_funds_state(
-                instance_pda.expect("Missing instance PDA"),
-                storage,
+                instance_pda,
+                storage.clone(),
                 rpc_client,
             );
 
-            if let Err(e) = process_release_funds(&mut processor_state, fetcher_rx, sender_tx).await
+            if let Err(e) = process_release_funds(
+                &mut processor_state,
+                fetcher_rx,
+                sender_tx,
+                storage_tx,
+                storage,
+                program_type,
+            )
+            .await
             {
                 tracing::error!("Process release funds error: {}", e);
             }
@@ -127,7 +287,14 @@ pub async fn run_processor(
             let mint_rpc_client = source_rpc_client.unwrap_or_else(|| rpc_client.clone());
             let mut processor_state = ProcessorState::new_with_storage(storage, mint_rpc_client);
 
-            if let Err(e) = process_deposit_funds(&mut processor_state, fetcher_rx, sender_tx).await
+            if let Err(e) = process_deposit_funds(
+                &mut processor_state,
+                fetcher_rx,
+                sender_tx,
+                storage_tx,
+                program_type,
+            )
+            .await
             {
                 tracing::error!("Deposit funds error: {}", e);
             }
@@ -135,132 +302,210 @@ pub async fn run_processor(
     }
 }
 
-pub async fn process_release_funds(
+/// Build the release_funds TransactionBuilder for a single withdrawal.
+///
+/// Kept out of the loop so error handling in the caller is a single
+/// Result<TransactionBuilder, OperatorError> to match on.
+async fn build_release_funds(
     processor_state: &mut ProcessorState,
-    mut fetcher_rx: mpsc::Receiver<DbTransaction>,
-    sender_tx: mpsc::Sender<TransactionBuilder>,
-) -> Result<(), OperatorError> {
+    transaction: &DbTransaction,
+) -> Result<TransactionBuilder, OperatorError> {
+    // `withdrawal_nonce IS NOT NULL` is enforced by the insert-trigger for
+    // withdrawal rows; a NULL here means the row was inserted by something
+    // other than the normal path and cannot be processed safely.
+    let Some(nonce_i64) = transaction.withdrawal_nonce else {
+        return Err(OperatorError::Program(ProgramError::InvalidBuilder {
+            reason: format!(
+                "withdrawal row {} has NULL withdrawal_nonce",
+                transaction.id
+            ),
+        }));
+    };
+    let nonce = nonce_i64 as u64;
+
     let release_funds_state = processor_state
         .release_funds_state
         .as_mut()
         .ok_or(OperatorError::MissingBuilder)?;
 
+    let mut builder = ReleaseFundsBuilder::new();
+
+    let mint = Pubkey::from_str(&transaction.mint).map_err(|e| OperatorError::InvalidPubkey {
+        pubkey: transaction.mint.clone(),
+        reason: e.to_string(),
+    })?;
+    let recipient =
+        Pubkey::from_str(&transaction.recipient).map_err(|e| OperatorError::InvalidPubkey {
+            pubkey: transaction.recipient.clone(),
+            reason: e.to_string(),
+        })?;
+
+    // Fetch mint metadata from cache (or storage if not cached)
+    let mint_metadata = processor_state.mint_cache.get_mint_metadata(&mint).await?;
+    let token_program = mint_metadata.token_program;
+
+    let allowed_mint_pda = release_funds_state.get_allowed_mint_pda(&mint);
+    let instance_ata = release_funds_state.get_instance_ata(&mint, &token_program);
+
+    let recipient_ata =
+        get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
+
+    // Sibling proofs and new withdrawal root are filled in by the sender once
+    // the nonce reaches the front of the in-flight queue.
+    builder
+        .payer(processor_state.admin_pubkey)
+        .operator(release_funds_state.operator_pubkey)
+        .instance(release_funds_state.instance_pda)
+        .operator_pda(release_funds_state.operator_pda)
+        .mint(mint)
+        .allowed_mint(allowed_mint_pda)
+        .user_ata(recipient_ata)
+        .instance_ata(instance_ata)
+        .token_program(token_program)
+        .user(recipient)
+        .transaction_nonce(nonce);
+
+    let amount = u64::try_from(transaction.amount).map_err(|_| {
+        OperatorError::Program(ProgramError::InvalidBuilder {
+            reason: format!(
+                "negative withdrawal amount {} for transaction {}",
+                transaction.amount, transaction.id
+            ),
+        })
+    })?;
+    builder.amount(amount);
+
+    // Remint info for recovery-on-permanent-failure.  Contra token program, not
+    // mainnet — remint happens on Contra.
+    let contra_token_program = processor_state.mint_cache.get_contra_token_program();
+    let remint_user_ata =
+        get_associated_token_address_with_program_id(&recipient, &mint, &contra_token_program);
+    let remint_info = WithdrawalRemintInfo {
+        transaction_id: transaction.id,
+        trace_id: transaction.trace_id.clone(),
+        mint,
+        user: recipient,
+        user_ata: remint_user_ata,
+        token_program: contra_token_program,
+        amount,
+    };
+
+    Ok(TransactionBuilder::ReleaseFunds(Box::new(
+        ReleaseFundsBuilderWithNonce {
+            builder,
+            nonce,
+            transaction_id: transaction.id,
+            trace_id: transaction.trace_id.clone(),
+            remint_info: Some(remint_info),
+        },
+    )))
+}
+
+/// Build the tree-rotation TransactionBuilder for a nonce landing on the
+/// MAX_TREE_LEAVES boundary (normal, non-poison path).
+fn build_scheduled_rotation(
+    admin_pubkey: Pubkey,
+    release_funds_state: &ReleaseFundsState,
+) -> TransactionBuilder {
+    let mut rotation_builder = ResetSmtRootBuilder::new();
+    rotation_builder
+        .payer(admin_pubkey)
+        .operator(release_funds_state.operator_pubkey)
+        .instance(release_funds_state.instance_pda)
+        .operator_pda(release_funds_state.operator_pda)
+        .event_authority(release_funds_state.event_authority_pda);
+    TransactionBuilder::ResetSmtRoot(Box::new(rotation_builder))
+}
+
+pub async fn process_release_funds(
+    processor_state: &mut ProcessorState,
+    mut fetcher_rx: mpsc::Receiver<DbTransaction>,
+    sender_tx: mpsc::Sender<TransactionBuilder>,
+    storage_tx: mpsc::Sender<TransactionStatusUpdate>,
+    storage: Arc<Storage>,
+    program_type: ProgramType,
+) -> Result<(), OperatorError> {
+    if processor_state.release_funds_state.is_none() {
+        return Err(OperatorError::MissingBuilder);
+    }
+
+    let pt_label = program_type.as_label();
+
     while let Some(transaction) = fetcher_rx.recv().await {
         let span = info_span!("process", trace_id = %transaction.trace_id, txn_id = transaction.id);
 
-        async {
-            let nonce = transaction
-                .withdrawal_nonce
-                .expect("withdrawal transaction must have withdrawal_nonce")
-                as u64;
+        let outcome: Result<(), OperatorError> = async {
+            // Build the withdrawal first so rotation + withdrawal dispatch are
+            // atomic from the sender's perspective.
+            let release_funds_tx = build_release_funds(processor_state, &transaction).await?;
 
-            // Check if we need to rotate the tree before processing this transaction
-            if nonce > 0 && nonce.is_multiple_of(MAX_TREE_LEAVES as u64) {
-                info!("Tree rotation boundary detected at nonce {}", nonce);
-
-                // Send ResetSmtRoot transaction BEFORE the boundary nonce
-                let mut rotation_builder = ResetSmtRootBuilder::new();
-                rotation_builder
-                    .payer(processor_state.admin_pubkey)
-                    .operator(release_funds_state.operator_pubkey)
-                    .instance(release_funds_state.instance_pda)
-                    .operator_pda(release_funds_state.operator_pda)
-                    .event_authority(release_funds_state.event_authority_pda);
-
-                let rotation_tx = TransactionBuilder::ResetSmtRoot(Box::new(rotation_builder));
-
-                send_guaranteed(&sender_tx, rotation_tx, "reset smt root")
-                    .await
-                    .map_err(OperatorError::ChannelSend)?;
-
-                info!("Sent ResetSmtRoot transaction for tree rotation");
+            // Scheduled rotation (normal path): when a nonce lands on the
+            // MAX_TREE_LEAVES boundary, rotate the tree BEFORE dispatching the
+            // boundary withdrawal.
+            if let Some(nonce_i64) = transaction.withdrawal_nonce {
+                let nonce = nonce_i64 as u64;
+                if nonce > 0 && nonce.is_multiple_of(MAX_TREE_LEAVES as u64) {
+                    info!(
+                        nonce,
+                        "Tree rotation boundary detected, dispatching ResetSmtRoot"
+                    );
+                    let release_funds_state = processor_state
+                        .release_funds_state
+                        .as_ref()
+                        .ok_or(OperatorError::MissingBuilder)?;
+                    let rotation_tx =
+                        build_scheduled_rotation(processor_state.admin_pubkey, release_funds_state);
+                    send_guaranteed(&sender_tx, rotation_tx, "reset smt root")
+                        .await
+                        .map_err(OperatorError::ChannelSend)?;
+                }
             }
 
-            let mut builder = ReleaseFundsBuilder::new();
-
-            let mint =
-                Pubkey::from_str(&transaction.mint).map_err(|e| OperatorError::InvalidPubkey {
-                    pubkey: transaction.mint.clone(),
-                    reason: e.to_string(),
-                })?;
-            let recipient = Pubkey::from_str(&transaction.recipient).map_err(|e| {
-                OperatorError::InvalidPubkey {
-                    pubkey: transaction.recipient.clone(),
-                    reason: e.to_string(),
-                }
-            })?;
-
-            // Fetch mint metadata from cache (or storage if not cached)
-            let mint_metadata = processor_state.mint_cache.get_mint_metadata(&mint).await?;
-            let token_program = mint_metadata.token_program;
-
-            let allowed_mint_pda = release_funds_state.get_allowed_mint_pda(&mint);
-            let instance_ata = release_funds_state.get_instance_ata(&mint, &token_program);
-
-            let recipient_ata =
-                get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
-
-            // Sibling proofs and  New withdrawal root not set, will be set by sender
-            builder
-                .payer(processor_state.admin_pubkey)
-                .operator(release_funds_state.operator_pubkey)
-                .instance(release_funds_state.instance_pda)
-                .operator_pda(release_funds_state.operator_pda)
-                .mint(mint)
-                .allowed_mint(allowed_mint_pda)
-                .user_ata(recipient_ata)
-                .instance_ata(instance_ata)
-                .token_program(token_program)
-                .user(recipient)
-                .transaction_nonce(nonce);
-
-            let amount = u64::try_from(transaction.amount).map_err(|_| {
-                OperatorError::Program(ProgramError::InvalidBuilder {
-                    reason: format!(
-                        "negative withdrawal amount {} for transaction {}",
-                        transaction.amount, transaction.id
-                    ),
-                })
-            })?;
-            builder.amount(amount);
-
-            // Build remint info for token recovery on permanent failure.
-            // Uses Contra token program (not mainnet) since remint happens on Contra.
-            let contra_token_program = processor_state.mint_cache.get_contra_token_program();
-            let remint_user_ata = get_associated_token_address_with_program_id(
-                &recipient,
-                &mint,
-                &contra_token_program,
-            );
-            let remint_info = WithdrawalRemintInfo {
-                transaction_id: transaction.id,
-                trace_id: transaction.trace_id.clone(),
-                mint,
-                user: recipient,
-                user_ata: remint_user_ata,
-                token_program: contra_token_program,
-                amount,
-            };
-
             info!("Processing withdrawal");
-
-            let wrapped =
-                TransactionBuilder::ReleaseFunds(Box::new(ReleaseFundsBuilderWithNonce {
-                    builder,
-                    nonce,
-                    transaction_id: transaction.id,
-                    trace_id: transaction.trace_id.clone(),
-                    remint_info: Some(remint_info),
-                }));
-
-            send_guaranteed(&sender_tx, wrapped, "processed release funds")
+            send_guaranteed(&sender_tx, release_funds_tx, "processed release funds")
                 .await
                 .map_err(OperatorError::ChannelSend)?;
 
-            Ok::<(), OperatorError>(())
+            Ok(())
         }
-        .instrument(span)
-        .await?;
+        .instrument(span.clone())
+        .await;
+
+        // A per-row error is classified.  For a deterministic poison-pill
+        // we quarantine the row, halt the whole withdrawal pipeline, and
+        // return so the supervisor can shut down cleanly.  Transient or
+        // fatal errors bubble up directly.
+        if let Err(err) = outcome {
+            match classify_processor_error(&err) {
+                ErrorDisposition::Quarantine(reason) => {
+                    warn!(
+                        txn_id = transaction.id,
+                        trace_id = %transaction.trace_id,
+                        reason,
+                        "Quarantining withdrawal and halting pipeline: {}",
+                        err
+                    );
+                    metrics::OPERATOR_TRANSACTION_QUARANTINED
+                        .with_label_values(&[pt_label, reason])
+                        .inc();
+                    quarantine_single(&storage_tx, &transaction, err.to_string()).await;
+                    halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx).await;
+                    return Ok(());
+                }
+                ErrorDisposition::Transient => {
+                    // Transient: surface the error so the supervisor can
+                    // restart us cleanly.
+                    return Err(err);
+                }
+                ErrorDisposition::Fatal => {
+                    error!(
+                        txn_id = transaction.id,
+                        "Fatal processor error, exiting task: {}", err
+                    );
+                    return Err(err);
+                }
+            }
+        }
     }
 
     Ok(())
@@ -270,11 +515,15 @@ pub async fn process_deposit_funds(
     processor_state: &mut ProcessorState,
     mut fetcher_rx: mpsc::Receiver<DbTransaction>,
     sender_tx: mpsc::Sender<TransactionBuilder>,
+    storage_tx: mpsc::Sender<TransactionStatusUpdate>,
+    program_type: ProgramType,
 ) -> Result<(), OperatorError> {
+    let pt_label = program_type.as_label();
+
     while let Some(transaction) = fetcher_rx.recv().await {
         let span = info_span!("process", trace_id = %transaction.trace_id, txn_id = transaction.id);
 
-        async {
+        let outcome: Result<(), OperatorError> = async {
             let proc_t0 = tokio::time::Instant::now();
             let mint =
                 Pubkey::from_str(&transaction.mint).map_err(|e| OperatorError::InvalidPubkey {
@@ -327,10 +576,35 @@ pub async fn process_deposit_funds(
                 );
             }
 
-            Ok::<(), OperatorError>(())
+            Ok(())
         }
         .instrument(span)
-        .await?;
+        .await;
+
+        // Deposit-side quarantine. Unlike withdrawals, deposits have no
+        // nonce, so a bad row is simply moved to
+        // ManualReview and the loop continues. The user's on-chain tokens
+        // are still locked in escrow until a human reviews the row.
+        if let Err(err) = outcome {
+            match classify_processor_error(&err) {
+                ErrorDisposition::Quarantine(reason) => {
+                    warn!(
+                        txn_id = transaction.id,
+                        trace_id = %transaction.trace_id,
+                        reason,
+                        "Quarantining deposit to ManualReview: {}",
+                        err
+                    );
+                    metrics::OPERATOR_TRANSACTION_QUARANTINED
+                        .with_label_values(&[pt_label, reason])
+                        .inc();
+                    quarantine_single(&storage_tx, &transaction, err.to_string()).await;
+                }
+                ErrorDisposition::Transient | ErrorDisposition::Fatal => {
+                    return Err(err);
+                }
+            }
+        }
     }
 
     Ok(())
@@ -339,7 +613,9 @@ pub async fn process_deposit_funds(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::{AccountError, StorageError, TransactionError};
     use crate::operator::find_allowed_mint_pda;
+    use crate::storage::common::models::TransactionType;
     use crate::storage::common::storage::mock::MockStorage;
 
     fn make_release_funds_state() -> ReleaseFundsState {
@@ -409,6 +685,35 @@ mod tests {
         assert_eq!(state.instance_atas.len(), 2);
     }
 
+    fn make_db_transaction(
+        id: i64,
+        mint: &str,
+        recipient: &str,
+        nonce: Option<i64>,
+        txn_type: crate::storage::common::models::TransactionType,
+    ) -> DbTransaction {
+        DbTransaction {
+            id,
+            signature: format!("sig_{id}"),
+            trace_id: format!("trace-{id}"),
+            slot: 100,
+            initiator: "initiator".to_string(),
+            recipient: recipient.to_string(),
+            mint: mint.to_string(),
+            amount: 1000,
+            memo: None,
+            transaction_type: txn_type,
+            withdrawal_nonce: nonce,
+            status: TransactionStatus::Processing,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            pending_remint_deadline_at: None,
+        }
+    }
+
     #[tokio::test]
     async fn process_release_funds_missing_state_errors() {
         let mock = MockStorage::new();
@@ -416,13 +721,21 @@ mod tests {
         let mut ps = ProcessorState {
             admin_pubkey: Pubkey::new_unique(),
             release_funds_state: None,
-            mint_cache: crate::operator::MintCache::new(storage),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
-        // Keep tx alive so channel isn't closed — error must come from missing state
         let (_tx, rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, _sender_rx) = mpsc::channel(1);
+        let (storage_tx, _storage_rx) = mpsc::channel(1);
 
-        let result = process_release_funds(&mut ps, rx, sender_tx).await;
+        let result = process_release_funds(
+            &mut ps,
+            rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
         assert!(
             matches!(result, Err(crate::error::OperatorError::MissingBuilder)),
             "expected MissingBuilder, got: {:?}",
@@ -442,7 +755,6 @@ mod tests {
             mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
 
-        // Add a mint to the mock storage so mint_cache can find it
         let mint_pubkey = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
         {
@@ -463,32 +775,28 @@ mod tests {
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
 
-        let txn = DbTransaction {
-            id: 1,
-            signature: "test_sig".to_string(),
-            trace_id: "trace-1".to_string(),
-            slot: 100,
-            initiator: "initiator".to_string(),
-            recipient: recipient.to_string(),
-            mint: mint_pubkey.to_string(),
-            amount: 1000,
-            memo: None,
-            transaction_type: crate::storage::common::models::TransactionType::Withdrawal,
-            withdrawal_nonce: Some(5),
-            status: crate::storage::common::models::TransactionStatus::Processing,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            processed_at: None,
-            counterpart_signature: None,
-            remint_signatures: None,
-            pending_remint_deadline_at: None,
-        };
+        let txn = make_db_transaction(
+            1,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            Some(5),
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
 
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx).await;
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
         assert!(result.is_ok());
 
         let msg = sender_rx.recv().await.unwrap();
@@ -532,33 +840,28 @@ mod tests {
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
 
-        // Use nonce at tree rotation boundary (MAX_TREE_LEAVES)
-        let txn = DbTransaction {
-            id: 1,
-            signature: "test_sig".to_string(),
-            trace_id: "trace-1".to_string(),
-            slot: 100,
-            initiator: "initiator".to_string(),
-            recipient: recipient.to_string(),
-            mint: mint_pubkey.to_string(),
-            amount: 1000,
-            memo: None,
-            transaction_type: crate::storage::common::models::TransactionType::Withdrawal,
-            withdrawal_nonce: Some(MAX_TREE_LEAVES as i64),
-            status: crate::storage::common::models::TransactionStatus::Processing,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            processed_at: None,
-            counterpart_signature: None,
-            remint_signatures: None,
-            pending_remint_deadline_at: None,
-        };
+        let txn = make_db_transaction(
+            1,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            Some(MAX_TREE_LEAVES as i64),
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
 
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx).await;
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
         assert!(result.is_ok());
 
         // First message must be ResetSmtRoot — rotation happens before the boundary withdrawal
@@ -581,52 +884,60 @@ mod tests {
         assert!(sender_rx.try_recv().is_err(), "unexpected third message");
     }
 
-    /// A mint field that cannot be parsed as a Pubkey must surface as an InvalidPubkey error
-    /// rather than panicking or silently skipping the transaction.
+    /// A mint field that cannot be parsed as a Pubkey halts the pipeline.
+    /// The poison row is marked ManualReview, no rotation is dispatched,
+    /// and subsequent active withdrawals are quarantined.
     #[tokio::test]
-    async fn process_release_funds_invalid_mint_errors() {
+    async fn process_release_funds_invalid_mint_quarantines_and_halts() {
         let mock = MockStorage::new();
         let storage = Arc::new(Storage::Mock(mock));
         let mut ps = ProcessorState {
             admin_pubkey: Pubkey::new_unique(),
             release_funds_state: Some(make_release_funds_state()),
-            mint_cache: crate::operator::MintCache::new(storage),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
-        let (sender_tx, _sender_rx) = mpsc::channel(10);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
-        let txn = DbTransaction {
-            id: 1,
-            signature: "test_sig".to_string(),
-            trace_id: "trace-1".to_string(),
-            slot: 100,
-            initiator: "initiator".to_string(),
-            recipient: Pubkey::new_unique().to_string(),
-            mint: "not_a_valid_pubkey".to_string(),
-            amount: 1000,
-            memo: None,
-            transaction_type: crate::storage::common::models::TransactionType::Withdrawal,
-            withdrawal_nonce: Some(1),
-            status: crate::storage::common::models::TransactionStatus::Processing,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            processed_at: None,
-            counterpart_signature: None,
-            remint_signatures: None,
-            pending_remint_deadline_at: None,
-        };
+        let txn = make_db_transaction(
+            1,
+            "not_a_valid_pubkey",
+            &Pubkey::new_unique().to_string(),
+            Some(1),
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
 
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let err = process_release_funds(&mut ps, fetcher_rx, sender_tx)
-            .await
-            .unwrap_err();
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        // Task must NOT crash on a poison row.
         assert!(
-            matches!(err, OperatorError::InvalidPubkey { ref pubkey, .. } if pubkey == "not_a_valid_pubkey"),
-            "expected InvalidPubkey for bad mint, got: {:?}",
-            err
+            result.is_ok(),
+            "expected Ok on quarantine, got: {:?}",
+            result
+        );
+
+        // A ManualReview status update was sent for the poison row.
+        let update = storage_rx.recv().await.expect("quarantine update sent");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert_eq!(update.transaction_id, 1);
+
+        // Sender must not have received anything — rotation is no longer
+        // part of the quarantine path.
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "unexpected message on sender channel"
         );
     }
 
@@ -647,32 +958,27 @@ mod tests {
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
 
-        let txn = DbTransaction {
-            id: 1,
-            signature: "test_sig".to_string(),
-            trace_id: "trace-1".to_string(),
-            slot: 100,
-            initiator: "initiator".to_string(),
-            recipient: recipient.to_string(),
-            mint: mint_pubkey.to_string(),
-            amount: 1000,
-            memo: None,
-            transaction_type: crate::storage::common::models::TransactionType::Deposit,
-            withdrawal_nonce: None,
-            status: crate::storage::common::models::TransactionStatus::Processing,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            processed_at: None,
-            counterpart_signature: None,
-            remint_signatures: None,
-            pending_remint_deadline_at: None,
-        };
+        let txn = make_db_transaction(
+            1,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            None,
+            crate::storage::common::models::TransactionType::Deposit,
+        );
 
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_deposit_funds(&mut ps, fetcher_rx, sender_tx).await;
+        let result = process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            ProgramType::Escrow,
+        )
+        .await;
         assert!(result.is_ok());
 
         let msg = sender_rx.recv().await.unwrap();
@@ -683,10 +989,10 @@ mod tests {
         assert_eq!(b.trace_id, "trace-1");
     }
 
-    /// A non-base58 mint string must fail with InvalidPubkey; the error propagates out of
-    /// process_deposit_funds rather than being swallowed.
+    /// A non-base58 mint string is quarantined rather than propagated — the
+    /// deposit task continues so other deposits still land.
     #[tokio::test]
-    async fn process_deposit_funds_invalid_mint_errors() {
+    async fn process_deposit_funds_invalid_mint_quarantines() {
         let mock = MockStorage::new();
         let storage = Arc::new(Storage::Mock(mock));
         let mut ps = ProcessorState {
@@ -697,39 +1003,36 @@ mod tests {
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, _sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
-        let txn = DbTransaction {
-            id: 1,
-            signature: "test_sig".to_string(),
-            trace_id: "trace-1".to_string(),
-            slot: 100,
-            initiator: "initiator".to_string(),
-            recipient: Pubkey::new_unique().to_string(),
-            mint: "not_a_valid_pubkey".to_string(),
-            amount: 1000,
-            memo: None,
-            transaction_type: crate::storage::common::models::TransactionType::Deposit,
-            withdrawal_nonce: None,
-            status: crate::storage::common::models::TransactionStatus::Processing,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            processed_at: None,
-            counterpart_signature: None,
-            remint_signatures: None,
-            pending_remint_deadline_at: None,
-        };
+        let txn = make_db_transaction(
+            1,
+            "not_a_valid_pubkey",
+            &Pubkey::new_unique().to_string(),
+            None,
+            crate::storage::common::models::TransactionType::Deposit,
+        );
 
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let err = process_deposit_funds(&mut ps, fetcher_rx, sender_tx)
-            .await
-            .unwrap_err();
+        let result = process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            ProgramType::Escrow,
+        )
+        .await;
         assert!(
-            matches!(err, OperatorError::InvalidPubkey { ref pubkey, .. } if pubkey == "not_a_valid_pubkey"),
-            "expected InvalidPubkey for bad mint, got: {:?}",
-            err
+            result.is_ok(),
+            "expected Ok on quarantine, got: {:?}",
+            result
         );
+
+        let update = storage_rx.recv().await.expect("quarantine update sent");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert_eq!(update.transaction_id, 1);
     }
 
     /// An already-closed fetcher channel means there are no transactions to process;
@@ -746,12 +1049,19 @@ mod tests {
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
 
         drop(fetcher_tx); // close channel immediately — no transactions to process
 
-        process_deposit_funds(&mut ps, fetcher_rx, sender_tx)
-            .await
-            .unwrap();
+        process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            ProgramType::Escrow,
+        )
+        .await
+        .unwrap();
 
         // Nothing was sent; channel is empty and the sender was dropped by the function
         assert!(
@@ -760,10 +1070,10 @@ mod tests {
         );
     }
 
-    /// A recipient field that is not a valid base58 pubkey must return an error; the ATA
-    /// derivation step must never be reached with garbage input.
+    /// A recipient field that is not a valid base58 pubkey must quarantine
+    /// the row (deposit has no tree to rotate — just the ManualReview alert).
     #[tokio::test]
-    async fn process_deposit_funds_invalid_recipient_errors() {
+    async fn process_deposit_funds_invalid_recipient_quarantines() {
         let mock = MockStorage::new();
         let storage = Arc::new(Storage::Mock(mock));
         let mut ps = ProcessorState {
@@ -774,45 +1084,41 @@ mod tests {
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, _sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
-        let txn = DbTransaction {
-            id: 1,
-            signature: "test_sig".to_string(),
-            trace_id: "trace-1".to_string(),
-            slot: 100,
-            initiator: "initiator".to_string(),
-            recipient: "not_a_valid_pubkey".to_string(), // invalid recipient
-            mint: Pubkey::new_unique().to_string(),
-            amount: 1000,
-            memo: None,
-            transaction_type: crate::storage::common::models::TransactionType::Deposit,
-            withdrawal_nonce: None,
-            status: crate::storage::common::models::TransactionStatus::Processing,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            processed_at: None,
-            counterpart_signature: None,
-            remint_signatures: None,
-            pending_remint_deadline_at: None,
-        };
+        let txn = make_db_transaction(
+            1,
+            &Pubkey::new_unique().to_string(),
+            "not_a_valid_pubkey",
+            None,
+            crate::storage::common::models::TransactionType::Deposit,
+        );
 
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let err = process_deposit_funds(&mut ps, fetcher_rx, sender_tx)
-            .await
-            .unwrap_err();
+        let result = process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            ProgramType::Escrow,
+        )
+        .await;
         assert!(
-            matches!(err, OperatorError::InvalidPubkey { ref pubkey, .. } if pubkey == "not_a_valid_pubkey"),
-            "expected InvalidPubkey for bad recipient, got: {:?}",
-            err
+            result.is_ok(),
+            "expected Ok on quarantine, got: {:?}",
+            result
         );
+
+        let update = storage_rx.recv().await.expect("quarantine update sent");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
     }
 
-    /// An unparseable recipient pubkey must fail with InvalidPubkey even when the mint is
-    /// valid and the release_funds_state is fully populated.
+    /// An unparseable recipient pubkey on a withdrawal quarantines the row
+    /// and halts the pipeline without dispatching a rotation.
     #[tokio::test]
-    async fn process_release_funds_invalid_recipient_errors() {
+    async fn process_release_funds_invalid_recipient_quarantines_and_halts() {
         let mock = MockStorage::new();
         let storage = Arc::new(Storage::Mock(mock));
         let mut ps = ProcessorState {
@@ -839,39 +1145,792 @@ mod tests {
         }
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
-        let (sender_tx, _sender_rx) = mpsc::channel(10);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
-        let txn = DbTransaction {
-            id: 1,
-            signature: "test_sig".to_string(),
-            trace_id: "trace-1".to_string(),
-            slot: 100,
-            initiator: "initiator".to_string(),
-            recipient: "not_a_valid_pubkey".to_string(), // invalid recipient
-            mint: mint_pubkey.to_string(),
-            amount: 1000,
-            memo: None,
-            transaction_type: crate::storage::common::models::TransactionType::Withdrawal,
-            withdrawal_nonce: Some(5),
-            status: crate::storage::common::models::TransactionStatus::Processing,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            processed_at: None,
-            counterpart_signature: None,
-            remint_signatures: None,
-            pending_remint_deadline_at: None,
-        };
+        let txn = make_db_transaction(
+            1,
+            &mint_pubkey.to_string(),
+            "not_a_valid_pubkey",
+            Some(5),
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
 
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let err = process_release_funds(&mut ps, fetcher_rx, sender_tx)
-            .await
-            .unwrap_err();
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let update = storage_rx.recv().await.expect("quarantine update sent");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+
         assert!(
-            matches!(err, OperatorError::InvalidPubkey { ref pubkey, .. } if pubkey == "not_a_valid_pubkey"),
-            "expected InvalidPubkey for bad recipient, got: {:?}",
-            err
+            sender_rx.try_recv().is_err(),
+            "no rotation should be dispatched on quarantine"
+        );
+    }
+
+    /// A withdrawal row missing `withdrawal_nonce` is poison — the builder
+    /// cannot be constructed.  Must quarantine rather than panic so the
+    /// task stays alive.
+    #[tokio::test]
+    async fn process_release_funds_missing_nonce_quarantines() {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, _sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let txn = make_db_transaction(
+            1,
+            &Pubkey::new_unique().to_string(),
+            &Pubkey::new_unique().to_string(),
+            None, // <- the poison: withdrawals should never have a NULL nonce
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
+
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let update = storage_rx.recv().await.expect("quarantine update sent");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+    }
+
+    // ── classify_processor_error ────────────────────────────────────────
+
+    /// Every `OperatorError` variant that can surface inside the per-row
+    /// async block must map to exactly one `ErrorDisposition`. A missing or
+    /// mis-mapped variant is a silent correctness hole — any new variant
+    /// added later will fail this test and force a conscious decision.
+    #[test]
+    fn classify_processor_error_covers_every_variant() {
+        // Quarantine variants — deterministic, cannot succeed on retry.
+        let invalid_pubkey = OperatorError::InvalidPubkey {
+            pubkey: "xxx".into(),
+            reason: "bad".into(),
+        };
+        assert!(matches!(
+            classify_processor_error(&invalid_pubkey),
+            ErrorDisposition::Quarantine("invalid_pubkey")
+        ));
+
+        let invalid_builder = OperatorError::Program(ProgramError::InvalidBuilder {
+            reason: "missing field".into(),
+        });
+        assert!(matches!(
+            classify_processor_error(&invalid_builder),
+            ErrorDisposition::Quarantine("invalid_builder")
+        ));
+
+        let other_program = OperatorError::Program(ProgramError::SmtNotInitialized);
+        assert!(matches!(
+            classify_processor_error(&other_program),
+            ErrorDisposition::Quarantine("program_error")
+        ));
+
+        // Fatal variants — processor is misconfigured or downstream is dead.
+        assert!(matches!(
+            classify_processor_error(&OperatorError::MissingBuilder),
+            ErrorDisposition::Fatal
+        ));
+        assert!(matches!(
+            classify_processor_error(&OperatorError::ChannelClosed {
+                component: "sender".into()
+            }),
+            ErrorDisposition::Fatal
+        ));
+        assert!(matches!(
+            classify_processor_error(&OperatorError::ShutdownChannelSend),
+            ErrorDisposition::Fatal
+        ));
+
+        // Transient variants — infra blips, supervisor restart is correct.
+        let storage_err = OperatorError::Storage(StorageError::DatabaseError {
+            message: "connection reset".into(),
+        });
+        assert!(matches!(
+            classify_processor_error(&storage_err),
+            ErrorDisposition::Transient
+        ));
+
+        let rpc_err = OperatorError::RpcError("429".into());
+        assert!(matches!(
+            classify_processor_error(&rpc_err),
+            ErrorDisposition::Transient
+        ));
+
+        let webhook_err = OperatorError::WebhookError("timeout".into());
+        assert!(matches!(
+            classify_processor_error(&webhook_err),
+            ErrorDisposition::Transient
+        ));
+
+        let account_err = OperatorError::Account(AccountError::AccountNotFound {
+            pubkey: Pubkey::new_unique(),
+        });
+        assert!(matches!(
+            classify_processor_error(&account_err),
+            ErrorDisposition::Transient
+        ));
+
+        let txn_err = OperatorError::Transaction(Box::new(TransactionError::Program(
+            ProgramError::SmtNotInitialized,
+        )));
+        assert!(matches!(
+            classify_processor_error(&txn_err),
+            ErrorDisposition::Transient
+        ));
+    }
+
+    // ── quarantine_single ───────────────────────────────────────────────
+
+    /// `quarantine_single` is the single source of truth for the
+    /// ManualReview status update.  Verify every field we write so a future
+    /// refactor cannot silently drop an attribute the webhook relies on.
+    #[tokio::test]
+    async fn quarantine_single_writes_complete_status_update() {
+        let (storage_tx, mut storage_rx) = mpsc::channel(1);
+        let txn = make_db_transaction(
+            77,
+            &Pubkey::new_unique().to_string(),
+            &Pubkey::new_unique().to_string(),
+            Some(9),
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
+
+        quarantine_single(&storage_tx, &txn, "bad row".into()).await;
+
+        let update = storage_rx.recv().await.expect("update was sent");
+        assert_eq!(update.transaction_id, 77);
+        assert_eq!(update.trace_id.as_deref(), Some("trace-77"));
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert_eq!(update.counterpart_signature, None);
+        assert!(update.processed_at.is_some());
+        assert_eq!(update.error_message.as_deref(), Some("bad row"));
+        assert_eq!(update.remint_signature, None);
+        assert!(!update.remint_attempted);
+    }
+
+    /// A closed `storage_tx` is observable at startup-shutdown race — we
+    /// only log, we do not panic.  Without this the supervisor restart
+    /// could infinite-loop on a half-torn-down process.
+    #[tokio::test]
+    async fn quarantine_single_survives_closed_channel() {
+        let (storage_tx, storage_rx) = mpsc::channel(1);
+        drop(storage_rx);
+        let txn = make_db_transaction(
+            1,
+            &Pubkey::new_unique().to_string(),
+            &Pubkey::new_unique().to_string(),
+            Some(0),
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
+
+        // Must not panic.  send_guaranteed will log and return Err; we swallow it.
+        quarantine_single(&storage_tx, &txn, "closed".into()).await;
+    }
+
+    // ── halt_withdrawal_pipeline ────────────────────────────────────────
+
+    /// Even when no rows are buffered in the fetcher channel, the DB sweep
+    /// must still run so pipeline-pause semantics hold: any row a sibling
+    /// instance already locked (`Processing`) is swept to `ManualReview`.
+    #[tokio::test]
+    async fn halt_withdrawal_pipeline_empty_channel_still_sweeps_db() {
+        let mock = MockStorage::new();
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            let mut processing = make_db_transaction(
+                10,
+                &Pubkey::new_unique().to_string(),
+                &Pubkey::new_unique().to_string(),
+                Some(1),
+                TransactionType::Withdrawal,
+            );
+            processing.status = TransactionStatus::Processing;
+            db.push(processing);
+        }
+        let storage = Storage::Mock(mock);
+        let (storage_tx, mut storage_rx) = mpsc::channel(4);
+        let (_fetcher_tx, mut fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+
+        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx).await;
+
+        // No in-flight rows were buffered — no channel-side quarantines.
+        assert!(storage_rx.try_recv().is_err());
+
+        // DB sweep still runs — the Processing row is now ManualReview.
+        let rows = match &storage {
+            Storage::Mock(m) => m.pending_transactions.lock().unwrap().clone(),
+            _ => unreachable!(),
+        };
+        assert_eq!(rows[0].status, TransactionStatus::ManualReview);
+    }
+
+    /// Every row buffered in `fetcher_rx` is individually quarantined —
+    /// the loop must drain, not short-circuit on first row.
+    #[tokio::test]
+    async fn halt_withdrawal_pipeline_drains_every_buffered_row() {
+        let mock = MockStorage::new();
+        let storage = Storage::Mock(mock);
+        let (storage_tx, mut storage_rx) = mpsc::channel(16);
+        let (fetcher_tx, mut fetcher_rx) = mpsc::channel::<DbTransaction>(8);
+
+        for id in 1..=5 {
+            fetcher_tx
+                .send(make_db_transaction(
+                    id,
+                    &Pubkey::new_unique().to_string(),
+                    &Pubkey::new_unique().to_string(),
+                    Some(id),
+                    TransactionType::Withdrawal,
+                ))
+                .await
+                .unwrap();
+        }
+        drop(fetcher_tx);
+
+        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx).await;
+
+        let mut ids = Vec::new();
+        while let Ok(update) = storage_rx.try_recv() {
+            assert_eq!(update.status, TransactionStatus::ManualReview);
+            ids.push(update.transaction_id);
+        }
+        ids.sort();
+        assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+    }
+
+    /// A DB sweep failure must not prevent the channel drain from
+    /// reporting what it already quarantined.  The offending row + buffered
+    /// rows are still visible in the alert stream — a strictly better
+    /// outcome than swallowing both.
+    #[tokio::test]
+    async fn halt_withdrawal_pipeline_db_failure_still_drains_channel() {
+        let mock = MockStorage::new();
+        mock.set_should_fail("quarantine_all_active_withdrawals", true);
+        let storage = Storage::Mock(mock);
+        let (storage_tx, mut storage_rx) = mpsc::channel(4);
+        let (fetcher_tx, mut fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+
+        fetcher_tx
+            .send(make_db_transaction(
+                42,
+                &Pubkey::new_unique().to_string(),
+                &Pubkey::new_unique().to_string(),
+                Some(7),
+                TransactionType::Withdrawal,
+            ))
+            .await
+            .unwrap();
+        drop(fetcher_tx);
+
+        // Must not panic; must complete.
+        halt_withdrawal_pipeline(&storage, &storage_tx, &mut fetcher_rx).await;
+
+        let update = storage_rx.recv().await.expect("buffered row quarantined");
+        assert_eq!(update.transaction_id, 42);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+    }
+
+    // ── process_release_funds: happy paths ──────────────────────────────
+
+    /// Multiple valid withdrawals stream through the processor in FIFO order.
+    /// Each emits a `ReleaseFunds` builder, nothing else is dispatched, and
+    /// the processor returns `Ok(())` when the channel closes.
+    #[tokio::test]
+    async fn process_release_funds_streams_multiple_valid_rows() {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        let mint_pubkey = Pubkey::new_unique();
+        {
+            let mock_storage = match storage.as_ref() {
+                Storage::Mock(m) => m,
+                _ => unreachable!(),
+            };
+            mock_storage.mints.lock().unwrap().insert(
+                mint_pubkey.to_string(),
+                crate::storage::common::models::DbMint {
+                    mint_address: mint_pubkey.to_string(),
+                    decimals: 6,
+                    token_program: spl_token::id().to_string(),
+                    created_at: chrono::Utc::now(),
+                },
+            );
+        }
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(16);
+        let (storage_tx, _storage_rx) = mpsc::channel(16);
+
+        let recipients: Vec<Pubkey> = (0..3).map(|_| Pubkey::new_unique()).collect();
+        for (i, r) in recipients.iter().enumerate() {
+            fetcher_tx
+                .send(make_db_transaction(
+                    (i + 1) as i64,
+                    &mint_pubkey.to_string(),
+                    &r.to_string(),
+                    Some((i + 1) as i64),
+                    crate::storage::common::models::TransactionType::Withdrawal,
+                ))
+                .await
+                .unwrap();
+        }
+        drop(fetcher_tx);
+
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let mut nonces = Vec::new();
+        while let Ok(msg) = sender_rx.try_recv() {
+            match msg {
+                TransactionBuilder::ReleaseFunds(b) => nonces.push(b.nonce),
+                other => panic!("unexpected builder: {:?}", std::mem::discriminant(&other)),
+            }
+        }
+        assert_eq!(nonces, vec![1, 2, 3]);
+    }
+
+    /// A boundary nonce where the builder build itself fails must NOT
+    /// dispatch the rotation — build_release_funds runs first, and an
+    /// error short-circuits before the rotation send.  This locks in the
+    /// §4.7 reorder: no sender-visible side effect without a successful
+    /// builder.
+    #[tokio::test]
+    async fn process_release_funds_boundary_poison_never_dispatches_rotation() {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // Mint is bad → build_release_funds fails → rotation never dispatched.
+        let txn = make_db_transaction(
+            1,
+            "not_a_valid_pubkey",
+            &Pubkey::new_unique().to_string(),
+            Some(MAX_TREE_LEAVES as i64),
+            crate::storage::common::models::TransactionType::Withdrawal,
+        );
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let update = storage_rx.recv().await.expect("quarantine fired");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+
+        // Sender must be empty — no rotation, no release.
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "no dispatch should happen when build_release_funds fails"
+        );
+    }
+
+    /// After a halt, the processor must STOP processing further buffered
+    /// rows — subsequent rows must be quarantined, not turned into
+    /// `ReleaseFunds` builders.
+    #[tokio::test]
+    async fn process_release_funds_halt_stops_processing_further_rows() {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let mint_pubkey = Pubkey::new_unique();
+        {
+            let mock_storage = match storage.as_ref() {
+                Storage::Mock(m) => m,
+                _ => unreachable!(),
+            };
+            mock_storage.mints.lock().unwrap().insert(
+                mint_pubkey.to_string(),
+                crate::storage::common::models::DbMint {
+                    mint_address: mint_pubkey.to_string(),
+                    decimals: 6,
+                    token_program: spl_token::id().to_string(),
+                    created_at: chrono::Utc::now(),
+                },
+            );
+        }
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        // Row 1: poison.  Row 2: would have been valid.
+        fetcher_tx
+            .send(make_db_transaction(
+                1,
+                "not_a_valid_pubkey",
+                &Pubkey::new_unique().to_string(),
+                Some(1),
+                crate::storage::common::models::TransactionType::Withdrawal,
+            ))
+            .await
+            .unwrap();
+        fetcher_tx
+            .send(make_db_transaction(
+                2,
+                &mint_pubkey.to_string(),
+                &Pubkey::new_unique().to_string(),
+                Some(2),
+                crate::storage::common::models::TransactionType::Withdrawal,
+            ))
+            .await
+            .unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        // No ReleaseFunds builder reached the sender — halt short-circuited row 2.
+        assert!(sender_rx.try_recv().is_err());
+    }
+
+    // ── process_deposit_funds: happy + corner ───────────────────────────
+
+    /// Multiple valid deposits stream through the processor; every row
+    /// becomes a `Mint` builder in FIFO order.
+    #[tokio::test]
+    async fn process_deposit_funds_streams_multiple_valid_rows() {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(16);
+        let (storage_tx, _storage_rx) = mpsc::channel(16);
+
+        for id in 1..=3 {
+            fetcher_tx
+                .send(make_db_transaction(
+                    id,
+                    &Pubkey::new_unique().to_string(),
+                    &Pubkey::new_unique().to_string(),
+                    None,
+                    crate::storage::common::models::TransactionType::Deposit,
+                ))
+                .await
+                .unwrap();
+        }
+        drop(fetcher_tx);
+
+        let result = process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            ProgramType::Escrow,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let mut ids = Vec::new();
+        while let Ok(msg) = sender_rx.try_recv() {
+            match msg {
+                TransactionBuilder::Mint(m) => ids.push(m.txn_id),
+                other => panic!("unexpected builder: {:?}", std::mem::discriminant(&other)),
+            }
+        }
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    /// Deposits have NO pipeline halt — a quarantined deposit must not
+    /// stop the loop.  Subsequent valid deposits still reach the sender.
+    /// This is the critical asymmetry with withdrawals: deposits have no
+    /// nonce gap to worry about.
+    #[tokio::test]
+    async fn process_deposit_funds_continues_after_quarantine() {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(16);
+        let (storage_tx, mut storage_rx) = mpsc::channel(16);
+
+        // poison, valid, poison, valid
+        fetcher_tx
+            .send(make_db_transaction(
+                1,
+                "not_a_valid_pubkey",
+                &Pubkey::new_unique().to_string(),
+                None,
+                crate::storage::common::models::TransactionType::Deposit,
+            ))
+            .await
+            .unwrap();
+        fetcher_tx
+            .send(make_db_transaction(
+                2,
+                &Pubkey::new_unique().to_string(),
+                &Pubkey::new_unique().to_string(),
+                None,
+                crate::storage::common::models::TransactionType::Deposit,
+            ))
+            .await
+            .unwrap();
+        fetcher_tx
+            .send(make_db_transaction(
+                3,
+                &Pubkey::new_unique().to_string(),
+                "not_a_valid_pubkey",
+                None,
+                crate::storage::common::models::TransactionType::Deposit,
+            ))
+            .await
+            .unwrap();
+        fetcher_tx
+            .send(make_db_transaction(
+                4,
+                &Pubkey::new_unique().to_string(),
+                &Pubkey::new_unique().to_string(),
+                None,
+                crate::storage::common::models::TransactionType::Deposit,
+            ))
+            .await
+            .unwrap();
+        drop(fetcher_tx);
+
+        let result = process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            ProgramType::Escrow,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        // Exactly two Mint builders (rows 2, 4) and two quarantines (rows 1, 3).
+        let mut sent_ids = Vec::new();
+        while let Ok(msg) = sender_rx.try_recv() {
+            match msg {
+                TransactionBuilder::Mint(m) => sent_ids.push(m.txn_id),
+                _ => panic!("only Mint expected on deposit path"),
+            }
+        }
+        sent_ids.sort();
+        assert_eq!(sent_ids, vec![2, 4]);
+
+        let mut quarantined = Vec::new();
+        while let Ok(u) = storage_rx.try_recv() {
+            assert_eq!(u.status, TransactionStatus::ManualReview);
+            quarantined.push(u.transaction_id);
+        }
+        quarantined.sort();
+        assert_eq!(quarantined, vec![1, 3]);
+    }
+
+    /// Poison-pill halts the whole withdrawal pipeline: buffered rows
+    /// already in-flight from the fetcher are individually quarantined and
+    /// every remaining Pending/Processing withdrawal in the DB is flipped
+    /// to ManualReview. The processor does not process the second row.
+    #[tokio::test]
+    async fn process_release_funds_halt_quarantines_in_flight_and_db() {
+        let mock = MockStorage::new();
+        // Seed the mock DB with two Pending and one Processing withdrawal.
+        // These represent rows that never left the fetcher (Pending) or
+        // that a sibling instance locked and hasn't confirmed yet
+        // (Processing).
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            let mut pending_a = make_db_transaction(
+                100,
+                &Pubkey::new_unique().to_string(),
+                &Pubkey::new_unique().to_string(),
+                Some(42),
+                TransactionType::Withdrawal,
+            );
+            pending_a.status = TransactionStatus::Pending;
+            let mut pending_b = make_db_transaction(
+                101,
+                &Pubkey::new_unique().to_string(),
+                &Pubkey::new_unique().to_string(),
+                Some(43),
+                TransactionType::Withdrawal,
+            );
+            pending_b.status = TransactionStatus::Pending;
+            let mut processing = make_db_transaction(
+                102,
+                &Pubkey::new_unique().to_string(),
+                &Pubkey::new_unique().to_string(),
+                Some(44),
+                TransactionType::Withdrawal,
+            );
+            processing.status = TransactionStatus::Processing;
+            db.push(pending_a);
+            db.push(pending_b);
+            db.push(processing);
+        }
+
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        // fetcher_rx capacity 4 so we can buffer three rows: the poison,
+        // plus two in-flight rows already delivered by the fetcher.
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let poison = make_db_transaction(
+            1,
+            "not_a_valid_pubkey",
+            &Pubkey::new_unique().to_string(),
+            Some(1),
+            TransactionType::Withdrawal,
+        );
+        let in_flight_a: DbTransaction = make_db_transaction(
+            2,
+            &Pubkey::new_unique().to_string(),
+            &Pubkey::new_unique().to_string(),
+            Some(2),
+            TransactionType::Withdrawal,
+        );
+        let in_flight_b: DbTransaction = make_db_transaction(
+            3,
+            &Pubkey::new_unique().to_string(),
+            &Pubkey::new_unique().to_string(),
+            Some(3),
+            TransactionType::Withdrawal,
+        );
+        fetcher_tx.send(poison).await.unwrap();
+        fetcher_tx.send(in_flight_a).await.unwrap();
+        fetcher_tx.send(in_flight_b).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "processor must exit cleanly, got {result:?}"
+        );
+
+        // Collect all status updates emitted on storage_tx.
+        let mut updates = Vec::new();
+        while let Ok(update) = storage_rx.try_recv() {
+            updates.push(update);
+        }
+        // The poison row + two in-flight rows should all be marked
+        // ManualReview on the channel (3 total).
+        assert_eq!(
+            updates.len(),
+            3,
+            "expected 3 channel-side quarantines, got: {updates:?}"
+        );
+        assert!(updates
+            .iter()
+            .all(|u| u.status == TransactionStatus::ManualReview));
+        let ids: Vec<i64> = updates.iter().map(|u| u.transaction_id).collect();
+        assert!(ids.contains(&1));
+        assert!(ids.contains(&2));
+        assert!(ids.contains(&3));
+
+        // Every Pending/Processing withdrawal in the mock DB is flipped to
+        // ManualReview by quarantine_all_active_withdrawals.
+        let mock_ref = match storage.as_ref() {
+            Storage::Mock(m) => m,
+            _ => unreachable!(),
+        };
+        let db_rows = mock_ref.pending_transactions.lock().unwrap();
+        for txn in db_rows.iter() {
+            assert_eq!(
+                txn.status,
+                TransactionStatus::ManualReview,
+                "row {} was not quarantined",
+                txn.id
+            );
+        }
+
+        // No rotation was dispatched to the sender.
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "no sender-side dispatch expected on halt"
         );
     }
 }

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -15,6 +15,7 @@ pub mod get_pending_remint_transactions;
 pub mod init_schema;
 pub mod insert_db_transaction;
 pub mod insert_db_transactions_batch;
+pub mod quarantine_all_active_withdrawals;
 pub mod set_pending_remint;
 pub mod update_committed_checkpoint;
 pub mod update_transaction_status;
@@ -194,6 +195,16 @@ impl Storage {
         &self,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         get_pending_remint_transactions::get_pending_remint_transactions(self).await
+    }
+
+    /// Mark every `Pending`/`Processing` withdrawal row as `ManualReview`.
+    ///
+    /// Invoked by the processor when a single withdrawal is unprocessable:
+    /// the whole withdrawal pipeline halts so a human can inspect and
+    /// decide on rotation/reinsert before drains resume. Returns the number
+    /// of rows flipped.
+    pub async fn quarantine_all_active_withdrawals(&self) -> Result<u64, StorageError> {
+        quarantine_all_active_withdrawals::quarantine_all_active_withdrawals(self).await
     }
 }
 
@@ -618,5 +629,121 @@ mod tests {
         let ids = storage.insert_db_transactions_batch(&txns).await.unwrap();
         assert_eq!(ids.len(), 2);
         assert_eq!(mock.inserted_transactions.lock().unwrap().len(), 1);
+    }
+
+    // ── quarantine_all_active_withdrawals ─────────────────────────────
+
+    /// Only Pending and Processing withdrawals flip to ManualReview.
+    /// Returns the exact number of rows affected so the caller can log
+    /// the blast radius.
+    #[tokio::test]
+    async fn quarantine_all_active_withdrawals_flips_pending_and_processing_only() {
+        let (storage, mock) = make_mock_storage();
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            let mut a = make_db_transaction();
+            a.transaction_type = TransactionType::Withdrawal;
+            a.status = TransactionStatus::Pending;
+            a.withdrawal_nonce = Some(1);
+            let mut b = make_db_transaction();
+            b.transaction_type = TransactionType::Withdrawal;
+            b.status = TransactionStatus::Processing;
+            b.withdrawal_nonce = Some(2);
+            db.push(a);
+            db.push(b);
+        }
+
+        let affected = storage.quarantine_all_active_withdrawals().await.unwrap();
+        assert_eq!(affected, 2);
+
+        let rows = mock.pending_transactions.lock().unwrap();
+        for txn in rows.iter() {
+            assert_eq!(txn.status, TransactionStatus::ManualReview);
+        }
+    }
+
+    /// Deposits are never touched by the withdrawal-halt path — a
+    /// poisoned withdrawal must not strand deposits, which have no nonce
+    /// and no gap semantics.
+    #[tokio::test]
+    async fn quarantine_all_active_withdrawals_leaves_deposits_untouched() {
+        let (storage, mock) = make_mock_storage();
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            let mut dep = make_db_transaction();
+            dep.transaction_type = TransactionType::Deposit;
+            dep.status = TransactionStatus::Pending;
+            let mut wd = make_db_transaction();
+            wd.transaction_type = TransactionType::Withdrawal;
+            wd.status = TransactionStatus::Pending;
+            wd.withdrawal_nonce = Some(1);
+            db.push(dep);
+            db.push(wd);
+        }
+
+        let affected = storage.quarantine_all_active_withdrawals().await.unwrap();
+        assert_eq!(affected, 1);
+
+        let rows = mock.pending_transactions.lock().unwrap();
+        let dep = rows
+            .iter()
+            .find(|t| t.transaction_type == TransactionType::Deposit)
+            .expect("deposit present");
+        assert_eq!(dep.status, TransactionStatus::Pending);
+
+        let wd = rows
+            .iter()
+            .find(|t| t.transaction_type == TransactionType::Withdrawal)
+            .expect("withdrawal present");
+        assert_eq!(wd.status, TransactionStatus::ManualReview);
+    }
+
+    /// Terminal statuses (Completed, Failed, ManualReview, PendingRemint)
+    /// are left alone so the webhook does not re-alert on already-handled
+    /// rows.
+    #[tokio::test]
+    async fn quarantine_all_active_withdrawals_leaves_terminal_rows_untouched() {
+        let (storage, mock) = make_mock_storage();
+        let terminal = [
+            TransactionStatus::Completed,
+            TransactionStatus::Failed,
+            TransactionStatus::ManualReview,
+            TransactionStatus::PendingRemint,
+        ];
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            for (i, status) in terminal.iter().enumerate() {
+                let mut t = make_db_transaction();
+                t.transaction_type = TransactionType::Withdrawal;
+                t.status = *status;
+                t.withdrawal_nonce = Some(i as i64 + 1);
+                db.push(t);
+            }
+        }
+
+        let affected = storage.quarantine_all_active_withdrawals().await.unwrap();
+        assert_eq!(affected, 0);
+
+        let rows = mock.pending_transactions.lock().unwrap();
+        for (i, status) in terminal.iter().enumerate() {
+            assert_eq!(rows[i].status, *status);
+        }
+    }
+
+    /// Storage-level failure surfaces as an `Err` so the processor can log
+    /// and continue the channel drain without silent loss.
+    #[tokio::test]
+    async fn quarantine_all_active_withdrawals_propagates_mock_failure() {
+        let (storage, mock) = make_mock_storage();
+        mock.set_should_fail("quarantine_all_active_withdrawals", true);
+        assert!(storage.quarantine_all_active_withdrawals().await.is_err());
+    }
+
+    /// The empty-DB case returns `0` — a successful no-op, not an error.
+    #[tokio::test]
+    async fn quarantine_all_active_withdrawals_empty_db_returns_zero() {
+        let (storage, _mock) = make_mock_storage();
+        let affected = storage.quarantine_all_active_withdrawals().await.unwrap();
+        assert_eq!(affected, 0);
     }
 }

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -658,7 +658,10 @@ mod tests {
             db.push(b);
         }
 
-        let affected = storage.quarantine_all_active_withdrawals(None).await.unwrap();
+        let affected = storage
+            .quarantine_all_active_withdrawals(None)
+            .await
+            .unwrap();
         assert_eq!(affected, 2);
 
         let rows = mock.pending_transactions.lock().unwrap();
@@ -686,7 +689,10 @@ mod tests {
             db.push(wd);
         }
 
-        let affected = storage.quarantine_all_active_withdrawals(None).await.unwrap();
+        let affected = storage
+            .quarantine_all_active_withdrawals(None)
+            .await
+            .unwrap();
         assert_eq!(affected, 1);
 
         let rows = mock.pending_transactions.lock().unwrap();
@@ -726,7 +732,10 @@ mod tests {
             }
         }
 
-        let affected = storage.quarantine_all_active_withdrawals(None).await.unwrap();
+        let affected = storage
+            .quarantine_all_active_withdrawals(None)
+            .await
+            .unwrap();
         assert_eq!(affected, 0);
 
         let rows = mock.pending_transactions.lock().unwrap();
@@ -751,7 +760,10 @@ mod tests {
     #[tokio::test]
     async fn quarantine_all_active_withdrawals_empty_db_returns_zero() {
         let (storage, _mock) = make_mock_storage();
-        let affected = storage.quarantine_all_active_withdrawals(None).await.unwrap();
+        let affected = storage
+            .quarantine_all_active_withdrawals(None)
+            .await
+            .unwrap();
         assert_eq!(affected, 0);
     }
 

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -201,10 +201,15 @@ impl Storage {
     ///
     /// Invoked by the processor when a single withdrawal is unprocessable:
     /// the whole withdrawal pipeline halts so a human can inspect and
-    /// decide on rotation/reinsert before drains resume. Returns the number
-    /// of rows flipped.
-    pub async fn quarantine_all_active_withdrawals(&self) -> Result<u64, StorageError> {
-        quarantine_all_active_withdrawals::quarantine_all_active_withdrawals(self).await
+    /// decide on rotation/reinsert before drains resume. `exclude_id` is
+    /// the poison row already quarantined through the async status-update
+    /// channel — excluding it here avoids a duplicate webhook. Returns the
+    /// number of rows flipped.
+    pub async fn quarantine_all_active_withdrawals(
+        &self,
+        exclude_id: Option<i64>,
+    ) -> Result<u64, StorageError> {
+        quarantine_all_active_withdrawals::quarantine_all_active_withdrawals(self, exclude_id).await
     }
 }
 
@@ -653,7 +658,7 @@ mod tests {
             db.push(b);
         }
 
-        let affected = storage.quarantine_all_active_withdrawals().await.unwrap();
+        let affected = storage.quarantine_all_active_withdrawals(None).await.unwrap();
         assert_eq!(affected, 2);
 
         let rows = mock.pending_transactions.lock().unwrap();
@@ -681,7 +686,7 @@ mod tests {
             db.push(wd);
         }
 
-        let affected = storage.quarantine_all_active_withdrawals().await.unwrap();
+        let affected = storage.quarantine_all_active_withdrawals(None).await.unwrap();
         assert_eq!(affected, 1);
 
         let rows = mock.pending_transactions.lock().unwrap();
@@ -721,7 +726,7 @@ mod tests {
             }
         }
 
-        let affected = storage.quarantine_all_active_withdrawals().await.unwrap();
+        let affected = storage.quarantine_all_active_withdrawals(None).await.unwrap();
         assert_eq!(affected, 0);
 
         let rows = mock.pending_transactions.lock().unwrap();
@@ -736,14 +741,52 @@ mod tests {
     async fn quarantine_all_active_withdrawals_propagates_mock_failure() {
         let (storage, mock) = make_mock_storage();
         mock.set_should_fail("quarantine_all_active_withdrawals", true);
-        assert!(storage.quarantine_all_active_withdrawals().await.is_err());
+        assert!(storage
+            .quarantine_all_active_withdrawals(None)
+            .await
+            .is_err());
     }
 
     /// The empty-DB case returns `0` — a successful no-op, not an error.
     #[tokio::test]
     async fn quarantine_all_active_withdrawals_empty_db_returns_zero() {
         let (storage, _mock) = make_mock_storage();
-        let affected = storage.quarantine_all_active_withdrawals().await.unwrap();
+        let affected = storage.quarantine_all_active_withdrawals(None).await.unwrap();
         assert_eq!(affected, 0);
+    }
+
+    /// `exclude_id` must skip the poison row so it is not flipped twice —
+    /// the caller has already quarantined it via the async status-update
+    /// channel and a second flip here would fire a duplicate webhook.
+    #[tokio::test]
+    async fn quarantine_all_active_withdrawals_exclude_id_skips_poison_row() {
+        let (storage, mock) = make_mock_storage();
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            let mut poison = make_db_transaction();
+            poison.id = 42;
+            poison.transaction_type = TransactionType::Withdrawal;
+            poison.status = TransactionStatus::Processing;
+            poison.withdrawal_nonce = Some(1);
+            let mut sibling = make_db_transaction();
+            sibling.id = 43;
+            sibling.transaction_type = TransactionType::Withdrawal;
+            sibling.status = TransactionStatus::Pending;
+            sibling.withdrawal_nonce = Some(2);
+            db.push(poison);
+            db.push(sibling);
+        }
+
+        let affected = storage
+            .quarantine_all_active_withdrawals(Some(42))
+            .await
+            .unwrap();
+        assert_eq!(affected, 1);
+
+        let rows = mock.pending_transactions.lock().unwrap();
+        let poison = rows.iter().find(|t| t.id == 42).unwrap();
+        assert_eq!(poison.status, TransactionStatus::Processing);
+        let sibling = rows.iter().find(|t| t.id == 43).unwrap();
+        assert_eq!(sibling.status, TransactionStatus::ManualReview);
     }
 }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -296,7 +296,10 @@ impl MockStorage {
         Ok(pending.clone())
     }
 
-    pub async fn quarantine_all_active_withdrawals(&self) -> Result<u64, StorageError> {
+    pub async fn quarantine_all_active_withdrawals(
+        &self,
+        exclude_id: Option<i64>,
+    ) -> Result<u64, StorageError> {
         self.check_should_fail("quarantine_all_active_withdrawals")?;
         let mut pending = self.pending_transactions.lock().unwrap();
         let mut affected = 0u64;
@@ -305,7 +308,8 @@ impl MockStorage {
                 txn.status,
                 TransactionStatus::Pending | TransactionStatus::Processing
             );
-            if txn.transaction_type == TransactionType::Withdrawal && quarantinable {
+            let excluded = exclude_id.is_some_and(|id| txn.id == id);
+            if txn.transaction_type == TransactionType::Withdrawal && quarantinable && !excluded {
                 txn.status = TransactionStatus::ManualReview;
                 affected += 1;
             }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -295,4 +295,21 @@ impl MockStorage {
         let pending = self.pending_remint_transactions.lock().unwrap();
         Ok(pending.clone())
     }
+
+    pub async fn quarantine_all_active_withdrawals(&self) -> Result<u64, StorageError> {
+        self.check_should_fail("quarantine_all_active_withdrawals")?;
+        let mut pending = self.pending_transactions.lock().unwrap();
+        let mut affected = 0u64;
+        for txn in pending.iter_mut() {
+            let quarantinable = matches!(
+                txn.status,
+                TransactionStatus::Pending | TransactionStatus::Processing
+            );
+            if txn.transaction_type == TransactionType::Withdrawal && quarantinable {
+                txn.status = TransactionStatus::ManualReview;
+                affected += 1;
+            }
+        }
+        Ok(affected)
+    }
 }

--- a/indexer/src/storage/common/storage/quarantine_all_active_withdrawals.rs
+++ b/indexer/src/storage/common/storage/quarantine_all_active_withdrawals.rs
@@ -11,15 +11,22 @@ use crate::{error::StorageError, storage::common::storage::Storage};
 /// into one actionable batch of `ManualReview` alerts and blocks the
 /// fetcher from pulling further rows (no `Pending` left to fetch).
 ///
+/// `exclude_id` is the poison row already quarantined via the async storage
+/// writer — excluding it here prevents a duplicate `ManualReview` webhook if
+/// the async update has not yet committed.
+///
 /// Terminal statuses (Completed, Failed, ManualReview, PendingRemint) are
 /// left alone so operators don't get re-alerted on already-handled rows.
-pub async fn quarantine_all_active_withdrawals(storage: &Storage) -> Result<u64, StorageError> {
+pub async fn quarantine_all_active_withdrawals(
+    storage: &Storage,
+    exclude_id: Option<i64>,
+) -> Result<u64, StorageError> {
     match storage {
         Storage::Postgres(db) => db
-            .quarantine_all_active_withdrawals_internal()
+            .quarantine_all_active_withdrawals_internal(exclude_id)
             .await
             .map_err(StorageError::from),
         #[cfg(test)]
-        Storage::Mock(mock_db) => mock_db.quarantine_all_active_withdrawals().await,
+        Storage::Mock(mock_db) => mock_db.quarantine_all_active_withdrawals(exclude_id).await,
     }
 }

--- a/indexer/src/storage/common/storage/quarantine_all_active_withdrawals.rs
+++ b/indexer/src/storage/common/storage/quarantine_all_active_withdrawals.rs
@@ -1,0 +1,25 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Mark every `Pending`/`Processing` withdrawal as `ManualReview`.
+///
+/// Called once per poison-pill detection in the withdrawal pipeline.
+/// Halting the whole pipeline (rather than skipping the single bad row) is
+/// the deliberate conservative choice: a quarantined withdrawal leaves a
+/// permanent nonce gap that the on-chain program rejects, so continuing to
+/// drain subsequent rows would produce a stream of on-chain failures until
+/// a human intervenes. Stopping immediately concentrates the blast radius
+/// into one actionable batch of `ManualReview` alerts and blocks the
+/// fetcher from pulling further rows (no `Pending` left to fetch).
+///
+/// Terminal statuses (Completed, Failed, ManualReview, PendingRemint) are
+/// left alone so operators don't get re-alerted on already-handled rows.
+pub async fn quarantine_all_active_withdrawals(storage: &Storage) -> Result<u64, StorageError> {
+    match storage {
+        Storage::Postgres(db) => db
+            .quarantine_all_active_withdrawals_internal()
+            .await
+            .map_err(StorageError::from),
+        #[cfg(test)]
+        Storage::Mock(mock_db) => mock_db.quarantine_all_active_withdrawals().await,
+    }
+}

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -863,17 +863,34 @@ impl PostgresDb {
 
     /// Flip every `Pending`/`Processing` withdrawal to `ManualReview`.
     ///
+    /// `exclude_id` is the poison row that the caller has already quarantined
+    /// via the async `storage_tx` writer. That update may not have hit the DB
+    /// yet when this sweep runs, so the row's status is still
+    /// `Pending`/`Processing` here; excluding it prevents a second
+    /// `ManualReview` webhook for the same transaction.
+    ///
     /// Terminal rows are left untouched so the webhook does not re-alert on
     /// already-handled transactions. Returns the number of rows affected.
-    pub async fn quarantine_all_active_withdrawals_internal(&self) -> Result<u64, sqlx::Error> {
+    ///
+    /// Scope is intentionally DB-wide over `transaction_type = 'withdrawal'`
+    /// to match the fetcher's own scope. The data model assumes a single
+    /// withdrawal operator per database; multi-instance isolation would
+    /// require an `instance_pda` column on `transactions` that does not exist
+    /// today.
+    pub async fn quarantine_all_active_withdrawals_internal(
+        &self,
+        exclude_id: Option<i64>,
+    ) -> Result<u64, sqlx::Error> {
         let result = sqlx::query(
             r#"
             UPDATE transactions
             SET status = 'manual_review', updated_at = NOW()
             WHERE transaction_type = 'withdrawal'
               AND status IN ('pending', 'processing')
+              AND ($1::BIGINT IS NULL OR id <> $1)
             "#,
         )
+        .bind(exclude_id)
         .execute(&self.pool)
         .await?;
 

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -861,6 +861,25 @@ impl PostgresDb {
         Ok(())
     }
 
+    /// Flip every `Pending`/`Processing` withdrawal to `ManualReview`.
+    ///
+    /// Terminal rows are left untouched so the webhook does not re-alert on
+    /// already-handled transactions. Returns the number of rows affected.
+    pub async fn quarantine_all_active_withdrawals_internal(&self) -> Result<u64, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'manual_review', updated_at = NOW()
+            WHERE transaction_type = 'withdrawal'
+              AND status IN ('pending', 'processing')
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+
     pub async fn upsert_mints_batch_internal(&self, mints: &[DbMint]) -> Result<(), StorageError> {
         if mints.is_empty() {
             return Ok(());


### PR DESCRIPTION
## Summary

A single unprocessable withdrawal row previously tore down the whole operator processor task. The resulting cascade left the operator as a zombie container — process alive, pipeline dead, no `/healthz` to tell Docker otherwise.

This PR converts that crash path into a **halt-and-quarantine** recovery: the poison row is moved to `ManualReview`, the fetcher channel is drained, and all active withdrawals for that `program_type` are swept to `ManualReview` so nothing is submitted on-chain against a stale nonce. Deposits are unaffected.

## Changes

- **Processor** — per-transaction errors no longer tear down the task; offending rows are classified and quarantined in place, and panics are replaced with typed errors.
- **Operator supervisor** — critical tasks are watched via `select!`; an unexpected exit triggers a clean shutdown instead of leaving a zombie container.
- **Storage** — new cascade sweep that flips all active withdrawals to `ManualReview` in one DB transaction, with the poison row excluded so it is not re-alerted.
- **Metrics** — quarantine and task-exit counters so dashboards can page without tailing logs.

## Impact

- Operator no longer crash-loops or wedges on a malformed withdrawal row.
- No on-chain nonce gap introduced by the recovery path.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,043 | 10,447 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24783254831) |
| Indexer | 14,402 | 16,742 | 86.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24783254831) |
| Gateway | 991 | 1,115 | 88.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24783254831) |
| Auth | 541 | 596 | 90.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24783254831) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | 8,292 | 12,429 | 66.7% | [e2e-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/24783254831) |
| **Total** | **33,269** | **41,329** | **80.5%** | |

> Last updated: 2026-04-22 14:31:11 UTC by E2E Integration