### PR TITLE
Fix/cleanup pre audit

### DIFF
--- a/.github/workflows/program-integration.yml
+++ b/.github/workflows/program-integration.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   integration-test:
     name: Program Integration Tests
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     timeout-minutes: 20
     steps:
       - name: Checkout repository

--- a/.github/workflows/program-unit.yml
+++ b/.github/workflows/program-unit.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   unit-test:
     name: Unit Tests with Coverage
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     timeout-minutes: 40
     steps:
       - name: Checkout repository

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
   init-coverage-table:
     name: Initialize Coverage Table
     if: github.event_name == 'pull_request'
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     steps:
       - name: Insert coverage skeleton into PR body
         uses: actions/github-script@v7
@@ -71,7 +71,7 @@ jobs:
 
   changes:
     name: Detect Changed Areas
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     outputs:
       rust_checks: ${{ steps.filter.outputs.rust_checks }}
       integration: ${{ steps.filter.outputs.integration }}
@@ -129,7 +129,7 @@ jobs:
     name: Build Shared Artifacts
     needs: changes
     if: needs.changes.outputs.integration == 'true' || needs.changes.outputs.core_indexer == 'true'
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     steps:
       - uses: actions/checkout@v4
 
@@ -164,7 +164,7 @@ jobs:
     name: Check
     needs: changes
     if: needs.changes.outputs.rust_checks == 'true'
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     steps:
       - uses: actions/checkout@v4
 
@@ -195,7 +195,7 @@ jobs:
     name: Format
     needs: changes
     if: needs.changes.outputs.rust_checks == 'true'
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     steps:
       - uses: actions/checkout@v4
 
@@ -228,7 +228,7 @@ jobs:
     name: Clippy
     needs: changes
     if: needs.changes.outputs.rust_checks == 'true'
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     steps:
       - uses: actions/checkout@v4
 
@@ -260,7 +260,7 @@ jobs:
     name: Rust Integration Tests + E2E Coverage
     needs: [changes, build-artifacts]
     if: needs.changes.outputs.integration == 'true'
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     steps:
       - uses: actions/checkout@v4
 
@@ -330,7 +330,7 @@ jobs:
     name: Core + Indexer Unit Coverage
     needs: [changes, build-artifacts]
     if: needs.changes.outputs.core_indexer == 'true'
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sdk-unit.yml
+++ b/.github/workflows/sdk-unit.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   typescript-sdk-unit:
     name: TypeScript SDK Unit Tests
-    runs-on: contra-runner-1
+    runs-on: private-channel-runner-1
     strategy:
       matrix:
         program: [private-channel-escrow-program, private-channel-withdraw-program]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ See [TECHNICAL_REQUIREMENTS.md](TECHNICAL_REQUIREMENTS.md) for detailed system r
 
 ```bash
 # Clone the repository
-git clone https://github.com/solana-foundation/contra.git
+git clone https://github.com/solana-foundation/solana-private-channels.git
 cd private_channel
 
 # Install dependencies for all projects
@@ -196,7 +196,7 @@ async fn my_test_function() {
 
 For questions about contributing to Solana Private Channels:
 
-- **GitHub Issues**: https://github.com/solana-foundation/contra/issues
+- **GitHub Issues**: https://github.com/solana-foundation/solana-private-channels/issues
 - **Stack Exchange**: Ask on https://solana.stackexchange.com/ (use the `private_channel` tag)
 
 ## License

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,16 @@ install-toolchain:
 	elif ! command -v solana >/dev/null 2>&1 || \
 	     [ "$$(solana --version 2>/dev/null | awk '{print $$2}')" != "$$SOLANA_VERSION" ]; then \
 	    echo "Installing Solana CLI v$$SOLANA_VERSION..."; \
-	    sh -c "$$(curl -sSfL https://release.anza.xyz/v$$SOLANA_VERSION/install)"; \
+	    attempt=0; \
+	    until sh -c "$$(curl -sSfL https://release.anza.xyz/v$$SOLANA_VERSION/install)"; do \
+	        attempt=$$((attempt + 1)); \
+	        if [ "$$attempt" -ge 3 ]; then \
+	            echo "Solana CLI install failed after 3 attempts"; exit 1; \
+	        fi; \
+	        delay=$$((attempt * 10)); \
+	        echo "Solana CLI install attempt $$attempt failed (transient network error from solana-install fetching the tarball); retrying in $${delay}s..."; \
+	        sleep "$$delay"; \
+	    done; \
 	else \
 	    echo "Solana CLI already at v$$SOLANA_VERSION — skipping"; \
 	fi

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Get Solana Private Channels running locally in under 5 minutes:
 
 ```bash
 # Clone repository
-git clone https://github.com/solana-foundation/contra.git
+git clone https://github.com/solana-foundation/solana-private-channels.git
 cd private_channel
 
 # Install dependencies

--- a/auth/Makefile
+++ b/auth/Makefile
@@ -15,7 +15,7 @@ fmt:
 # Run unit tests
 unit-test:
 	@echo "Running unit tests for private-channel-auth..."
-	@cargo test --lib
+	@cargo test --lib --bins
 
 # Run integration tests (requires Docker for testcontainers)
 integration-test:
@@ -26,13 +26,13 @@ integration-test:
 unit-coverage:
 	@echo "Running unit tests with coverage for private-channel-auth..."
 	@mkdir -p ../coverage
-	@cargo llvm-cov --lib --tests --lcov --output-path ../coverage/coverage-auth-unit.lcov
+	@cargo llvm-cov --lib --bins --tests --lcov --output-path ../coverage/coverage-auth-unit.lcov
 
 # Generate HTML coverage report
 coverage-html:
 	@echo "Generating HTML coverage report for private-channel-auth..."
 	@mkdir -p ../coverage
