### PR TITLE
fix(indexer): use DepositEvent amount instead of instruction args

### DIFF
--- a/indexer/src/indexer/datasource/common/parser/escrow.rs
+++ b/indexer/src/indexer/datasource/common/parser/escrow.rs
@@ -21,8 +21,10 @@ const RESET_SMT_ROOT: u8 = 8;
 // Event related constants
 const EVENT_IX_TAG_LE: &[u8] = &[0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
 const ALLOW_MINT_EVENT_DISCRIMINATOR: u8 = 1;
+const DEPOSIT_EVENT_DISCRIMINATOR: u8 = 6;
 const EVENT_DISCRIMINATOR_INDEX: usize = 8;
 const EVENT_DECIMALS_INDEX: usize = 73;
+const EVENT_AMOUNT_INDEX: usize = 73;
 
 // ******************************************************************************************
 // Instruction types
@@ -43,6 +45,7 @@ pub enum EscrowInstruction {
     Deposit {
         accounts: DepositAccounts,
         data: DepositData,
+        event: DepositEvent,
     },
     ReleaseFunds {
         accounts: ReleaseFundsAccounts,
@@ -195,6 +198,11 @@ pub struct AllowMintEvent {
     pub decimals: u8,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, BorshDeserialize)]
+pub struct DepositEvent {
+    pub amount: u64,
+}
+
 // ******************************************************************************************
 // Parse instructions
 // ******************************************************************************************
@@ -217,7 +225,7 @@ pub fn parse_escrow_instruction(
     match discriminator {
         CREATE_INSTANCE => parse_create_instance(ix_data, instruction, account_keys),
         ALLOW_MINT => parse_allow_mint(ix_data, instruction, account_keys, inner_instructions),
-        DEPOSIT => parse_deposit(ix_data, instruction, account_keys),
+        DEPOSIT => parse_deposit(ix_data, instruction, account_keys, inner_instructions),
         RELEASE_FUNDS => parse_release_funds(ix_data, instruction, account_keys),
         RESET_SMT_ROOT => parse_reset_smt_root(instruction, account_keys),
         _ => Ok(None), // Unsupported instruction type
@@ -320,6 +328,7 @@ fn parse_deposit(
     data: &[u8],
     instruction: &CompiledInstruction,
     account_keys: &[Pubkey],
+    inner_instructions: &[InnerInstructions],
 ) -> Result<Option<EscrowInstruction>, ParserError> {
     let ix_data = <DepositData as borsh::BorshDeserialize>::deserialize(&mut &data[..])?;
 
@@ -347,10 +356,36 @@ fn parse_deposit(
         private_channel_escrow_program: account_keys[instruction.accounts[11] as usize],
     };
 
-    Ok(Some(EscrowInstruction::Deposit {
-        accounts,
-        data: ix_data,
-    }))
+    for inner_instruction_set in inner_instructions {
+        for inner_instruction in &inner_instruction_set.instructions {
+            let Ok(event_data) = bs58::decode(&inner_instruction.data).into_vec() else {
+                continue;
+            };
+
+            if event_data.len() >= 145
+                && event_data.starts_with(EVENT_IX_TAG_LE)
+                && event_data[EVENT_DISCRIMINATOR_INDEX] == DEPOSIT_EVENT_DISCRIMINATOR
+            {
+                let amount_bytes: [u8; 8] = event_data[EVENT_AMOUNT_INDEX..EVENT_AMOUNT_INDEX + 8]
+                    .try_into()
+                    .map_err(|_| ParserError::InstructionParseFailed {
+                        reason: "DepositEvent amount slice not 8 bytes".to_string()
+                    })?;
+                
+                let amount = u64::from_le_bytes(amount_bytes);
+
+                return Ok(Some(EscrowInstruction::Deposit {
+                    accounts,
+                    data: ix_data,
+                    event: DepositEvent { amount }
+                }))
+            }
+        }
+    }
+
+    Err(ParserError::InstructionParseFailed {
+        reason: "No deposit event found".to_string(),
+    })
 }
 
 /// Parse ReleaseFunds instruction
@@ -473,6 +508,29 @@ mod tests {
         data.extend_from_slice(&1000u64.to_le_bytes()); // amount
         data.push(0); // None for recipient (Option discriminator = 0)
         data
+    }
+
+    /// Build inner instructions carrying a valid DepositEvent CPI with the
+    /// given received `amount`. Layout: tag(8) + disc(1) + instance_seed(32)
+    /// + user(32) + amount(8 LE) + recipient(32) + mint(32) = 145 bytes.
+    fn create_deposit_inner_instructions(amount: u64) -> Vec<InnerInstructions> {
+        let mut data = vec![];
+        data.extend_from_slice(EVENT_IX_TAG_LE);
+        data.push(DEPOSIT_EVENT_DISCRIMINATOR);
+        data.extend_from_slice(&[0u8; 32]); // instance_seed
+        data.extend_from_slice(&[0u8; 32]); // user
+        data.extend_from_slice(&amount.to_le_bytes());
+        data.extend_from_slice(&[0u8; 32]); // recipient
+        data.extend_from_slice(&[0u8; 32]); // mint
+
+        vec![InnerInstructions {
+            index: 0,
+            instructions: vec![CompiledInstruction {
+                program_id_index: 0,
+                accounts: vec![],
+                data: bs58::encode(&data).into_string(),
+            }],
+        }]
     }
 
     /// Create minimal valid Borsh-encoded data for ReleaseFunds instruction
@@ -611,11 +669,21 @@ mod tests {
         let instruction = create_instruction_with_accounts(12, "dummy".to_string());
         let account_keys = create_n_account_keys(12);
 
-        let result = parse_deposit(&borsh_data, &instruction, &account_keys);
+        // data.amount = 1000 (caller-requested), event.amount = 990 (net received).
+        // Asserting on 990 proves the parser uses the event, not the instruction args.
+        let result = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &create_deposit_inner_instructions(990),
+        );
 
-        assert!(result.is_ok());
-        let parsed = result.unwrap();
-        assert!(parsed.is_some());
+        let parsed = result.unwrap().expect("Some");
+        if let EscrowInstruction::Deposit { event, .. } = parsed {
+            assert_eq!(event.amount, 990);
+        } else {
+            panic!("Expected Deposit instruction");
+        }
     }
 
     #[test]
@@ -624,11 +692,23 @@ mod tests {
         let instruction = create_instruction_with_accounts(11, "dummy".to_string()); // Only 11 accounts (need 12)
         let account_keys = create_n_account_keys(11);
 
-        let result = parse_deposit(&borsh_data, &instruction, &account_keys);
+        let result = parse_deposit(&borsh_data, &instruction, &account_keys, &[]);
 
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Insufficient accounts"), "Error: {}", err);
+    }
+
+    #[test]
+    fn test_deposit_no_event_errs() {
+        let borsh_data = create_deposit_borsh_data();
+        let instruction = create_instruction_with_accounts(12, "dummy".to_string());
+        let account_keys = create_n_account_keys(12);
+
+        let result = parse_deposit(&borsh_data, &instruction, &account_keys, &[]);
+
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("No deposit event found"), "Error: {}", err);
     }
 
     // ============================================================================

--- a/indexer/src/indexer/datasource/common/parser/escrow.rs
+++ b/indexer/src/indexer/datasource/common/parser/escrow.rs
@@ -23,7 +23,10 @@ const EVENT_IX_TAG_LE: &[u8] = &[0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d]
 const ALLOW_MINT_EVENT_DISCRIMINATOR: u8 = 1;
 const DEPOSIT_EVENT_DISCRIMINATOR: u8 = 6;
 const EVENT_DISCRIMINATOR_INDEX: usize = 8;
+// AllowMintEvent: tag(8)+disc(1)+instance_seed(32)+mint(32) = 73
 const EVENT_DECIMALS_INDEX: usize = 73;
+// DepositEvent: tag(8)+disc(1)+instance_seed(32)+user(32) = 73
+// (same offset, different event)
 const EVENT_AMOUNT_INDEX: usize = 73;
 
 // ******************************************************************************************
@@ -366,19 +369,19 @@ fn parse_deposit(
                 && event_data.starts_with(EVENT_IX_TAG_LE)
                 && event_data[EVENT_DISCRIMINATOR_INDEX] == DEPOSIT_EVENT_DISCRIMINATOR
             {
+                // Safety: the `>= 145` guard above guarantees this slice is
+                // always exactly 8 bytes; the unwrap cannot panic.
                 let amount_bytes: [u8; 8] = event_data[EVENT_AMOUNT_INDEX..EVENT_AMOUNT_INDEX + 8]
                     .try_into()
-                    .map_err(|_| ParserError::InstructionParseFailed {
-                        reason: "DepositEvent amount slice not 8 bytes".to_string()
-                    })?;
-                
+                    .unwrap();
+
                 let amount = u64::from_le_bytes(amount_bytes);
 
                 return Ok(Some(EscrowInstruction::Deposit {
                     accounts,
                     data: ix_data,
-                    event: DepositEvent { amount }
-                }))
+                    event: DepositEvent { amount },
+                }));
             }
         }
     }

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -222,7 +222,7 @@ fn convert_to_db_models(
 
     match &instruction_meta.instruction {
         ProgramInstruction::Escrow(escrow_ix) => match escrow_ix.as_ref() {
-            EscrowInstruction::Deposit { accounts, data } => {
+            EscrowInstruction::Deposit { accounts, data, event } => {
                 let recipient = data
                     .recipient
                     .map(|r| r.to_string())
@@ -235,7 +235,7 @@ fn convert_to_db_models(
                             signature.clone(),
                             instruction_meta.slot,
                             accounts.mint.to_string(),
-                            data.amount,
+                            event.amount,
                         )
                         .initiator(accounts.user.to_string())
                         .recipient(recipient)
@@ -286,7 +286,7 @@ mod tests {
     use super::*;
     use crate::indexer::datasource::common::parser::{
         AllowMintAccounts, AllowMintData, AllowMintEvent, DepositAccounts, DepositData,
-        ResetSmtRootAccounts, WithdrawFundsAccounts, WithdrawFundsData,
+        DepositEvent, ResetSmtRootAccounts, WithdrawFundsAccounts, WithdrawFundsData,
     };
     use crate::storage::common::storage::mock::MockStorage;
     use solana_sdk::pubkey::Pubkey;
@@ -324,6 +324,10 @@ mod tests {
                     amount: 1000,
                     recipient,
                 },
+                // event.amount differs from data.amount to prove the operator
+                // is fed the event-reported received amount (e.g. net of a
+                // Token-2022 transfer fee), not the caller-requested amount.
+                event: DepositEvent { amount: 990 },
             })),
             slot,
             program_type: ProgramType::Escrow,
@@ -410,7 +414,9 @@ mod tests {
         let txn = txn.unwrap();
         assert_eq!(txn.signature, "sig1");
         assert_eq!(txn.slot, 100);
-        assert_eq!(txn.amount, 1000);
+        // event.amount = 990, data.amount = 1000 (see make_deposit_instruction).
+        // The DB row must carry the event-reported amount.
+        assert_eq!(txn.amount, 990);
         assert_eq!(txn.recipient, recipient.to_string());
         assert_eq!(txn.initiator, make_pubkey(1).to_string());
         assert!(matches!(txn.transaction_type, TransactionType::Deposit));

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -222,7 +222,11 @@ fn convert_to_db_models(
 
     match &instruction_meta.instruction {
         ProgramInstruction::Escrow(escrow_ix) => match escrow_ix.as_ref() {
-            EscrowInstruction::Deposit { accounts, data, event } => {
+            EscrowInstruction::Deposit {
+                accounts,
+                data,
+                event,
+            } => {
                 let recipient = data
                     .recipient
                     .map(|r| r.to_string())

--- a/integration/tests/indexer/yellowstone_inner_and_unknown.rs
+++ b/integration/tests/indexer/yellowstone_inner_and_unknown.rs
@@ -63,8 +63,8 @@ fn block_meta(slot: u64) -> SubscribeUpdate {
 }
 
 /// Build an escrow Deposit transaction carrying one `meta.inner_instructions`
-/// entry. The inner frame only needs to parse shape-wise — its contents are
-/// not validated by the outer branch we're covering.
+/// entry. The inner frame is a valid DepositEvent CPI — required by the
+/// parser, which reads the authoritative received amount from the event.
 fn deposit_with_inner_instructions(slot: u64) -> SubscribeUpdate {
     let program_id =
         solana_sdk::pubkey::Pubkey::from_str(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID).unwrap();
@@ -104,13 +104,21 @@ fn deposit_with_inner_instructions(slot: u64) -> SubscribeUpdate {
         message: Some(message),
     };
 
-    // Attach a `meta` with one inner-instruction set. The inner frame
-    // references program_id_index 12 (same as outer) with arbitrary
-    // data — the branch we're covering just shape-maps whatever arrives.
+    // Attach a `meta` with one inner-instruction set carrying a valid
+    // DepositEvent CPI: EVENT_IX_TAG(8) + disc=6 + instance_seed(32)
+    // + user(32) + amount=1000 LE(8) + recipient(32) + mint(32) = 145 bytes.
+    let mut event_data = vec![];
+    event_data.extend_from_slice(&0x1d9acb512ea545e4u64.to_le_bytes());
+    event_data.push(6);
+    event_data.extend_from_slice(&[0u8; 32]);
+    event_data.extend_from_slice(&[0u8; 32]);
+    event_data.extend_from_slice(&1_000u64.to_le_bytes());
+    event_data.extend_from_slice(&[0u8; 32]);
+    event_data.extend_from_slice(&[0u8; 32]);
     let inner_ix = ProtoInnerInstruction {
         program_id_index: 12,
         accounts: vec![0u8, 1, 2],
-        data: vec![0xAA, 0xBB],
+        data: event_data,
         stack_height: Some(2),
     };
     let inner_set = ProtoInnerInstructions {

--- a/integration/tests/indexer/yellowstone_wiring.rs
+++ b/integration/tests/indexer/yellowstone_wiring.rs
@@ -31,12 +31,16 @@ use yellowstone_grpc_proto::geyser::{
     SubscribeUpdateTransaction, SubscribeUpdateTransactionInfo,
 };
 use yellowstone_grpc_proto::solana::storage::confirmed_block::{
-    CompiledInstruction as ProtoCompiledInstruction, Message as ProtoMessage, MessageHeader,
-    Transaction as ProtoTransaction,
+    CompiledInstruction as ProtoCompiledInstruction, InnerInstruction as ProtoInnerInstruction,
+    InnerInstructions as ProtoInnerInstructions, Message as ProtoMessage, MessageHeader,
+    Transaction as ProtoTransaction, TransactionStatusMeta,
 };
 
 /// Build a well-formed `SubscribeUpdate` carrying a single escrow Deposit
-/// instruction (discriminator 6 + 8-byte amount + 1-byte `Option::None`).
+/// instruction (discriminator 6 + 8-byte amount + 1-byte `Option::None`)
+/// plus a `meta.inner_instructions` entry carrying the matching DepositEvent
+/// CPI — required by the parser, which reads the authoritative received
+/// amount from the event rather than the instruction args.
 ///
 /// The account list is padded with deterministic junk pubkeys so parsing the
 /// Deposit accounts (12 required) succeeds.
@@ -84,11 +88,35 @@ fn deposit_tx_update(slot: u64) -> SubscribeUpdate {
         message: Some(message),
     };
 
+    // DepositEvent payload: EVENT_IX_TAG(8) + disc=6 + instance_seed(32)
+    // + user(32) + amount=1000 LE(8) + recipient(32) + mint(32) = 145 bytes.
+    let mut event_data = vec![];
+    event_data.extend_from_slice(&0x1d9acb512ea545e4u64.to_le_bytes());
+    event_data.push(6);
+    event_data.extend_from_slice(&[0u8; 32]);
+    event_data.extend_from_slice(&[0u8; 32]);
+    event_data.extend_from_slice(&1_000u64.to_le_bytes());
+    event_data.extend_from_slice(&[0u8; 32]);
+    event_data.extend_from_slice(&[0u8; 32]);
+
+    let meta = TransactionStatusMeta {
+        inner_instructions: vec![ProtoInnerInstructions {
+            index: 0,
+            instructions: vec![ProtoInnerInstruction {
+                program_id_index: 12,
+                accounts: vec![],
+                data: event_data,
+                stack_height: Some(2),
+            }],
+        }],
+        ..Default::default()
+    };
+
     let tx_info = SubscribeUpdateTransactionInfo {
         signature: vec![7u8; 64],
         is_vote: false,
         transaction: Some(transaction),
-        meta: None,
+        meta: Some(meta),
         index: 0,
     };
 


### PR DESCRIPTION
Summary
Fixes SOLA3-6 (Extreme): deposit indexing minted the caller-requested amount instead of the escrow's actually-received amount. For fee-bearing Token-2022 mints this let a user mint more on the private channel than what reached escrow, breaking the 1:1 backing invariant.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,620 | 11,100 | 86.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26067449392) |
| Indexer | 15,058 | 17,744 | 84.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26067449392) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26067449392) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26067449392) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 9,977 | 12,331 | 80.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26067449392) |
| **Total** | **36,366** | **43,170** | **84.2%** | |

> Last updated: 2026-05-19 00:18:41 UTC by E2E Integration