### PR TITLE
docs(runbooks): add operator recovery runbooks for Failed/ManualReview alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OBS_SERVICES := cadvisor prometheus grafana
 
 .PHONY: all help
 .PHONY: install install-toolchain check-toolchain check-docker build fmt generate-idl generate-clients
-.PHONY: unit-test integration-test all-test
+.PHONY: unit-test integration-test all-test drills drill
 .PHONY: ci-unit-test ci-integration-test ci-integration-test-prebuilt ci-integration-test-build-test-tree ci-integration-test-indexer
 .PHONY: unit-test-ci integration-test-ci integration-test-ci-prebuilt integration-test-ci-build-test-tree integration-test-ci-indexer integration-test-ci-no-build
 .PHONY: unit-coverage coverage-html all-coverage ci-unit-coverage ci-e2e-coverage
@@ -261,6 +261,24 @@ integration-test-ci-no-build:
 	@$(MAKE) ci-integration-test-build-test-tree
 
 all-test: unit-test integration-test
+
+# Runbook drills are #[ignore]-flagged in the indexer test suite so they're
+# skipped by default. They spin up a real Postgres via testcontainers and
+# verify the SQL in docs/runbooks/*.md still matches the schema and the
+# operator code's contracts. They are NOT in CI by design, run them
+# manually before merging a runbook edit, or after touching processor.rs /
+# sender/transaction.rs / sender/remint.rs / db_transaction_writer.rs /
+# db_transaction_writer's webhook serializer / the indexer schema.
+drills:
+	@cargo test -p contra-indexer --test runbook_drills -- --ignored --nocapture
+
+drill:
+	@if [ -z "$(NAME)" ]; then \
+	    echo "usage: make drill NAME=drill_3"; \
+	    echo "       (run a single drill by name; substring match is fine)"; \
+	    exit 1; \
+	fi
+	@cargo test -p contra-indexer --test runbook_drills -- --ignored --nocapture $(NAME)
 
 unit-coverage:
 	@echo "Running unit tests with coverage..."

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -97,8 +97,17 @@ pins the relevant contract.
 | `drill_9_path_b_signature_uniqueness_fence` | withdrawal | Mark-completed-with-sig is idempotent; unique index rejects cross-row collision. |
 | `drill_10_deposit_failed_recovery_flows` | deposit | `LANDED` → completed-with-sig; `NOT_LANDED` → re-arm; bad data → failed. |
 | `drill_11_program_type_labels_match_runbooks` | both | Pins `ProgramType::as_label` to `withdraw` / `escrow`. |
+| `drill_12_withdrawal_failed_recovery_flows` | withdrawal | `withdrawal_failed.md` LANDED → completed-with-sig; cross-row signature fence still applies on `failed`; NOT_LANDED is terminal (markdown + operator code grep); AMBIGUOUS escalates without SQL. |
+| `drill_13_withdrawal_failed_reminted_reconcile` | withdrawal | `failed_reminted` transition writes `remint_signatures`; runbook contains zero mutating SQL; LANDED verdict cannot be silently absorbed via `SET status='completed'`; webhook `remint_signature` (singular) ↔ DB `remint_signatures` (plural) asymmetry pinned. |
 
-Trigger:
+Trigger (`make` shorthand, runs from repo root):
+
+```bash
+make drills                  # all drills
+make drill NAME=drill_2      # single drill (substring match)
+```
+
+Or directly via cargo:
 
 ```bash
 cargo test -p contra-indexer --test runbook_drills -- --ignored --nocapture
@@ -111,5 +120,9 @@ RUST_LOG=trace cargo test -p contra-indexer --test runbook_drills -- \
 ### When to run drills
 
 - Before merging a runbook edit.
-- After changes to: `processor.rs`, `sender/transaction.rs`,
-  `sender/remint.rs`, `db_transaction_writer.rs`, or the indexer schema.
+- After changes to: `processor.rs`, `sender/transaction.rs` (and in
+  particular `send_fatal_error`, the source of the rare withdrawal
+  `failed` transition that drill_12 protects), `sender/remint.rs`,
+  `db_transaction_writer.rs` (including its webhook-payload serializer
+  — drill_13 anchors on the `"remint_signature"` JSON key string
+  literal), or the indexer schema.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,115 @@
+# Runbooks - Operator
+
+Operator runbooks for the Contra payment-channel system. Covers both the
+withdrawal operator (Contra → Solana releases) and the deposit / escrow
+operator (Solana → Contra mints). Start here when an alert fires.
+
+The two operators have different failure shapes: withdrawals can halt
+the pipeline (SMT nonce gap), deposits cannot. The dispatch table below
+routes by webhook + `transaction_type`.
+
+## Alert dispatch
+
+The **alert webhook** in `db_transaction_writer.rs` is the only
+configured paging mechanism today. It fires on `Failed`,
+`FailedReminted`, and `ManualReview` status transitions (single attempt,
+no retries). All dispatch below is keyed on the webhook payload.
+
+| Alert (webhook payload) | `transaction_type` | Symptom | Runbook |
+|---|---|---|---|
+| `status=manual_review` | `withdrawal` | Single row stopped; pipeline may also be halted. | [`withdrawal_manual_review.md`](withdrawal_manual_review.md) |
+| `status=manual_review` | `deposit` | Single row stopped (deterministic build error). No halt, no collateral. | [`deposit_manual_review.md`](deposit_manual_review.md) |
+| `status=failed` | `withdrawal` | Single row terminated without on-chain proof. Rare for withdrawals. | [`withdrawal_failed.md`](withdrawal_failed.md) |
+| `status=failed` | `deposit` | **Primary deposit alert.** Sender-side terminal failure (RPC, build, confirmation, on-chain rejection). | [`deposit_failed.md`](deposit_failed.md) |
+| `status=failed_reminted` | `withdrawal` | Withdrawal failed; remint succeeded. Reconcile only. | [`withdrawal_failed_reminted.md`](withdrawal_failed_reminted.md) |
+
+
+## First action regardless of alert
+
+1. Capture the alert payload (transaction_id, error_message, processed_at,
+   `transaction_type`).
+2. Run the on-chain verification procedure that matches the
+   `transaction_type`:
+   - Withdrawals → [`_verify_onchain_release.md`](_verify_onchain_release.md)
+   - Deposits → [`_verify_onchain_mint.md`](_verify_onchain_mint.md)
+3. Do not take recovery action until you have a verdict.
+
+## Recovery SQL is bookkeeping; fund restoration is human-in-the-loop
+
+A core design property of these runbooks: the recovery `UPDATE`
+statements only change the operator's view of a row. They do not move
+on-chain funds, mint, burn, or refund anything. That separation is
+intentional - it lets a single human-readable command resolve the
+operator's state without coupling it to any chain action that might
+itself fail.
+
+The system has exactly one **automatic** restoration path: a
+withdrawal that fails sender-side on Solana auto-remints the user's
+burned Contra tokens. That outcome ends with `status=failed_reminted`
+and no human action.
+
+Every other terminal outcome - withdrawal `failed` after a build error,
+withdrawal where both the on-chain release and the auto-remint failed,
+deposit `manual_review` with bad row data, deposit `failed` whose
+underlying condition can't be remedied -
+**routes to a human via Tier 1 escalation**. The recovery SQL marks
+the operator's bookkeeping done; the actual fund restoration (manual
+remint, compensating release, off-chain refund) is a separate step
+the on-call operator coordinates with treasury and tracks in the
+incident record.
+
+When you run a recovery `UPDATE`, you are not "fixing the user." You
+are making the operator's state consistent so the pipeline can
+resume. The user-side fix lives in the Tier 1 escalation channel.
+The runbooks call this out at every relevant site.
+
+## Reference
+
+- [`_glossary.md`](_glossary.md) - status state machine, webhook schema,
+  metrics, withdrawal/deposit asymmetries.
+- [`_verify_onchain_release.md`](_verify_onchain_release.md) - withdrawal
+  on-chain check (Solana mainnet).
+- [`_verify_onchain_mint.md`](_verify_onchain_mint.md) - deposit
+  on-chain check (Contra chain).
+- [`_escalation.md`](_escalation.md) - escalation tiers and contacts.
+  Every "escalate" call-site in the recovery runbooks links here.
+
+## Drills
+
+[`indexer/tests/runbook_drills.rs`](../../indexer/tests/runbook_drills.rs)
+contains eleven `#[ignore]`-flagged drills that verify these runbooks'
+commands actually do what the prose claims. Drills are **manually
+triggered, not in CI** - they exist so a human about to use a runbook
+(or about to publish an edit) can confirm the diagnostic and recovery
+flows still work. Each drill prints the runbook section it verifies and
+pins the relevant contract.
+
+| Drill | Side | Verifies |
+|---|---|---|
+| `drill_1_error_message_contracts_present_in_source` | both | Source contains every `error_message` substring the dispatch tables match on. |
+| `drill_2_path_a_data_error_recovery` | withdrawal | Triage SQL orders the trigger row first; recovery SQL reaches the documented end-state. |
+| `drill_3_path_b_landed_marks_completed_with_signature` | withdrawal | On `LANDED`, mark `completed` with the observed signature (prevents double-credit). |
+| `drill_4_path_c_not_landed_re_arms_with_same_nonce` | withdrawal | Re-arm preserves `withdrawal_nonce`; nonce-uniqueness index still enforces. |
+| `drill_5_halt_sweep_excludes_poison_only` | withdrawal | Bulk-quarantine flips every active withdrawal except the excluded poison id. |
+| `drill_6_recovery_query_skips_terminal_statuses` | withdrawal | Recovery query skips rows already resolved to a terminal status. |
+| `drill_7_halt_sweep_does_not_touch_terminals` | withdrawal | Bulk-quarantine leaves terminal-status rows alone. |
+| `drill_8_alertable_set_matches_runbook_dispatch` | both | Webhook fires on exactly `Failed`, `FailedReminted`, `ManualReview`. |
+| `drill_9_path_b_signature_uniqueness_fence` | withdrawal | Mark-completed-with-sig is idempotent; unique index rejects cross-row collision. |
+| `drill_10_deposit_failed_recovery_flows` | deposit | `LANDED` → completed-with-sig; `NOT_LANDED` → re-arm; bad data → failed. |
+| `drill_11_program_type_labels_match_runbooks` | both | Pins `ProgramType::as_label` to `withdraw` / `escrow`. |
+
+Trigger:
+
+```bash
+cargo test -p contra-indexer --test runbook_drills -- --ignored --nocapture
+
+# Single drill, with trace logs for debugging:
+RUST_LOG=trace cargo test -p contra-indexer --test runbook_drills -- \
+    --ignored --nocapture drill_2
+```
+
+### When to run drills
+
+- Before merging a runbook edit.
+- After changes to: `processor.rs`, `sender/transaction.rs`,
+  `sender/remint.rs`, `db_transaction_writer.rs`, or the indexer schema.

--- a/docs/runbooks/_escalation.md
+++ b/docs/runbooks/_escalation.md
@@ -1,0 +1,86 @@
+# Escalation - Operator Runbooks
+
+When a runbook says "escalate", come here. The link annotation in the
+source runbook tells you which tier you're in (e.g.
+`[escalate](_escalation.md) (Tier 2)`). Page the right destination and
+send the prescribed payload.
+
+## Tier 1 - Stranded user funds (page immediately)
+
+Funds are demonstrably out of the user's control and not recoverable
+by re-arming the row.
+
+Page: the on-call operator.
+Also notify: the treasury / refund-coordination owner, and customer
+support.
+
+Send:
+- `transaction_id`, `transaction_type`, `amount`, `mint`, `recipient`.
+- Originating signature (Solana for deposits, Contra-side for
+  withdrawals).
+- On-chain verdict from the verify procedure and every signature
+  checked.
+- Which leg failed and why funds are stranded.
+- Whether the user needs proactive comms before the next operator tick.
+
+## Tier 2 - AMBIGUOUS on-chain state (page, less urgent)
+
+Verification could not produce `LANDED` or `NOT_LANDED`. Cause is
+usually RPC unreachable, signature lookback rotated past `processed_at`,
+or evidence is contradictory (e.g. sig finalized but SMT leaf empty).
+Funds may or may not be stranded; no recovery action is safe yet.
+
+Page: the on-call operator.
+Do NOT notify treasury or customer support until the verdict resolves -
+those are Tier 1 only.
+
+Send:
+- `transaction_id`, `transaction_type`, `amount`, `mint`, `recipient`.
+- Originating signature (Solana for deposits, Contra-side for
+  withdrawals).
+- On-chain verdict from the verify procedure and every signature
+  checked.
+- Specific RPC endpoint queried and the exact failure (timeout,
+  `MethodNotFound`, error message).
+- `processed_at` and the oldest signature timestamp the RPC returned
+  (to assess if the lookback window rotated past the row).
+- Whether retry is appropriate once RPC visibility recovers, and the
+  proposed re-check plan.
+
+## Tier 3 - Code-defect signals (file P1 ticket, no immediate page)
+
+The operator state machine produced an outcome the runbook says
+shouldn't happen. Funds are not at immediate risk - the existing fence
+(webhook, idempotency memo, unique-index, etc.) held - but the
+underlying bug needs fixing before recurrence.
+
+File: a P1 ticket against the engineering team that owns the operator.
+
+Capture:
+- `transaction_id`, `transaction_type`, `amount`, `mint`, `recipient`.
+- Originating signature (Solana for deposits, Contra-side for
+  withdrawals).
+- On-chain verdict from the verify procedure and every signature
+  checked.
+- The runbook section that says this shouldn't happen, quoted.
+- Reproduction steps if known.
+- Whether to halt similar incidents (manually flip active rows to
+  `manual_review` so the operator stops processing them) until
+  patched, or whether the existing fence is enough to let normal
+  operation continue.
+
+## Decision: which tier?
+
+If you arrived here without a tier annotation in the source link, use
+this quick test:
+
+1. Are user funds demonstrably stuck and not recoverable by SQL?
+   → **Tier 1.**
+2. Is the on-chain verdict `AMBIGUOUS` or contradictory?
+   → **Tier 2.**
+3. Operator did the wrong thing but funds are safe (existing fence held)?
+   → **Tier 3.**
+4. None of the above?
+   → You probably don't need to escalate; finish the runbook recovery.
+
+When in doubt, escalate to the higher tier.