-	@cargo llvm-cov --lib --tests --html --output-dir ../coverage/coverage-auth-html
+	@cargo llvm-cov --lib --bins --tests --html --output-dir ../coverage/coverage-auth-html
 
 # Run all coverage tasks
 all-coverage: unit-coverage coverage-html

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -130,3 +130,156 @@ async fn attach_wallet(pool: &sqlx::PgPool, args: AttachWalletArgs) -> Result<()
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::pubkey::Pubkey;
+    use sqlx::PgPool;
+    use std::sync::Mutex;
+    use testcontainers::{runners::AsyncRunner, ContainerAsync};
+    use testcontainers_modules::postgres::Postgres;
+
+    // env::set_var / remove_var mutate process-global state. The two `run` tests
+    // touch AUTH_DATABASE_URL — serialize them so they don't race when the
+    // surrounding test runner schedules them in parallel.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    async fn start_pool() -> (PgPool, ContainerAsync<Postgres>) {
+        let container = Postgres::default()
+            .with_db_name("auth_test")
+            .with_user("postgres")
+            .with_password("password")
+            .start()
+            .await
+            .expect("failed to start postgres container");
+        let host = container.get_host().await.unwrap();
+        let port = container.get_host_port_ipv4(5432).await.unwrap();
+        let url = format!("postgres://postgres:password@{}:{}/auth_test", host, port);
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&url)
+            .await
+            .expect("failed to connect");
+        db::init_schema(&pool).await.expect("schema init");
+        (pool, container)
+    }
+
+    fn attach_args(username: &str, pubkey: &str) -> AttachWalletArgs {
+        AttachWalletArgs {
+            username: username.into(),
+            pubkey: pubkey.into(),
+        }
+    }
+
+    fn run_args(command: Command) -> Args {
+        Args {
+            log_level: "info".into(),
+            json_logs: false,
+            command,
+        }
+    }
+
+    #[tokio::test]
+    async fn run_rejects_missing_database_url() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev = env::var("AUTH_DATABASE_URL").ok();
+        env::remove_var("AUTH_DATABASE_URL");
+
+        let result = run(run_args(Command::AttachWallet(attach_args("u", "p")))).await;
+
+        match prev {
+            Some(p) => env::set_var("AUTH_DATABASE_URL", p),
+            None => env::remove_var("AUTH_DATABASE_URL"),
+        }
+
+        let err = result.expect_err("expected error");
+        assert!(err.to_string().contains("is not set"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn run_rejects_non_postgres_url() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev = env::var("AUTH_DATABASE_URL").ok();
+        env::set_var("AUTH_DATABASE_URL", "mysql://localhost/test");
+
+        let result = run(run_args(Command::AttachWallet(attach_args("u", "p")))).await;
+
+        match prev {
+            Some(p) => env::set_var("AUTH_DATABASE_URL", p),
+            None => env::remove_var("AUTH_DATABASE_URL"),
+        }
+
+        let err = result.expect_err("expected error");
+        assert!(
+            err.to_string().contains("must be a PostgreSQL URL"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_wallet_rejects_invalid_pubkey() {
+        let (pool, _c) = start_pool().await;
+        let err = attach_wallet(&pool, attach_args("alice", "not-base58"))
+            .await
+            .expect_err("expected error");
+        assert!(err.to_string().contains("invalid pubkey"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn attach_wallet_rejects_unknown_user() {
+        let (pool, _c) = start_pool().await;
+        let pubkey = Pubkey::new_unique().to_string();
+        let err = attach_wallet(&pool, attach_args("ghost", &pubkey))
+            .await
+            .expect_err("expected error");
+        assert!(err.to_string().contains("user not found"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn attach_wallet_succeeds_for_known_user() {
+        let (pool, _c) = start_pool().await;
+        let user = db::insert_user(&pool, "bob", "$argon2id$placeholder")
+            .await
+            .expect("insert user");
+        let pubkey = Pubkey::new_unique().to_string();
+
+        attach_wallet(&pool, attach_args("bob", &pubkey))
+            .await
+            .expect("attach should succeed");
+
+        let wallets = db::list_verified_wallets(&pool, user.id)
+            .await
+            .expect("list wallets");
+        assert_eq!(wallets.len(), 1);
+        assert_eq!(wallets[0].pubkey, pubkey);
+    }
+
+    #[tokio::test]
+    async fn attach_wallet_reports_already_attached() {
+        let (pool, _c) = start_pool().await;
+        let user = db::insert_user(&pool, "carol", "$argon2id$placeholder")
+            .await
+            .expect("insert user");
+        let pubkey = Pubkey::new_unique().to_string();
+
+        attach_wallet(&pool, attach_args("carol", &pubkey))
+            .await
+            .expect("first attach should succeed");
+
+        let err = attach_wallet(&pool, attach_args("carol", &pubkey))
+            .await
+            .expect_err("second attach should fail");
+        assert!(
+            err.to_string().contains("is already attached"),
+            "got: {err}"
+        );
+
+        // The failed second attach must not duplicate the row.
+        let wallets = db::list_verified_wallets(&pool, user.id)
+            .await
+            .expect("list wallets");
+        assert_eq!(wallets.len(), 1, "failed attach should not duplicate row");
+        assert_eq!(wallets[0].pubkey, pubkey);
+    }
+}

--- a/bench-tps/src/load_deposit.rs
+++ b/bench-tps/src/load_deposit.rs
@@ -67,7 +67,8 @@ fn build_deposit_tx(
         token_program: spl_token::id(),
         associated_token_program: spl_associated_token_account::id(),
         event_authority: config.event_authority,
-        private_channel_escrow_program: private_channel_escrow_program_client::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
+        private_channel_escrow_program:
+            private_channel_escrow_program_client::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
     };
 
     let deposit_ix = accounts.instruction(DepositInstructionArgs {

--- a/bench-tps/src/load_withdraw.rs
+++ b/bench-tps/src/load_withdraw.rs
@@ -12,7 +12,9 @@ use {
         bench_metrics::{BENCH_SENT_TOTAL, FLOW_WITHDRAW},
         types::{BatchQueue, BenchState, WithdrawConfig, MAX_QUEUE_DEPTH},
     },
-    private_channel_withdraw_program_client::instructions::{WithdrawFunds, WithdrawFundsInstructionArgs},
+    private_channel_withdraw_program_client::instructions::{
+        WithdrawFunds, WithdrawFundsInstructionArgs,
+    },
     solana_sdk::{
         hash::Hash, instruction::Instruction, pubkey, pubkey::Pubkey, signature::Keypair,
         signer::Signer, transaction::Transaction,

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -44,10 +44,10 @@ use {
         bench_metrics_init, {FLOW_DEPOSIT, FLOW_TRANSFER, FLOW_WITHDRAW},
     },
     clap::Parser,
-    private_channel_core::client::load_keypair,
     load::{build_destinations, run_generator, run_sender_task},
     load_deposit::{run_deposit_generator, run_deposit_sender_thread},
     load_withdraw::{run_withdraw_generator, run_withdraw_sender_thread},
+    private_channel_core::client::load_keypair,
     setup_deposit::find_instance_pda,
     solana_sdk::{signature::Keypair, signer::Signer},
     std::{
@@ -471,7 +471,8 @@ async fn run_withdraw(args: args::WithdrawArgs) -> Result<()> {
 
     let _ = gen_handle.await;
     let _ = bh_handle.await;
-    let (start_private_channel_count, end_private_channel_count) = private_channel_metrics_handle.await.unwrap_or((0, 0));
+    let (start_private_channel_count, end_private_channel_count) =
+        private_channel_metrics_handle.await.unwrap_or((0, 0));
     let (start_mints, end_mints) = if let Some(h) = operator_handle {
         h.await.unwrap_or((0, 0))
     } else {
@@ -482,7 +483,8 @@ async fn run_withdraw(args: args::WithdrawArgs) -> Result<()> {
     }
 
     let sent = sent_count.load(Ordering::Relaxed);
-    let private_channel_burned = end_private_channel_count.saturating_sub(start_private_channel_count);
+    let private_channel_burned =
+        end_private_channel_count.saturating_sub(start_private_channel_count);
     let private_channel_tps = private_channel_burned as f64 / args.duration as f64;
 
     if args.operator_metrics_url.is_some() {

--- a/bench-tps/src/setup_deposit.rs
+++ b/bench-tps/src/setup_deposit.rs
@@ -423,8 +423,10 @@ pub async fn run_setup_deposit_phase(
     // every first deposit, blocking the sender loop ~200 ms each time.
     // ------------------------------------------------------------------
     let t6b = Instant::now();
-    let private_channel_rpc =
-        RpcClient::new_with_commitment(private_channel_rpc_url.to_string(), CommitmentConfig::confirmed());
+    let private_channel_rpc = RpcClient::new_with_commitment(
+        private_channel_rpc_url.to_string(),
+        CommitmentConfig::confirmed(),
+    );
     let private_channel_mint_sig = 'send: {
         let mut last_err = String::new();
         for (attempt, &delay_secs) in send_retry_delays.iter().enumerate() {
@@ -466,7 +468,9 @@ pub async fn run_setup_deposit_phase(
     )
     .await?;
     if !retry.is_empty() {
-        return Err(anyhow::anyhow!("PrivateChannel initialize_mint failed to confirm"));
+        return Err(anyhow::anyhow!(
+            "PrivateChannel initialize_mint failed to confirm"
+        ));
     }
     info!(
         %mint,

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -55,8 +55,6 @@ use {
 const OLDEST_SYNCED_ACCOUNT_AGE: u64 = 60 * 60; // 1 hour
 struct AccountWithMeta {
     account: AccountSharedData,
-    // TODO: Implement this after we move settlement to a separate stage
-    #[allow(dead_code)]
     synced_since: Option<u64>,
     // Whether we deleted this account. We can't remove an account from the
     // HashMap while we keep it in-memory because it will fallback to the

--- a/core/src/accounts/types.rs
+++ b/core/src/accounts/types.rs
@@ -92,7 +92,14 @@ impl StoredTransaction {
                                                 .into_vec()
                                                 .unwrap_or_default(),
                                         },
-                                        _ => panic!("Unexpected instruction type"),
+                                        // `inner_instructions` is constructed solely from
+                                        // `UiInstruction::Compiled` by `StoredTransaction`'s
+                                        // own builders (see `UiInstruction::Compiled(...)`
+                                        // construction further down in this file). The
+                                        // `Parsed` variant is never produced or accepted.
+                                        _ => unreachable!(
+                                            "inner_instructions only contains Compiled variants"
+                                        ),
                                     },
                                     stack_height: None,
                                 })

--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -179,12 +179,14 @@ impl AdminVm {
             processing_results.push(Ok(ProcessedTransaction::Executed(Box::new(executed))));
         }
 
+        // All three of these fields are intentional no-ops on the admin path:
+        //  - error_metrics / execute_timings: defaulting to zero contributes
+        //    nothing to the merged output (see execution.rs::merge_svm_outputs).
+        //  - balance_collector: gasless execution does not record balance
+        //    changes (see execution.rs:250).
         LoadAndExecuteSanitizedTransactionsOutput {
-            // TODO: Not implemented
             error_metrics: TransactionErrorMetrics::default(),
-            // TODO: No implemented
             execute_timings: ExecuteTimings::default(),
-            // TODO: Not implemented
             balance_collector: None,
             processing_results,
         }

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -288,7 +288,7 @@ docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .
 
 ## Get Help
 
-Solana Private Channels is still in the early stages of development. If you run into issues or bugs, please [create an issue](https://github.com/solana-foundation/contra/issues) and outline your steps to reproduce it. 
+Solana Private Channels is still in the early stages of development. If you run into issues or bugs, please [create an issue](https://github.com/solana-foundation/solana-private-channels/issues) and outline your steps to reproduce it. 
 
 ## Configuration Reference
 

--- a/docs/TECHNICAL_REQUIREMENTS.md
+++ b/docs/TECHNICAL_REQUIREMENTS.md
@@ -153,7 +153,7 @@ See [`PITR.md`](PITR.md) for the WAL archive setup.
 
 For questions about technical requirements or deployment assistance:
 
-- **GitHub Issues**: https://github.com/solana-foundation/contra/issues
+- **GitHub Issues**: https://github.com/solana-foundation/solana-private-channels/issues
 - **Stack Exchange**: Ask on https://solana.stackexchange.com/ (use the `private_channel` tag)
 - **Documentation**: See [ARCHITECTURE.md](ARCHITECTURE.md) and [DEVNET_QUICKSTART.md](DEVNET_QUICKSTART.md)
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -18,7 +18,7 @@ no retries). All dispatch below is keyed on the webhook payload.
 | Alert (webhook payload) | `transaction_type` | Symptom | Runbook |
 |---|---|---|---|
 | `status=manual_review` | `withdrawal` | Single row stopped; pipeline may also be halted. | [`withdrawal_manual_review.md`](withdrawal_manual_review.md) |
-| `status=manual_review` | `deposit` | Single row stopped (deterministic build error). No halt, no collateral. | [`deposit_manual_review.md`](deposit_manual_review.md) |
+| `status=manual_review` | `deposit` | Single row stopped — either deterministic build error (processor) or sender-side post-JIT mint failure (mint authority mismatch / corrupt state). No halt, no collateral. | [`deposit_manual_review.md`](deposit_manual_review.md) |
 | `status=failed` | `withdrawal` | Single row terminated without on-chain proof. Rare for withdrawals. | [`withdrawal_failed.md`](withdrawal_failed.md) |
 | `status=failed` | `deposit` | **Primary deposit alert.** Sender-side terminal failure (RPC, build, confirmation, on-chain rejection). | [`deposit_failed.md`](deposit_failed.md) |
 | `status=failed_reminted` | `withdrawal` | Withdrawal failed; remint succeeded. Reconcile only. | [`withdrawal_failed_reminted.md`](withdrawal_failed_reminted.md) |
@@ -99,6 +99,7 @@ pins the relevant contract.
 | `drill_11_program_type_labels_match_runbooks` | both | Pins `ProgramType::as_label` to `withdraw` / `escrow`. |
 | `drill_12_withdrawal_failed_recovery_flows` | withdrawal | `withdrawal_failed.md` LANDED → completed-with-sig; cross-row signature fence still applies on `failed`; NOT_LANDED is terminal (markdown + operator code grep); AMBIGUOUS escalates without SQL. |
 | `drill_13_withdrawal_failed_reminted_reconcile` | withdrawal | `failed_reminted` transition writes `remint_signatures`; runbook contains zero mutating SQL; LANDED verdict cannot be silently absorbed via `SET status='completed'`; webhook `remint_signature` (singular) ↔ DB `remint_signatures` (plural) asymmetry pinned. |
+| `drill_14_deposit_manual_review_post_jit_recovery_flows` | deposit | `deposit_manual_review.md` § Path D: post-JIT trigger strings present in `mint.rs`; re-arm SQL flips `manual_review` → `pending` and is targeted by id (not error_message); idempotency memo prefix anchored. |
 
 Trigger (`make` shorthand, runs from repo root):
 
@@ -121,8 +122,11 @@ RUST_LOG=trace cargo test -p private-channel-indexer --test runbook_drills -- \
 
 - Before merging a runbook edit.
 - After changes to: `processor.rs`, `sender/transaction.rs` (and in
-  particular `send_fatal_error`, the source of the rare withdrawal
-  `failed` transition that drill_12 protects), `sender/remint.rs`,
-  `db_transaction_writer.rs` (including its webhook-payload serializer
-  — drill_13 anchors on the `"remint_signature"` JSON key string
-  literal), or the indexer schema.
+  particular `send_fatal_error` — drill_12; or the
+  `JitOutcome::ManualReview` caller-arm dispatch which emits the
+  `ManualReview` status update inline — drill_14), `sender/mint.rs`
+  (the `JitOutcome::ManualReview` reason strings live here — drill_14
+  specifically), `sender/remint.rs`, `db_transaction_writer.rs`
+  (including its webhook-payload serializer — drill_13 anchors on the
+  `"remint_signature"` JSON key string literal), or the indexer
+  schema.

--- a/docs/runbooks/deposit_failed.md
+++ b/docs/runbooks/deposit_failed.md
@@ -18,10 +18,10 @@ maps to a specific sender-side site:
 | `error_message` | Source | Trigger |
 |---|---|---|
 | starts with `Failed idempotency lookup for transaction_id` | `sender/mint.rs` | `getSignaturesForAddress` RPC failed during pre-send memo scan. |
-| `Mint initialization failed` | `sender/transaction.rs` | Recipient's mint or ATA wasn't initialized; just-in-time init also failed. |
+| `Mint initialization failed` | `sender/transaction.rs` | The just-in-time `InitializeMint` transaction itself failed (e.g. RPC outage during init or send error). The *post-JIT* mint failure case (mint exists but unusable) has been peeled off into [`deposit_manual_review.md`](deposit_manual_review.md) § Path D. |
 | `Unexpected mint error` | `sender/transaction.rs` | `MintNotInitialized` confirmation result on a non-Mint tx (defensive; should never fire). |
 | `Confirmation failed - transaction status unknown, unsafe to retry` | `sender/transaction.rs` | RPC polling timed out for a non-idempotent send; mint may or may not have landed. |
-| free-form (often a program-error debug repr) | `sender/transaction.rs` | On-chain program error during confirmation (e.g. paused mint, bad mint authority) or RPC confirmation error. |
+| free-form (often a program-error debug repr) | `sender/transaction.rs` | On-chain program error during confirmation (e.g. paused mint, bad mint authority — `OwnerMismatch` from SPL Token's `mint_to`) or RPC confirmation error. **The most common rotated-admin-key case lands here, not in `manual_review`** — `OwnerMismatch` is `Custom(3)`, which is not in the JIT-trigger classifier's allow-list. |
 
 ## Recovery
 
@@ -91,6 +91,14 @@ Stop. [Escalate](_escalation.md) (Tier 2). Do not act.
 Re-arming to `pending` in the `AMBIGUOUS` case relies on the operator's
 own idempotency check; that check uses the same lookback window and will
 be just as blind. Do not lean on it alone for an old `processed_at`.
+
+## Cross-link — when ManualReview is the right runbook
+
+If you expected `Mint initialization failed` here but the row is in
+`manual_review` instead, see
+[`deposit_manual_review.md`](deposit_manual_review.md) § Path D —
+that's the path for a successful (or unnecessary) JIT followed by a
+structural mint problem (wrong authority, corrupt data).
 
 ## Special case - `Failed idempotency lookup`
 

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -16,6 +16,16 @@ Practically: a single deposit `manual_review` is a single row in trouble.
 Other deposits keep flowing. There is no collateral, no sweep, no halt to
 recover from.
 
+There are **two trigger surfaces** that can land a deposit in
+`manual_review`:
+
+1. **Processor-side row-data validation** — deterministic per-row error
+   raised before any RPC call (Paths A / B / C below).
+2. **Sender-side post-JIT mint failure** — the operator's just-in-time
+   mint-init helper found the on-chain mint in a state it cannot fix by
+   re-issuing `mint_to` (wrong authority on the private channel mint, or
+   corrupt mint data). See **Path D** for recovery.
+
 ## Symptom
 
 - Webhook with `status=manual_review`, `transaction_type=deposit`.
@@ -23,15 +33,23 @@ recover from.
 
 ## Triage
 
-There is one trigger surface: a deterministic per-row error in
-`processor.rs::process_deposit_funds`. `error_message` will contain one
-of:
+`error_message` distinguishes the two trigger surfaces and dispatches to
+the right Path below.
+
+### Processor-side surface (`processor.rs::process_deposit_funds`)
 
 | `error_message` contains | Cause |
 |---|---|
 | `invalid_pubkey` | `mint` or `recipient` field is not a valid base58 pubkey. |
 | `invalid_builder` | Builder rejected the row's data (e.g. negative amount). |
 | `program_error` | Generic builder error not covered by the specific variants. |
+
+### Sender-side post-JIT surface (`sender/mint.rs`)
+
+| `error_message` contains | Cause |
+|---|---|
+| `Mint instruction failed after JIT: mint_authority mismatch` | The on-chain mint's `mint_authority` is not the operator's admin pubkey. Two known triggers: (a) an existing mint on the private channel is owned by a different authority and `mint_to` produced one of the three classified `InstructionError` variants (rare — the most common rotated-admin case produces `OwnerMismatch` → `Custom(3)`, which routes to `Failed` instead of here); (b) post-`InitializeMint` race where another party initialized the same mint with a different authority during our send window. |
+| `Mint instruction failed after JIT: corrupt mint state` | The mint's account data does not decode as a valid SPL Mint (`COption` discriminant invalid, length mismatched). Defensive — should not occur in normal operation; investigate before any recovery. |
 
 Pull the row:
 
@@ -113,10 +131,84 @@ UPDATE transactions SET status = 'pending', updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
+### Path D - sender-side post-JIT failure
+
+Triggered by the sender-side surface above (`error_message` starting
+with `Mint instruction failed after JIT:`). The operator's JIT helper
+examined on-chain reality and found the mint structurally unusable.
+Treat as a **configuration alarm**, not a transient.
+
+**Why this differs from `deposit_failed`.** The post-JIT path landed
+in `manual_review` (not `failed`) specifically because JIT's structural
+check distinguished it from generic program errors — the on-chain mint
+state needs human investigation before any retry can succeed.
+
+#### Step 1 - verify on-chain
+
+Run [`_verify_onchain_mint.md`](_verify_onchain_mint.md). Like Paths
+A / B / C but mandatory here: structural mint problems can mask a
+prior `mint_to` that landed.
+
+#### Step 2 - branch on verdict
+
+##### `LANDED <signature>` — mint already succeeded
+
+Mark `completed` with the observed signature (same SQL as
+[`deposit_failed.md`](deposit_failed.md) Path B). The unique partial
+index on `counterpart_signature` still applies; if it rejects the
+update, escalate before retrying.
+
+##### `NOT_LANDED` — inspect mint authority on the private channel
+
+```bash
+spl-token display <mint> --url <private-channel-rpc>
+```
+
+Compare the displayed `Mint authority` to the operator's current
+admin pubkey.
+
+- **Authority mismatch — current authority still accessible.**
+  Treasury / admin signs
+
+  ```bash
+  spl-token authorize <mint> mint-authority <new-authority>
+  ```
+
+  to point the mint at the current operator admin. Then re-arm to
+  `pending` (SQL below). The idempotency memo prevents double-mint.
+- **Authority mismatch — current authority lost** (e.g. old admin key
+  destroyed during rotation). The mint is permanently unusable.
+  **Escalate (Tier 1).** Recovery is a manual coordinated mint
+  replacement: deploy a fresh mint, migrate any existing balances
+  out-of-band, mark the deposit `failed`, and refund the depositor
+  through the same Tier 1 channel `deposit_failed` Path A uses.
+  **Do not re-arm to `pending`** — the next mint attempt will fail
+  the same way.
+- **`error_message` contains `corrupt mint state`.** Escalate (Tier
+  2). Corrupt mint data on a deployed chain is a structural anomaly
+  engineering must investigate before any recovery. Do not re-arm.
+
+##### `AMBIGUOUS`
+
+Stop. Escalate (Tier 2). Do not act.
+
+#### Re-arm SQL
+
+Only for the recoverable authority case after the underlying authority
+correction has been performed:
+
+```sql
+UPDATE transactions SET status = 'pending', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
 ## Post-incident artifacts
 
 - Transaction id, originating Solana `signature`, `recipient`, `mint`.
 - Full webhook `error_message`.
 - Recovery action taken.
-- If Path A: refund tracking ticket.
+- For Path A: refund tracking ticket.
+- For Path D: on-chain `mint_authority` before/after, the
+  `spl-token authorize` signature (if applicable), and the engineering
+  ticket for any mint-replacement coordination.
 

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -11,6 +11,7 @@ use solana_keychain::SolanaSigner;
 use solana_rpc_client_api::client_error::ErrorKind;
 use solana_rpc_client_api::request::RpcError;
 use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::program_option::COption;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use solana_transaction_status::parse_instruction::ParsedInstruction;
@@ -34,32 +35,151 @@ struct ExpectedMintInstruction {
     amount: u64,
 }
 
-/// Attempt JIT mint initialization by sending initialize_mint transaction first
-/// Returns Some(mint_to_instruction) if successful, None if failed
+/// Verdict from `try_jit_mint_initialization`. The caller in
+/// `transaction.rs` matches on this to decide whether to recursively retry,
+/// quarantine the deposit to ManualReview, or route to the existing
+/// PermanentFailure path. The `String` payloads are operator-visible
+/// `error_message`s; ManualReview reasons are constructed in full here
+/// (with the literal `"Mint instruction failed after JIT: "` prefix) so
+/// `drill_1` can grep the runbook-dispatch substrings in a single source
+/// file.
+pub enum JitOutcome {
+    /// Mint is correctly initialized with the operator's admin as
+    /// `mint_authority`. Caller should retry the supplied instruction.
+    Retry(InstructionWithSigners),
+
+    /// Mint exists on-chain but in a state the operator cannot fix by
+    /// re-issuing `mint_to` (wrong authority, corrupt data, or post-init
+    /// inconsistency). Caller routes to `ManualReview`.
+    ManualReview(String),
+
+    /// Transient or builder failure (RPC, mint cache miss, build error).
+    /// Caller routes to the existing permanent-failure path (`Failed`
+    /// status).
+    PermanentFailure(String),
+}
+
+/// Outcome of decoding raw mint account bytes and comparing the embedded
+/// `mint_authority` to the operator's admin pubkey. Drives the
+/// `JitOutcome` branching in `try_jit_mint_initialization`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum AuthorityCheck {
+    /// Mint decoded; `is_initialized = true`; `mint_authority` equals the
+    /// supplied expected authority. Retry is safe.
+    Match,
+    /// Mint decoded; `is_initialized = true`; `mint_authority` does NOT
+    /// equal the expected authority. Holds the actual authority for log /
+    /// error context. Quarantine to ManualReview.
+    Mismatch(Pubkey),
+    /// Mint decoded but `is_initialized = false`. The account is allocated
+    /// and SPL-Token-owned but not yet a mint. JIT proceeds to
+    /// InitializeMint.
+    Uninitialized,
+    /// Decode failed: data length wrong, COption discriminant invalid, or
+    /// other corruption. Quarantine to ManualReview — the operator cannot
+    /// recover this without engineering intervention.
+    CorruptData,
+}
+
+/// Decode `data` as an SPL `Mint` and classify it relative to the supplied
+/// expected authority.
+///
+/// SPL's `Mint::unpack` rejects uninitialized data (returns `Err`), which
+/// would conflate the legitimate "mint allocated but `is_initialized =
+/// false`" state with genuine corruption. To distinguish, this helper uses
+/// `Mint::unpack_unchecked` and inspects `is_initialized` itself.
+///
+/// Returns:
+/// - `Match` if decoded, initialized, and `mint_authority` equals the
+///   supplied `expected_authority`.
+/// - `Mismatch(actual)` if decoded and initialized but the authority
+///   differs. A mint with `mint_authority = COption::None` is treated as
+///   `Mismatch(Pubkey::default())` — the operator cannot `mint_to` a
+///   no-authority mint either way.
+/// - `Uninitialized` if the bytes decode but `is_initialized = false`
+///   (allocated, SPL-Token-owned, but not yet a mint).
+/// - `CorruptData` for any decode failure (wrong length, invalid `COption`
+///   discriminant, etc.).
+pub(super) fn decode_and_check_authority(
+    data: &[u8],
+    expected_authority: &Pubkey,
+) -> AuthorityCheck {
+    // `unpack_unchecked` differs from `unpack` only in skipping the
+    // is_initialized check, so wrong-length / invalid-discriminant inputs
+    // still surface as `Err` here.
+    let mint = match Mint::unpack_unchecked(data) {
+        Ok(m) => m,
+        Err(_) => return AuthorityCheck::CorruptData,
+    };
+    if !mint.is_initialized {
+        return AuthorityCheck::Uninitialized;
+    }
+    match mint.mint_authority {
+        COption::Some(actual) if actual == *expected_authority => AuthorityCheck::Match,
+        COption::Some(actual) => AuthorityCheck::Mismatch(actual),
+        COption::None => AuthorityCheck::Mismatch(Pubkey::default()),
+    }
+}
+
+// Operator-visible error_message literals constructed in this file.
+// Pinned by `drill_1_error_message_contracts_present_in_source` and the
+// runbook dispatch tables in `docs/runbooks/deposit_manual_review.md`.
+const MR_AUTHORITY_MISMATCH_PRECHECK: &str =
+    "Mint instruction failed after JIT: mint_authority mismatch — admin key rotated or mint owned by another authority";
+const MR_AUTHORITY_MISMATCH_POSTINIT: &str =
+    "Mint instruction failed after JIT: mint_authority mismatch — race with concurrent admin rotation during InitializeMint";
+const MR_CORRUPT_MINT_STATE: &str =
+    "Mint instruction failed after JIT: corrupt mint state on-chain — decode failed";
+
+/// Attempt JIT mint initialization. Returns a `JitOutcome` verdict for the
+/// caller to dispatch (Retry / ManualReview / PermanentFailure).
 pub(super) async fn try_jit_mint_initialization(
     state: &mut SenderState,
     transaction_id: i64,
     instruction: InstructionWithSigners,
-) -> Option<InstructionWithSigners> {
-    // 1. Get cached builder
-    let builder = state.mint_builders.get(&transaction_id)?.clone();
+) -> JitOutcome {
+    // 1. Get cached builder + extract mint.
+    let Some(builder) = state.mint_builders.get(&transaction_id).cloned() else {
+        return JitOutcome::PermanentFailure(format!(
+            "no cached MintToBuilder for transaction_id {}",
+            transaction_id
+        ));
+    };
+    let Some(mint) = builder.get_mint() else {
+        return JitOutcome::PermanentFailure(format!(
+            "MintToBuilder for transaction_id {} is missing mint pubkey",
+            transaction_id
+        ));
+    };
 
-    // 2. Extract mint pubkey
-    let mint = builder.get_mint()?;
+    let admin_pubkey = SignerUtil::admin_signer().pubkey();
 
-    // 3. Check if mint is initialized on PrivateChannel. An account may exist at the
-    // mint address (allocated via `create_account`) with non-empty zeroed data
-    // and `is_initialized = false`; treating that as "present" skips JIT and
-    // the subsequent `mint_to` fails with `UninitializedAccount`. Gate on
-    // initialization, matching the `mint_is_initialized_on_chain` fallback.
+    // 2. Pre-check on-chain mint state.
     match state.rpc_client.get_account_data(&mint).await {
-        Ok(data) if is_initialized_mint_data(&data) => return Some(instruction),
-        Ok(_) => {
-            info!(
-                "Mint {} not initialized on PrivateChannel - attempting JIT initialization",
-                mint
-            );
-        }
+        Ok(data) => match decode_and_check_authority(&data, &admin_pubkey) {
+            AuthorityCheck::Match => return JitOutcome::Retry(instruction),
+            AuthorityCheck::Mismatch(actual) => {
+                warn!(
+                    "JIT pre-check: mint {} initialized with authority {} (expected admin {})",
+                    mint, actual, admin_pubkey
+                );
+                return JitOutcome::ManualReview(MR_AUTHORITY_MISMATCH_PRECHECK.to_string());
+            }
+            AuthorityCheck::CorruptData => {
+                warn!(
+                    "JIT pre-check: mint {} bytes do not decode as SPL Mint",
+                    mint
+                );
+                return JitOutcome::ManualReview(MR_CORRUPT_MINT_STATE.to_string());
+            }
+            AuthorityCheck::Uninitialized => {
+                info!(
+                    "Mint {} not initialized on PrivateChannel - attempting JIT initialization",
+                    mint
+                );
+                // fall through to init path
+            }
+        },
         Err(e) => {
             warn!(
                 "RPC error checking mint {} - assuming it doesn't exist: {}",
@@ -69,10 +189,10 @@ pub(super) async fn try_jit_mint_initialization(
         }
     }
 
-    // 4. Look up mint decimals from mint cache
+    // 3. Look up mint decimals from mint cache.
     let Ok(mint_metadata) = state.mint_cache.get_mint_metadata(&mint).await else {
         error!("Mint {} not found in mint cache", mint);
-        return None;
+        return JitOutcome::PermanentFailure(format!("mint not in mint cache: {}", mint));
     };
 
     info!(
@@ -80,8 +200,7 @@ pub(super) async fn try_jit_mint_initialization(
         mint_metadata.decimals, mint
     );
 
-    // 5. Build InitializeMint transaction
-    let admin_pubkey = SignerUtil::admin_signer().pubkey();
+    // 4. Build InitializeMint transaction.
     let init_mint_builder = InitializeMintBuilder::new(
         mint,
         mint_metadata.decimals,
@@ -92,7 +211,7 @@ pub(super) async fn try_jit_mint_initialization(
 
     let init_tx_builder = TransactionBuilder::InitializeMint(Box::new(init_mint_builder));
 
-    // 6. Convert to instruction using existing function
+    // 5. Convert to instruction.
     let init_instruction = match state
         .handle_transaction_builder(init_tx_builder.clone())
         .await
@@ -100,11 +219,14 @@ pub(super) async fn try_jit_mint_initialization(
         Ok(ix) => ix,
         Err(e) => {
             error!("Failed to build InitializeMint instruction: {}", e);
-            return None;
+            return JitOutcome::PermanentFailure(format!(
+                "Failed to build InitializeMint instruction: {}",
+                e
+            ));
         }
     };
 
-    // 7. Send transaction using existing function
+    // 6. Send transaction.
     info!("Sending InitializeMint transaction for mint {}", mint);
     let sig = match sign_and_send_transaction(
         state.rpc_client.clone(),
@@ -116,11 +238,14 @@ pub(super) async fn try_jit_mint_initialization(
         Ok(s) => s,
         Err(e) => {
             error!("Failed to send InitializeMint transaction: {}", e);
-            return None;
+            return JitOutcome::PermanentFailure(format!(
+                "Failed to send InitializeMint transaction: {}",
+                e
+            ));
         }
     };
 
-    // 8. Check confirmation using existing function
+    // 7. Wait for confirmation.
     let result = match check_transaction_status(
         state.rpc_client.clone(),
         &sig,
@@ -133,57 +258,134 @@ pub(super) async fn try_jit_mint_initialization(
         Ok(r) => r,
         Err(e) => {
             error!("Failed to check InitializeMint status: {}", e);
-            return None;
+            return JitOutcome::PermanentFailure(format!(
+                "Failed to check InitializeMint status: {}",
+                e
+            ));
         }
     };
 
+    // 8. Branch on confirmation result.
     match result {
         ConfirmationResult::Confirmed => {
             // `Confirmed` covers both a successful InitializeMint and the
             // `AccountAlreadyInitialized` race, which the extra error check
             // on this builder remaps to `Confirmed` without an RPC re-check.
             info!("InitializeMint transaction confirmed: {}", sig);
-            Some(instruction)
+
+            // Re-fetch and check authority — catches the race where another
+            // party initialized the same mint with a different authority
+            // during our send window.
+            let check = match state.rpc_client.get_account_data(&mint).await {
+                Ok(data) => decode_and_check_authority(&data, &admin_pubkey),
+                Err(_) => {
+                    mint_authority_check_with_backoff(&state.rpc_client, &mint, &admin_pubkey).await
+                }
+            };
+            jit_verdict(check, instruction, &mint, None)
         }
         _ => {
             // Fallback for unknown failures (network blips, timeouts): re-read
             // the mint on-chain with backoff in case it was initialized out-of-band.
-            if mint_is_initialized_on_chain(&state.rpc_client, &mint).await {
-                info!(
-                    "InitializeMint tx {} not confirmed (result={:?}), but mint {} is already \
-                     initialized on-chain — treating JIT as success",
-                    sig, result, mint
-                );
-                return Some(instruction);
-            }
-            error!(
-                "InitializeMint transaction could not be confirmed: {:?}",
-                result
-            );
-            None
+            let check =
+                mint_authority_check_with_backoff(&state.rpc_client, &mint, &admin_pubkey).await;
+            jit_verdict(check, instruction, &mint, Some(&result))
         }
     }
 }
 
-/// returns true if `data` decodes as an initialized SPL `Mint`.
-/// Non-Mint-length or malformed data → false. Zeroed Mint::LEN data → false.
-fn is_initialized_mint_data(data: &[u8]) -> bool {
-    Mint::unpack(data)
-        .map(|m| m.is_initialized)
-        .unwrap_or(false)
+/// Map an `AuthorityCheck` to a `JitOutcome`.
+///
+/// `fallback_result`:
+/// - `None` → post-`Confirmed` context (InitializeMint succeeded; we're
+///   re-checking the on-chain state to catch the post-init authority race).
+/// - `Some(result)` → fallback context (the InitializeMint poll did NOT
+///   return `Confirmed` — timeout / RPC error — and we're re-reading the
+///   mint with backoff in case it landed out-of-band).
+///
+/// The two contexts only diverge in two arms:
+/// - `Match`: the fallback path logs an info "treating-as-success" message
+///   so operators can see the race-recovery happen; post-init is silent.
+/// - `Uninitialized`: post-init treats this as an RPC inconsistency
+///   (InitializeMint said Confirmed but the mint isn't there); fallback
+///   treats it as the canonical "InitializeMint could not be confirmed"
+///   permanent failure that drives the existing Failed-runbook dispatch.
+fn jit_verdict(
+    check: AuthorityCheck,
+    instruction: InstructionWithSigners,
+    mint: &Pubkey,
+    fallback_result: Option<&ConfirmationResult>,
+) -> JitOutcome {
+    match check {
+        AuthorityCheck::Match => {
+            if let Some(result) = fallback_result {
+                info!(
+                    "InitializeMint not confirmed cleanly (result={:?}), but mint {} reads as \
+                     initialized with admin authority — treating JIT as success",
+                    result, mint
+                );
+            }
+            JitOutcome::Retry(instruction)
+        }
+        AuthorityCheck::Mismatch(actual) => {
+            warn!(
+                "JIT: mint {} initialized with authority {} (expected admin)",
+                mint, actual
+            );
+            JitOutcome::ManualReview(MR_AUTHORITY_MISMATCH_POSTINIT.to_string())
+        }
+        AuthorityCheck::CorruptData => {
+            warn!("JIT: mint {} bytes do not decode as SPL Mint", mint);
+            JitOutcome::ManualReview(MR_CORRUPT_MINT_STATE.to_string())
+        }
+        AuthorityCheck::Uninitialized => match fallback_result {
+            Some(result) => {
+                error!(
+                    "InitializeMint transaction could not be confirmed: {:?}",
+                    result
+                );
+                JitOutcome::PermanentFailure(
+                    "InitializeMint transaction could not be confirmed".to_string(),
+                )
+            }
+            None => {
+                error!(
+                    "JIT post-init: InitializeMint confirmed but mint {} reads as uninitialized",
+                    mint
+                );
+                JitOutcome::PermanentFailure(format!(
+                    "InitializeMint confirmed but mint {} reads as uninitialized — RPC inconsistency",
+                    mint
+                ))
+            }
+        },
+    }
 }
 
-/// Returns whether the mint is initialized on PrivateChannel, retrying with backoff
-/// to absorb read-RPC lag after a racing InitializeMint. Any error or
-/// uninitialized result on the final attempt is reported as `false`.
-async fn mint_is_initialized_on_chain(rpc_client: &RpcClientWithRetry, mint: &Pubkey) -> bool {
+/// Read the mint on-chain with backoff, returning the `AuthorityCheck`
+/// from the first successful decode. Absorbs read-RPC lag after a racing
+/// InitializeMint. On exhausted attempts with no successful decode,
+/// returns `Uninitialized` (the most conservative "I couldn't confirm
+/// it's there" reading — caller maps this to PermanentFailure on the   
+/// fallback path).
+async fn mint_authority_check_with_backoff(
+    rpc_client: &RpcClientWithRetry,
+    mint: &Pubkey,
+    expected_authority: &Pubkey,
+) -> AuthorityCheck {
     const ATTEMPTS: u32 = 4;
     const BACKOFF_MS: u64 = 250;
 
+    let mut last_check = AuthorityCheck::Uninitialized;
     for attempt in 0..ATTEMPTS {
         match rpc_client.get_account_data(mint).await {
-            Ok(data) if is_initialized_mint_data(&data) => return true,
-            Ok(_) => {}
+            Ok(data) => {
+                let check = decode_and_check_authority(&data, expected_authority);
+                if !matches!(check, AuthorityCheck::Uninitialized) {
+                    return check;
+                }
+                last_check = check;
+            }
             Err(e) => {
                 if attempt + 1 == ATTEMPTS {
                     warn!(
@@ -197,7 +399,7 @@ async fn mint_is_initialized_on_chain(rpc_client: &RpcClientWithRetry, mint: &Pu
             tokio::time::sleep(tokio::time::Duration::from_millis(BACKOFF_MS)).await;
         }
     }
-    false
+    last_check
 }
 
 /// Check recent ATA signatures for an already-confirmed mint carrying this transaction's
@@ -657,11 +859,12 @@ pub(super) fn cleanup_mint_builder(state: &mut SenderState, transaction_id: Opti
 #[cfg(test)]
 mod tests {
     use super::{
-        accounts_and_amount_match, expected_mint_instruction, instruction_has_expected_mint,
-        instruction_has_memo, is_initialized_mint_data, is_method_not_found_error, memo_matches,
-        parse_token_instruction_mint_amount, partially_decoded_instruction_has_expected_mint,
-        raw_instruction_has_expected_mint, strip_memo_length_prefix,
-        transaction_matches_expected_mint, ExpectedMintInstruction,
+        accounts_and_amount_match, decode_and_check_authority, expected_mint_instruction,
+        instruction_has_expected_mint, instruction_has_memo, is_method_not_found_error,
+        memo_matches, parse_token_instruction_mint_amount,
+        partially_decoded_instruction_has_expected_mint, raw_instruction_has_expected_mint,
+        strip_memo_length_prefix, transaction_matches_expected_mint, AuthorityCheck,
+        ExpectedMintInstruction,
     };
     use crate::operator::utils::instruction_util::{MintToBuilder, MintToBuilderWithTxnId};
     use solana_rpc_client_api::{
@@ -1521,14 +1724,14 @@ mod tests {
         assert_eq!(strip_memo_length_prefix("[123]no-space"), "[123]no-space");
     }
 
-    // Tests for the pure `is_initialized_mint_data` helper that drives the
-    // on-chain re-check in `try_jit_mint_initialization`. The async
-    // `mint_is_initialized_on_chain` wrapper is exercised indirectly via this
-    // helper plus the RPC boundary.
+    // Tests for `decode_and_check_authority`, the pure helper that drives
+    // the JIT pre-check, post-confirm re-check, and fallback backoff. Four
+    // variants must each be reachable: Match / Mismatch / Uninitialized /
+    // CorruptData.
 
-    fn pack_mint(is_initialized: bool) -> Vec<u8> {
+    fn pack_mint(is_initialized: bool, authority: COption<Pubkey>) -> Vec<u8> {
         let mint = Mint {
-            mint_authority: COption::Some(Pubkey::new_unique()),
+            mint_authority: authority,
             supply: 0,
             decimals: 6,
             is_initialized,
@@ -1539,45 +1742,96 @@ mod tests {
         data
     }
 
-    // Empty account data means the mint account was never created.
+    /// Initialized mint with `mint_authority` matching the supplied admin.
     #[test]
-    fn is_initialized_mint_data_empty_is_false() {
-        assert!(!is_initialized_mint_data(&[]));
+    fn decode_and_check_authority_match_returns_match() {
+        let admin = Pubkey::new_unique();
+        let data = pack_mint(true, COption::Some(admin));
+        assert_eq!(
+            decode_and_check_authority(&data, &admin),
+            AuthorityCheck::Match
+        );
     }
 
-    // Data of the wrong length (too short or too long) cannot be a valid mint.
+    /// Initialized mint with `mint_authority` set to a different pubkey
+    /// (the rotated-admin / different-operator scenario). Helper must
+    /// surface the actual authority for log/error context.
     #[test]
-    fn is_initialized_mint_data_wrong_length_is_false() {
-        assert!(!is_initialized_mint_data(&[0u8; 10]));
-        assert!(!is_initialized_mint_data(&[0xFFu8; Mint::LEN + 1]));
+    fn decode_and_check_authority_mismatch_returns_mismatch() {
+        let admin = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+        let data = pack_mint(true, COption::Some(other));
+        match decode_and_check_authority(&data, &admin) {
+            AuthorityCheck::Mismatch(actual) => assert_eq!(actual, other),
+            other => panic!("expected Mismatch, got {:?}", other),
+        }
     }
 
-    // A rent-exempt-but-uninitialized mint account (correct length, all zeros)
-    // is rejected by `Mint::unpack` because `is_initialized` is 0.
+    /// Initialized mint whose authority has been cleared (`COption::None`)
+    /// is treated as a mismatch with `Pubkey::default()` — the operator
+    /// cannot mint without an authority either way.
     #[test]
-    fn is_initialized_mint_data_zeroed_mint_len_is_false() {
-        assert!(!is_initialized_mint_data(&[0u8; Mint::LEN]));
+    fn decode_and_check_authority_no_authority_returns_mismatch_default() {
+        let admin = Pubkey::new_unique();
+        let data = pack_mint(true, COption::None);
+        match decode_and_check_authority(&data, &admin) {
+            AuthorityCheck::Mismatch(actual) => assert_eq!(actual, Pubkey::default()),
+            other => panic!("expected Mismatch, got {:?}", other),
+        }
     }
 
-    // Properly packed, initialized mint data is recognized as initialized.
+    /// Mint allocated and SPL-Token-owned but with `is_initialized = false`
+    /// (the legitimate JIT case where InitializeMint should run).
     #[test]
-    fn is_initialized_mint_data_packed_initialized_mint_is_true() {
-        let data = pack_mint(true);
-        assert!(is_initialized_mint_data(&data));
+    fn decode_and_check_authority_uninitialized_returns_uninitialized() {
+        let admin = Pubkey::new_unique();
+        let data = pack_mint(false, COption::Some(admin));
+        assert_eq!(
+            decode_and_check_authority(&data, &admin),
+            AuthorityCheck::Uninitialized
+        );
     }
 
-    // `Mint::pack` with `is_initialized = false` produces data that
-    // `Mint::unpack` rejects, so the helper reports "not initialized".
+    /// Empty account data — the mint account was never created. Pre-fix
+    /// this returned `false` from the old bool helper; the new helper
+    /// reports `CorruptData` (decode-fail) rather than `Uninitialized`,
+    /// because there is no reliable way to distinguish "account doesn't
+    /// exist" from "account has wrong-length corrupt data" via account
+    /// data alone. Both cases need JIT to attempt InitializeMint, but the
+    /// caller distinguishes by also checking `Err` from the RPC; this test
+    /// pins that empty/short data lands in `CorruptData`.
     #[test]
-    fn is_initialized_mint_data_packed_uninitialized_mint_is_false() {
-        let data = pack_mint(false);
-        assert!(!is_initialized_mint_data(&data));
+    fn decode_and_check_authority_empty_returns_corrupt() {
+        let admin = Pubkey::new_unique();
+        assert_eq!(
+            decode_and_check_authority(&[], &admin),
+            AuthorityCheck::CorruptData
+        );
     }
 
-    // Arbitrary bytes of the correct length are not a valid mint layout.
+    /// Data of the wrong length cannot decode as a mint.
     #[test]
-    fn is_initialized_mint_data_random_bytes_is_false() {
+    fn decode_and_check_authority_wrong_length_returns_corrupt() {
+        let admin = Pubkey::new_unique();
+        assert_eq!(
+            decode_and_check_authority(&[0u8; 10], &admin),
+            AuthorityCheck::CorruptData
+        );
+        assert_eq!(
+            decode_and_check_authority(&[0xFFu8; Mint::LEN + 1], &admin),
+            AuthorityCheck::CorruptData
+        );
+    }
+
+    /// Random bytes of the correct length usually contain an invalid
+    /// `COption` discriminant byte — `Mint::unpack` rejects them.
+    #[test]
+    fn decode_and_check_authority_random_bytes_returns_corrupt() {
+        let admin = Pubkey::new_unique();
         let data: Vec<u8> = (0u8..Mint::LEN as u8).collect();
-        assert!(!is_initialized_mint_data(&data));
+        assert_eq!(
+            decode_and_check_authority(&data, &admin),
+            AuthorityCheck::CorruptData
+        );
     }
 }

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -5,7 +5,7 @@ mod state;
 mod transaction;
 pub mod types;
 
-pub use mint::{find_existing_mint_signature, find_existing_mint_signature_with_memo};
+pub use mint::{find_existing_mint_signature, find_existing_mint_signature_with_memo, JitOutcome};
 pub use types::TransactionStatusUpdate;
 
 #[cfg(any(test, feature = "test-mock-storage"))]
@@ -48,7 +48,7 @@ pub mod test_hooks {
         state: &mut SenderState,
         transaction_id: i64,
         instruction: super::types::InstructionWithSigners,
-    ) -> Option<super::types::InstructionWithSigners> {
+    ) -> super::mint::JitOutcome {
         super::mint::try_jit_mint_initialization(state, transaction_id, instruction).await
     }
 

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -21,7 +21,7 @@ use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tracing::{error, info, info_span, warn, Instrument};
 
 use super::mint::{
-    cleanup_mint_builder, find_existing_mint_signature, try_jit_mint_initialization,
+    cleanup_mint_builder, find_existing_mint_signature, try_jit_mint_initialization, JitOutcome,
 };
 use super::proof::{cleanup_failed_transaction, rebuild_with_regenerated_proof};
 use super::types::{
@@ -421,42 +421,67 @@ pub(super) fn handle_confirmation_result<'a>(
                 metrics::OPERATOR_TRANSACTION_ERRORS
                     .with_label_values(&[pt, "mint_not_initialized"])
                     .inc();
-                if let Some(txn_id) = ctx.transaction_id {
-                    if state.mint_builders.contains_key(&txn_id) {
-                        warn!("Mint account not initialized - attempting JIT initialization");
-
-                        if let Some(new_instruction) =
-                            try_jit_mint_initialization(state, txn_id, instruction.clone()).await
-                        {
-                            info!("Retrying with JIT mint initialization");
-                            send_and_confirm(
-                                state,
-                                new_instruction,
-                                compute_unit_price,
-                                ctx,
-                                retry_policy,
-                                extra_error_checks_policy,
-                                storage_tx,
-                            )
-                            .await;
-                        } else {
-                            handle_permanent_failure(
-                                state,
-                                ctx,
-                                storage_tx,
-                                "Mint initialization failed",
-                            )
-                            .await;
-                        }
-                    } else {
-                        error!("MintNotInitialized error for non-Mint transaction");
-                        handle_permanent_failure(state, ctx, storage_tx, "Unexpected mint error")
-                            .await;
-                    }
-                } else {
+                let Some(txn_id) = ctx.transaction_id else {
                     error!("MintNotInitialized error without transaction_id");
                     handle_permanent_failure(state, ctx, storage_tx, "Mint initialization failed")
                         .await;
+                    return;
+                };
+                if !state.mint_builders.contains_key(&txn_id) {
+                    error!("MintNotInitialized error for non-Mint transaction");
+                    handle_permanent_failure(state, ctx, storage_tx, "Unexpected mint error").await;
+                    return;
+                }
+                warn!(
+                    "Mint not initialized — running JIT verdict for txn {}",
+                    txn_id
+                );
+                match try_jit_mint_initialization(state, txn_id, instruction.clone()).await {
+                    JitOutcome::Retry(new_instruction) => {
+                        info!("JIT verdict: Retry — re-issuing mint instruction");
+                        send_and_confirm(
+                            state,
+                            new_instruction,
+                            compute_unit_price,
+                            ctx,
+                            retry_policy,
+                            extra_error_checks_policy,
+                            storage_tx,
+                        )
+                        .await;
+                    }
+                    JitOutcome::ManualReview(reason) => {
+                        metrics::OPERATOR_TRANSACTION_ERRORS
+                            .with_label_values(&[pt, "mint_jit_manual_review"])
+                            .inc();
+                        error!("JIT verdict: ManualReview — {}", reason);
+                        send_guaranteed(
+                            storage_tx,
+                            TransactionStatusUpdate {
+                                transaction_id: txn_id,
+                                trace_id: ctx.trace_id.clone(),
+                                status: TransactionStatus::ManualReview,
+                                counterpart_signature: None,
+                                processed_at: Some(Utc::now()),
+                                error_message: Some(reason),
+                                remint_signature: None,
+                                remint_attempted: false,
+                            },
+                            "transaction status update",
+                        )
+                        .await
+                        .ok();
+                        // Release the cached MintToBuilder so it doesn't
+                        // linger past the terminal transition. For deposits
+                        // ctx.withdrawal_nonce is None, so the remint /
+                        // pending_signatures cleanup is a no-op; Mirrors
+                        // the cleanup pattern in handle_permanent_failure.
+                        cleanup_failed_transaction(state, ctx.withdrawal_nonce);
+                        state.mint_builders.remove(&txn_id);
+                    }
+                    JitOutcome::PermanentFailure(reason) => {
+                        handle_permanent_failure(state, ctx, storage_tx, &reason).await;
+                    }
                 }
             }
             Ok(ConfirmationResult::Retry) => match retry_policy {

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -263,6 +263,19 @@ fn drill_1_error_message_contracts_present_in_source() {
             "Confirmation failed - transaction status unknown, unsafe to retry",
             "indexer/src/operator/sender/transaction.rs",
         ),
+        // Deposit — sender side, post-JIT ManualReview path.
+        // `deposit_manual_review.md` § Path D dispatches on these.
+        // Constructed in full inside mint.rs (the caller arm in
+        // transaction.rs passes the reason through unchanged) so this
+        // drill can grep for the literals in a single source file.
+        (
+            "Mint instruction failed after JIT: mint_authority mismatch",
+            "indexer/src/operator/sender/mint.rs",
+        ),
+        (
+            "Mint instruction failed after JIT: corrupt mint state",
+            "indexer/src/operator/sender/mint.rs",
+        ),
         // Deposit — idempotency memo prefix. Anchors `_verify_onchain_mint.md`
         // step 3.
         (
@@ -923,6 +936,123 @@ async fn drill_10_deposit_failed_recovery_flows() -> Result<(), Box<dyn std::err
     assert_eq!(status_of(&pool, mr_id).await?, "failed");
 
     eprintln!("Deposit recovery flows verified end-to-end.");
+    Ok(())
+}
+
+// ── Drill 14: deposit_manual_review.md § Path D recovery flows ─────────────
+//
+// `deposit_manual_review.md` § Path D documents recovery for the
+// sender-side post-JIT ManualReview path. This drill pins:
+//
+//   1. The two new error_message substrings exist in mint.rs (also
+//      covered by drill_1 globally; re-asserted here so the drill is
+//      self-contained for an operator running it ad-hoc).
+//   2. The idempotency memo prefix is still anchored — the recovery
+//      flow re-arms to `pending`, and that re-arm is only safe because
+//      the operator's pre-send memo scan dedupes on this prefix.
+//   3. Recovery SQL flips `manual_review` → `pending` for the trigger
+//      row only; collateral and terminal rows are untouched.
+//   4. Recovery SQL is targeted by `id`, not by `error_message` — pins
+//      that drill_14's contract is fungible across the two new
+//      runbook substrings (and any future ones in the same Path D
+//      table).
+//   5. Webhook alertability is structurally guaranteed by drill_8 —
+//      this drill only narrates the dependency for the on-call reader.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_14_deposit_manual_review_post_jit_recovery_flows(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "deposit_manual_review.md",
+        "Path D — sender-side post-JIT failure",
+    );
+
+    // ── Step 1: source contract presence ──────────────────────────────
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+    for substr in [
+        "Mint instruction failed after JIT: mint_authority mismatch",
+        "Mint instruction failed after JIT: corrupt mint state",
+    ] {
+        let path = workspace_root.join("indexer/src/operator/sender/mint.rs");
+        let content =
+            std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+        assert!(
+            content.contains(substr),
+            "Path D dispatch substring missing from mint.rs: {substr:?}",
+        );
+        eprintln!("OK   mint.rs: {substr:?}");
+    }
+
+    // ── Step 2: idempotency memo prefix anchored ──────────────────────
+    let constants_path = workspace_root.join("indexer/src/operator/constants.rs");
+    let constants_content = std::fs::read_to_string(&constants_path)
+        .unwrap_or_else(|e| panic!("read {constants_path:?}: {e}"));
+    assert!(
+        constants_content.contains("private_channel:mint-idempotency:"),
+        "idempotency memo prefix must remain anchored — Path D re-arm \
+         relies on the pre-send memo scan to prevent double-mint",
+    );
+    eprintln!("OK   constants.rs: idempotency memo prefix anchored");
+
+    // ── Steps 3 + 4: recovery SQL is structural and targeted by id ────
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    // Seed three deposits: trigger (manual_review), collateral
+    // (pending), terminal (completed). The Path D re-arm SQL must
+    // touch only the trigger row.
+    let trigger_id = seed_deposit(&pool, "manual_review").await?;
+    let collateral_id = seed_deposit(&pool, "pending").await?;
+    let terminal_id = seed_deposit(&pool, "completed").await?;
+
+    sqlx::query("UPDATE transactions SET status='pending', updated_at=NOW() WHERE id=$1")
+        .bind(trigger_id)
+        .execute(&pool)
+        .await?;
+
+    assert_eq!(
+        status_of(&pool, trigger_id).await?,
+        "pending",
+        "Path D re-arm must flip the trigger row to pending"
+    );
+    assert_eq!(
+        status_of(&pool, collateral_id).await?,
+        "pending",
+        "collateral row must be untouched by Path D re-arm"
+    );
+    assert_eq!(
+        status_of(&pool, terminal_id).await?,
+        "completed",
+        "terminal row must be untouched by Path D re-arm"
+    );
+
+    // Repeat the re-arm against a different ManualReview row — the SQL
+    // is fungible across error_message values (Path D's two
+    // substrings, and the processor-side ManualReview substrings from
+    // Paths A/B/C). This catches a future "smart" runbook edit that
+    // adds a `WHERE error_message LIKE …` clause and breaks
+    // fungibility with drill_10.
+    let other_mr_id = seed_deposit(&pool, "manual_review").await?;
+    sqlx::query("UPDATE transactions SET status='pending', updated_at=NOW() WHERE id=$1")
+        .bind(other_mr_id)
+        .execute(&pool)
+        .await?;
+    assert_eq!(
+        status_of(&pool, other_mr_id).await?,
+        "pending",
+        "re-arm must work regardless of which ManualReview substring was the trigger"
+    );
+
+    // ── Step 5: webhook alertability cross-reference ─────────────────
+    eprintln!(
+        "Webhook alertability for ManualReview is pinned structurally by drill_8 — \
+         drill_14 does not re-test that contract."
+    );
+
+    eprintln!("Path D recovery flows verified end-to-end.");
     Ok(())
 }
 

--- a/integration/tests/indexer/jit_mint_helper.rs
+++ b/integration/tests/indexer/jit_mint_helper.rs
@@ -3,9 +3,13 @@
 //! `test_hooks::jit_mint_init` wrapper.
 //!
 //! Drives the production helper against a scripted `MockRpcServer`, so the
-//! full code path — on-chain probe, `InitializeMint` send, confirmation
-//! poll, and `mint_is_initialized_on_chain` backoff — is exercised
-//! end-to-end rather than replayed by hand at the wire layer.
+//! full code path — on-chain probe, `decode_and_check_authority` branching,
+//! `InitializeMint` send, confirmation poll, post-init authority recheck,
+//! and backoff fallback — is exercised end-to-end rather than replayed by
+//! hand at the wire layer.
+//!
+//! Each test pins one branch of the rewritten `JitOutcome` decision flow
+//! described in `mint.rs`.
 
 #[path = "sender_fixtures.rs"]
 mod sender_fixtures;
@@ -15,7 +19,7 @@ use {
     private_channel_indexer::{
         config::ProgramType,
         operator::{
-            sender::{test_hooks, types::InstructionWithSigners},
+            sender::{test_hooks, types::InstructionWithSigners, JitOutcome},
             utils::instruction_util::MintToBuilder,
             SignerUtil,
         },
@@ -40,11 +44,19 @@ use {
 };
 
 /// Pack an SPL `Mint` into its on-chain bytes so the byte layout the
-/// production helper decodes in `is_initialized_mint_data` matches what
+/// production helper decodes in `decode_and_check_authority` matches what
 /// a real Solana validator would return for `getAccountInfo`.
-fn pack_mint_bytes(is_initialized: bool) -> Vec<u8> {
+///
+/// `authority`:
+/// - `COption::Some(admin_pubkey)` → simulates an initialized mint where
+///   the operator's admin owns the authority (Match case).
+/// - `COption::Some(other)` → simulates a rotated-/foreign-authority mint
+///   (Mismatch case).
+/// - `COption::None` → simulates a mint whose authority was cleared (also
+///   Mismatch in the helper).
+fn pack_mint_bytes(is_initialized: bool, authority: COption<Pubkey>) -> Vec<u8> {
     let mint = Mint {
-        mint_authority: COption::Some(Pubkey::new_unique()),
+        mint_authority: authority,
         supply: 0,
         decimals: 6,
         is_initialized,
@@ -52,6 +64,29 @@ fn pack_mint_bytes(is_initialized: bool) -> Vec<u8> {
     };
     let mut data = vec![0u8; Mint::LEN];
     Mint::pack(mint, &mut data).expect("pack mint");
+    data
+}
+
+/// Initialized mint owned by the operator's admin. Match case.
+fn admin_owned_initialized_mint_bytes() -> Vec<u8> {
+    let admin = SignerUtil::admin_signer().pubkey();
+    pack_mint_bytes(true, COption::Some(admin))
+}
+
+/// Initialized mint owned by some *other* pubkey. Mismatch case (the
+/// rotated-admin scenario the runbook's Path D documents).
+fn foreign_authority_initialized_mint_bytes() -> Vec<u8> {
+    pack_mint_bytes(true, COption::Some(Pubkey::new_unique()))
+}
+
+/// Build `Mint::LEN` bytes that fail to decode. Setting the
+/// `mint_authority` `COption` discriminant (offset 0..4) to an invalid
+/// value makes `Mint::unpack_unchecked` reject the buffer with
+/// `InvalidAccountData`.
+fn corrupt_mint_bytes() -> Vec<u8> {
+    let mut data = vec![0u8; Mint::LEN];
+    // COption discriminants only allow {0, 1}; 0xFF is invalid.
+    data[0] = 0xFF;
     data
 }
 
@@ -73,7 +108,7 @@ fn account_info_reply(data: &[u8]) -> Reply {
 
 /// Build a `MintToBuilder` with the minimum field set
 /// `try_jit_mint_initialization` reads (`get_mint`, plus enough to flow
-/// through `handle_transaction_builder` if scenarios 2–6 reach the
+/// through `handle_transaction_builder` if scenarios reach the
 /// InitializeMint build path).
 fn make_mint_builder(mint: Pubkey) -> MintToBuilder {
     let mut builder = MintToBuilder::new();
@@ -91,9 +126,15 @@ fn make_mint_builder(mint: Pubkey) -> MintToBuilder {
 }
 
 /// Test fixture: builds a fresh `SenderState` with a `MockRpcServer`.
-/// When `populate_builder` is true, pre-inserts a `MintToBuilder` for
-/// `txn_id` so the JIT helper can read it; when false, the helper hits
-/// its "no cached builder" early-return branch on first lookup.
+///
+/// `populate_builder` controls whether `state.mint_builders` is pre-seeded
+/// for `txn_id` (when false, the helper hits its no-cached-builder
+/// PermanentFailure branch on first lookup).
+///
+/// `populate_mint_cache` controls whether `mock_storage.mints` carries a
+/// `DbMint` for the mint pubkey. The mint-cache-miss test relies on
+/// passing `false` here so `get_mint_metadata` returns the
+/// `PermanentFailure("mint not in mint cache")` branch.
 struct Fixture {
     state: private_channel_indexer::operator::sender::types::SenderState,
     mock: MockRpcServer,
@@ -102,19 +143,25 @@ struct Fixture {
 }
 
 async fn build_fixture(populate_builder: bool) -> Fixture {
+    build_fixture_inner(populate_builder, true).await
+}
+
+async fn build_fixture_inner(populate_builder: bool, populate_mint_cache: bool) -> Fixture {
     ensure_admin_signer_env();
     let mock = MockRpcServer::start().await;
     let mock_storage = MockStorage::new();
 
     let mint = Pubkey::new_unique();
-    // Pre-populate the mint cache so `get_mint_metadata` resolves from
-    // storage rather than falling back to RPC. This keeps the per-scenario
-    // RPC scripts focused on the JIT helper's own calls (account probe,
-    // blockhash, send, confirm, backoff).
-    mock_storage.mints.lock().unwrap().insert(
-        mint.to_string(),
-        DbMint::new(mint.to_string(), 6, spl_token::id().to_string()),
-    );
+    if populate_mint_cache {
+        // Pre-populate the mint cache so `get_mint_metadata` resolves from
+        // storage rather than falling back to RPC. This keeps the
+        // per-scenario RPC scripts focused on the JIT helper's own calls
+        // (account probe, blockhash, send, confirm, backoff).
+        mock_storage.mints.lock().unwrap().insert(
+            mint.to_string(),
+            DbMint::new(mint.to_string(), 6, spl_token::id().to_string()),
+        );
+    }
 
     let storage = Arc::new(Storage::Mock(mock_storage));
     let mut state = test_hooks::new_sender_state(
@@ -147,29 +194,31 @@ async fn build_fixture(populate_builder: bool) -> Fixture {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Mint already initialized — fast-path return.
+// Pre-check: mint already initialized with admin authority — Retry.
 // ─────────────────────────────────────────────────────────────────────
 //
-// One getAccountInfo reply with an initialized mint. The helper must
-// short-circuit and return Some(instruction) without sending any
-// transaction.
+// One getAccountInfo reply with an initialized mint whose authority is
+// the operator's admin. The helper must short-circuit and return
+// `JitOutcome::Retry(_)` without sending any transaction.
 #[tokio::test]
-async fn jit_returns_some_when_mint_already_initialized() {
-    let fixture = build_fixture(true).await;
+async fn jit_returns_retry_when_mint_already_initialized_with_admin_authority() {
     let Fixture {
         mut state,
         mock,
         txn_id,
         instruction,
-    } = fixture;
+    } = build_fixture(true).await;
 
-    mock.enqueue("getAccountInfo", account_info_reply(&pack_mint_bytes(true)));
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply(&admin_owned_initialized_mint_bytes()),
+    );
 
-    let result = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
     assert!(
-        result.is_some(),
-        "fast-path on initialized mint must return Some(instruction)"
+        matches!(outcome, JitOutcome::Retry(_)),
+        "fast-path on initialized mint with admin authority must return Retry"
     );
     assert_eq!(
         mock.call_count("getAccountInfo"),
@@ -181,34 +230,149 @@ async fn jit_returns_some_when_mint_already_initialized() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Full happy path — uninit probe → InitializeMint sent → confirmed.
+// Pre-check: mint initialized with a *different* authority — ManualReview.
 // ─────────────────────────────────────────────────────────────────────
 //
-// Probe sees uninit bytes, helper builds + sends InitializeMint, the
-// confirmation comes back clean, and the helper returns the original
-// `instruction` for downstream `mint_to`.
+// The bug-fix path. Pre-fix, the JIT helper saw `is_initialized = true`
+// and blindly returned `Some(original_instruction)`, causing the caller
+// to retry the doomed `mint_to` and loop forever. The new helper inspects
+// `mint_authority` and routes to ManualReview.
 #[tokio::test]
-async fn jit_completes_full_initialize_then_returns_some() {
-    let fixture = build_fixture(true).await;
+async fn jit_returns_manual_review_when_mint_authority_mismatch() {
     let Fixture {
         mut state,
         mock,
         txn_id,
         instruction,
-    } = fixture;
+    } = build_fixture(true).await;
 
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply(&foreign_authority_initialized_mint_bytes()),
+    );
+
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+
+    match outcome {
+        JitOutcome::ManualReview(reason) => {
+            assert!(
+                reason.contains("Mint instruction failed after JIT: mint_authority mismatch"),
+                "ManualReview reason must carry the runbook-dispatch substring; got {reason:?}"
+            );
+        }
+        other => panic!("expected ManualReview, got {:?}", debug_outcome(&other)),
+    }
+    assert_eq!(mock.call_count("getAccountInfo"), 1);
+    assert_eq!(
+        mock.call_count("sendTransaction"),
+        0,
+        "authority mismatch must abort before sending InitializeMint"
+    );
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Pre-check: mint initialized with `mint_authority = COption::None`
+// (authority cleared via SetAuthority) — also ManualReview.
+// ─────────────────────────────────────────────────────────────────────
+//
+// Pins the `AuthorityCheck::Mismatch(Pubkey::default())` branch in
+// `decode_and_check_authority` (a mint with no authority is treated as
+// a mismatch — the operator can't `mint_to` a no-authority mint).
+#[tokio::test]
+async fn jit_returns_manual_review_when_mint_authority_cleared() {
+    let Fixture {
+        mut state,
+        mock,
+        txn_id,
+        instruction,
+    } = build_fixture(true).await;
+
+    let no_authority_bytes = pack_mint_bytes(true, COption::None);
+    mock.enqueue("getAccountInfo", account_info_reply(&no_authority_bytes));
+
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+
+    match outcome {
+        JitOutcome::ManualReview(reason) => {
+            assert!(
+                reason.contains("Mint instruction failed after JIT: mint_authority mismatch"),
+                "no-authority mint must surface the mismatch substring; got {reason:?}"
+            );
+        }
+        other => panic!("expected ManualReview, got {:?}", debug_outcome(&other)),
+    }
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Pre-check: mint bytes do not decode as SPL Mint — ManualReview.
+// ─────────────────────────────────────────────────────────────────────
+//
+// Defensive — should not occur in normal operation. Pins the
+// `AuthorityCheck::CorruptData` branch.
+#[tokio::test]
+async fn jit_returns_manual_review_when_mint_data_corrupt() {
+    let Fixture {
+        mut state,
+        mock,
+        txn_id,
+        instruction,
+    } = build_fixture(true).await;
+
+    mock.enqueue("getAccountInfo", account_info_reply(&corrupt_mint_bytes()));
+
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+
+    match outcome {
+        JitOutcome::ManualReview(reason) => {
+            assert!(
+                reason.contains("Mint instruction failed after JIT: corrupt mint state"),
+                "ManualReview reason must carry the corrupt-state runbook substring; got {reason:?}"
+            );
+        }
+        other => panic!("expected ManualReview, got {:?}", debug_outcome(&other)),
+    }
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Full happy path — uninit probe → InitializeMint sent → confirmed
+// → post-init authority recheck = match → Retry.
+// ─────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn jit_completes_full_initialize_then_returns_retry() {
+    let Fixture {
+        mut state,
+        mock,
+        txn_id,
+        instruction,
+    } = build_fixture(true).await;
+
+    // Pre-check: account exists with right size but is_initialized=false.
     mock.enqueue("getAccountInfo", account_info_reply(&[0u8; Mint::LEN]));
     mock.enqueue("getLatestBlockhash", blockhash_reply());
     mock.enqueue("sendTransaction", send_transaction_echo_reply());
     mock.enqueue("getSignatureStatuses", confirmed_status_reply());
+    // Post-confirm authority recheck: now initialized with admin authority.
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply(&admin_owned_initialized_mint_bytes()),
+    );
 
-    let result = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
     assert!(
-        result.is_some(),
-        "full happy path must return Some(instruction)"
+        matches!(outcome, JitOutcome::Retry(_)),
+        "full happy path must return Retry"
     );
-    assert_eq!(mock.call_count("getAccountInfo"), 1);
+    assert_eq!(
+        mock.call_count("getAccountInfo"),
+        2,
+        "1 initial probe + 1 post-confirm authority recheck"
+    );
     assert_eq!(mock.call_count("getLatestBlockhash"), 1);
     assert_eq!(mock.call_count("sendTransaction"), 1);
     assert_eq!(mock.call_count("getSignatureStatuses"), 1);
@@ -216,25 +380,106 @@ async fn jit_completes_full_initialize_then_returns_some() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Initial probe returns an RPC error — fail-safe falls through to JIT.
+// Post-init authority mismatch — race during InitializeMint → ManualReview.
 // ─────────────────────────────────────────────────────────────────────
 //
-// A permanent RPC error on the first probe (`-32601` = method-not-found,
-// which `RpcClientWithRetry` does NOT retry) flows into the fail-safe
-// branch: the helper assumes the mint doesn't exist and continues with
-// JIT. We use `-32601` rather than a transient code (e.g. `-32000`)
-// because `is_permanent_rpc_error` short-circuits the retry loop, sparing
-// the test the ~3 s exponential-backoff wall-clock cost while exercising
-// the same source-side `Err(_)` arm.
+// Pre-check sees uninit, send + confirm succeed, but the post-init
+// authority recheck reads back a *different* authority — somebody
+// initialized the same mint with another key during our send window.
+// Routes to ManualReview with the post-init reason string.
 #[tokio::test]
-async fn jit_falls_through_when_initial_probe_returns_rpc_error() {
-    let fixture = build_fixture(true).await;
+async fn jit_returns_manual_review_when_post_init_authority_mismatch() {
     let Fixture {
         mut state,
         mock,
         txn_id,
         instruction,
-    } = fixture;
+    } = build_fixture(true).await;
+
+    mock.enqueue("getAccountInfo", account_info_reply(&[0u8; Mint::LEN]));
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("sendTransaction", send_transaction_echo_reply());
+    mock.enqueue("getSignatureStatuses", confirmed_status_reply());
+    // Post-confirm sees the racing concurrent-rotation outcome.
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply(&foreign_authority_initialized_mint_bytes()),
+    );
+
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+
+    match outcome {
+        JitOutcome::ManualReview(reason) => {
+            assert!(
+                reason.contains("Mint instruction failed after JIT: mint_authority mismatch"),
+                "post-init mismatch must carry the mint_authority-mismatch substring; got \
+                 {reason:?}"
+            );
+            assert!(
+                reason.contains("race with concurrent admin rotation"),
+                "post-init mismatch reason must distinguish itself from the pre-check one; got \
+                 {reason:?}"
+            );
+        }
+        other => panic!("expected ManualReview, got {:?}", debug_outcome(&other)),
+    }
+    assert_eq!(mock.call_count("sendTransaction"), 1);
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Mint cache miss — PermanentFailure.
+// ─────────────────────────────────────────────────────────────────────
+//
+// Pre-check sees uninit (would normally fall through to init), but
+// `get_mint_metadata` fails because the mint cache is empty. Routes to
+// PermanentFailure with the cache-miss reason string.
+#[tokio::test]
+async fn jit_returns_permanent_failure_when_mint_cache_miss() {
+    let Fixture {
+        mut state,
+        mock,
+        txn_id,
+        instruction,
+    } = build_fixture_inner(true, false).await;
+
+    mock.enqueue("getAccountInfo", account_info_reply(&[0u8; Mint::LEN]));
+
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+
+    match outcome {
+        JitOutcome::PermanentFailure(reason) => {
+            assert!(
+                reason.contains("mint not in mint cache"),
+                "cache-miss must surface the cache-miss reason; got {reason:?}"
+            );
+        }
+        other => panic!("expected PermanentFailure, got {:?}", debug_outcome(&other)),
+    }
+    assert_eq!(
+        mock.call_count("sendTransaction"),
+        0,
+        "cache miss must abort before sending InitializeMint"
+    );
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Initial probe RPC error — fail-safe falls through to JIT init.
+// ─────────────────────────────────────────────────────────────────────
+//
+// `-32601` (method-not-found) is a permanent RPC error that
+// `RpcClientWithRetry` does NOT retry, so the helper falls into the
+// fail-safe branch and proceeds with InitializeMint. After confirm, the
+// post-init authority recheck sees admin-owned initialized data → Retry.
+#[tokio::test]
+async fn jit_falls_through_when_initial_probe_returns_rpc_error() {
+    let Fixture {
+        mut state,
+        mock,
+        txn_id,
+        instruction,
+    } = build_fixture(true).await;
 
     mock.enqueue(
         "getAccountInfo",
@@ -243,38 +488,36 @@ async fn jit_falls_through_when_initial_probe_returns_rpc_error() {
     mock.enqueue("getLatestBlockhash", blockhash_reply());
     mock.enqueue("sendTransaction", send_transaction_echo_reply());
     mock.enqueue("getSignatureStatuses", confirmed_status_reply());
+    // Post-confirm authority recheck sees admin-owned init.
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply(&admin_owned_initialized_mint_bytes()),
+    );
 
-    let result = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
     assert!(
-        result.is_some(),
+        matches!(outcome, JitOutcome::Retry(_)),
         "RPC error on probe must not abort JIT — fail-safe branch must continue to send"
     );
     // Probe = 1 (no retry on -32601), then full JIT sequence proceeds.
-    assert_eq!(mock.call_count("getAccountInfo"), 1);
+    // 1 failed probe + 1 post-confirm recheck = 2.
+    assert_eq!(mock.call_count("getAccountInfo"), 2);
     assert_eq!(mock.call_count("sendTransaction"), 1);
     mock.shutdown().await;
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// sendTransaction fails — helper returns None without polling for confirmation.
+// sendTransaction fails — PermanentFailure without polling.
 // ─────────────────────────────────────────────────────────────────────
-//
-// Probe sees uninit, blockhash succeeds, send fails. The helper must
-// abort without polling for confirmation. `RetryPolicy::Idempotent`
-// (which InitializeMint uses) retries up to 5 times on transient errors;
-// we return `-32601` so `is_permanent_rpc_error` short-circuits, the
-// helper aborts after a single send attempt, and the test wall-clock
-// stays bounded.
 #[tokio::test]
-async fn jit_returns_none_when_send_transaction_fails() {
-    let fixture = build_fixture(true).await;
+async fn jit_returns_permanent_failure_when_send_transaction_fails() {
     let Fixture {
         mut state,
         mock,
         txn_id,
         instruction,
-    } = fixture;
+    } = build_fixture(true).await;
 
     mock.enqueue("getAccountInfo", account_info_reply(&[0u8; Mint::LEN]));
     mock.enqueue("getLatestBlockhash", blockhash_reply());
@@ -283,12 +526,17 @@ async fn jit_returns_none_when_send_transaction_fails() {
         Reply::error(-32601, "method not found (simulated send failure)"),
     );
 
-    let result = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
-    assert!(
-        result.is_none(),
-        "sendTransaction failure must abort JIT and return None"
-    );
+    match outcome {
+        JitOutcome::PermanentFailure(reason) => {
+            assert!(
+                reason.contains("Failed to send InitializeMint transaction"),
+                "send failure must surface the send-failure reason; got {reason:?}"
+            );
+        }
+        other => panic!("expected PermanentFailure, got {:?}", debug_outcome(&other)),
+    }
     assert_eq!(mock.call_count("sendTransaction"), 1);
     assert_eq!(
         mock.call_count("getSignatureStatuses"),
@@ -299,42 +547,42 @@ async fn jit_returns_none_when_send_transaction_fails() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Send succeeds but stays unconfirmed — backoff probe finds it initialized.
+// Send succeeds but stays unconfirmed — backoff probe finds it
+// initialized with admin authority → Retry.
 // ─────────────────────────────────────────────────────────────────────
 //
-// Probe sees uninit, send succeeds, but the InitializeMint never
-// confirms (status returns `null` on every poll). After
-// MAX_POLL_ATTEMPTS_CONFIRMATION=5 nulls, `check_transaction_status`
-// returns `ConfirmationResult::Retry`, which lands in the
-// `mint_is_initialized_on_chain` backoff. The very first backoff
-// `getAccountInfo` returns initialized bytes, so the helper treats JIT
-// as success and returns `Some(instruction)`.
+// After 5 null status responses `check_transaction_status` returns
+// `ConfirmationResult::Retry`, which lands in the
+// `mint_authority_check_with_backoff` fallback. The first backoff
+// `getAccountInfo` returns admin-owned init bytes, so the helper treats
+// JIT as a successful race-recovery and returns Retry.
 #[tokio::test]
-async fn jit_returns_some_when_backoff_recovers_from_unconfirmed() {
-    let fixture = build_fixture(true).await;
+async fn jit_returns_retry_when_backoff_recovers_with_admin_authority() {
     let Fixture {
         mut state,
         mock,
         txn_id,
         instruction,
-    } = fixture;
+    } = build_fixture(true).await;
 
-    // Initial probe: uninit (drives JIT).
     mock.enqueue("getAccountInfo", account_info_reply(&[0u8; Mint::LEN]));
     mock.enqueue("getLatestBlockhash", blockhash_reply());
     mock.enqueue("sendTransaction", send_transaction_echo_reply());
-    // 5× pending so check_transaction_status returns Retry.
     for _ in 0..5 {
         mock.enqueue("getSignatureStatuses", null_status_reply());
     }
-    // First backoff probe sees the racing InitializeMint settled.
-    mock.enqueue("getAccountInfo", account_info_reply(&pack_mint_bytes(true)));
+    // First backoff probe sees the racing InitializeMint settled with
+    // admin authority.
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply(&admin_owned_initialized_mint_bytes()),
+    );
 
-    let result = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
     assert!(
-        result.is_some(),
-        "race-recovery branch must return Some when backoff observes init"
+        matches!(outcome, JitOutcome::Retry(_)),
+        "race-recovery branch must return Retry when backoff sees admin-authority init"
     );
     assert_eq!(
         mock.call_count("getAccountInfo"),
@@ -347,26 +595,21 @@ async fn jit_returns_some_when_backoff_recovers_from_unconfirmed() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Send succeeds but stays unconfirmed — backoff exhausts, helper returns None.
+// Backoff observes mint initialized with foreign authority → ManualReview.
 // ─────────────────────────────────────────────────────────────────────
 //
-// Same scripted prefix as the race-recovery test, but every backoff probe sees
-// uninit. After ATTEMPTS=4 backoff polls,
-// `mint_is_initialized_on_chain` returns false and the helper logs an
-// error and returns None.
-//
-// Wall-clock note: this is the only test that pays the full
-// 4 × BACKOFF_MS = ~750 ms for the backoff loop; do not duplicate this
-// shape elsewhere.
+// Same scripted prefix as the race-recovery test, but the backoff probe
+// reads back a foreign authority. Routes to ManualReview with the
+// post-init mismatch reason (`race with concurrent admin rotation`),
+// matching the documented contract.
 #[tokio::test]
-async fn jit_returns_none_when_backoff_exhausts_with_uninit() {
-    let fixture = build_fixture(true).await;
+async fn jit_returns_manual_review_when_backoff_recovers_with_authority_mismatch() {
     let Fixture {
         mut state,
         mock,
         txn_id,
         instruction,
-    } = fixture;
+    } = build_fixture(true).await;
 
     mock.enqueue("getAccountInfo", account_info_reply(&[0u8; Mint::LEN]));
     mock.enqueue("getLatestBlockhash", blockhash_reply());
@@ -374,18 +617,64 @@ async fn jit_returns_none_when_backoff_exhausts_with_uninit() {
     for _ in 0..5 {
         mock.enqueue("getSignatureStatuses", null_status_reply());
     }
-    // 4 backoff probes (matches ATTEMPTS=4 in mint_is_initialized_on_chain),
-    // every one sees uninit so the loop exhausts.
+    // Backoff sees concurrent rotation with a foreign authority.
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply(&foreign_authority_initialized_mint_bytes()),
+    );
+
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+
+    match outcome {
+        JitOutcome::ManualReview(reason) => {
+            assert!(
+                reason.contains("race with concurrent admin rotation"),
+                "backoff mismatch must reuse the post-init mismatch reason; got {reason:?}"
+            );
+        }
+        other => panic!("expected ManualReview, got {:?}", debug_outcome(&other)),
+    }
+    assert_eq!(mock.call_count("sendTransaction"), 1);
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Backoff exhausts with uninit reads — PermanentFailure.
+// ─────────────────────────────────────────────────────────────────────
+//
+// Wall-clock note: this is the only test that pays the full
+// 4 × BACKOFF_MS = ~750 ms for the backoff loop; do not duplicate this
+// shape elsewhere.
+#[tokio::test]
+async fn jit_returns_permanent_failure_when_backoff_exhausts_with_uninit() {
+    let Fixture {
+        mut state,
+        mock,
+        txn_id,
+        instruction,
+    } = build_fixture(true).await;
+
+    mock.enqueue("getAccountInfo", account_info_reply(&[0u8; Mint::LEN]));
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("sendTransaction", send_transaction_echo_reply());
+    for _ in 0..5 {
+        mock.enqueue("getSignatureStatuses", null_status_reply());
+    }
     for _ in 0..4 {
         mock.enqueue("getAccountInfo", account_info_reply(&[0u8; Mint::LEN]));
     }
 
-    let result = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
-    assert!(
-        result.is_none(),
-        "backoff exhaustion with uninit reads must surface as None"
-    );
+    match outcome {
+        JitOutcome::PermanentFailure(reason) => {
+            assert!(
+                reason.contains("InitializeMint transaction could not be confirmed"),
+                "exhausted-backoff must surface the could-not-be-confirmed reason; got {reason:?}"
+            );
+        }
+        other => panic!("expected PermanentFailure, got {:?}", debug_outcome(&other)),
+    }
     assert_eq!(
         mock.call_count("getAccountInfo"),
         5,
@@ -396,31 +685,43 @@ async fn jit_returns_none_when_backoff_exhausts_with_uninit() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// No cached builder — early return, zero RPC calls.
+// No cached builder — PermanentFailure, zero RPC calls.
 // ─────────────────────────────────────────────────────────────────────
-//
-// `state.mint_builders` is empty for the queried txn_id. The helper
-// must early-return None without issuing any RPC call.
 #[tokio::test]
-async fn jit_returns_none_when_no_cached_builder() {
-    let fixture = build_fixture(false).await; // do NOT pre-populate.
+async fn jit_returns_permanent_failure_when_no_cached_builder() {
     let Fixture {
         mut state,
         mock,
         txn_id,
         instruction,
-    } = fixture;
+    } = build_fixture(false).await; // do NOT pre-populate.
 
-    let result = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
+    let outcome = test_hooks::jit_mint_init(&mut state, txn_id, instruction).await;
 
-    assert!(
-        result.is_none(),
-        "missing builder must short-circuit with None"
-    );
+    match outcome {
+        JitOutcome::PermanentFailure(reason) => {
+            assert!(
+                reason.contains("no cached MintToBuilder"),
+                "missing-builder branch must surface its specific reason; got {reason:?}"
+            );
+        }
+        other => panic!("expected PermanentFailure, got {:?}", debug_outcome(&other)),
+    }
     assert_eq!(
         mock.call_count("getAccountInfo"),
         0,
         "early return must skip every RPC call"
     );
     mock.shutdown().await;
+}
+
+/// `JitOutcome` doesn't derive `Debug` (the `Retry` variant carries
+/// non-Debug `InstructionWithSigners`), so panic messages need a
+/// hand-rolled summary.
+fn debug_outcome(outcome: &JitOutcome) -> String {
+    match outcome {
+        JitOutcome::Retry(_) => "Retry(_)".to_string(),
+        JitOutcome::ManualReview(reason) => format!("ManualReview({reason:?})"),
+        JitOutcome::PermanentFailure(reason) => format!("PermanentFailure({reason:?})"),
+    }
 }

--- a/integration/tests/indexer/sender_onchain_error_arms.rs
+++ b/integration/tests/indexer/sender_onchain_error_arms.rs
@@ -23,23 +23,37 @@
 mod sender_fixtures;
 
 use {
+    base64::{engine::general_purpose::STANDARD, Engine as _},
     private_channel_escrow_program_client::errors::PrivateChannelEscrowProgramError,
     private_channel_indexer::{
+        config::ProgramType,
         error::{ProgramError, TransactionError},
         operator::{
             sender::{test_hooks, types::TransactionStatusUpdate},
             utils::{
-                instruction_util::{ExtraErrorCheckPolicy, RetryPolicy},
+                instruction_util::{ExtraErrorCheckPolicy, MintToBuilder, RetryPolicy},
                 transaction_util::ConfirmationResult,
             },
+            SignerUtil,
         },
-        storage::TransactionStatus,
+        storage::{
+            common::{models::DbMint, storage::mock::MockStorage},
+            Storage, TransactionStatus,
+        },
     },
     sender_fixtures::{
         blockhash_reply, build_default_sender_state, confirmed_status_reply, deposit_ctx,
-        make_instruction, send_transaction_echo_reply,
+        ensure_admin_signer_env, make_config, make_instruction, send_transaction_echo_reply,
     },
-    solana_sdk::signature::Signature,
+    serde_json::json,
+    solana_keychain::SolanaSigner,
+    solana_sdk::{commitment_config::CommitmentLevel, pubkey::Pubkey, signature::Signature},
+    spl_token::{
+        solana_program::{program_option::COption, program_pack::Pack},
+        state::Mint,
+    },
+    std::sync::Arc,
+    test_utils::mock_rpc::MockRpcServer,
 };
 
 /// Drive the hook with a synthesised `result` and return the single
@@ -230,5 +244,294 @@ async fn retry_under_idempotent_policy_recursively_resends_and_completes() {
     // Recursive call hit the wire exactly once.
     assert_eq!(mock.call_count("sendTransaction"), 1);
     assert_eq!(mock.call_count("getSignatureStatuses"), 1);
+    mock.shutdown().await;
+}
+
+// ============================================================================
+// JIT-verdict caller-arm tests
+//
+// These exercise the rewritten `MintNotInitialized` arm in
+// `handle_confirmation_result` (sender/transaction.rs) end-to-end. Each
+// drives the JIT body via mocked RPC into one of the three `JitOutcome`
+// variants and asserts the resulting `TransactionStatusUpdate` shape.
+// ============================================================================
+
+/// Build a `SenderState` with optional pre-seeded mint cache + builder for
+/// the JIT-driven caller-arm tests. The default `build_default_sender_state`
+/// fixture doesn't seed anything; these tests need both knobs.
+async fn build_state_for_jit_caller_arm(
+    populate_mint_cache: bool,
+) -> (
+    private_channel_indexer::operator::sender::types::SenderState,
+    tokio::sync::mpsc::Receiver<TransactionStatusUpdate>,
+    tokio::sync::mpsc::Sender<TransactionStatusUpdate>,
+    MockRpcServer,
+    Pubkey,
+) {
+    ensure_admin_signer_env();
+    let mock = MockRpcServer::start().await;
+    let mock_storage = MockStorage::new();
+    let mint = Pubkey::new_unique();
+    if populate_mint_cache {
+        mock_storage.mints.lock().unwrap().insert(
+            mint.to_string(),
+            DbMint::new(mint.to_string(), 6, spl_token::id().to_string()),
+        );
+    }
+    let storage = Arc::new(Storage::Mock(mock_storage));
+    let state = test_hooks::new_sender_state(
+        &make_config(mock.url(), ProgramType::Escrow),
+        CommitmentLevel::Confirmed,
+        None,
+        storage,
+        1,
+        1,
+        None,
+    )
+    .expect("SenderState construction must succeed under Mock storage");
+    let (storage_tx, storage_rx) = tokio::sync::mpsc::channel(8);
+    (state, storage_rx, storage_tx, mock, mint)
+}
+
+fn make_mint_builder_for_caller_arm(mint: Pubkey) -> MintToBuilder {
+    let mut builder = MintToBuilder::new();
+    let admin = SignerUtil::admin_signer().pubkey();
+    builder
+        .mint(mint)
+        .recipient(Pubkey::new_unique())
+        .recipient_ata(Pubkey::new_unique())
+        .payer(admin)
+        .mint_authority(admin)
+        .token_program(spl_token::id())
+        .amount(1_000)
+        .idempotency_memo("private_channel:mint-idempotency:1".to_string());
+    builder
+}
+
+fn pack_mint_with_authority(authority: COption<Pubkey>) -> Vec<u8> {
+    let mint = Mint {
+        mint_authority: authority,
+        supply: 0,
+        decimals: 6,
+        is_initialized: true,
+        freeze_authority: COption::None,
+    };
+    let mut data = vec![0u8; Mint::LEN];
+    Mint::pack(mint, &mut data).expect("pack mint");
+    data
+}
+
+fn account_info_reply_bytes(data: &[u8]) -> test_utils::mock_rpc::Reply {
+    test_utils::mock_rpc::Reply::result(json!({
+        "context": { "slot": 100 },
+        "value": {
+            "data": [STANDARD.encode(data), "base64"],
+            "executable": false,
+            "lamports": 1_461_600u64,
+            "owner": spl_token::id().to_string(),
+            "rentEpoch": 0u64,
+            "space": data.len(),
+        }
+    }))
+}
+
+/// Drive the caller arm with `Ok(MintNotInitialized)` after seeding the
+/// mint_builders entry. Pulled out so each test reads as a wire-script
+/// + assertions block.
+async fn drive_caller_arm_with_jit_setup(
+    state: &mut private_channel_indexer::operator::sender::types::SenderState,
+    txn_id: i64,
+    mint: Pubkey,
+    storage_tx: &tokio::sync::mpsc::Sender<TransactionStatusUpdate>,
+) {
+    state
+        .mint_builders
+        .insert(txn_id, make_mint_builder_for_caller_arm(mint));
+    let ctx = deposit_ctx(txn_id);
+    test_hooks::handle_confirmation_result(
+        state,
+        Ok(ConfirmationResult::MintNotInitialized),
+        Signature::new_unique(),
+        None,
+        &ctx,
+        make_instruction(),
+        RetryPolicy::None,
+        // Synthesised `Ok(MintNotInitialized)` bypasses the classifier so
+        // ExtraErrorCheckPolicy::None is fine here.
+        &ExtraErrorCheckPolicy::None,
+        storage_tx,
+    )
+    .await
+}
+
+/// JitOutcome::Retry path — the caller-arm match must invoke the
+/// recursive `send_and_confirm` and emit `Completed`.
+#[tokio::test]
+async fn mint_not_initialized_jit_retry_completes() {
+    let (mut state, mut storage_rx, storage_tx, mock, mint) =
+        build_state_for_jit_caller_arm(true).await;
+
+    // JIT pre-check sees admin-owned init → Retry without sending init.
+    let admin_bytes = pack_mint_with_authority(COption::Some(SignerUtil::admin_signer().pubkey()));
+    mock.enqueue("getAccountInfo", account_info_reply_bytes(&admin_bytes));
+
+    // Recursive send_and_confirm wire scripting — succeeds.
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("sendTransaction", send_transaction_echo_reply());
+    mock.enqueue("getSignatureStatuses", confirmed_status_reply());
+
+    drive_caller_arm_with_jit_setup(&mut state, 5001, mint, &storage_tx).await;
+
+    let update = storage_rx
+        .recv()
+        .await
+        .expect("Retry path must drive the recursive send to a status update");
+    assert_eq!(update.transaction_id, 5001);
+    assert_eq!(
+        update.status,
+        TransactionStatus::Completed,
+        "JitOutcome::Retry must complete via recursive send_and_confirm; got {:?}",
+        update.status
+    );
+    mock.shutdown().await;
+}
+
+/// JitOutcome::ManualReview (authority mismatch) — the caller arm must
+/// emit a ManualReview status with the runbook-dispatch substring and
+/// release the cached MintToBuilder.
+#[tokio::test]
+async fn mint_not_initialized_jit_manual_review_authority_mismatch() {
+    let (mut state, mut storage_rx, storage_tx, mock, mint) =
+        build_state_for_jit_caller_arm(true).await;
+
+    // JIT pre-check sees foreign authority → ManualReview before any send.
+    let foreign_bytes = pack_mint_with_authority(COption::Some(Pubkey::new_unique()));
+    mock.enqueue("getAccountInfo", account_info_reply_bytes(&foreign_bytes));
+
+    let txn_id: i64 = 5002;
+    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, &storage_tx).await;
+
+    let update = storage_rx
+        .recv()
+        .await
+        .expect("ManualReview path must emit a status update");
+    assert_eq!(update.transaction_id, txn_id);
+    assert_eq!(update.status, TransactionStatus::ManualReview);
+    let msg = update
+        .error_message
+        .clone()
+        .expect("ManualReview must carry an error_message");
+    assert!(
+        msg.contains("Mint instruction failed after JIT: mint_authority mismatch"),
+        "ManualReview error_message must round-trip the runbook-dispatch substring; got {msg:?}"
+    );
+    assert!(update.processed_at.is_some());
+    assert!(
+        !state.mint_builders.contains_key(&txn_id),
+        "ManualReview branch must release the cached MintToBuilder"
+    );
+    assert_eq!(
+        mock.call_count("sendTransaction"),
+        0,
+        "authority-mismatch must abort before sending InitializeMint"
+    );
+    mock.shutdown().await;
+}
+
+/// JitOutcome::ManualReview (corrupt mint state) — pins the second
+/// runbook-dispatch substring.
+#[tokio::test]
+async fn mint_not_initialized_jit_manual_review_corrupt_state() {
+    let (mut state, mut storage_rx, storage_tx, mock, mint) =
+        build_state_for_jit_caller_arm(true).await;
+
+    // Corrupt bytes (invalid COption discriminant) → CorruptData → ManualReview.
+    let mut data = vec![0u8; Mint::LEN];
+    data[0] = 0xFF;
+    mock.enqueue("getAccountInfo", account_info_reply_bytes(&data));
+
+    let txn_id: i64 = 5003;
+    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, &storage_tx).await;
+
+    let update = storage_rx
+        .recv()
+        .await
+        .expect("CorruptData ManualReview path must emit a status update");
+    assert_eq!(update.transaction_id, txn_id);
+    assert_eq!(update.status, TransactionStatus::ManualReview);
+    let msg = update.error_message.unwrap_or_default();
+    assert!(
+        msg.contains("Mint instruction failed after JIT: corrupt mint state"),
+        "ManualReview must carry the corrupt-state runbook substring; got {msg:?}"
+    );
+    mock.shutdown().await;
+}
+
+/// JitOutcome::PermanentFailure — the caller arm routes through
+/// `handle_permanent_failure` and the resulting status is Failed.
+#[tokio::test]
+async fn mint_not_initialized_jit_permanent_failure() {
+    // Mint cache empty → JIT body returns PermanentFailure("mint not in mint cache").
+    let (mut state, mut storage_rx, storage_tx, mock, mint) =
+        build_state_for_jit_caller_arm(false).await;
+
+    // Pre-check sees uninit (would normally fall through to init) but
+    // get_mint_metadata fails because the cache is empty.
+    mock.enqueue(
+        "getAccountInfo",
+        account_info_reply_bytes(&[0u8; Mint::LEN]),
+    );
+
+    let txn_id: i64 = 5004;
+    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, &storage_tx).await;
+
+    let update = storage_rx
+        .recv()
+        .await
+        .expect("PermanentFailure path must emit a status update");
+    assert_eq!(update.transaction_id, txn_id);
+    assert_eq!(
+        update.status,
+        TransactionStatus::Failed,
+        "JitOutcome::PermanentFailure must route through handle_permanent_failure"
+    );
+    let msg = update.error_message.unwrap_or_default();
+    assert!(
+        msg.contains("mint not in mint cache"),
+        "Failed error_message must surface the permanent-failure reason; got {msg:?}"
+    );
+    mock.shutdown().await;
+}
+
+/// `MintNotInitialized` without a `transaction_id` short-circuits to
+/// `handle_permanent_failure("Mint initialization failed")` — covers the
+/// `let Some(txn_id) = ...` else-branch in the caller arm.
+#[tokio::test]
+async fn mint_not_initialized_no_txn_id_routes_to_failed() {
+    let (mut state, mut storage_rx, storage_tx, mock) = build_default_sender_state().await;
+
+    let ctx = private_channel_indexer::operator::sender::types::TransactionContext {
+        transaction_id: None,
+        withdrawal_nonce: None,
+        trace_id: None,
+    };
+
+    test_hooks::handle_confirmation_result(
+        &mut state,
+        Ok(ConfirmationResult::MintNotInitialized),
+        Signature::new_unique(),
+        None,
+        &ctx,
+        make_instruction(),
+        RetryPolicy::None,
+        &ExtraErrorCheckPolicy::None,
+        &storage_tx,
+    )
+    .await;
+
+    // No transaction_id → no status update emitted (send_fatal_error
+    // guards on Some(transaction_id)).
+    drop(storage_tx);
+    assert!(storage_rx.recv().await.is_none());
     mock.shutdown().await;
 }

--- a/private-channel-escrow-program/clients/rust/Cargo.toml
+++ b/private-channel-escrow-program/clients/rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 description = "Rust client for the PrivateChannel Escrow Program"
 license = "MIT"
-repository = "https://github.com/solana-foundation/private_channel/private-channel-escrow-program"
+repository = "https://github.com/solana-foundation/solana-private-channels"
 
 [dependencies]
 borsh = { workspace = true }

--- a/private-channel-escrow-program/package.json
+++ b/private-channel-escrow-program/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "main": "index.js",
     "description": "Solana Private Channels Escrow Program",
-    "repository": "git@github.com:solana-foundation/contra.git",
+    "repository": "git@github.com:solana-foundation/solana-private-channels.git",
     "license": "MIT",
     "scripts": {
         "build": "cd clients/typescript && tsc",

--- a/private-channel-withdraw-program/clients/rust/Cargo.toml
+++ b/private-channel-withdraw-program/clients/rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 description = "Rust client for the PrivateChannel Withdraw Program"
 license = "MIT"
-repository = "https://github.com/solana-foundation/private_channel/private-channel-withdraw-program"
+repository = "https://github.com/solana-foundation/solana-private-channels"
 
 [dependencies]
 borsh = { workspace = true }

--- a/private-channel-withdraw-program/package.json
+++ b/private-channel-withdraw-program/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "main": "index.js",
     "description": "Solana Private Channels Withdraw Program",
-    "repository": "git@github.com:solana-foundation/contra.git",
+    "repository": "git@github.com:solana-foundation/solana-private-channels.git",
     "license": "MIT",
     "scripts": {
         "build": "cd clients/typescript && tsc",


### PR DESCRIPTION
## Summary

Branch cleanup ahead of audit. One major change is the operator JIT
mint bug fix which turns a silent-loop failure mode into an explicit
`ManualReview`. Bundled with auth coverage recovery, 
hygiene fixes, and rename follow-up from #112.

## Scope

- **`fix(indexer)` JIT mint verdict** [ticket](https://linear.app/solana-fndn/issue/EXO-29/tighten-deposit-jit-mint-error-classification-to-surface-terminal): `try_jit_mint_initialization`
  returns a 3-way `JitOutcome` (`Retry` / `ManualReview` / `PermanentFailure`)
  instead of `Option<…>`. Decodes the on-chain mint via
  `Mint::unpack_unchecked` so post-init failures (rotated admin authority,
  corrupt mint) reach a terminal status + webhook instead of looping.
- **`test(auth)` admin CLI coverage**: 6 in-binary tests covering
  `run`'s env-var validation and the four `attach_wallet` branches.
- **`chore(core)` pre-audit hygiene**: three small fixes an auditor
  would otherwise call out:
  - `vm/admin.rs`: misleading "TODO: Not implemented" comments → block
    comment naming the gasless-path no-ops.
  - `accounts/bob.rs`: stale `#[allow(dead_code)]` on `synced_since` (the
    field is live).
  - `accounts/types.rs`: `panic!()` → `unreachable!()` with invariant.
- **`chore` rename follow-ups (Contra → Solana Private Channels)**:
  - CI runner: `contra-runner-1` → `private-channel-runner-1` across all
    four workflows.
  - Repo URL in `README.md`, `CONTRIBUTING.md`, `docs/{DEVNET_QUICKSTART,
    TECHNICAL_REQUIREMENTS}.md`, both program `package.json`s, and both
    generated-client `Cargo.toml`s (the latter also fixes the malformed
    `…/private_channel/…` URL; survives `make generate-clients` via
    `preserveConfigFiles`).
- **`docs(runbooks)`**: refreshed alert-dispatch table + new "Path D"
  recovery section for the JIT `ManualReview` outcomes.
- **`chore(bench-tps)`**: formatting + small cleanups, no behavior
  change.


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,200 | 10,622 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/25557280673) |
| Indexer | 14,997 | 17,689 | 84.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/25557280673) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/25557280673) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/25557280673) |
| Withdraw Program | 120 | 232 | 51.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/25557280681) |
| Escrow Program | 1,185 | 1,963 | 60.4% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/25557280681) |
| E2E Integration | 9,840 | 12,166 | 80.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/25557280673) |
| **Total** | **37,053** | **44,667** | **83.0%** | |

> Last updated: 2026-05-08 13:33:33 UTC by E2E Integration