### PR TITLE
docs: rewrite technical requirements around empirical sizing

### DIFF
--- a/bench-tps/scripts/run.sh
+++ b/bench-tps/scripts/run.sh
@@ -333,8 +333,13 @@ fi
 # ---------------------------------------------------------------------------
 COMPOSE=(docker compose -f "${REPO_ROOT}/docker-compose.yml" --env-file "${REPO_ROOT}/versions.env" --env-file "${BENCH_ENV}")
 
-BUILT_IMAGES=(contra-write-node contra-read-node contra-gateway contra-streamer contra-activity contra-validator contra-indexer-solana contra-indexer-contra contra-operator-solana contra-operator-contra contra-prometheus)
-BUILT_SERVICES=(write-node read-node gateway streamer activity validator indexer-solana indexer-contra operator-solana operator-contra prometheus)
+# All Rust services (write-node, read-node, gateway, streamer, activity,
+# indexer-*, operator-*) share a single `contra-app` image via the
+# x-contra-app YAML anchor in docker-compose.yml. Validator, prometheus,
+# and grafana each build their own image (no `image:` field in compose →
+# tagged as `<project>-<service>:latest`).
+BUILT_IMAGES=(contra-app contra-validator contra-prometheus contra-grafana)
+BUILT_SERVICES=(write-node read-node gateway streamer activity validator indexer-solana indexer-contra operator-solana operator-contra prometheus grafana)
 
 images_exist() {
     # docker image inspect exits non-zero if any image in the list is missing.

--- a/docs/TECHNICAL_REQUIREMENTS.md
+++ b/docs/TECHNICAL_REQUIREMENTS.md
@@ -1,171 +1,154 @@
 # Technical Requirements
 
-This document outlines the hardware, software, and network requirements for running Contra infrastructure components.
+This document specifies the hardware, software, and network requirements for
+running the Contra stack.
+
+## Reference machine specs
+
+A single recommended floor for running the full stack on one host. Grow from
+here along the [Scalability dimensions](#scalability-dimensions) when this
+floor stops being enough.
+
+| vCPUs | RAM | Disk | Network |
+|---|---|---|---|
+| **24** | **32 GB** | **300 GB NVMe** (state + 1–3 days hot history) | **1 Gbps** |
+
+This colocates the full stack on a single host: one write node, one read
+node, both Postgres instances, indexers, operators, and the gateway. To
+grow beyond it, see [Scalability dimensions](#scalability-dimensions).
+
+### Per-component sizing (single host or split deployment)
+
+The dominant CPU consumer at high TPS is the write node's pipeline; the
+gateway and Postgres primary are the next two. Other services are cheap and
+mostly I/O-bound.
+
+| Component | vCPUs (~1k TPS) | RAM |
+|---|---|---|
+| Write node | 3.7–4.3 | 3.2–3.7 GB |
+| Postgres replica | 0.8–0.9 | 2.9–5.2 GB |
+| Postgres primary | 0.9 | 0.5–1.0 GB † |
+| Gateway  | 1.3 | 110–125 MB |
+| Read node | 0.4–0.5 | 180–665 MB |
+| Indexer (Contra) | 0.2 | 0.3–1.4 GB † |
+| Postgres indexer | 0.1 | 230 MB |
+
+† Postgres primary RAM scales with its in-memory cache size; the indexer's
+RAM grows with the size of the indexed dataset.
+
+Only the three Postgres containers need disk; size them per
+[Storage sizing](#storage-sizing) and use NVMe for the primary.
+
+*Streamer, Solana indexer, and Solana/Contra operators each take <0.1 core
+and ~30 MB RAM, and are not material to sizing.*
+
+*Measured 2026-05-05 on a 16-core / 62 GB host. 
+
+### Storage sizing
+
+Storage has two independent drivers.
+
+**1. Working state, token accounts.** ~165 bytes per token account.
+
+| Token accounts | Disk |
+|---|---|
+| 100k | 17 MB |
+| 1M | 165 MB |
+| 10M | 1.65 GB |
+
+**2. Block + transaction history.** Linear in TPS × retention.
+
+| TPS | 1 day | 3 days | 7 days |
+|---|---|---|---|
+| 100 | 4.5 GB | 13.5 GB | 31.5 GB |
+| 1k | 45 GB | 135 GB | 315 GB |
+| 10k | 450 GB | 1.35 TB | 3.15 TB |
+
+**Recommendation:** retain 1–3 days hot on NVMe; archive older blocks to
+S3-compatible object storage. The PITR setup (see [PITR.md](PITR.md))
+streams WAL to archive volumes, wire those volumes to S3 lifecycle policies.
 
 ---
 
-## Hardware Requirements
+## Software requirements
 
-*The following hardware estimates are theoretical projections based on per-component analysis (e.g., Ed25519 throughput per core). They have not been validated under sustained load. Use as sizing guidance, not guarantees.*
-
-### Contra Write Node Requirements (per Contra instance)
-
-The Contra Write Node is the primary bottleneck for transaction throughput. Requirements scale linearly with target TPS:
-
-| Target TPS | CPU Cores | Memory | Network Bandwidth | 
-|------------|-----------|--------|-------------------|
-| **100k** | 2.3 | 8GB | 367 Mbps |  
-| **200k** | 4.6 | 8GB | 733 Mbps |
-| **300k** | 6.9 | 8GB | 1.10 Gbps |
-| **400k** | 9.2 | 8GB | 1.47 Gbps |
-| **500k** | 11.5 | 8GB | 1.83 Gbps |
-| **600k** | 13.7 | 8GB | 2.20 Gbps |
-| **700k** | 16.0 | 8GB | 2.56 Gbps |
-| **800k** | 18.3 | 8GB | 2.93 Gbps |
-| **900k** | 20.6 | 8GB | 3.30 Gbps |
-| **1,000k** | 22.9 | 8GB | 3.66 Gbps |
-
-**Notes:**
-- CPU requirements are based on signature verification parallelization (~43,600 TPS per core)
-- Memory remains constant at 8GB for most workloads
-- Network bandwidth assumes sustained TPS with ~300-byte average transaction size
-- Fractional cores should be rounded up to the next available vCPU count
-
-### Storage Requirements by Token Accounts
-
-Token account state is the primary driver of base storage requirements:
-
-| Token Accounts | Disk Size Required |
-|----------------|-------------------|
-| **100k** | 16.5 MB |
-| **200k** | 33.0 MB |
-| **300k** | 49.5 MB |
-| **400k** | 66.0 MB |
-| **500k** | 82.5 MB |
-| **600k** | 99.0 MB |
-| **700k** | 115.5 MB |
-| **800k** | 132.0 MB |
-| **900k** | 148.5 MB |
-| **1,000k** | 165.0 MB |
-
-**Notes:**
-- Assumes ~165 bytes per token account
-- This is the baseline state storage requirement
-- Additional storage is required for blocks/transactions (see retention schedule below)
-
-### Storage Requirements by Block/Transaction Retention
-
-At 100k sustained TPS, storage requirements grow based on retention period:
-
-| Retention Duration | Disk Size Required |
-|--------------------|-------------------|
-| **1 day** | 4.51 TB |
-| **2 days** | 9.02 TB |
-| **3 days** | 13.53 TB |
-| **4 days** | 18.04 TB |
-| **5 days** | 22.55 TB |
-| **6 days** | 27.06 TB |
-| **7 days** | 31.57 TB |
-
-**Notes:**
-- Based on 100k TPS sustained load
-- Storage scales linearly with TPS (200k TPS = 2x storage)
-- Blocks and transactions can be truncated and backed up to cheaper archival storage
-- **Recommended:** Retain 1-3 days online, archive older data to S3/GCS/Azure Blob
-
-### Contra Read Node Requirements
-
-Read nodes are horizontally scalable and run PostgreSQL read replicas:
-
-| Component | CPU | RAM | Storage | Network |
-|-----------|-----|-----|---------|---------|
-| **Contra Read Node** | 4-8 cores | 8GB | Same as write node | Up to write node bandwidth |
-
-**Notes:**
-- CPU requirements are significantly lower than write nodes (no signature verification)
-- Storage requirements match write nodes (full database replicas)
-- Network bandwidth can approach write node levels if serving high query volumes with low eventual consistency latency
-- Scale horizontally by adding more read replicas behind a load balancer
-
-### Supporting Infrastructure
-
-These components have minimal compute requirements relative to the write node. Specific benchmarks are pending, but general guidance:
-
-| Component | Notes |
-|-----------|-------|
-| **PostgreSQL Primary** | Scales with write node TPS. NVMe storage recommended for WAL throughput. |
-| **PostgreSQL Replica** | Matches primary storage. CPU scales with query load. |
-| **Indexer (Mainnet)** | Lightweight — primarily I/O bound (RPC/gRPC reads + DB writes). 2-4 cores, 4GB RAM typical. |
-| **Indexer (Contra)** | Same as Mainnet indexer. |
-| **Operator (Mainnet)** | Lightweight — polls DB, builds and submits transactions. 2-4 cores, 4GB RAM typical. |
-| **Operator (Contra)** | Same as Mainnet operator. |
-| **Gateway** | Stateless RPC proxy. Scales horizontally. 2-4 cores, 2GB RAM typical. |
-| **Streamer** | WebSocket transaction streamer. Scales with subscriber count. 2-4 cores, 2GB RAM typical. |
+| Software | Minimum | Purpose |
+|---|---|---|
+| [Rust](https://rust-lang.org/tools/install/) | 1.91+ | Build (`rust-toolchain.toml` is authoritative) |
+| [Solana CLI](https://solana.com/docs/intro/installation) | 3.1.13 | Program deployment; `make install-toolchain` |
+| [Docker](https://docs.docker.com/get-docker/) | 26.0+ | Container runtime |
+| [Docker Compose](https://docs.docker.com/compose/install/) | 2.20+ | Stack orchestration |
+| [PostgreSQL](https://www.postgresql.org/download/) | 16+ | Database (skip if using bundled containers) |
+| [pnpm](https://pnpm.io/installation) | 10.0+ | TypeScript client builds |
 
 
-## Software Requirements
+---
 
-### Required Software
+## Network requirements
 
-| Software | Minimum Version | Purpose |
-|----------|----------------|---------|
-| [**Rust**](https://rust-lang.org/tools/install/) | 1.91+ | Building Contra programs and core components (pinned via `rust-toolchain.toml`) |
-| [**Solana CLI**](https://solana.com/docs/intro/installation) | See [`versions.env`](../versions.env) | Program deployment and interaction. Install via `make install-toolchain`. |
-| [**Docker**](https://docs.docker.com/get-docker/) | 26.0+ | Containerized deployment |
-| [**Docker Compose**](https://docs.docker.com/compose/install/) | 2.20+ | Multi-container orchestration |
-| [**PostgreSQL**](https://www.postgresql.org/download/) | 16+ | Database (if not using Docker) |
-| [**pnpm**](https://pnpm.io/installation) | 10.0+ | TypeScript client development |
+### Ports (defaults)
 
-### Operating System Support
+| Service | Port | Exposure |
+|---|---|---|
+| Gateway (RPC) | 8899 | Public, clients |
+| Streamer (WebSocket) | 8902 | Public, clients |
+| Grafana | 37429 | Restricted, operators only |
 
-Contra has been tested on the following operating systems:
+All other services bind to internal ports on the Docker network and don't
+need to be exposed at the host firewall; see `docker-compose.yml` for defaults.
 
-- **Linux**: Ubuntu 22.04+, Debian 12+, RHEL 9+
-- **macOS**: 15.0+
+### Firewall
 
-## Network Requirements
+- **Public ingress:** 8899 (gateway), 8902 (streamer).
+- **Outbound:** 443 to Solana mainnet RPC, 10000 to Yellowstone gRPC (if used).
+- **Internal:** allow all between Contra services on the private network.
 
-### Port Allocation
+---
 
-The following ports are used by Contra services by default:
+## Scalability dimensions
 
-| Service | Port | Protocol | Purpose |
-|---------|------|----------|---------|
-| **Contra Write Node** | 8900 | TCP | Transaction submission |
-| **Contra Read Node** | 8901 | TCP | Account queries |
-| **Gateway** | 8899 | TCP | Unified RPC endpoint |
-| **PostgreSQL Primary** | 5432 | TCP | Database connections |
-| **PostgreSQL Replica** | 5433 | TCP | Read-only database connections |
-| **PostgreSQL Indexer** | 5434 | TCP | Indexer database connections |
-| **Prometheus** | 9090 | TCP | Metrics collection |
-| **Grafana** | 37429 | TCP | Metrics visualization |
-| **cAdvisor** | 8080 | TCP | Container metrics |
-| **Streamer** | 8902 | TCP | WebSocket transaction streaming |
-| **Solana Validator** | 18899 | TCP | Local validator RPC (dev only) |
-| **Yellowstone gRPC** | 10000 | TCP | Geyser streaming (dev only) |
+When a single instance is no longer enough, scale along these dimensions
+independently.
 
-### Firewall Configuration
+### 1. Write-node throughput (vertical)
 
-**Inbound Rules** (Public-facing):
-- Port 8899 (Gateway): Allow from application servers
-- Ports 8900, 8901 (Contra Nodes): Allow from trusted IPs only
+Tune the write node's 5-stage pipeline via environment variables:
 
-**Outbound Rules**:
-- Port 443 (HTTPS): Allow to Solana Mainnet RPC endpoint(s)
-- Port 10000 (gRPC): Allow to Yellowstone gRPC endpoint(s) (if using Yellowstone)
+| Knob | Default | Effect |
+|---|---|---|
+| `CONTRA_SIGVERIFY_WORKERS` | 4 | Parallel Ed25519 verification workers. Primary CPU lever. |
+| `CONTRA_SIGVERIFY_QUEUE_SIZE` | 1000 | Bounded backlog before sigverify. Trade burst tolerance for memory. |
+| `CONTRA_MAX_TX_PER_BATCH` | 256 | Sequencer batch size; larger amortises executor overhead. |
+| `CONTRA_BATCH_DEADLINE_MS` | 10 | Force-flush timer for partial batches. |
+| `CONTRA_MAX_SVM_WORKERS` | 8 | Executor's parallel SVM threads per batch. |
+| `CONTRA_BLOCKTIME_MS` | 100 | Settlement interval. |
 
-**Internal Rules** (Between services):
-- Allow all traffic between Contra services on the same network
-- PostgreSQL replication: Allow port 5432 from replica to primary
+See [`CONFIG.md`](CONFIG.md) for the full reference and restart procedure.
 
+### 2. Read replicas (horizontal)
 
+- Add Postgres read replicas behind additional read nodes.
+- Front them with a load balancer, or use the gateway's built-in fanout.
+
+### 3. Indexer parallelism (horizontal)
+
+- Run multiple indexer instances over disjoint slot ranges.
+- Prefer Yellowstone gRPC over RPC polling for real-time ingestion.
+- Allocate 2–4 vCPUs per indexer instance.
+
+See [`INDEXER.md`](INDEXER.md) for datasource strategies and Yellowstone setup.
+
+### 4. Storage tiering
+
+- **Hot:** NVMe for working state and 1–3 days of recent blocks.
+- **Warm:** SSD for replicas and PITR archive volumes.
+- **Cold:** S3-compatible object storage for older blocks; configure WAL
+  archive volumes with lifecycle rules.
+
+See [`PITR.md`](PITR.md) for the WAL archive setup.
+
+---
 
 ## Support
 
-For questions about technical requirements or deployment assistance:
-
-- **GitHub Issues**: https://github.com/solana-foundation/contra/issues
-- **Stack Exchange**: Ask on https://solana.stackexchange.com/ (use the `contra` tag)
-- **Documentation**: See [ARCHITECTURE.md](ARCHITECTURE.md) and [DEVNET_QUICKSTART.md](DEVNET_QUICKSTART.md)
-
-
+Issues and questions: https://github.com/solana-foundation/contra/issues

--- a/docs/TECHNICAL_REQUIREMENTS.md
+++ b/docs/TECHNICAL_REQUIREMENTS.md
@@ -42,7 +42,7 @@ Only the three Postgres containers need disk; size them per
 *Streamer, Solana indexer, and Solana/Contra operators each take <0.1 core
 and ~30 MB RAM, and are not material to sizing.*
 
-*Measured 2026-05-05 on a 16-core / 62 GB host. 
+*Measured 2026-05-05 on a 16-core / 62 GB host.*
 
 ### Storage sizing
 
@@ -75,7 +75,7 @@ streams WAL to archive volumes, wire those volumes to S3 lifecycle policies.
 | Software | Minimum | Purpose |
 |---|---|---|
 | [Rust](https://rust-lang.org/tools/install/) | 1.91+ | Build (`rust-toolchain.toml` is authoritative) |
-| [Solana CLI](https://solana.com/docs/intro/installation) | 3.1.13 | Program deployment; `make install-toolchain` |
+| [Solana CLI](https://solana.com/docs/intro/installation) | 3.1.13 (see [`versions.env`](../versions.env)) | Program deployment; `make install-toolchain` |
 | [Docker](https://docs.docker.com/get-docker/) | 26.0+ | Container runtime |
 | [Docker Compose](https://docs.docker.com/compose/install/) | 2.20+ | Stack orchestration |
 | [PostgreSQL](https://www.postgresql.org/download/) | 16+ | Database (skip if using bundled containers) |


### PR DESCRIPTION
## Summary

Rewrites `docs/TECHNICAL_REQUIREMENTS.md` from a tier-based, projection-heavy
spec into a single empirically-grounded floor with a per-component breakdown
and a focused scalability section.

Also bundles a small `bench-tps/scripts/run.sh` fix that surfaced while
running the benches.

## How the spec was measured

- Ran `bench-tps/scripts/run.sh transfer` against the full docker-compose
  stack on a 16-core / 62 GB host, twice (60 s and 120 s windows).
- Sampled per-thread / per-container CPU, RSS, and starvation signals (pidstat-based) during steady state.
- The stack saturated ~9 of 12 service cores at ~1k landed TPS; per-component
  numbers in the doc are taken directly from those samples.
- Floor (24 vCPU / 32 GB / 300 GB NVMe / 1 Gbps) is sized to ~2.5x the
  observed footprint, rounded to clean cloud sizes.

## Changes

- `docs/TECHNICAL_REQUIREMENTS.md`:
  - Single recommended floor replaces the dev/staging/prod tier table.
  - Per-component sizing reflects measured CPU + RAM at ~1k TPS.
  - Storage tables for token-account state and block/tx history at 100, 1k,
    10k TPS.
  - Network section trimmed to public-facing ports only.
  - Scalability section simplified; cross-references to `CONFIG.md`,
    `INDEXER.md`, `PITR.md` for follow-up actions.
- `bench-tps/scripts/run.sh`: fix `images_exist()`. The old check listed 11
  per-service image tags that never existed (compose actually produces 4 via
  the `x-contra-app` YAML anchor), forcing a 5+ minute rebuild on every
  invocation.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...