--- a/docs/runbooks/_glossary.md
+++ b/docs/runbooks/_glossary.md
@@ -1,0 +1,118 @@
+# Glossary - Operator Status & Alert Surface
+
+Reference for every other runbook in this directory. Not standalone.
+
+Covers both withdrawal and deposit operators. Behavioral differences
+between the two are called out inline.
+
+## Status state machine
+
+Defined in `indexer/src/storage/common/models.rs`. Enum `TransactionStatus`,
+DB type `transaction_status`.
+
+| Status | Terminal? | Webhook? | Meaning |
+|---|---|---|---|
+| `pending` | no | no | Inserted by indexer, not yet picked up by operator. |
+| `processing` | no | no | Fetcher locked it; processor or sender is acting on it. |
+| `pending_remint` | no | no | **Withdrawal-only.** Failed but signatures were stashed; finality check queued. Recovery query (`get_pending_remint_transactions`) re-loads these on restart. Deposits never enter this state. |
+| `completed` | yes | no | Withdrawal release or deposit mint confirmed on-chain. |
+| `failed` | yes | yes | Terminal failure with no on-chain proof. **Primary alert for deposits** (sender-side failures terminate here since there is no remint path). Rare for withdrawals - those go through `pending_remint`. |
+| `failed_reminted` | yes | yes | **Withdrawal-only.** Original withdrawal failed, remint of burned Contra tokens succeeded. Deposits do not have a remint path. |
+| `manual_review` | yes | yes | Operator stopped acting on this row. Requires human triage. Withdrawals: six triggers (build error → halt, pre-flight bail → no halt, four sender-side ambiguities). Deposits: build error only (no halt, no sweep). |
+
+Webhook receivers should treat `failed`, `failed_reminted`, `manual_review` as
+the alertable set. Source: `indexer/src/operator/db_transaction_writer.rs`,
+the `is_alertable` match.
+
+## Webhook payload shape
+
+```json
+{
+  "transaction_id": 123,
+  "trace_id": "uuid",
+  "status": "manual_review" | "failed" | "failed_reminted",
+  "counterpart_signature": "<sig>" | null,
+  "error_message": "<string>" | null,
+  "processed_at": "<rfc3339>",
+  "timestamp": "<rfc3339>",
+  "remint_signature": "<sig>" | null,
+  "remint_status": "success" | "failed" | null
+}
+```
+
+Webhook config: 10s timeout, **single attempt, no retries**
+(`db_transaction_writer.rs`). A dropped webhook means a missed alert. The
+ERROR-level log line `Transaction <id> <Status>` always fires, so logs are the
+backup.
+
+## Pipeline-halt asymmetry
+
+Withdrawals halt the entire pipeline on a deterministic per-row error
+(`processor.rs::halt_withdrawal_pipeline`). The reason is on-chain: a
+quarantined withdrawal would leave a permanent gap in the SMT that
+rejects every subsequent nonce. Halt + sweep is safer than bleeding
+errors downstream.
+
+Deposits never halt. The deposit loop (`process_deposit_funds`)
+continues after each quarantine. There is no SMT, no nonce, no
+sequential dependency between deposits.
+
+This is why the withdrawal runbooks have a dedicated halt runbook and
+the deposit ones do not.
+
+## Withdrawal nonce and SMT
+
+- Each withdrawal row has `withdrawal_nonce: BIGINT NOT NULL`.
+- The on-chain SMT has `MAX_TREE_LEAVES` slots (see
+  `indexer/src/operator/tree_constants.rs`). Leaf position = `nonce % MAX_TREE_LEAVES`.
+- A quarantined withdrawal occupies its leaf logically (the next nonce
+  expects sequential progression). The pipeline halts because subsequent
+  nonces would fail at the program until the tree is rotated.
+- Rotation: `ResetSmtRootBuilder` (escrow program). Triggered automatically
+  when a nonce hits the `MAX_TREE_LEAVES` boundary; no admin CLI entrypoint
+  exists today.
+
+## On-chain references
+
+- Escrow program ID: see `versions.env` and `core/` config.
+- Operator account: signer for `release_funds`. Recent signature history is
+  the authoritative source for "did this withdrawal land?" - see
+  `_verify_onchain_release.md`.
+
+## Idempotency memo (deposit-side)
+
+Every deposit mint carries a deterministic memo:
+`contra:mint-idempotency:<transaction_id>`
+(`indexer/src/operator/constants.rs::MINT_IDEMPOTENCY_MEMO_PREFIX`).
+Before sending, the operator scans the recipient ATA's recent signatures
+on the Contra chain (`find_existing_mint_signature_with_memo`) and
+short-circuits to `Completed` if a memo'd signature is already
+finalized.
+
+This is the primary fence against double-minting on retry. It works only
+within the RPC's signature lookback window - older history is invisible
+to the scan, which is why the verify-on-chain procedure escalates as
+`AMBIGUOUS` when `processed_at` predates the window.
+
+Withdrawals have an analogous fence: the `pending_remint` recovery
+checks finality of stashed signatures before reminting.
+
+## Roles in this directory
+
+- `_glossary.md` - this file. Reference, no actions.
+- `_verify_onchain_release.md` - withdrawal-side verification: did a
+  release land on Solana?
+- `_verify_onchain_mint.md` - deposit-side verification: did a mint
+  land on Contra?
+- `_escalation.md` - escalation tiers and contacts. Every "escalate"
+  reference in the recovery runbooks links here.
+- `withdrawal_manual_review.md` - withdrawal manual review, dispatches
+  by trigger site.
+- `withdrawal_failed.md` - narrow runbook for the rare withdrawal
+  `Failed`.
+- `withdrawal_failed_reminted.md` - withdrawal reconciliation only; not
+  a recovery.
+- `deposit_manual_review.md` - deposit manual review (build error
+  only).
+- `deposit_failed.md` - primary deposit alert runbook.
+- `README.md` - alert-to-runbook dispatch.

--- a/docs/runbooks/_verify_onchain_mint.md
+++ b/docs/runbooks/_verify_onchain_mint.md
@@ -1,0 +1,128 @@
+# Procedure - Verify On-Chain Mint
+
+**Scope:** deposit operator only. This procedure verifies whether a
+`MintTo` instruction landed on the **Contra chain** (the channel side, not
+Solana mainnet). For withdrawals, see
+[`_verify_onchain_release.md`](_verify_onchain_release.md).
+
+Run this before taking any deposit recovery action. **Do not skip - this
+is the gate that prevents double-minting Contra tokens to the user.**
+
+## Inputs
+
+You need:
+- `transaction_id` - DB primary key of the deposit row.
+- The recipient ATA - derivable from `recipient` and `mint` columns of the
+  row, or already in `counterpart_signature`'s associated transaction.
+- A working RPC endpoint for the **Contra chain** (the channel, served by
+  the gateway / read-node, not the Solana mainnet RPC). The operator's
+  `COMMON_RPC_URL` env var is the same endpoint.
+
+## Output
+
+Exactly one of:
+- `LANDED <signature>` - mint confirmed on Contra; tokens were minted.
+- `NOT_LANDED` - no mint in operator history for this transaction_id.
+- `AMBIGUOUS` - RPC unreachable, no decisive evidence, or the lookback
+  window does not cover `processed_at`.
+
+**If output is `AMBIGUOUS`, stop. [Escalate](_escalation.md) (Tier 2).
+Do not retry.** A blind retry
+risks double-minting if the original mint actually landed but is outside
+the RPC's signature lookback window.
+
+## Procedure
+
+### Step 1 - pull row state
+
+```sql
+SELECT id,
+       recipient,
+       mint,
+       counterpart_signature,
+       status,
+       updated_at
+  FROM transactions
+ WHERE id = :transaction_id;
+```
+
+If `counterpart_signature` is set, the operator already recorded a mint
+sig - verify it directly in Step 2 and skip Step 3.
+
+### Step 2 - confirm a known signature
+
+```bash
+solana confirm -v <counterpart_signature> --url <contra-rpc-url>
+```
+
+- `Finalized`, no error → output `LANDED <counterpart_signature>`.
+- `Failed` or `not found` → continue to Step 3 (the recorded sig may have
+  been speculative; the actual mint may differ).
+- RPC error → output `AMBIGUOUS`.
+  [Escalate](_escalation.md) (Tier 2).
+
+### Step 3 - search by idempotency memo
+
+The operator attaches a deterministic memo to every mint:
+`contra:mint-idempotency:<transaction_id>`
+(`indexer/src/operator/constants.rs::MINT_IDEMPOTENCY_MEMO_PREFIX`).
+
+Derive the recipient ATA:
+
+```bash
+spl-token address \
+  --token <mint> \
+  --owner <recipient> \
+  --url <contra-rpc-url> \
+  --verbose
+```
+
+Scan recent signatures on that ATA:
+
+```bash
+solana transaction-history <recipient-ata> --limit 1000 --url <contra-rpc-url>
+```
+
+For each candidate, fetch and inspect:
+
+```bash
+solana confirm -v <signature> --url <contra-rpc-url>
+```
+
+A match has all of:
+- A `MintTo` instruction targeting the same mint and recipient ATA.
+- A memo instruction whose data contains
+  `contra:mint-idempotency:<transaction_id>`.
+- `Finalized` commitment, no error.
+
+Outcomes:
+- One match → output `LANDED <signature>`. Use this signature in
+  recovery.
+- No match within the lookback window AND `processed_at` is more recent
+  than the oldest signature returned → output `NOT_LANDED`.
+- No match BUT `processed_at` predates the oldest signature returned →
+  output `AMBIGUOUS` (the original mint may have rotated out of the RPC's
+  history window). [Escalate](_escalation.md) (Tier 2).
+- RPC unreachable → output `AMBIGUOUS`.
+
+## Idempotency safety net
+
+The operator's `find_existing_mint_signature_with_memo`
+(`indexer/src/operator/sender/mint.rs`) runs the same memo-scan on every
+deposit attempt before sending. If you re-arm a deposit row to `pending`
+without recovery and the original mint did land, the next operator tick
+will find the existing memo'd signature and short-circuit to `Completed`
+without minting again.
+
+This safety net works only when the original mint is still inside the
+RPC's signature lookback window. **It is the primary defense against
+double-minting on retry, but it is not a substitute for this procedure
+in `AMBIGUOUS` cases.**
+
+## After running this procedure
+
+Capture the verdict, the signature(s) checked, and the RPC endpoint used
+in the incident record. Without this trail, a future user dispute or
+reconciliation mismatch cannot tell whether a row's
+`counterpart_signature` was actually verified on Contra or hand-picked,
+and a postmortem cannot reproduce the recovery decision.

--- a/docs/runbooks/_verify_onchain_release.md
+++ b/docs/runbooks/_verify_onchain_release.md
@@ -1,0 +1,112 @@
+# Procedure - Verify On-Chain Release
+
+**Scope:** withdrawal operator only. This procedure verifies whether a
+`release_funds` instruction landed on Solana mainnet. It does **not**
+apply to deposits.
+
+Shared across every withdrawal recovery runbook. Run it before taking any
+action. **Do not skip - this is the gate that prevents double-crediting
+users.**
+
+## Inputs
+
+You need:
+- `transaction_id` - DB primary key of the withdrawal row.
+- Operator pubkey - the signer that submits `release_funds`. Available via
+  the operator container env.
+- A working Solana RPC endpoint pointed at the same cluster the operator is
+  running against.
+
+## Output
+
+Exactly one of:
+- `LANDED <signature>` - release confirmed on-chain. Funds moved.
+- `NOT_LANDED` - no release in operator history for this nonce.
+- `AMBIGUOUS` - RPC unreachable, response inconclusive, or a sig appears
+  but cannot be confirmed finalized.
+
+**If output is `AMBIGUOUS`, stop. [Escalate](_escalation.md) (Tier 2).
+Do not proceed to recovery.**
+
+## Procedure
+
+### Step 1 - pull row state
+
+Run against the indexer Postgres primary:
+
+```sql
+SELECT id,
+       withdrawal_nonce,
+       status,
+       counterpart_signature,
+       remint_signatures,
+       error_message,
+       updated_at
+  FROM transactions
+ WHERE id = :transaction_id;
+```
+
+Record the values. `remint_signatures` is the array of withdrawal signatures
+that were stashed before the failure; if non-NULL it is the fastest path.
+
+### Step 2 - if `remint_signatures` is non-empty, check those first
+
+For each signature in `remint_signatures`:
+
+```bash
+solana confirm -v <signature> --url <rpc-url>
+```
+
+Possible outcomes:
+- One reports `Finalized` and **no error** → output `LANDED <signature>`.
+  Use this signature in the recovery step.
+- All report `Failed` or `not found` → continue to Step 3.
+- RPC errors or returns inconclusive → output `AMBIGUOUS`.
+  [Escalate](_escalation.md) (Tier 2).
+
+### Step 3 - operator signature history scan
+
+Required for sites that never stashed a signature (build error, pre-flight
+bail, "no signatures to verify"). Also a backstop when Step 2 was empty.
+
+```bash
+solana transaction-history <operator-pubkey> --limit 1000 --url <rpc-url>
+```
+
+For each candidate signature returned, decode the transaction and check
+whether it is a `release_funds` carrying `transaction_nonce =
+<withdrawal_nonce>`:
+
+```bash
+solana confirm -v <signature> --url <rpc-url>
+```
+
+The instruction data for `release_funds` includes the nonce as a `u64` -
+match against `withdrawal_nonce` from Step 1.
+
+Outcomes:
+- A signature matches the nonce and is `Finalized` → `LANDED <signature>`.
+- No matching signature in the recent window and the row is older than the
+  RPC's history window (typically ~1k–2k recent sigs per pubkey) →
+  `NOT_LANDED`.
+- RPC unavailable or window doesn't cover the row's `updated_at` →
+  `AMBIGUOUS`.
+
+## What "AMBIGUOUS" means in practice
+
+Funds are stranded until the verdict resolves. Do not retry, do not remint,
+do not mark Completed. Wait for RPC to recover and re-run the procedure, or
+[escalate](_escalation.md) (Tier 2) for a deeper on-chain audit.
+
+The operator code itself implements the same fence: when the sender cannot
+verify whether a release landed, it routes the row to `manual_review` with
+`error_message` containing `no signatures to verify - remint unsafe`
+(`indexer/src/operator/sender/transaction.rs`). Honor that fence.
+
+## After running this procedure
+
+Capture the verdict, the signature(s) checked, and the RPC endpoint used
+in the incident record. Without this trail, a future user dispute or
+reconciliation mismatch cannot tell whether a row's
+`counterpart_signature` was actually verified or hand-picked, and a
+postmortem cannot reproduce the recovery decision.

--- a/docs/runbooks/_verify_onchain_release.md
+++ b/docs/runbooks/_verify_onchain_release.md
@@ -40,7 +40,6 @@ SELECT id,
        status,
        counterpart_signature,
        remint_signatures,
-       error_message,
        updated_at
   FROM transactions
  WHERE id = :transaction_id;

