### PR TITLE
feat(auth): add admin CLI to attach wallets [EXO-22]

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -101,6 +101,18 @@ There are two roles: `user` (default) and `operator`.
 UPDATE contra_auth.users SET role = 'operator' WHERE username = 'alice';
 ```
 
+## Admin CLI
+
+Operator-only commands for managing users directly against the auth database. Requires `AUTH_DATABASE_URL` (same DB the auth service uses).
+
+### Attach a wallet to a user
+
+Inserts a row into `contra_auth.verified_wallets` without running the challenge/signature flow — the operator is asserting trust, the user does not prove ownership. Use this for provisioning or recovery, not as a substitute for the normal verification flow.
+
+```bash
+AUTH_DATABASE_URL=postgres://... cargo run -p auth --bin admin -- attach-wallet --username alice --pubkey <base58>
+```
+
 ## Wallet verification flow
 
 Wallets are not trusted on assertion — the user must cryptographically prove they control the private key.

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -1,10 +1,10 @@
 use {
     anyhow::{anyhow, Result},
     clap::{Parser, Subcommand},
-    contra_auth::db,
+    contra_auth::{db, error::AppError},
     solana_sdk::pubkey::Pubkey,
     sqlx::postgres::PgPoolOptions,
-    std::str::FromStr,
+    std::{env, str::FromStr},
     tracing::{error, info},
 };
 
@@ -14,10 +14,6 @@ use {
     about = "Manual administrative commands for the contra-auth database"
 )]
 struct Args {
-    /// Auth database connection URL (PostgreSQL)
-    #[arg(long, env = "AUTH_DATABASE_URL")]
-    database_url: String,
-
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, default_value = "info", env = "CONTRA_LOG_LEVEL")]
     log_level: String,
@@ -73,15 +69,18 @@ fn init_logging(log_level: &str, json_logs: bool) {
 }
 
 async fn run(args: Args) -> Result<()> {
-    if !args.database_url.starts_with("postgres://")
-        && !args.database_url.starts_with("postgresql://")
-    {
+    // Read AUTH_DATABASE_URL from the environment rather than a CLI flag so the
+    // password never lands in argv (visible via `ps` and shell history).
+    let database_url =
+        env::var("AUTH_DATABASE_URL").map_err(|_| anyhow!("AUTH_DATABASE_URL is not set"))?;
+
+    if !database_url.starts_with("postgres://") && !database_url.starts_with("postgresql://") {
         return Err(anyhow!("AUTH_DATABASE_URL must be a PostgreSQL URL"));
     }
 
     let pool = PgPoolOptions::new()
         .max_connections(1)
-        .connect(&args.database_url)
+        .connect(&database_url)
         .await
         .map_err(|e| anyhow!("Failed to connect to auth DB: {}", e))?;
 
@@ -93,13 +92,29 @@ async fn run(args: Args) -> Result<()> {
 }
 
 async fn attach_wallet(pool: &sqlx::PgPool, args: AttachWalletArgs) -> Result<()> {
-    Pubkey::from_str(&args.pubkey).map_err(|_| anyhow!("invalid pubkey: {}", args.pubkey))?;
+    let pubkey = Pubkey::from_str(&args.pubkey)
+        .map_err(|_| anyhow!("invalid pubkey: {}", args.pubkey))?
+        .to_string();
 
     let user = db::find_user_by_username(pool, &args.username)
         .await?
         .ok_or_else(|| anyhow!("user not found: {}", args.username))?;
 
-    let wallet = db::insert_verified_wallet(pool, user.id, &args.pubkey).await?;
+    let wallet = db::insert_verified_wallet(pool, user.id, &pubkey)
+        .await
+        .map_err(|e| match e {
+            // Unique constraint on (user_id, pubkey) — wallet already attached.
+            AppError::Db(sqlx::Error::Database(ref db_err))
+                if db_err.constraint() == Some("verified_wallets_user_id_pubkey_key") =>
+            {
+                anyhow!(
+                    "wallet {} is already attached to user {}",
+                    pubkey,
+                    args.username
+                )
+            }
+            other => anyhow::Error::new(other),
+        })?;
 
     info!(
         user_id = %user.id,

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -1,0 +1,117 @@
+use {
+    anyhow::{anyhow, Result},
+    clap::{Parser, Subcommand},
+    contra_auth::db,
+    solana_sdk::pubkey::Pubkey,
+    sqlx::postgres::PgPoolOptions,
+    std::str::FromStr,
+    tracing::{error, info},
+};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "contra-auth-admin",
+    about = "Manual administrative commands for the contra-auth database"
+)]
+struct Args {
+    /// Auth database connection URL (PostgreSQL)
+    #[arg(long, env = "AUTH_DATABASE_URL")]
+    database_url: String,
+
+    /// Log level (trace, debug, info, warn, error)
+    #[arg(long, default_value = "info", env = "CONTRA_LOG_LEVEL")]
+    log_level: String,
+
+    /// Enable JSON logging format
+    #[arg(long, env = "CONTRA_JSON_LOGS")]
+    json_logs: bool,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Attach a wallet to a user without verification — operator asserts trust
+    AttachWallet(AttachWalletArgs),
+}
+
+#[derive(Parser, Debug)]
+struct AttachWalletArgs {
+    /// Username of the user to attach the wallet to
+    #[arg(long)]
+    username: String,
+
+    /// Base58-encoded Solana pubkey to attach to the user
+    #[arg(long)]
+    pubkey: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    init_logging(&args.log_level, args.json_logs);
+
+    if let Err(e) = run(args).await {
+        error!("Command failed: {:?}", e);
+        std::process::exit(1);
+    }
+}
+
+fn init_logging(log_level: &str, json_logs: bool) {
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level));
+
+    if json_logs {
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .json()
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(env_filter).init();
+    }
+}
+
+async fn run(args: Args) -> Result<()> {
+    if !args.database_url.starts_with("postgres://")
+        && !args.database_url.starts_with("postgresql://")
+    {
+        return Err(anyhow!("AUTH_DATABASE_URL must be a PostgreSQL URL"));
+    }
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&args.database_url)
+        .await
+        .map_err(|e| anyhow!("Failed to connect to auth DB: {}", e))?;
+
+    match args.command {
+        Command::AttachWallet(args) => attach_wallet(&pool, args).await?,
+    }
+
+    Ok(())
+}
+
+async fn attach_wallet(pool: &sqlx::PgPool, args: AttachWalletArgs) -> Result<()> {
+    Pubkey::from_str(&args.pubkey).map_err(|_| anyhow!("invalid pubkey: {}", args.pubkey))?;
+
+    let user = db::find_user_by_username(pool, &args.username)
+        .await?
+        .ok_or_else(|| anyhow!("user not found: {}", args.username))?;
+
+    let wallet = db::insert_verified_wallet(pool, user.id, &args.pubkey).await?;
+
+    info!(
+        user_id = %user.id,
+        username = %user.username,
+        pubkey = %wallet.pubkey,
+        "attached wallet"
+    );
+
+    println!(
+        "attached wallet {} to user {} ({})",
+        wallet.pubkey, user.username, user.id
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Adds `auth` admin CLI with one subcommand, `attach-wallet --username --pubkey`, for operators to attach a pubkey to a user without the challenge/signature flow. 
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,043 | 10,447 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25064564391) |
| Indexer | 14,428 | 16,916 | 85.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25064564391) |
| Gateway | 991 | 1,115 | 88.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25064564391) |
| Auth | 541 | 667 | 81.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25064564391) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **25,003** | **29,145** | **85.8%** | |

> Last updated: 2026-04-28 16:26:03 UTC by Auth