--- a/docs/runbooks/_verify_onchain_release.md
+++ b/docs/runbooks/_verify_onchain_release.md
@@ -100,7 +100,7 @@ do not mark Completed. Wait for RPC to recover and re-run the procedure, or
 
 The operator code itself implements the same fence: when the sender cannot
 verify whether a release landed, it routes the row to `manual_review` with
-`error_message` containing `no signatures to verify - remint unsafe`
+`error_message` containing `no signatures to verify — remint unsafe`
 (`indexer/src/operator/sender/transaction.rs`). Honor that fence.
 
 ## After running this procedure

--- a/docs/runbooks/deposit_failed.md
+++ b/docs/runbooks/deposit_failed.md
@@ -1,0 +1,113 @@
+# Runbook - Deposit `Failed`
+
+Triggered by webhook payload `status=failed` for a row with
+`transaction_type='deposit'`. Unlike on the withdrawal side, this is the
+**primary** terminal alert for deposits - there is no remint path, so
+sender-side failures land here instead of in `ManualReview`.
+
+## Symptom
+
+- Webhook with `status=failed`, `transaction_type=deposit`.
+- ERROR log: `Transaction <id> Failed`.
+
+## Triage - dispatch by `error_message`
+
+`error_message` is on the webhook payload (not in the DB). Each value
+maps to a specific sender-side site:
+
+| `error_message` | Source | Trigger |
+|---|---|---|
+| starts with `Failed idempotency lookup for transaction_id` | `sender/mint.rs` | `getSignaturesForAddress` RPC failed during pre-send memo scan. |
+| `Mint initialization failed` | `sender/transaction.rs` | Recipient's mint or ATA wasn't initialized; just-in-time init also failed. |
+| `Unexpected mint error` | `sender/transaction.rs` | `MintNotInitialized` confirmation result on a non-Mint tx (defensive; should never fire). |
+| `Confirmation failed - transaction status unknown, unsafe to retry` | `sender/transaction.rs` | RPC polling timed out for a non-idempotent send; mint may or may not have landed. |
+| free-form (often a program-error debug repr) | `sender/transaction.rs` | On-chain program error during confirmation (e.g. paused mint, bad mint authority) or RPC confirmation error. |
+
+## Recovery
+
+The decision shape is the same for every trigger: did the mint land on
+Contra or not?
+
+### Step 1 - verify on-chain
+
+Run [`_verify_onchain_mint.md`](_verify_onchain_mint.md). The verdict
+drives every recovery path below.
+
+### Step 2 - branch on verdict
+
+#### `LANDED <signature>` - mint actually succeeded
+
+The user already received Contra-side tokens. The `Failed` status is
+incorrect; make it `completed` with the observed signature:
+
+```sql
+UPDATE transactions
+   SET status = 'completed',
+       counterpart_signature = :signature,
+       updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+If this UPDATE is rejected by the unique partial index on
+`counterpart_signature`, **stop**. The signature is already attached to a
+different row. [Escalate](_escalation.md) (Tier 3 - operator
+misidentified row) before proceeding; running ahead would silently
+double-credit.
+
+File via the Tier 3 process: `Failed` was wrong, which means either:
+- The confirmation timeout fired but the tx finalized after - common
+  case; the runbook fix is enough.
+- The classifier or routing has a bug that prevented the success path
+  from running.
+
+#### `NOT_LANDED` - mint genuinely did not happen
+
+Re-arm the row to `pending`. The idempotency memo is a safety net even
+if a previous attempt did broadcast: the operator's pre-send memo scan
+short-circuits to `Completed` if it finds a memo'd signature.
+
+```sql
+UPDATE transactions SET status = 'pending', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+Before re-arming for `Mint initialization failed` specifically: confirm
+the underlying mint account and authority are correctly set up on the
+Contra chain. Without that, the next attempt fails the same way.
+
+For program-error cases (paused mint, bad authority, etc.), fix the
+underlying condition first, then re-arm.
+
+#### `AMBIGUOUS` - RPC unreachable, history rotated, or inconclusive
+
+Stop. [Escalate](_escalation.md) (Tier 2). Do not act.
+
+- If RPC is recovering, retry the verification procedure once visibility
+  is back.
+- If the original `processed_at` predates the RPC's signature lookback
+  window, engineering must do an out-of-band audit via archived block
+  history before any recovery action.
+
+Re-arming to `pending` in the `AMBIGUOUS` case relies on the operator's
+own idempotency check; that check uses the same lookback window and will
+be just as blind. Do not lean on it alone for an old `processed_at`.
+
+## Special case - `Failed idempotency lookup`
+
+This trigger fires when the operator's pre-send memo scan itself
+errored (RPC down at attempt time). The mint was **not** sent
+afterwards. On-chain verification will most likely return `NOT_LANDED`
+and Step 2's re-arm path applies. The retry is safe because the next
+attempt will run the memo scan again (and will detect any prior
+landed mint).
+
+## Post-incident artifacts
+
+- Transaction id, originating Solana deposit `signature`, `recipient`,
+  `mint`, `amount`.
+- Full webhook `error_message` and `error_reason` metric label.
+- On-chain verdict (`LANDED <sig>` / `NOT_LANDED` / `AMBIGUOUS`).
+- Recovery action taken.
+- If the trigger pointed to environmental misconfiguration (paused mint,
+  bad authority), the remediation step taken on the Contra side.
+

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -1,0 +1,122 @@
+# Runbook - Deposit `ManualReview`
+
+Triggered by webhook payload `status=manual_review` for a row with
+`transaction_type='deposit'`.
+
+## Scope and key differences vs. withdrawals
+
+Deposits never halt the pipeline. The processor's classifier
+(`processor.rs::classify_processor_error`) is shared with the withdrawal
+side, but the deposit loop continues after each quarantine
+(`process_deposit_funds`, `processor.rs:704-722` - note the absence of
+`halt_withdrawal_pipeline` and the loop `continue` semantics). There is
+no SMT, no nonce, no remint.
+
+Practically: a single deposit `manual_review` is a single row in trouble.
+Other deposits keep flowing. There is no collateral, no sweep, no halt to
+recover from.
+
+## Symptom
+
+- Webhook with `status=manual_review`, `transaction_type=deposit`.
+- ERROR-level log line `Transaction <id> ManualReview`.
+
+## Triage
+
+There is one trigger surface: a deterministic per-row error in
+`processor.rs::process_deposit_funds`. `error_message` will contain one
+of:
+
+| `error_message` contains | Cause |
+|---|---|
+| `invalid_pubkey` | `mint` or `recipient` field is not a valid base58 pubkey. |
+| `invalid_builder` | Builder rejected the row's data (e.g. negative amount). |
+| `program_error` | Generic builder error not covered by the specific variants. |
+
+Pull the row:
+
+```sql
+SELECT id, signature, recipient, mint, amount, slot, updated_at
+  FROM transactions
+ WHERE id = :transaction_id;
+```
+
+`signature` is the originating Solana deposit signature (immutable
+reference). Use it to inspect the on-chain deposit if you need to confirm
+what was actually deposited:
+
+```bash
+solana confirm -v <signature> --url <solana-rpc-url>
+```
+
+## Recovery
+
+Deposits do not need on-chain mint verification before recovery - the
+quarantine triggers on row-data validation, before any RPC call. The
+idempotency memo (`contra:mint-idempotency:<transaction_id>`) prevents
+double-mint on retry even if the mint somehow did land.
+
+That said: **if `error_message` is `program_error`** the trigger is less
+specific and may indicate a real on-chain rejection. In that case run
+[`_verify_onchain_mint.md`](_verify_onchain_mint.md) before deciding.
+
+### Path A - bad data, unrecoverable
+
+The row's `mint` or `recipient` is malformed beyond fixing (e.g. the
+indexer captured corrupt input). Mark `failed`; refund out-of-band.
+
+```sql
+UPDATE transactions SET status = 'failed', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+The user's tokens are locked in escrow on Solana but no Contra-side
+mint will be issued. [Escalate](_escalation.md) (Tier 1) for refund
+coordination -
+typically a manual `release_funds` back to the depositor.
+
+### Path B - data correctable
+
+Rare; happens when `mint` or `recipient` was canonically wrong but the
+underlying intent is recoverable from the originating Solana transaction.
+Correct the columns and re-arm:
+
+```sql
+UPDATE transactions
+   SET status = 'pending',
+       mint = :corrected_mint,
+       recipient = :corrected_recipient,
+       updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+No operator restart required. The fetcher will pick the row up on its
+next tick.
+
+### Path C - conservative classification
+
+If `error_message` describes a transient condition (RPC error, DB error
+surfaced as `OperatorError::Program`), the classifier in
+`classify_processor_error` quarantined on the side of caution rather
+than retrying. This is the intended behavior: misclassifying a
+deterministic error as transient could put the operator into a tight
+retry loop. The asymmetric cost favors a noisy quarantine over a silent
+retry.
+
+Re-arm to `pending` (safe - idempotency memo prevents duplicate mint),
+then [escalate](_escalation.md) (Tier 3) so the taxonomy can be
+extended to classify this error variant explicitly. Do not patch
+in-place.
+
+```sql
+UPDATE transactions SET status = 'pending', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+## Post-incident artifacts
+
+- Transaction id, originating Solana `signature`, `recipient`, `mint`.
+- Full webhook `error_message`.
+- Recovery action taken.
+- If Path A: refund tracking ticket.
+

--- a/docs/runbooks/withdrawal_failed.md
+++ b/docs/runbooks/withdrawal_failed.md
@@ -1,0 +1,52 @@
+# Runbook - Withdrawal `Failed`
+
+Triggered by webhook `status=failed` for a row with `transaction_type='withdrawal'`.
+
+## Why this is rare for withdrawals
+
+The withdrawal failure path normally goes
+`processing → pending_remint → {completed, failed_reminted, manual_review}`.
+The terminal `failed` status is set by `send_fatal_error` in
+`indexer/src/operator/sender/transaction.rs`, which is reached when the
+sender's `TransactionContext` carries no remint info - primarily for non-
+withdrawal transactions (deposits, mint init, SMT rotation).
+
+A withdrawal row reaching `failed` therefore means one of:
+- The row was misrouted (a non-withdrawal tx that incorrectly carried
+  `transaction_type='withdrawal'`). Investigate the indexer.
+- A code change moved a withdrawal-specific failure to `send_fatal_error`.
+  Investigate recent commits to `sender/transaction.rs`.
+- Operator-side bug.
+
+## Procedure
+
+1. **Confirm `transaction_type`.** If `deposit`, this runbook does not apply
+   - deposit-side recovery is out of scope here.
+2. **Run [`_verify_onchain_release.md`](_verify_onchain_release.md).** Funds
+   risk depends on whether the release actually landed:
+   - `LANDED <sig>`: critical bug - `failed` was wrong. The user got their
+     funds; the row should be `completed`. Fix:
+     ```sql
+     UPDATE transactions
+        SET status = 'completed',
+            counterpart_signature = :sig,
+            updated_at = NOW()
+      WHERE id = :transaction_id;
+     ```
+     [Escalate](_escalation.md) (Tier 3 - code-defect) on the operator
+     code path that produced this; the classifier or routing has a bug.
+     Capture `error_message`, the `failed` `processed_at`, and the
+     discovered signature.
+   - `NOT_LANDED`: no on-chain action; user's Contra-side state must be
+     reconciled (burn may have completed without release). Treat the same as
+     Path B in [`withdrawal_manual_review.md`](withdrawal_manual_review.md):
+     check burn state, [escalate](_escalation.md) (Tier 1) for manual
+     restoration if needed. Do not re-arm a `failed` row - the status is
+     terminal by contract.
+   - `AMBIGUOUS`: [escalate](_escalation.md) (Tier 2). Do not act.
+
+## Post-incident
+
+`Failed` on a withdrawal is a code defect signal, not just an ops event.
+Always file a follow-up ticket against the operator regardless of recovery
+outcome.

--- a/docs/runbooks/withdrawal_failed_reminted.md
+++ b/docs/runbooks/withdrawal_failed_reminted.md
@@ -1,0 +1,44 @@
+# Runbook - Withdrawal `FailedReminted`
+
+Triggered by webhook `status=failed_reminted`. **This is a success outcome.**
+The original withdrawal failed on Solana; the channel-side remint restored
+the user's burned Contra tokens.
+
+## Symptom
+
+- Webhook payload: `status=failed_reminted`, `remint_signature=<sig>`,
+  `remint_status=success`.
+- ERROR log line `Transaction <id> FailedReminted` (the writer logs every
+  alertable status at ERROR for paging visibility - this one is benign).
+
+No funds are stranded. No recovery action needed.
+
+## Reconciliation steps
+
+1. **Confirm the remint signature on-chain.**
+   ```bash
+   solana confirm -v <remint_signature> --url <rpc-url>
+   ```
+   Expected: `Finalized` with no error. The remint targets the Contra-side
+   token program, so use the channel read node's RPC.
+2. **Confirm the original withdrawal did NOT land** by running
+   [`_verify_onchain_release.md`](_verify_onchain_release.md). Expected
+   verdict: `NOT_LANDED`. If `LANDED`, the user has been double-credited
+   (got funds on Solana AND a remint) -
+   [escalate immediately](_escalation.md) (Tier 1).
+3. **Close the alert** in your tracker. Note the remint signature.
+
+## When to investigate further
+
+- If `error_message` indicates a transient cause (RPC timeout, blockhash
+  expiry) the original withdrawal may have been recoverable without remint.
+  Repeated occurrences suggest the retry/backoff config or the
+  `RetryPolicy::None` decision in `sender/remint.rs::attempt_remint` needs
+  revisiting.
+- If multiple `failed_reminted` events fire within a short window, file a
+  ticket - the underlying RPC or program is unstable.
+
+## Post-incident
+
+Capture: transaction_id, original `error_message`, remint_signature, and the
+on-chain verdict for both. These feed any reconciliation reports.

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -227,5 +227,5 @@ Capture in the incident record:
 - Recovery action taken (SQL run, sig used, escalation path).
 - RPC endpoint used for verification.
 
-These feeds the audit trail for any user-facing reconciliation.
+These feed the audit trail for any user-facing reconciliation.
 

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -1,0 +1,231 @@
+# Runbook - Withdrawal `ManualReview`
+
+Triggered by webhook payload `status=manual_review` for a withdrawal row.
+
+## Symptom
+
+- Webhook with `status=manual_review` for one or more transaction IDs.
+- ERROR-level log line: `Transaction <id> ManualReview`.
+- May or may not be paired with a pipeline halt: if the trigger error
+  was a build-side deterministic failure (Path A.halting below), the
+  operator's `halt_withdrawal_pipeline` ran and bulk-flipped every
+  active withdrawal to `manual_review`. Multiple webhooks for the same
+  timestamp burst confirm a halt occurred.
+
+## Triage - dispatch by `error_message`
+
+`error_message` is on the **alert webhook payload**, not in the
+`transactions` table. Read it from the alert that paged you, the operator
+ERROR log line `Transaction <id> error: <message>`, or the upstream alert
+store.
+
+Pull the row's DB-side state:
+
+```sql
+SELECT id, withdrawal_nonce, status, counterpart_signature,
+       remint_signatures, updated_at
+  FROM transactions
+ WHERE id = :transaction_id;
+```
+
+Match the webhook's `error_message` against the table below to pick the
+recovery path. Substring match - the messages are concatenations and may
+have prefixes.
+
+| `error_message` contains | Path | Halts pipeline? | Source |
+|---|---|---|---|
+| `invalid_pubkey`, `invalid_builder`, `program_error` | A.halting | yes | `processor.rs` quarantine |
+| `withdrawal pipeline halted after poison-pill` | A.halting (collateral row) | yes | halt sweep, channel drain |
+| (empty `error_message`, status flipped without a quarantine update) | A.halting (collateral row) | yes | `quarantine_all_active_withdrawals` |
+| `mint paused:` | A.non-halting | no | pre-flight |
+| `insufficient escrow balance:` | A.non-halting | no | pre-flight |
+| `remint failed:` | B - stranded after remint failure | no | `sender/remint.rs` |
+| `finality check failed after` | C - ambiguous (RPC unreachable) | no | `sender/remint.rs` |
+| `failed to persist pending remint:` | C - ambiguous (DB lost the sig) | no | `sender/transaction.rs` |
+| `no signatures to verify` | C - ambiguous (RPC may have broadcast) | no | `sender/transaction.rs` |
+
+## Path A.halting - build error that halted the pipeline
+
+The trigger row's data is bad in a way that would corrupt the SMT (NULL
+nonce, malformed pubkey, builder rejection). The processor quarantined the
+trigger and ran `halt_withdrawal_pipeline`, which drained the fetcher
+channel and bulk-flipped every `pending`/`processing` withdrawal to
+`manual_review`. Recovery has to handle both the trigger and the
+collateral.
+
+1. **Verify on-chain.** Run [`_verify_onchain_release.md`](_verify_onchain_release.md)
+   for the trigger row. Expected verdict: `NOT_LANDED` (build failed before
+   any RPC call). If `LANDED` → switch to Path C reconciliation. If
+   `AMBIGUOUS` → [escalate](_escalation.md) (Tier 2).
+2. **Identify the trigger row** (oldest `manual_review` by `updated_at`):
+   ```sql
+   SELECT id, withdrawal_nonce, updated_at
+     FROM transactions
+    WHERE transaction_type = 'withdrawal'
+      AND status = 'manual_review'
+    ORDER BY updated_at ASC
+    LIMIT 20;
+   ```
+   The first row is the poison-pill (paired with the original webhook).
+   Subsequent rows are collateral from the halt sweep - those came in as
+   webhooks too, but with no quarantine `error_message` (the sweep doesn't
+   send a `TransactionStatusUpdate` per row; status is flipped in bulk via
+   `quarantine_all_active_withdrawals`).
+3. **Decide the trigger row's fate.**
+   - Bad data, unrecoverable (e.g. malformed mint pubkey, NULL nonce):
+     ```sql
+     UPDATE transactions SET status = 'failed', updated_at = NOW()
+      WHERE id = :poison_id;
+     ```
+     `failed` is terminal; webhook already fired. The user must be refunded
+     out-of-band - capture in the incident record.
+   - Transient error conservatively quarantined as deterministic
+     (rare; see "Conservative classification" below): fix the row data
+     and re-arm to `pending`.
+4. **Re-arm sweep rows:**
+   ```sql
+   UPDATE transactions
+      SET status = 'pending', updated_at = NOW()
+    WHERE transaction_type = 'withdrawal'
+      AND status = 'manual_review'
+      AND id <> :poison_id;
+   ```
+   The `transactions` table does not store `error_message` - it lives in the
+   alert payload only. Distinguishing trigger from collateral happens in
+   triage (Step 2: oldest `updated_at` is the trigger), not in the re-arm
+   query. If you have *multiple* unresolved trigger rows from different
+   incidents, recover them one at a time and exclude each via `id <> :id`.
+5. **Restart the withdraw operator** (Docker: `docker compose restart
+   contra-operator-contra`). The fetcher picks up `pending` rows and
+   processing resumes.
+6. **Confirm recovery** by watching for new `Completed` webhooks for
+   the re-armed rows.
+
+## Path A.non-halting - pre-flight bail (paused mint, escrow drain)
+
+The pre-flight check (`processor.rs::check_withdrawal_preflights`) bailed
+on a row whose mint is paused or whose target ATA does not have enough
+on-chain balance. The processor quarantined **only this row** and
+**continued the loop** - there is no halt and no collateral. Other
+withdrawals are unaffected.
+
+1. **Verify on-chain.** Run [`_verify_onchain_release.md`](_verify_onchain_release.md)
+   for this row. Expected: `NOT_LANDED` (pre-flight aborted before send).
+   If `LANDED` → switch to Path C reconciliation. If `AMBIGUOUS` →
+   [escalate](_escalation.md) (Tier 2).
+2. **Confirm the pre-flight condition still holds.**
+   - `mint paused:` - check the mint's PausableConfig extension on Solana
+     (`solana account <mint>` and decode the Token-2022 extension). If
+     still paused, the row cannot be retried until the mint is unpaused;
+     hold or refund.
+   - `insufficient escrow balance:` - check the escrow ATA balance vs.
+     the row's amount. A permanent delegate may have drained the ATA. If
+     the deficit is permanent, refund out-of-band; do not re-arm.
+3. **If the condition has cleared, re-arm just this row:**
+   ```sql
+   UPDATE transactions
+      SET status = 'pending', updated_at = NOW()
+    WHERE id = :transaction_id;
+   ```
+4. **No operator restart is needed.** The processor did not halt; the
+   fetcher will pick up the re-armed row on its next tick.
+5. **If the condition is permanent**, mark `failed` and capture the
+   refund obligation in the incident record:
+   ```sql
+   UPDATE transactions SET status = 'failed', updated_at = NOW()
+    WHERE id = :transaction_id;
+   ```
+
+### Conservative classification - trigger is safe to re-arm
+
+Cross-cuts both A.halting and A.non-halting.
+
+If `error_message` describes a transient condition (RPC error, DB error
+surfaced as an `OperatorError::Program`), the classifier in
+`indexer/src/operator/processor.rs::classify_processor_error` quarantined
+on the side of caution rather than retrying. This is the intended
+behavior: misclassifying a deterministic error as transient could put
+the operator into a tight retry loop that consumes nonces against a
+broken row and corrupts the SMT. The asymmetric cost favors a noisy
+quarantine over a silent retry.
+
+What this means for recovery: the trigger row is safe to retry, not
+just the collateral. Re-arm the affected row(s) including the trigger;
+for the halting variant, re-arm via Step 4.
+[Escalate](_escalation.md) (Tier 3) so the taxonomy can be extended to
+classify this error variant explicitly. Do not patch in-place during
+incident response.
+
+## Path B - stranded after remint failure
+
+The original withdrawal failed AND the remint also failed. Both the on-chain
+release and the channel-side remint may have left partial state.
+`error_message` looks like: `<original_error> | remint failed: <remint_error>`.
+
+1. **Verify on-chain release.** Run
+   [`_verify_onchain_release.md`](_verify_onchain_release.md).
+   - If `LANDED <sig>` → user already received funds on Solana. The remint
+     would have been a duplicate; its failure was the right outcome. Mark
+     completed:
+     ```sql
+     UPDATE transactions
+        SET status = 'completed',
+            counterpart_signature = :sig,
+            updated_at = NOW()
+      WHERE id = :transaction_id;
+     ```
+     Done. No further action.
+   - If `NOT_LANDED` → continue.
+   - If `AMBIGUOUS` → [escalate](_escalation.md) (Tier 2).
+2. **Verify the remint signature on the channel side.** The remint targets
+   the Contra side, not Solana mainnet. Check the contra read node for the
+   user's ATA balance before/after `processed_at`. If the balance moved, the
+   remint actually succeeded and the failure was a confirmation glitch - mark
+   `failed_reminted` and capture the remint signature manually.
+3. **If both confirmed not-landed,** the user's funds are stuck:
+   - Their Contra-side tokens were burned for the withdrawal.
+   - Solana-side release did not happen.
+   - Remint to restore burned tokens did not happen.
+   - **[Escalate](_escalation.md) (Tier 1).** Out-of-band restoration
+     (manual mint or manual release) is the only path. Do not flip the
+     row's status until restoration is reconciled - the alert state
+     preserves the trail.
+
+## Path C - ambiguous on-chain state
+
+The withdrawal *may* have landed; the operator could not verify before
+committing the row to manual review. Three sub-triggers; same recovery.
+
+1. **Verify on-chain.** Run
+   [`_verify_onchain_release.md`](_verify_onchain_release.md). This is
+   the entire decision.
+2. **If `LANDED <sig>`:** withdrawal succeeded; do NOT remint. Mark completed
+   with the observed signature:
+   ```sql
+   UPDATE transactions
+      SET status = 'completed',
+          counterpart_signature = :sig,
+          updated_at = NOW()
+    WHERE id = :transaction_id;
+   ```
+3. **If `NOT_LANDED`:** withdrawal did not happen. The user's Contra tokens
+   may or may not be burned (depends on the trigger sub-site). Confirm burn
+   state via channel read node before deciding:
+   - Burned, no release → re-arm to `pending` and restart operator. The
+     withdrawal will be re-attempted; the channel-side burn is idempotent.
+   - Not burned → no user impact; close the alert and re-arm.
+4. **If `AMBIGUOUS`:** stop. [Escalate](_escalation.md) (Tier 2). Wait
+   for RPC visibility to recover. Do not act.
+
+## Post-incident artifacts (required)
+
+Capture in the incident record:
+- Transaction id, withdrawal nonce, `processed_at`.
+- Full `error_message` content.
+- Trigger site (which row of the dispatch table).
+- On-chain verdict (`LANDED <sig>` / `NOT_LANDED` / `AMBIGUOUS`).
+- Recovery action taken (SQL run, sig used, escalation path).
+- RPC endpoint used for verification.
+
+These feeds the audit trail for any user-facing reconciliation.
+

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -1,0 +1,933 @@
+//! Manually-triggered drills that verify the operations runbooks under
+//! `docs/runbooks/`. Every drill is `#[ignore]`-flagged so default
+//! `cargo test` skips them; trigger explicitly:
+//!
+//!     cargo test --test runbook_drills -- --ignored --nocapture
+//!     cargo test --test runbook_drills -- --ignored drill_path_a -- --nocapture
+//!
+//! Drills are NOT in CI. They exist so a human running through a runbook can
+//! verify the diagnostic and recovery commands in it actually work against
+//! a real Postgres schema. Each drill prints, in order:
+//!
+//! 1. Which runbook + section it verifies.
+//! 2. The seeded condition.
+//! 3. The diagnostic SQL output.
+//! 4. The post-recovery state.
+//!
+//! Use `RUST_LOG=trace cargo test --test runbook_drills -- --ignored` to see
+//! tracing output if a drill needs debugging.
+
+use chrono::Utc;
+use contra_indexer::{
+    storage::{PostgresDb, Storage},
+    PostgresConfig,
+};
+use solana_sdk::{pubkey::Pubkey, signature::Signature};
+use sqlx::{PgPool, Row};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+/// Spin up a fresh Postgres container with the indexer schema applied.
+/// The container handle must be kept alive for the duration of the drill.
+async fn start_postgres(
+) -> Result<(PgPool, Storage, testcontainers::ContainerAsync<Postgres>), Box<dyn std::error::Error>>
+{
+    let container = Postgres::default()
+        .with_db_name("runbook_drills")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await?;
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let url = format!("postgres://postgres:password@{host}:{port}/runbook_drills");
+    let pool = PgPool::connect(&url).await?;
+    let storage = Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: url,
+            max_connections: 5,
+        })
+        .await?,
+    );
+    storage.init_schema().await?;
+    Ok((pool, storage, container))
+}
+
+/// Insert a withdrawal row directly into the desired state. Bypasses the
+/// operator code path — drills verify the runbook against the post-trigger
+/// DB shape, so seeding the shape directly is correct.
+///
+/// Returns the generated row id. The trigger auto-assigns
+/// `withdrawal_nonce` if not provided, but here we want explicit control.
+async fn seed_withdrawal(
+    pool: &PgPool,
+    status: &str,
+    nonce: i64,
+    error_message: Option<&str>,
+) -> Result<i64, sqlx::Error> {
+    let row = sqlx::query(
+        r#"
+        INSERT INTO transactions
+            (signature, slot, initiator, recipient, mint, amount,
+             transaction_type, status, withdrawal_nonce,
+             trace_id, processed_at, created_at, updated_at)
+        VALUES
+            ($1, 100, $2, $3, $4, 1000,
+             'withdrawal'::transaction_type,
+             $5::transaction_status, $6,
+             $7, $8, NOW(), NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(Signature::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(status)
+    .bind(nonce)
+    .bind(uuid::Uuid::new_v4().to_string())
+    .bind(error_message.map(|_| Utc::now()))
+    .fetch_one(pool)
+    .await?
+    .get::<i64, _>(0);
+
+    // error_message is not a column — runbook surfaces it via the alert
+    // payload (TransactionStatusUpdate). For drill purposes we attach it via
+    // a side table so the dispatch SQL can read it. Schema doesn't actually
+    // store error_message; drills that need it stage it separately.
+    if let Some(_msg) = error_message {
+        // No column to write to. The runbook reads error_message from the
+        // webhook payload, not from the DB. Drills that exercise dispatch
+        // pass the message in-process (see drill bodies).
+    }
+    Ok(row)
+}
+
+/// Insert a deposit row directly. Deposits have no `withdrawal_nonce` (the
+/// schema's auto-assign trigger only fires on withdrawals).
+async fn seed_deposit(
+    pool: &PgPool,
+    status: &str,
+) -> Result<i64, sqlx::Error> {
+    let row = sqlx::query(
+        r#"
+        INSERT INTO transactions
+            (signature, slot, initiator, recipient, mint, amount,
+             transaction_type, status, trace_id, processed_at,
+             created_at, updated_at)
+        VALUES
+            ($1, 100, $2, $3, $4, 1000,
+             'deposit'::transaction_type,
+             $5::transaction_status, $6, NOW(), NOW(), NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(Signature::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(status)
+    .bind(uuid::Uuid::new_v4().to_string())
+    .fetch_one(pool)
+    .await?
+    .get::<i64, _>(0);
+    Ok(row)
+}
+
+/// Convenience: read the status of a row.
+async fn status_of(pool: &PgPool, id: i64) -> Result<String, sqlx::Error> {
+    let s: String = sqlx::query_scalar("SELECT status::text FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await?;
+    Ok(s)
+}
+
+/// Convenience: count rows by status.
+async fn count_status(pool: &PgPool, status: &str) -> Result<i64, sqlx::Error> {
+    let n: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE status::text = $1")
+            .bind(status)
+            .fetch_one(pool)
+            .await?;
+    Ok(n)
+}
+
+/// Print a banner so `--nocapture` output makes it obvious which runbook
+/// section a given drill is verifying.
+fn drill_header(runbook: &str, section: &str) {
+    eprintln!("\n──────────────────────────────────────────────");
+    eprintln!("DRILL: docs/runbooks/{runbook}");
+    eprintln!("       § {section}");
+    eprintln!("──────────────────────────────────────────────");
+}
+
+// ── Drill 1: dispatch table — error_message contracts ───────────────────────
+//
+// The dispatch table in withdrawal_manual_review.md keys recovery on
+// substrings of `error_message`. Those substrings live in the operator
+// source. If a contributor changes a string without updating the runbook,
+// dispatch silently breaks.
+//
+// This drill greps the source for each contract substring and fails if any
+// one is missing. It does not need Postgres.
+
+#[test]
+#[ignore]
+fn drill_1_error_message_contracts_present_in_source() {
+    drill_header(
+        "withdrawal_manual_review.md",
+        "Triage — dispatch by error_message",
+    );
+
+    // Each entry: (substring the runbook dispatches on, file expected to contain it).
+    // Substrings are matched literally, including the unicode em-dash where
+    // the source uses it.
+    let contracts: &[(&str, &str)] = &[
+        // Withdrawal — processor side.
+        ("invalid_pubkey", "indexer/src/operator/processor.rs"),
+        ("invalid_builder", "indexer/src/operator/processor.rs"),
+        ("program_error", "indexer/src/operator/processor.rs"),
+        ("mint paused:", "indexer/src/operator/processor.rs"),
+        (
+            "insufficient escrow balance:",
+            "indexer/src/operator/processor.rs",
+        ),
+        (
+            "withdrawal pipeline halted after poison-pill",
+            "indexer/src/operator/processor.rs",
+        ),
+        // Withdrawal — sender side.
+        (
+            "remint failed:",
+            "indexer/src/operator/sender/remint.rs",
+        ),
+        (
+            "finality check failed after",
+            "indexer/src/operator/sender/remint.rs",
+        ),
+        (
+            "failed to persist pending remint:",
+            "indexer/src/operator/sender/transaction.rs",
+        ),
+        (
+            "no signatures to verify — remint unsafe",
+            "indexer/src/operator/sender/transaction.rs",
+        ),
+        // Deposit — sender side. The processor-side strings (invalid_pubkey,
+        // invalid_builder, program_error) are shared with withdrawals via
+        // `classify_processor_error` and already covered above.
+        (
+            "Failed idempotency lookup for transaction_id",
+            "indexer/src/operator/sender/mint.rs",
+        ),
+        (
+            "Mint initialization failed",
+            "indexer/src/operator/sender/transaction.rs",
+        ),
+        (
+            "Unexpected mint error",
+            "indexer/src/operator/sender/transaction.rs",
+        ),
+        (
+            "Confirmation failed - transaction status unknown, unsafe to retry",
+            "indexer/src/operator/sender/transaction.rs",
+        ),
+        // Deposit — idempotency memo prefix. Anchors `_verify_onchain_mint.md`
+        // step 3.
+        (
+            "contra:mint-idempotency:",
+            "indexer/src/operator/constants.rs",
+        ),
+    ];
+
+    // The integration test runs from the indexer crate root.
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+
+    let mut missing: Vec<String> = Vec::new();
+    for (substr, path) in contracts {
+        let full = workspace_root.join(path);
+        let content = std::fs::read_to_string(&full)
+            .unwrap_or_else(|e| panic!("read {full:?}: {e}"));
+        if content.contains(substr) {
+            eprintln!("OK   {path}: {substr:?}");
+        } else {
+            eprintln!("MISS {path}: {substr:?}");
+            missing.push(format!("{path}: {substr:?}"));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "runbook dispatch table contracts missing in source: {missing:#?}"
+    );
+}
+
+// ── Drill 2: Path A — data error, re-arm collateral, mark trigger Failed ────
+//
+// Verifies that `withdrawal_manual_review.md § Path A` recovery SQL works:
+//   1. Triage query returns rows in the right order (poison row first).
+//   2. Mark-failed SQL terminates the trigger row.
+//   3. Re-arm SQL flips collateral rows back to `pending`, leaves the
+//      trigger row alone.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_2_path_a_data_error_recovery() -> Result<(), Box<dyn std::error::Error>> {
+    drill_header("withdrawal_manual_review.md", "Path A — data error");
+
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    // Seed 1 poison row + 4 collateral sweep rows, all in `manual_review`.
+    // Poison has the older `updated_at` so it sorts first in the triage
+    // query; collateral rows have NULL error_message (the runbook treats
+    // empty error_message as the marker for collateral).
+    let poison_id = seed_withdrawal(&pool, "manual_review", 1, Some("invalid_pubkey")).await?;
+
+    // Force the poison row's updated_at to be older so it sorts first.
+    sqlx::query("UPDATE transactions SET updated_at = NOW() - INTERVAL '1 minute' WHERE id = $1")
+        .bind(poison_id)
+        .execute(&pool)
+        .await?;
+
+    let mut collateral_ids = Vec::new();
+    for n in 2..=5 {
+        let id = seed_withdrawal(&pool, "manual_review", n, None).await?;
+        collateral_ids.push(id);
+    }
+
+    // ── Triage query (verbatim from runbook) ────────────────────────────
+    let rows = sqlx::query(
+        r#"
+        SELECT id, withdrawal_nonce, updated_at
+          FROM transactions
+         WHERE transaction_type = 'withdrawal'
+           AND status = 'manual_review'
+         ORDER BY updated_at ASC
+         LIMIT 20
+        "#,
+    )
+    .fetch_all(&pool)
+    .await?;
+    eprintln!("triage returned {} rows", rows.len());
+    let first_id: i64 = rows[0].get("id");
+    assert_eq!(
+        first_id, poison_id,
+        "triage must return poison row first (oldest updated_at)"
+    );
+    assert_eq!(rows.len(), 5, "all 5 manual_review rows visible");
+
+    // ── Mark trigger as failed (verbatim from runbook step 3) ──────────
+    sqlx::query("UPDATE transactions SET status = 'failed', updated_at = NOW() WHERE id = $1")
+        .bind(poison_id)
+        .execute(&pool)
+        .await?;
+    assert_eq!(status_of(&pool, poison_id).await?, "failed");
+
+    // ── Re-arm collateral (verbatim from runbook step 4) ───────────────
+    // Note: drill seeds collateral with error_message = NULL, so the runbook's
+    // `error_message IS NULL` filter applies cleanly. (The DB schema has no
+    // error_message column today; the runbook semantics rely on the alert
+    // payload, but the recovery SQL itself is column-free for the dispatch.)
+    let updated = sqlx::query(
+        r#"
+        UPDATE transactions
+           SET status = 'pending', updated_at = NOW()
+         WHERE transaction_type = 'withdrawal'
+           AND status = 'manual_review'
+           AND id <> $1
+        "#,
+    )
+    .bind(poison_id)
+    .execute(&pool)
+    .await?;
+    assert_eq!(
+        updated.rows_affected(),
+        4,
+        "exactly 4 collateral rows re-armed"
+    );
+
+    // ── Post-state assertions ──────────────────────────────────────────
+    assert_eq!(count_status(&pool, "manual_review").await?, 0);
+    assert_eq!(count_status(&pool, "failed").await?, 1);
+    assert_eq!(count_status(&pool, "pending").await?, 4);
+    for id in collateral_ids {
+        assert_eq!(status_of(&pool, id).await?, "pending");
+    }
+
+    eprintln!("Path A recovery SQL verified end-to-end.");
+    Ok(())
+}
+
+// ── Drill 3: Path B — stranded, on-chain LANDED → mark Completed ────────────
+//
+// Verifies the most dangerous Path B branch: when on-chain verification
+// reveals the original release actually landed, the runbook says to mark
+// the row Completed with the observed signature. This is the path that
+// prevents double-credit when remint failure obscures a successful release.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_3_path_b_landed_marks_completed_with_signature(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "withdrawal_manual_review.md",
+        "Path B — stranded; on-chain LANDED branch",
+    );
+
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    // Seed: row in manual_review (post-remint-failure), nonce 7. The
+    // webhook payload for this row would carry
+    // error_message="<orig> | remint failed: <err>".
+    let id = seed_withdrawal(&pool, "manual_review", 7, Some("remint failed: timeout")).await?;
+
+    // Drill simulates the operator running `_verify_onchain_release.md`
+    // and getting verdict `LANDED <observed_sig>`.
+    let observed_sig = Signature::new_unique().to_string();
+    eprintln!("simulated on-chain verification: LANDED {observed_sig}");
+
+    // ── Recovery (verbatim from runbook Path B step 1, LANDED branch) ──
+    let updated = sqlx::query(
+        r#"
+        UPDATE transactions
+           SET status = 'completed',
+               counterpart_signature = $2,
+               updated_at = NOW()
+         WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .bind(&observed_sig)
+    .execute(&pool)
+    .await?;
+    assert_eq!(updated.rows_affected(), 1);
+
+    // ── Post-state ────────────────────────────────────────────────────
+    let row = sqlx::query(
+        "SELECT status::text AS status, counterpart_signature FROM transactions WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await?;
+    let status: String = row.get("status");
+    let cs: Option<String> = row.get("counterpart_signature");
+    assert_eq!(status, "completed");
+    assert_eq!(cs.as_deref(), Some(observed_sig.as_str()));
+
+    // The unique index on counterpart_signature WHERE NOT NULL must accept this.
+    eprintln!("Path B LANDED-branch recovery verified — row marked completed with observed sig.");
+    Ok(())
+}
+
+// ── Drill 4: Path C — ambiguous, NOT_LANDED → re-arm to pending ─────────────
+//
+// Verifies that re-arming a `manual_review` withdrawal back to `pending`
+// preserves `withdrawal_nonce` — the on-chain SMT leaf is keyed on this,
+// and a re-attempt must hit the same leaf. Also verifies the schema's
+// unique-nonce-per-withdrawal constraint does not block re-arming (the
+// row keeps the same nonce; no new row is inserted).
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_4_path_c_not_landed_re_arms_with_same_nonce(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "withdrawal_manual_review.md",
+        "Path C — ambiguous; NOT_LANDED branch (re-arm)",
+    );
+
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    // Seed: row in manual_review with a specific nonce. Webhook
+    // error_message would be e.g. "no signatures to verify — remint unsafe".
+    let original_nonce: i64 = 42;
+    let id = seed_withdrawal(
+        &pool,
+        "manual_review",
+        original_nonce,
+        Some("no signatures to verify — remint unsafe"),
+    )
+    .await?;
+
+    // Simulated verdict: NOT_LANDED (on-chain confirmed nothing happened).
+    eprintln!("simulated on-chain verification: NOT_LANDED");
+
+    // ── Recovery (Path C, NOT_LANDED branch — re-arm to pending) ──────
+    let updated = sqlx::query(
+        "UPDATE transactions SET status = 'pending', updated_at = NOW() WHERE id = $1",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await?;
+    assert_eq!(updated.rows_affected(), 1);
+
+    // ── Post-state: status flipped, nonce preserved ───────────────────
+    let row = sqlx::query("SELECT status::text AS s, withdrawal_nonce FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(&pool)
+        .await?;
+    let status: String = row.get("s");
+    let nonce: Option<i64> = row.get("withdrawal_nonce");
+    assert_eq!(status, "pending");
+    assert_eq!(
+        nonce,
+        Some(original_nonce),
+        "nonce must be preserved across re-arm — SMT leaf identity"
+    );
+
+    // ── Verify the nonce uniqueness constraint still holds ────────────
+    // If we tried to insert a second withdrawal with the same nonce, the
+    // unique partial index `idx_transactions_withdrawal_nonce_unique`
+    // should reject it. The runbook implicitly relies on this — re-arming
+    // is safe because no other row can claim the same nonce.
+    let dup = sqlx::query(
+        r#"
+        INSERT INTO transactions
+            (signature, slot, initiator, recipient, mint, amount,
+             transaction_type, status, withdrawal_nonce,
+             trace_id, created_at, updated_at)
+        VALUES
+            ($1, 100, $2, $3, $4, 1000,
+             'withdrawal'::transaction_type,
+             'pending'::transaction_status, $5,
+             $6, NOW(), NOW())
+        "#,
+    )
+    .bind(Signature::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(original_nonce)
+    .bind(uuid::Uuid::new_v4().to_string())
+    .execute(&pool)
+    .await;
+    assert!(
+        dup.is_err(),
+        "nonce uniqueness must reject a second withdrawal with the same nonce"
+    );
+
+    eprintln!("Path C NOT_LANDED re-arm verified; nonce identity preserved.");
+    Ok(())
+}
+
+// ── Drill 5: pipeline halt sweep ────────────────────────────────────────────
+//
+// Verifies the bulk sweep used in `withdrawal_manual_review.md § Path A.halting`:
+// the operator's `quarantine_all_active_withdrawals` flips every Pending
+// or Processing withdrawal to ManualReview, with one row excluded. Drives
+// it via the actual storage method (not raw SQL) so a future change to
+// the implementation is caught.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_5_halt_sweep_excludes_poison_only(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "withdrawal_manual_review.md",
+        "Path A.halting - quarantine_all_active_withdrawals semantics",
+    );
+
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    // Seed: 1 poison (already manual_review), 3 pending, 2 processing,
+    // plus a `completed` row that must NOT be touched (terminal).
+    let poison_id = seed_withdrawal(&pool, "manual_review", 1, Some("invalid_pubkey")).await?;
+    let mut pending_ids = Vec::new();
+    for n in 2..=4 {
+        pending_ids.push(seed_withdrawal(&pool, "pending", n, None).await?);
+    }
+    let mut processing_ids = Vec::new();
+    for n in 5..=6 {
+        processing_ids.push(seed_withdrawal(&pool, "processing", n, None).await?);
+    }
+    let completed_id = seed_withdrawal(&pool, "completed", 7, None).await?;
+
+    // Run the actual sweep used by the operator's halt path.
+    let affected = storage
+        .quarantine_all_active_withdrawals(Some(poison_id))
+        .await?;
+
+    // Should affect exactly the 5 pending+processing rows.
+    eprintln!("sweep affected {affected} rows");
+    assert_eq!(
+        affected, 5,
+        "sweep must touch exactly Pending+Processing rows other than the poison id"
+    );
+
+    // Poison stays as it was, completed untouched, the 5 actives now manual_review.
+    assert_eq!(status_of(&pool, poison_id).await?, "manual_review");
+    assert_eq!(status_of(&pool, completed_id).await?, "completed");
+    for id in pending_ids.iter().chain(processing_ids.iter()) {
+        assert_eq!(
+            status_of(&pool, *id).await?,
+            "manual_review",
+            "row {id} should have been swept"
+        );
+    }
+
+    // Final shape must match what the runbook tells the operator to expect:
+    // 6 rows in manual_review (poison + 5 swept), 1 completed.
+    assert_eq!(count_status(&pool, "manual_review").await?, 6);
+    assert_eq!(count_status(&pool, "pending").await?, 0);
+    assert_eq!(count_status(&pool, "processing").await?, 0);
+    assert_eq!(count_status(&pool, "completed").await?, 1);
+
+    eprintln!("Halt sweep semantics verified — exclude_id is honored, terminals untouched.");
+    Ok(())
+}
+
+// ── Drill 6: PendingRemint recovery — terminal statuses do not re-queue ────
+//
+// The glossary lists `pending_remint` as the only status reloaded by the
+// recovery query on operator restart. Path B and Path C recovery actions
+// flip rows to `completed` / `failed_reminted` / `manual_review` — those
+// must NOT re-enter the remint queue, otherwise a runbook recovery could
+// trigger a duplicate remint on the next operator restart.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_6_recovery_query_skips_terminal_statuses(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header("_glossary.md", "PendingRemint recovery contract");
+
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    let deadline = Utc::now() + chrono::Duration::seconds(32);
+    let sig = Signature::new_unique().to_string();
+
+    // Seed three rows that all *started* in pending_remint, then were
+    // resolved by recovery actions per the runbook.
+    let to_completed = seed_withdrawal(&pool, "processing", 100, None).await?;
+    storage
+        .set_pending_remint(to_completed, vec![sig.clone()], deadline)
+        .await?;
+    let to_failed_reminted = seed_withdrawal(&pool, "processing", 101, None).await?;
+    storage
+        .set_pending_remint(to_failed_reminted, vec![sig.clone()], deadline)
+        .await?;
+    let to_manual_review = seed_withdrawal(&pool, "processing", 102, None).await?;
+    storage
+        .set_pending_remint(to_manual_review, vec![sig.clone()], deadline)
+        .await?;
+    // Plus one that stays in pending_remint — the only one recovery should return.
+    let still_pending = seed_withdrawal(&pool, "processing", 103, None).await?;
+    storage
+        .set_pending_remint(still_pending, vec![sig.clone()], deadline)
+        .await?;
+
+    // Apply the recovery actions the runbook prescribes.
+    sqlx::query("UPDATE transactions SET status='completed', counterpart_signature=$2 WHERE id=$1")
+        .bind(to_completed)
+        .bind(&sig)
+        .execute(&pool)
+        .await?;
+    sqlx::query("UPDATE transactions SET status='failed_reminted' WHERE id=$1")
+        .bind(to_failed_reminted)
+        .execute(&pool)
+        .await?;
+    sqlx::query("UPDATE transactions SET status='manual_review' WHERE id=$1")
+        .bind(to_manual_review)
+        .execute(&pool)
+        .await?;
+
+    // Recovery query returns only the unresolved row.
+    let pending = storage.get_pending_remint_transactions().await?;
+    assert_eq!(
+        pending.len(),
+        1,
+        "exactly one PendingRemint row should re-enter the queue on restart"
+    );
+    assert_eq!(pending[0].id, still_pending);
+
+    eprintln!("Recovery query verified — no re-queue for completed/failed_reminted/manual_review.");
+    Ok(())
+}
+
+// ── Drill 7: terminal statuses are immune to halt sweep ─────────────────────
+//
+// The glossary marks `completed`, `failed`, `failed_reminted`, and
+// `manual_review` as terminal. The halt sweep must not touch any of them.
+// This drill confirms the WHERE clause `status IN ('pending', 'processing')`
+// is the actual gate — change it to `status NOT IN ('completed', ...)` and
+// the runbook's terminality claim breaks.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_7_halt_sweep_does_not_touch_terminals(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "_glossary.md",
+        "Terminal statuses (Completed / Failed / FailedReminted / ManualReview)",
+    );
+
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    // One row in each terminal status.
+    let completed = seed_withdrawal(&pool, "completed", 1, None).await?;
+    let failed = seed_withdrawal(&pool, "failed", 2, None).await?;
+    let failed_reminted = seed_withdrawal(&pool, "failed_reminted", 3, None).await?;
+    let manual_review = seed_withdrawal(&pool, "manual_review", 4, None).await?;
+    // Plus one active row so the sweep has *something* to do.
+    let active = seed_withdrawal(&pool, "pending", 5, None).await?;
+
+    let affected = storage.quarantine_all_active_withdrawals(None).await?;
+    assert_eq!(
+        affected, 1,
+        "sweep should only touch the one Pending row; terminals are immune"
+    );
+
+    assert_eq!(status_of(&pool, completed).await?, "completed");
+    assert_eq!(status_of(&pool, failed).await?, "failed");
+    assert_eq!(status_of(&pool, failed_reminted).await?, "failed_reminted");
+    assert_eq!(
+        status_of(&pool, manual_review).await?,
+        "manual_review",
+        "manual_review row should not double-flip"
+    );
+    assert_eq!(status_of(&pool, active).await?, "manual_review");
+
+    eprintln!("Terminal-status immunity to sweep verified.");
+    Ok(())
+}
+
+// ── Drill 8: webhook contract — alertable set matches README dispatch ───────
+//
+// The README dispatches alerts on three webhook statuses: `failed`,
+// `failed_reminted`, `manual_review`. The glossary makes the same claim.
+// Both depend on `db_transaction_writer.rs::is_alertable`. This drill
+// pins the contract by reading the source — drift in either direction
+// (adding an unalerted terminal, or alerting on a non-terminal) breaks
+// the runbook dispatch.
+
+#[test]
+#[ignore]
+fn drill_8_alertable_set_matches_runbook_dispatch() {
+    drill_header("README.md", "Alert dispatch table — alertable status set");
+
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+    let writer = workspace_root.join("indexer/src/operator/db_transaction_writer.rs");
+    let src = std::fs::read_to_string(&writer).expect("read db_transaction_writer.rs");
+
+    // Locate the `is_alertable` match block.
+    let start = src
+        .find("let is_alertable = matches!(")
+        .expect("is_alertable definition not found — runbook dispatch may be stale");
+    let end = src[start..]
+        .find(");")
+        .expect("malformed is_alertable block")
+        + start;
+    let block = &src[start..end];
+    eprintln!("is_alertable block:\n{block}");
+
+    // Each runbook-claimed alertable status must appear in the match block.
+    for variant in ["TransactionStatus::Failed", "TransactionStatus::FailedReminted", "TransactionStatus::ManualReview"] {
+        assert!(
+            block.contains(variant),
+            "runbook claims {variant} fires webhook but is_alertable does not list it"
+        );
+    }
+
+    // Conversely: any non-terminal that is_alertable lists would be a
+    // surprise to the runbook. Pin the count of variants in the match.
+    let variant_count = block.matches("TransactionStatus::").count();
+    assert_eq!(
+        variant_count, 3,
+        "is_alertable lists {variant_count} variants; runbook README + glossary expect exactly 3 \
+         (Failed, FailedReminted, ManualReview). Update both if this changes."
+    );
+
+    eprintln!("Webhook alertable-set contract verified against runbook dispatch.");
+}
+
+// ── Drill 9: Path B recovery — counterpart_signature uniqueness fence ──────
+//
+// The schema has a unique partial index on counterpart_signature where it is
+// not null (`idx_transactions_counterpart_signature`, `db.rs::init_schema`).
+// This is a safety fence: if an operator running Path B's "mark Completed
+// with the observed signature" recovery somehow misidentifies which row the
+// on-chain action belonged to, the UPDATE must fail rather than silently
+// attaching the same signature to two rows.
+//
+// Two sub-scenarios:
+//   (a) Idempotent re-run — a recovery executed twice with the same sig
+//       on the same row succeeds (no-op effect).
+//   (b) Cross-row collision — the sig is already attached to a *different*
+//       row; the UPDATE must be rejected.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_9_path_b_signature_uniqueness_fence(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "withdrawal_manual_review.md",
+        "Path B — counterpart_signature uniqueness fence (safety)",
+    );
+
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    // ── Sub-scenario (a): idempotent re-run ───────────────────────────
+    let id_a = seed_withdrawal(&pool, "manual_review", 100, Some("remint failed: x")).await?;
+    let sig = Signature::new_unique().to_string();
+
+    // First recovery: attach sig.
+    sqlx::query(
+        "UPDATE transactions SET status='completed', counterpart_signature=$2, updated_at=NOW()
+          WHERE id=$1",
+    )
+    .bind(id_a)
+    .bind(&sig)
+    .execute(&pool)
+    .await?;
+    assert_eq!(status_of(&pool, id_a).await?, "completed");
+
+    // Second recovery on the same row with the same sig: must succeed (idempotent).
+    let rerun = sqlx::query(
+        "UPDATE transactions SET status='completed', counterpart_signature=$2, updated_at=NOW()
+          WHERE id=$1",
+    )
+    .bind(id_a)
+    .bind(&sig)
+    .execute(&pool)
+    .await;
+    assert!(
+        rerun.is_ok(),
+        "idempotent re-run of Path B recovery must succeed; got {rerun:?}"
+    );
+    eprintln!("(a) idempotent Path B re-run: ok");
+
+    // ── Sub-scenario (b): cross-row collision ─────────────────────────
+    // Seed a second row in manual_review (a different incident).
+    let id_b = seed_withdrawal(&pool, "manual_review", 101, Some("remint failed: y")).await?;
+
+    // Operator runs Path B on row B but supplies the SAME signature already
+    // attached to row A. This would silently double-credit if not rejected;
+    // the schema must reject it.
+    let bad = sqlx::query(
+        "UPDATE transactions SET status='completed', counterpart_signature=$2, updated_at=NOW()
+          WHERE id=$1",
+    )
+    .bind(id_b)
+    .bind(&sig)
+    .execute(&pool)
+    .await;
+    assert!(
+        bad.is_err(),
+        "cross-row counterpart_signature collision must be rejected by unique index"
+    );
+    eprintln!(
+        "(b) cross-row Path B with conflicting sig rejected: {}",
+        bad.err().unwrap()
+    );
+
+    // Row B must still be in manual_review (UPDATE rolled back).
+    assert_eq!(status_of(&pool, id_b).await?, "manual_review");
+
+    eprintln!("Path B signature uniqueness fence verified.");
+    Ok(())
+}
+
+// ── Drill 10: deposit_failed.md recovery flows ──────────────────────────────
+//
+// Walks both LANDED and NOT_LANDED branches of `deposit_failed.md § Step 2`.
+// Deposits use the same SQL shape as withdrawals (mark Completed with sig /
+// re-arm to Pending) but no nonce identity to preserve.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_10_deposit_failed_recovery_flows() -> Result<(), Box<dyn std::error::Error>> {
+    drill_header("deposit_failed.md", "Step 2 — branch on verdict (LANDED / NOT_LANDED)");
+
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    // ── LANDED branch ──────────────────────────────────────────────────
+    let landed_id = seed_deposit(&pool, "failed").await?;
+    let observed_sig = Signature::new_unique().to_string();
+    eprintln!("LANDED branch: simulated verdict {observed_sig}");
+
+    sqlx::query(
+        "UPDATE transactions SET status='completed', counterpart_signature=$2, updated_at=NOW()
+          WHERE id=$1",
+    )
+    .bind(landed_id)
+    .bind(&observed_sig)
+    .execute(&pool)
+    .await?;
+    assert_eq!(status_of(&pool, landed_id).await?, "completed");
+    let cs: Option<String> = sqlx::query_scalar(
+        "SELECT counterpart_signature FROM transactions WHERE id=$1",
+    )
+    .bind(landed_id)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(cs.as_deref(), Some(observed_sig.as_str()));
+
+    // ── NOT_LANDED branch — re-arm to pending ─────────────────────────
+    let not_landed_id = seed_deposit(&pool, "failed").await?;
+    eprintln!("NOT_LANDED branch: re-arming");
+    sqlx::query("UPDATE transactions SET status='pending', updated_at=NOW() WHERE id=$1")
+        .bind(not_landed_id)
+        .execute(&pool)
+        .await?;
+    assert_eq!(status_of(&pool, not_landed_id).await?, "pending");
+
+    // Deposits have no nonce, so no nonce-uniqueness contract to verify here
+    // (unlike withdrawals — see drill_4). Two pending deposits coexist freely.
+    let _other = seed_deposit(&pool, "pending").await?;
+
+    // ── deposit_manual_review.md — Path A (mark failed) ───────────────
+    let mr_id = seed_deposit(&pool, "manual_review").await?;
+    sqlx::query("UPDATE transactions SET status='failed', updated_at=NOW() WHERE id=$1")
+        .bind(mr_id)
+        .execute(&pool)
+        .await?;
+    assert_eq!(status_of(&pool, mr_id).await?, "failed");
+
+    eprintln!("Deposit recovery flows verified end-to-end.");
+    Ok(())
+}
+
+// ── Drill 11: program_type label contract ───────────────────────────────────
+//
+// The README + glossary tell operators to filter metrics by
+// `program_type="withdraw"` for withdrawals and `program_type="escrow"` for
+// deposits (not "deposit" — easy to get wrong). Pin the source.
+
+#[test]
+#[ignore]
+fn drill_11_program_type_labels_match_runbooks() {
+    drill_header("_glossary.md", "Metrics — program_type label values");
+
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+    let cfg = workspace_root.join("indexer/src/config.rs");
+    let src = std::fs::read_to_string(&cfg).expect("read config.rs");
+
+    // Locate `as_label` and confirm the two arms emit the expected strings.
+    let start = src.find("fn as_label(").expect("as_label not found");
+    let end = src[start..].find('}').map(|i| start + i + 1).expect("malformed");
+    let block = &src[start..end];
+    eprintln!("as_label block:\n{block}");
+
+    assert!(
+        block.contains("ProgramType::Escrow => \"escrow\""),
+        "deposit operator's program_type label must be \"escrow\" \
+         (runbooks reference it explicitly; \"deposit\" would silently miss)"
+    );
+    assert!(
+        block.contains("ProgramType::Withdraw => \"withdraw\""),
+        "withdrawal operator's program_type label must be \"withdraw\""
+    );
+
+    eprintln!("program_type label contract verified.");
+}

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -3,7 +3,7 @@
 //! `cargo test` skips them; trigger explicitly:
 //!
 //!     cargo test --test runbook_drills -- --ignored --nocapture
-//!     cargo test --test runbook_drills -- --ignored drill_path_a -- --nocapture
+//!     cargo test --test runbook_drills -- --ignored --nocapture drill_2
 //!
 //! Drills are NOT in CI. They exist so a human running through a runbook can
 //! verify the diagnostic and recovery commands in it actually work against
@@ -56,16 +56,18 @@ async fn start_postgres(
 }
 
 /// Insert a withdrawal row directly into the desired state. Bypasses the
-/// operator code path — drills verify the runbook against the post-trigger
+/// operator code path: drills verify the runbook against the post-trigger
 /// DB shape, so seeding the shape directly is correct.
 ///
-/// Returns the generated row id. The trigger auto-assigns
-/// `withdrawal_nonce` if not provided, but here we want explicit control.
+/// `error_message` is descriptive only. The `transactions` table has no
+/// such column - the operator surfaces it on the alert webhook payload,
+/// not in DB state. The argument exists so caller-side test code reads
+/// like the runbook's dispatch table.
 async fn seed_withdrawal(
     pool: &PgPool,
     status: &str,
     nonce: i64,
-    error_message: Option<&str>,
+    _error_message: Option<&str>,
 ) -> Result<i64, sqlx::Error> {
     let row = sqlx::query(
         r#"
@@ -88,29 +90,16 @@ async fn seed_withdrawal(
     .bind(status)
     .bind(nonce)
     .bind(uuid::Uuid::new_v4().to_string())
-    .bind(error_message.map(|_| Utc::now()))
+    .bind(Utc::now())
     .fetch_one(pool)
     .await?
     .get::<i64, _>(0);
-
-    // error_message is not a column — runbook surfaces it via the alert
-    // payload (TransactionStatusUpdate). For drill purposes we attach it via
-    // a side table so the dispatch SQL can read it. Schema doesn't actually
-    // store error_message; drills that need it stage it separately.
-    if let Some(_msg) = error_message {
-        // No column to write to. The runbook reads error_message from the
-        // webhook payload, not from the DB. Drills that exercise dispatch
-        // pass the message in-process (see drill bodies).
-    }
     Ok(row)
 }
 
 /// Insert a deposit row directly. Deposits have no `withdrawal_nonce` (the
 /// schema's auto-assign trigger only fires on withdrawals).
-async fn seed_deposit(
-    pool: &PgPool,
-    status: &str,
-) -> Result<i64, sqlx::Error> {
+async fn seed_deposit(pool: &PgPool, status: &str) -> Result<i64, sqlx::Error> {
     let row = sqlx::query(
         r#"
         INSERT INTO transactions
@@ -147,11 +136,10 @@ async fn status_of(pool: &PgPool, id: i64) -> Result<String, sqlx::Error> {
 
 /// Convenience: count rows by status.
 async fn count_status(pool: &PgPool, status: &str) -> Result<i64, sqlx::Error> {
-    let n: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE status::text = $1")
-            .bind(status)
-            .fetch_one(pool)
-            .await?;
+    let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE status::text = $1")
+        .bind(status)
+        .fetch_one(pool)
+        .await?;
     Ok(n)
 }
 
@@ -200,10 +188,7 @@ fn drill_1_error_message_contracts_present_in_source() {
             "indexer/src/operator/processor.rs",
         ),
         // Withdrawal — sender side.
-        (
-            "remint failed:",
-            "indexer/src/operator/sender/remint.rs",
-        ),
+        ("remint failed:", "indexer/src/operator/sender/remint.rs"),
         (
             "finality check failed after",
             "indexer/src/operator/sender/remint.rs",
@@ -252,8 +237,8 @@ fn drill_1_error_message_contracts_present_in_source() {
     let mut missing: Vec<String> = Vec::new();
     for (substr, path) in contracts {
         let full = workspace_root.join(path);
-        let content = std::fs::read_to_string(&full)
-            .unwrap_or_else(|e| panic!("read {full:?}: {e}"));
+        let content =
+            std::fs::read_to_string(&full).unwrap_or_else(|e| panic!("read {full:?}: {e}"));
         if content.contains(substr) {
             eprintln!("OK   {path}: {substr:?}");
         } else {
@@ -459,19 +444,19 @@ async fn drill_4_path_c_not_landed_re_arms_with_same_nonce(
     eprintln!("simulated on-chain verification: NOT_LANDED");
 
     // ── Recovery (Path C, NOT_LANDED branch — re-arm to pending) ──────
-    let updated = sqlx::query(
-        "UPDATE transactions SET status = 'pending', updated_at = NOW() WHERE id = $1",
-    )
-    .bind(id)
-    .execute(&pool)
-    .await?;
+    let updated =
+        sqlx::query("UPDATE transactions SET status = 'pending', updated_at = NOW() WHERE id = $1")
+            .bind(id)
+            .execute(&pool)
+            .await?;
     assert_eq!(updated.rows_affected(), 1);
 
     // ── Post-state: status flipped, nonce preserved ───────────────────
-    let row = sqlx::query("SELECT status::text AS s, withdrawal_nonce FROM transactions WHERE id = $1")
-        .bind(id)
-        .fetch_one(&pool)
-        .await?;
+    let row =
+        sqlx::query("SELECT status::text AS s, withdrawal_nonce FROM transactions WHERE id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await?;
     let status: String = row.get("s");
     let nonce: Option<i64> = row.get("withdrawal_nonce");
     assert_eq!(status, "pending");
@@ -526,8 +511,7 @@ async fn drill_4_path_c_not_landed_re_arms_with_same_nonce(
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
-async fn drill_5_halt_sweep_excludes_poison_only(
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn drill_5_halt_sweep_excludes_poison_only() -> Result<(), Box<dyn std::error::Error>> {
     drill_header(
         "withdrawal_manual_review.md",
         "Path A.halting - quarantine_all_active_withdrawals semantics",
@@ -592,8 +576,8 @@ async fn drill_5_halt_sweep_excludes_poison_only(
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
-async fn drill_6_recovery_query_skips_terminal_statuses(
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn drill_6_recovery_query_skips_terminal_statuses() -> Result<(), Box<dyn std::error::Error>>
+{
     drill_header("_glossary.md", "PendingRemint recovery contract");
 
     let (pool, storage, _pg) = start_postgres().await?;
@@ -659,8 +643,7 @@ async fn drill_6_recovery_query_skips_terminal_statuses(
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
-async fn drill_7_halt_sweep_does_not_touch_terminals(
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn drill_7_halt_sweep_does_not_touch_terminals() -> Result<(), Box<dyn std::error::Error>> {
     drill_header(
         "_glossary.md",
         "Terminal statuses (Completed / Failed / FailedReminted / ManualReview)",
@@ -729,7 +712,11 @@ fn drill_8_alertable_set_matches_runbook_dispatch() {
     eprintln!("is_alertable block:\n{block}");
 
     // Each runbook-claimed alertable status must appear in the match block.
-    for variant in ["TransactionStatus::Failed", "TransactionStatus::FailedReminted", "TransactionStatus::ManualReview"] {
+    for variant in [
+        "TransactionStatus::Failed",
+        "TransactionStatus::FailedReminted",
+        "TransactionStatus::ManualReview",
+    ] {
         assert!(
             block.contains(variant),
             "runbook claims {variant} fires webhook but is_alertable does not list it"
@@ -765,8 +752,7 @@ fn drill_8_alertable_set_matches_runbook_dispatch() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
-async fn drill_9_path_b_signature_uniqueness_fence(
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn drill_9_path_b_signature_uniqueness_fence() -> Result<(), Box<dyn std::error::Error>> {
     drill_header(
         "withdrawal_manual_review.md",
         "Path B — counterpart_signature uniqueness fence (safety)",
@@ -844,7 +830,10 @@ async fn drill_9_path_b_signature_uniqueness_fence(
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn drill_10_deposit_failed_recovery_flows() -> Result<(), Box<dyn std::error::Error>> {
-    drill_header("deposit_failed.md", "Step 2 — branch on verdict (LANDED / NOT_LANDED)");
+    drill_header(
+        "deposit_failed.md",
+        "Step 2 — branch on verdict (LANDED / NOT_LANDED)",
+    );
 
     let (pool, _storage, _pg) = start_postgres().await?;
 
@@ -862,12 +851,11 @@ async fn drill_10_deposit_failed_recovery_flows() -> Result<(), Box<dyn std::err
     .execute(&pool)
     .await?;
     assert_eq!(status_of(&pool, landed_id).await?, "completed");
-    let cs: Option<String> = sqlx::query_scalar(
-        "SELECT counterpart_signature FROM transactions WHERE id=$1",
-    )
-    .bind(landed_id)
-    .fetch_one(&pool)
-    .await?;
+    let cs: Option<String> =
+        sqlx::query_scalar("SELECT counterpart_signature FROM transactions WHERE id=$1")
+            .bind(landed_id)
+            .fetch_one(&pool)
+            .await?;
     assert_eq!(cs.as_deref(), Some(observed_sig.as_str()));
 
     // ── NOT_LANDED branch — re-arm to pending ─────────────────────────
@@ -915,7 +903,10 @@ fn drill_11_program_type_labels_match_runbooks() {
 
     // Locate `as_label` and confirm the two arms emit the expected strings.
     let start = src.find("fn as_label(").expect("as_label not found");
-    let end = src[start..].find('}').map(|i| start + i + 1).expect("malformed");
+    let end = src[start..]
+        .find('}')
+        .map(|i| start + i + 1)
+        .expect("malformed");
     let block = &src[start..end];
     eprintln!("as_label block:\n{block}");
 

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -125,6 +125,49 @@ async fn seed_deposit(pool: &PgPool, status: &str) -> Result<i64, sqlx::Error> {
     Ok(row)
 }
 
+/// Seed a `failed_reminted` withdrawal row with the supplied remint
+/// signatures bound to the `remint_signatures TEXT[]` column. The runbook
+/// `withdrawal_failed_reminted.md` Step 1 hard-requires this column to be
+/// non-empty for the reconciliation flow to mean anything; the upstream
+/// production path enforces that via `set_pending_remint(…)` running
+/// before the `FailedReminted` status transition (see
+/// `sender/remint.rs::attempt_remint`). Drills bypass that path and seed
+/// directly, so they need a helper that mirrors the post-transition
+/// shape.
+async fn seed_failed_reminted(
+    pool: &PgPool,
+    nonce: i64,
+    remint_sigs: &[&str],
+) -> Result<i64, sqlx::Error> {
+    let sigs: Vec<String> = remint_sigs.iter().map(|s| s.to_string()).collect();
+    let row = sqlx::query(
+        r#"
+        INSERT INTO transactions
+            (signature, slot, initiator, recipient, mint, amount,
+             transaction_type, status, withdrawal_nonce,
+             remint_signatures, trace_id, processed_at, created_at, updated_at)
+        VALUES
+            ($1, 100, $2, $3, $4, 1000,
+             'withdrawal'::transaction_type,
+             'failed_reminted'::transaction_status, $5,
+             $6, $7, $8, NOW(), NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(Signature::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(Pubkey::new_unique().to_string())
+    .bind(nonce)
+    .bind(&sigs)
+    .bind(uuid::Uuid::new_v4().to_string())
+    .bind(Utc::now())
+    .fetch_one(pool)
+    .await?
+    .get::<i64, _>(0);
+    Ok(row)
+}
+
 /// Convenience: read the status of a row.
 async fn status_of(pool: &PgPool, id: i64) -> Result<String, sqlx::Error> {
     let s: String = sqlx::query_scalar("SELECT status::text FROM transactions WHERE id = $1")
@@ -921,4 +964,367 @@ fn drill_11_program_type_labels_match_runbooks() {
     );
 
     eprintln!("program_type label contract verified.");
+}
+
+// ── Drill 12: withdrawal_failed.md recovery flows ───────────────────────────
+//
+// `withdrawal_failed.md` covers the rare case of a withdrawal row reaching
+// the terminal `failed` status (per `_glossary.md:14-22`, this normally
+// only happens for deposits, withdrawals go through `pending_remint`).
+// The runbook routes by the on-chain release verdict from
+// `_verify_onchain_release.md`. This drill walks each branch:
+//
+//   - LANDED  → mark Completed with the observed signature (code-defect
+//                path: the row should never have been `failed`).
+//   - NOT_LANDED → `failed` is terminal; the runbook says "Do not re-arm".
+//   - AMBIGUOUS  → no SQL; escalate Tier 2.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_12_withdrawal_failed_recovery_flows() -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "withdrawal_failed.md",
+        "Step 2 — branch on verdict (LANDED / NOT_LANDED / AMBIGUOUS)",
+    );
+
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    // ── (1) LANDED branch — mark Completed with observed sig ──────────────
+    // The runbook's recovery query at `withdrawal_failed.md:30-35`. Verifies
+    // the SQL still parses against the schema and produces the documented
+    // end-state on a `failed` starting state.
+    let nonce_a: i64 = 200;
+    let id_a = seed_withdrawal(
+        &pool,
+        "failed",
+        nonce_a,
+        Some("misrouted to send_fatal_error"),
+    )
+    .await?;
+    let observed_sig = Signature::new_unique().to_string();
+    eprintln!("(1) LANDED branch: simulated verdict {observed_sig}");
+
+    let updated = sqlx::query(
+        "UPDATE transactions SET status='completed', counterpart_signature=$2, updated_at=NOW()
+          WHERE id=$1",
+    )
+    .bind(id_a)
+    .bind(&observed_sig)
+    .execute(&pool)
+    .await?;
+    assert_eq!(updated.rows_affected(), 1);
+
+    let row = sqlx::query(
+        "SELECT status::text AS s, counterpart_signature, withdrawal_nonce
+           FROM transactions WHERE id=$1",
+    )
+    .bind(id_a)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(row.get::<String, _>("s"), "completed");
+    assert_eq!(
+        row.get::<Option<String>, _>("counterpart_signature")
+            .as_deref(),
+        Some(observed_sig.as_str())
+    );
+    assert_eq!(
+        row.get::<Option<i64>, _>("withdrawal_nonce"),
+        Some(nonce_a),
+        "nonce must be preserved — SMT leaf identity per _glossary.md:62-68"
+    );
+
+    // ── (2) Cross-row signature uniqueness fence ──────────────────────────
+    // Mirrors drill_9 sub-(b), starting state `failed` instead of
+    // `manual_review`. Pins that the same double-credit fence active on
+    // manual_review recovery also fires for `failed` recovery — a future
+    // schema change that scoped the unique partial index to specific
+    // statuses would fail this assertion.
+    let id_b = seed_withdrawal(&pool, "failed", 201, Some("second incident")).await?;
+    let bad = sqlx::query(
+        "UPDATE transactions SET status='completed', counterpart_signature=$2, updated_at=NOW()
+          WHERE id=$1",
+    )
+    .bind(id_b)
+    .bind(&observed_sig) // collision with row A
+    .execute(&pool)
+    .await;
+    assert!(
+        bad.is_err(),
+        "cross-row counterpart_signature collision must be rejected by unique index"
+    );
+    assert_eq!(
+        status_of(&pool, id_b).await?,
+        "failed",
+        "row B must remain `failed` after rejected UPDATE"
+    );
+    eprintln!("(2) cross-row sig fence active on `failed` recovery: ok");
+
+    // ── (3) NOT_LANDED branch — `failed` is terminal ──────────────────────
+    // The runbook says: "Do not re-arm a `failed` row - the status is
+    // terminal by contract." Pin via two complementary checks.
+    //
+    // (3a) Markdown scan: `withdrawal_failed.md` does not contain a
+    //      `failed → pending` UPDATE. Direct test of the runbook itself.
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+    let runbook = workspace_root.join("docs/runbooks/withdrawal_failed.md");
+    let runbook_text = std::fs::read_to_string(&runbook).expect("read withdrawal_failed.md");
+    assert!(
+        !runbook_text.contains("status = 'pending'") && !runbook_text.contains("status='pending'"),
+        "withdrawal_failed.md must not contain a `failed → pending` UPDATE — \
+         the runbook's terminal-status contract would be silently violated"
+    );
+
+    // (3b) Code grep: no operator code path re-arms a `failed` row to
+    //      `pending` via *literal* SQL. Note: the operator uses sqlx
+    //      parameterised queries, so this tripwire only catches literal-
+    //      SQL violations (rare in this codebase). The primary defense is
+    //      sub-3a (markdown scan); 3b is defense-in-depth for the case
+    //      where someone bypasses the storage abstraction with raw SQL.
+    let operator_dir = workspace_root.join("indexer/src/operator");
+    let mut violations: Vec<String> = Vec::new();
+    for entry in walkdir(&operator_dir) {
+        if entry.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let src = match std::fs::read_to_string(&entry) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        // Look for any UPDATE that mentions both status='failed' as a
+        // selector and status='pending' as a setter in close proximity.
+        // The substring search is conservative — it matches the SQL
+        // shape the operator code would have to use to violate the
+        // contract.
+        let mentions_failed = src.contains("status='failed'") || src.contains("status = 'failed'");
+        let flips_to_pending =
+            src.contains("SET status='pending'") || src.contains("SET status = 'pending'");
+        if mentions_failed && flips_to_pending {
+            violations.push(entry.display().to_string());
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "operator code must not re-arm `failed` rows to `pending`; found in: {violations:?}"
+    );
+    eprintln!("(3) NOT_LANDED branch terminal contract verified (markdown + code grep)");
+
+    // ── (4) AMBIGUOUS branch — no SQL, escalate Tier 2 ────────────────────
+    // Pin via markdown scan: the AMBIGUOUS paragraph contains no SQL and
+    // contains the word "Escalate".
+    let ambiguous_idx = runbook_text
+        .find("`AMBIGUOUS`")
+        .expect("withdrawal_failed.md must mention AMBIGUOUS verdict");
+    let ambiguous_para =
+        &runbook_text[ambiguous_idx..ambiguous_idx + 200.min(runbook_text.len() - ambiguous_idx)];
+    assert!(
+        ambiguous_para.contains("Escalate") || ambiguous_para.contains("escalate"),
+        "AMBIGUOUS branch must escalate; got:\n{ambiguous_para}"
+    );
+    assert!(
+        !ambiguous_para.contains("UPDATE"),
+        "AMBIGUOUS branch must contain no SQL; got:\n{ambiguous_para}"
+    );
+    eprintln!("(4) AMBIGUOUS branch: escalate, no SQL — verified");
+
+    eprintln!("withdrawal_failed.md recovery flows verified end-to-end.");
+    Ok(())
+}
+
+// ── Drill 13: withdrawal_failed_reminted.md reconciliation contract ─────────
+//
+// `withdrawal_failed_reminted.md` is a SUCCESS-OUTCOME runbook — the
+// original withdrawal failed on Solana, then the channel-side remint
+// succeeded, and no funds are stranded. The reconciliation is read-only:
+// confirm the remint signature on-chain, confirm the original release did
+// NOT land, close the alert. The runbook contains zero recovery SQL.
+//
+// This drill pins:
+//   (1) the upstream production path that writes `remint_signatures`
+//       before the FailedReminted transition,
+//   (2) the Step 1 query shape,
+//   (3) the read-only contract — no mutating SQL in the runbook,
+//   (4) the double-credit fence — if release LANDED, escalate, do not
+//       silently mark Completed,
+//   (5) the webhook ↔ DB naming asymmetry: webhook payload uses
+//       `remint_signature` (singular), DB column is `remint_signatures`
+//       (plural array). Per `_glossary.md:35`.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_13_withdrawal_failed_reminted_reconcile() -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "withdrawal_failed_reminted.md",
+        "Reconciliation contract (read-only) + double-credit fence",
+    );
+
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+
+    // ── (1) Production code path: FailedReminted preceded by remint_signatures ─
+    // The runbook's Step 1 hard-requires non-empty `remint_signatures`. The
+    // schema does NOT enforce this (no CHECK constraint); the upstream
+    // operator code does, and it does so across two files (deliberately
+    // decoupled — signatures are stashed during the original send so a
+    // restart between send and confirmation can recover). Pin both legs:
+    //
+    //   (1a) sender/transaction.rs calls `set_pending_remint(tx_id, sigs, …)`
+    //        — this is the persistence call site; runs BEFORE any
+    //        FailedReminted transition.
+    //   (1b) sender/remint.rs is the only file that writes the
+    //        FailedReminted status — confirms the transition has a single
+    //        source we can reason about.
+    //   (1c) the storage layer's set_pending_remint binds the
+    //        `remint_signatures` column — runbook Step 1's column lookup
+    //        will find what was written.
+    let tx_src = workspace_root.join("indexer/src/operator/sender/transaction.rs");
+    let tx_text = std::fs::read_to_string(&tx_src).expect("read sender/transaction.rs");
+    assert!(
+        tx_text.contains(".set_pending_remint(") || tx_text.contains("set_pending_remint("),
+        "(1a) sender/transaction.rs must call set_pending_remint(…) to stash \
+         remint signatures before any FailedReminted transition"
+    );
+
+    let remint_src = workspace_root.join("indexer/src/operator/sender/remint.rs");
+    let remint_text = std::fs::read_to_string(&remint_src).expect("read sender/remint.rs");
+    assert!(
+        remint_text.contains("TransactionStatus::FailedReminted"),
+        "(1b) sender/remint.rs must contain the FailedReminted status transition"
+    );
+
+    let storage_src = workspace_root.join("indexer/src/storage/postgres/db.rs");
+    let storage_text = std::fs::read_to_string(&storage_src).expect("read db.rs");
+    let spr_idx = storage_text
+        .find("fn set_pending_remint")
+        .expect("(1c) db.rs must define set_pending_remint");
+    let spr_window = &storage_text[spr_idx..(spr_idx + 1500).min(storage_text.len())];
+    assert!(
+        spr_window.contains("remint_signatures"),
+        "(1c) db.rs::set_pending_remint must bind the `remint_signatures` column"
+    );
+    eprintln!("(1) FailedReminted ↔ remint_signatures persistence pinned across both files: ok");
+
+    // ── (2) Step 1 query shape works on a well-formed seeded row ──────────
+    // Seeds with two signatures (mirrors retry-attempt array shape). Runs
+    // the implicit query backing Step 1: read the column, expect an array
+    // of length ≥ 1.
+    let sig1 = Signature::new_unique().to_string();
+    let sig2 = Signature::new_unique().to_string();
+    let id = seed_failed_reminted(&pool, 300, &[&sig1, &sig2]).await?;
+
+    let stored_sigs: Vec<String> =
+        sqlx::query_scalar("SELECT remint_signatures FROM transactions WHERE id=$1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await?;
+    assert!(
+        !stored_sigs.is_empty(),
+        "seeded failed_reminted row must have non-empty remint_signatures"
+    );
+    assert_eq!(stored_sigs.len(), 2);
+    eprintln!(
+        "(2) Step 1 query returned {} remint signatures: {:?}",
+        stored_sigs.len(),
+        stored_sigs
+    );
+
+    // ── (3) Read-only contract — no mutating SQL in the runbook ───────────
+    // The whole runbook is "verify and close". A future edit that sneaks in
+    // an UPDATE/INSERT/DELETE on the row's status would silently shift the
+    // contract. Markdown scan: zero mutating SQL keywords.
+    let runbook = workspace_root.join("docs/runbooks/withdrawal_failed_reminted.md");
+    let runbook_text =
+        std::fs::read_to_string(&runbook).expect("read withdrawal_failed_reminted.md");
+    for keyword in &["UPDATE transactions", "INSERT INTO", "DELETE FROM"] {
+        assert!(
+            !runbook_text.contains(keyword),
+            "withdrawal_failed_reminted.md must not contain `{keyword}` — \
+             the runbook is read-only by design (success-outcome reconciliation)"
+        );
+    }
+    eprintln!("(3) read-only contract verified — no mutating SQL in runbook");
+
+    // ── (4) Double-credit fence on LANDED verdict ─────────────────────────
+    // If `_verify_onchain_release.md` returns LANDED, the user has been
+    // double-credited. Runbook prescribes Tier 1 escalation, NOT a status
+    // flip. Pin via two checks:
+    //
+    // (4a) No `SET status='completed'` in the file. Already implied by (3),
+    //      but called out separately because the contract semantics differ.
+    assert!(
+        !runbook_text.contains("status = 'completed'")
+            && !runbook_text.contains("status='completed'"),
+        "withdrawal_failed_reminted.md must not contain a `SET status='completed'` — \
+         that would silently absorb a double-credit on LANDED verdict"
+    );
+
+    // (4b) The LANDED paragraph (lines 26-28 of the runbook at time of
+    //      writing) escalates to Tier 1.
+    let landed_idx = runbook_text
+        .find("If `LANDED`")
+        .expect("runbook must discuss LANDED branch");
+    let landed_para_end = (landed_idx + 400).min(runbook_text.len());
+    let landed_para = &runbook_text[landed_idx..landed_para_end];
+    assert!(
+        landed_para.contains("escalate") || landed_para.contains("Escalate"),
+        "LANDED branch must escalate; got:\n{landed_para}"
+    );
+    assert!(
+        landed_para.contains("Tier 1"),
+        "LANDED branch must escalate Tier 1 (double-credit is funds-at-risk); got:\n{landed_para}"
+    );
+    eprintln!("(4) double-credit fence pinned: no completed-flip; LANDED → Tier 1");
+
+    // ── (5) Webhook ↔ DB naming asymmetry ─────────────────────────────────
+    // Glossary at `_glossary.md:35` declares the webhook payload uses
+    // `remint_signature` (singular). The DB column is `remint_signatures`
+    // (plural array). Both must be present; if either is renamed without
+    // the other, the runbook reader's mental model breaks.
+    let writer_src = workspace_root.join("indexer/src/operator/db_transaction_writer.rs");
+    let writer_text = std::fs::read_to_string(&writer_src).expect("read db_transaction_writer.rs");
+    assert!(
+        writer_text.contains("\"remint_signature\""),
+        "webhook serializer in db_transaction_writer.rs must emit JSON key \
+         `remint_signature` (singular) — matches _glossary.md:35"
+    );
+
+    let db_src = workspace_root.join("indexer/src/storage/postgres/db.rs");
+    let db_text = std::fs::read_to_string(&db_src).expect("read db.rs");
+    assert!(
+        db_text.contains("remint_signatures TEXT[]"),
+        "DB column must be `remint_signatures TEXT[]` (plural array) — \
+         matches the migration at db.rs ALTER TABLE"
+    );
+    eprintln!("(5) webhook/DB asymmetry pinned: `remint_signature` ↔ `remint_signatures TEXT[]`");
+
+    eprintln!("withdrawal_failed_reminted.md reconciliation contract verified.");
+    Ok(())
+}
+
+// Minimal recursive-walk helper used by drill_12's code grep. Avoids
+// pulling in `walkdir` as a new dev-dep just for two drills.
+fn walkdir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out: Vec<std::path::PathBuf> = Vec::new();
+    let mut stack: Vec<std::path::PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
 }


### PR DESCRIPTION
## Summary

Adds operator runbooks for the alert webhooks the indexer/operator already
fires today. No procedure existed for recovering user funds when a
withdrawal or deposit landed in `Failed` or `ManualReview`.

Covers both operators (withdrawal and deposit) and is keyed entirely off
the alert webhook payload (`status` + `transaction_type`). Each runbook
reaches a single recovery action via on-chain verification first; the
SQL is pure bookkeeping, with fund restoration explicitly routed to a
human via tiered escalation.

## What's added

- **9 runbooks under `docs/runbooks/`**: alert-to-runbook dispatch in
  `README.md`, plus per-alert recovery procedures, two on-chain
  verification procedures (release on Solana, mint on Contra), an
  escalation tier doc, and a glossary covering the status state machine
  and operator asymmetries.
- **11 `#[ignore]`-flagged drills in `indexer/tests/runbook_drills.rs`**
  that pin every runbook claim against the source, schema, and storage
  layer. 

## Design decisions

- **Webhook-driven only.** The dispatch table keys exclusively on the
  alert webhook (single configured paging mechanism). 
- **Recovery SQL is bookkeeping, not fund movement.** Auto-remint is
  the one automatic restoration path. Every other terminal outcome
  routes a human via Tier 1 escalation. Documented up-front in the
  README.
  
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,202 | 10,623 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25455242384) |
| Indexer | 14,963 | 17,559 | 85.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25455242384) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25455242384) |
| Auth | 565 | 708 | 79.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25455242384) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| E2E Integration | 9,738 | 12,063 | 80.7% | [e2e-coverage-reports](https://github.com/solana-foundation/contra/actions/runs/25455242384) |
| **Total** | **35,462** | **42,117** | **84.2%** | |

> Last updated: 2026-05-06 19:24:06 UTC by E2E Integration