### PR TITLE
feat(operator): recover stuck Processing transactions after operator crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ ci-integration-test-prebuilt:
 	@cd integration && cargo test --test mock_rpc_retry -- --nocapture
 	@cd integration && cargo test --test checkpoint_partial_flush -- --nocapture
 	@cd integration && cargo test --test remint_recovery -- --nocapture
+	@cd integration && cargo test --test stuck_processing_recovery -- --nocapture
 	@cd integration && cargo test --test bootstrap_validation -- --nocapture
 	@cd integration && cargo test --test yellowstone_wiring -- --nocapture
 	@cd integration && cargo test --test malformed_yellowstone_update -- --nocapture
@@ -238,6 +239,7 @@ ci-integration-test-indexer:
 	@cd integration && cargo test --test mock_rpc_retry -- --nocapture
 	@cd integration && cargo test --test checkpoint_partial_flush -- --nocapture
 	@cd integration && cargo test --test remint_recovery -- --nocapture
+	@cd integration && cargo test --test stuck_processing_recovery -- --nocapture
 	@cd integration && cargo test --test bootstrap_validation -- --nocapture
 	@cd integration && cargo test --test yellowstone_wiring -- --nocapture
 	@cd integration && cargo test --test malformed_yellowstone_update -- --nocapture

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -8,6 +8,14 @@ The two operators have different failure shapes: withdrawals can halt
 the pipeline (SMT nonce gap), deposits cannot. The dispatch table below
 routes by webhook + `transaction_type`.
 
+> **One halt has no dedicated alert.** The **SMT-root-mismatch startup
+> halt** fires no "pipeline halted" event - it surfaces as repeated
+> per-row `failed` webhooks whose `error_message` carries `SMT root
+> mismatch` (plus `SMT root mismatch detected` in the operator logs).
+> Recognize it by that pattern, not a single alert, and not via this
+> dispatch table. See
+> [`withdrawal_pipeline_halt_runbook.md`](withdrawal_pipeline_halt_runbook.md).
+
 ## Alert dispatch
 
 The **alert webhook** in `db_transaction_writer.rs` is the only
@@ -72,6 +80,8 @@ The runbooks call this out at every relevant site.
   on-chain check (private channel chain).
 - [`_escalation.md`](_escalation.md) - escalation tiers and contacts.
   Every "escalate" call-site in the recovery runbooks links here.
+- [`withdrawal_pipeline_halt_runbook.md`](withdrawal_pipeline_halt_runbook.md) -
+  the SMT-root-mismatch startup halt (log-discovered, not paged).
 
 ## Drills
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -100,6 +100,8 @@ pins the relevant contract.
 | `drill_12_withdrawal_failed_recovery_flows` | withdrawal | `withdrawal_failed.md` LANDED → completed-with-sig; cross-row signature fence still applies on `failed`; NOT_LANDED is terminal (markdown + operator code grep); AMBIGUOUS escalates without SQL. |
 | `drill_13_withdrawal_failed_reminted_reconcile` | withdrawal | `failed_reminted` transition writes `remint_signatures`; runbook contains zero mutating SQL; LANDED verdict cannot be silently absorbed via `SET status='completed'`; webhook `remint_signature` (singular) ↔ DB `remint_signatures` (plural) asymmetry pinned. |
 | `drill_14_deposit_manual_review_post_jit_recovery_flows` | deposit | `deposit_manual_review.md` § Path D: post-JIT trigger strings present in `mint.rs`; re-arm SQL flips `manual_review` → `pending` and is targeted by id (not error_message); idempotency memo prefix anchored. |
+| `drill_15_deposit_manual_review_recovery_idempotency_failure_flow` | deposit | `deposit_manual_review.md` § Path E: recovery-worker `deposit idempotency:` triage substring present in `recovery.rs`; re-arm SQL flips `manual_review` → `pending` and is row-scoped by id. |
+| `drill_16_withdrawal_manual_review_recovery_missing_nonce_flow` | withdrawal | `withdrawal_manual_review.md` § Path F: recovery-worker `withdrawal row missing nonce` triage substring present in `recovery.rs`; recovery branch SQL is row-scoped; no re-arm SQL exists for this path. |
 
 Trigger (`make` shorthand, runs from repo root):
 

--- a/docs/runbooks/deposit_failed.md
+++ b/docs/runbooks/deposit_failed.md
@@ -67,7 +67,7 @@ if a previous attempt did broadcast: the operator's pre-send memo scan
 short-circuits to `Completed` if it finds a memo'd signature.
 
 ```sql
-UPDATE transactions SET status = 'pending', updated_at = NOW()
+UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -52,6 +52,7 @@ to the right Path below.
 | `invalid_builder` | Builder rejected the row's data (e.g. negative amount). |
 | `program_error` | Generic builder error not covered by the specific variants. |
 | `deposit idempotency:` | The recovery worker could not authoritatively decide whether the deposit's mint already landed. Row was quarantined on uncertainty rather than risk a double-mint. Indicates RPC health, not a row defect. See **Path E**. |
+| `recovery requeues without progress` | The recovery worker demoted this `processing` deposit 3 times (mint never landed each cycle) and quarantined rather than loop forever. Row data is fine; the mint keeps failing to land. See **Path G**. |
 
 ### Sender-side post-JIT surface (`sender/mint.rs`)
 
@@ -117,6 +118,7 @@ Correct the columns and re-arm:
 ```sql
 UPDATE transactions
    SET status = 'pending',
+       recovery_requeue_attempts = 0,
        mint = :corrected_mint,
        recipient = :corrected_recipient,
        updated_at = NOW()
@@ -142,7 +144,7 @@ extended to classify this error variant explicitly. Do not patch
 in-place.
 
 ```sql
-UPDATE transactions SET status = 'pending', updated_at = NOW()
+UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
@@ -213,16 +215,19 @@ Only for the recoverable authority case after the underlying authority
 correction has been performed:
 
 ```sql
-UPDATE transactions SET status = 'pending', updated_at = NOW()
+UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
 ### Path E - recovery-worker idempotency lookup failed
 
 `error_message` starts with `deposit idempotency:`. The recovery worker
-intentionally refuses to demote on RPC failure (the live mint path
-fails-open on the same condition; recovery cannot, because recovery has
-no second chance to catch a duplicate).
+quarantines rather than demote when the idempotency lookup fails on RPC
+error, because demoting would re-pick the row and risk a double-mint. This
+is the same fail-closed stance as the live mint path, which on the same RPC
+failure also stops without minting (it routes to a terminal failure via
+`send_fatal_error` rather than minting unverified). Both paths refuse to
+proceed on uncertainty; they differ only in terminal state.
 
 #### Step 1 - check RPC health
 
@@ -258,7 +263,7 @@ The mint did not land. Re-arm to `pending`; the idempotency memo
 prevents duplicate mint on the next attempt.
 
 ```sql
-UPDATE transactions SET status = 'pending', updated_at = NOW()
+UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
@@ -331,7 +336,7 @@ VALUES
   (:mint, 'allowed', :allow_mint_slot, :allow_mint_signature, NOW())
 ON CONFLICT (mint_address, effective_slot) DO NOTHING;
 
-UPDATE transactions SET status = 'pending', updated_at = NOW()
+UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
@@ -376,6 +381,50 @@ The `AllowMint` exists but binds to a different escrow instance than
 ours. The operator should never see foreign-instance rows — this is the
 SOLA2-27 attack surface, not an operations recovery.
 [Escalate](_escalation.md) (Tier 3). No SQL.
+
+### Path G - requeue cap exhausted (mint never landed)
+
+`error_message` contains `recovery requeues without progress`. Each
+recovery pass whose idempotency scan finds no existing mint (`NotLanded`)
+demotes the stuck `processing` deposit back to `pending` for a fresh
+mint. After `MAX_RECOVERY_REQUEUE_ATTEMPTS` (3) such requeues with the
+mint still never landing, recovery quarantines instead of looping. So the
+mint was retried 3 times and never landed. The lookup *succeeded* each
+time and said not-landed (distinct from Path E, where the lookup itself
+*failed* on RPC error); the row data is valid (distinct from Path A).
+
+#### Step 1 - verify on-chain
+
+Run [`_verify_onchain_mint.md`](_verify_onchain_mint.md). Expected
+verdict: `NOT_LANDED`. If `LANDED` -> the idempotency scan missed a landed
+mint; mark `completed` per **Path E** (`LANDED` branch) and
+[escalate](_escalation.md) (Tier 2) - the scan has a defect (e.g. the sig
+is past its lookback window).
+
+#### Step 2 - find why the mint never lands
+
+The deposit mint is fire-and-forget (`spawn_fire_and_store`), so a
+repeating failure points at a deterministic mint rejection (paused/frozen
+mint, `mint_authority` mismatch, compute) or the sender never
+broadcasting. Read the operator logs for this `transaction_id`'s mint send
+error. A deterministic cause means re-arming will loop again ->
+[escalate](_escalation.md) (Tier 2) to engineering.
+
+#### Step 3 - resolve, then re-arm
+
+Fix the root cause first. Then re-arm to `pending` **and reset the requeue
+counter** - re-arming without the reset re-quarantines on the next stall,
+since the counter is already at the cap. The idempotency memo still guards
+against a double-mint on retry:
+
+```sql
+UPDATE transactions
+   SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+If the mint can never land (unrecoverable), mark `failed` and
+[escalate](_escalation.md) (Tier 1) for refund coordination.
 
 ## Post-incident artifacts
 

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -16,7 +16,7 @@ Practically: a single deposit `manual_review` is a single row in trouble.
 Other deposits keep flowing. There is no collateral, no sweep, no halt to
 recover from.
 
-There are **two trigger surfaces** that can land a deposit in
+There are **three trigger surfaces** that can land a deposit in
 `manual_review`:
 
 1. **Processor-side row-data validation** — deterministic per-row error
@@ -25,6 +25,11 @@ There are **two trigger surfaces** that can land a deposit in
    mint-init helper found the on-chain mint in a state it cannot fix by
    re-issuing `mint_to` (wrong authority on the private channel mint, or
    corrupt mint data). See **Path D** for recovery.
+3. **Recovery-worker idempotency lookup failed** — the periodic
+   stuck-row recovery worker found a stale `Processing` deposit, tried
+   the idempotency memo lookup against the PrivateChannel RPC, and the
+   RPC was unreachable. Row data is fine; no on-chain mint attempted.
+   See **Path E**.
 
 ## Symptom
 
@@ -33,8 +38,8 @@ There are **two trigger surfaces** that can land a deposit in
 
 ## Triage
 
-`error_message` distinguishes the two trigger surfaces and dispatches to
-the right Path below.
+`error_message` distinguishes the three trigger surfaces and dispatches
+to the right Path below.
 
 ### Processor-side surface (`processor.rs::process_deposit_funds`)
 
@@ -43,6 +48,7 @@ the right Path below.
 | `invalid_pubkey` | `mint` or `recipient` field is not a valid base58 pubkey. |
 | `invalid_builder` | Builder rejected the row's data (e.g. negative amount). |
 | `program_error` | Generic builder error not covered by the specific variants. |
+| `deposit idempotency:` | The recovery worker could not authoritatively decide whether the deposit's mint already landed. Row was quarantined on uncertainty rather than risk a double-mint. Indicates RPC health, not a row defect. See **Path E**. |
 
 ### Sender-side post-JIT surface (`sender/mint.rs`)
 
@@ -202,6 +208,55 @@ UPDATE transactions SET status = 'pending', updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
+### Path E - recovery-worker idempotency lookup failed
+
+`error_message` starts with `deposit idempotency:`. The recovery worker
+intentionally refuses to demote on RPC failure (the live mint path
+fails-open on the same condition; recovery cannot, because recovery has
+no second chance to catch a duplicate).
+
+#### Step 1 - check RPC health
+
+Inspect the suffix of `error_message` to identify the underlying RPC
+transport failure (timeout, connection refused, HTTP 5xx, etc.).
+Confirm against the operator's current PrivateChannel RPC endpoint:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' \
+  <private-channel-rpc-url>
+```
+
+If RPC is unhealthy, address that first. If RPC is healthy now,
+proceed.
+
+#### Step 2 - verify on-chain
+
+Run [`_verify_onchain_mint.md`](_verify_onchain_mint.md). The row was
+quarantined because the recovery worker could not answer this question
+itself; resolving the runbook requires the same answer.
+
+#### Step 3 - branch on verdict
+
+##### `LANDED <signature>` — mint already succeeded
+
+Mark `completed` with the observed signature (same SQL as
+[`deposit_failed.md`](deposit_failed.md) Path B).
+
+##### `NOT_LANDED` — re-arm
+
+The mint did not land. Re-arm to `pending`; the idempotency memo
+prevents duplicate mint on the next attempt.
+
+```sql
+UPDATE transactions SET status = 'pending', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+##### `AMBIGUOUS`
+
+Stop. [Escalate](_escalation.md) (Tier 2). Do not act.
+
 ## Post-incident artifacts
 
 - Transaction id, originating Solana `signature`, `recipient`, `mint`.
@@ -211,4 +266,6 @@ UPDATE transactions SET status = 'pending', updated_at = NOW()
 - For Path D: on-chain `mint_authority` before/after, the
   `spl-token authorize` signature (if applicable), and the engineering
   ticket for any mint-replacement coordination.
+- For Path E: RPC endpoint health snapshot and the
+  `getHealth` / verification responses captured at triage time.
 

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -46,6 +46,7 @@ have prefixes.
 | `withdrawal row missing nonce` | F - corrupt withdrawal row | no | recovery worker quarantine |
 | `no broadcast signatures recorded; cannot verify release landed` | C - ambiguous (recovery cannot prove outcome) | no | recovery worker quarantine |
 | `could not verify release landed (` | C - ambiguous (RPC unreachable during recovery) | no | recovery worker quarantine |
+| `recovery requeues without progress` | G - requeue cap exhausted (release never landed) | no | recovery worker quarantine |
 
 ## Path A.halting - build error that halted the pipeline
 
@@ -88,7 +89,7 @@ collateral.
 4. **Re-arm sweep rows:**
    ```sql
    UPDATE transactions
-      SET status = 'pending', updated_at = NOW()
+      SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
     WHERE transaction_type = 'withdrawal'
       AND status = 'manual_review'
       AND id <> :poison_id;
@@ -127,7 +128,7 @@ withdrawals are unaffected.
 3. **If the condition has cleared, re-arm just this row:**
    ```sql
    UPDATE transactions
-      SET status = 'pending', updated_at = NOW()
+      SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
     WHERE id = :transaction_id;
    ```
 4. **No operator restart is needed.** The processor did not halt; the
@@ -234,6 +235,15 @@ committing the row to manual review. Sub-triggers below; same recovery.
 4. **If `AMBIGUOUS`:** stop. [Escalate](_escalation.md) (Tier 2). Wait
    for RPC visibility to recover. Do not act.
 
+> **If the quarantined release actually landed** (verdict `LANDED`, but
+> the row was quarantined with `no broadcast signatures recorded; cannot
+> verify release landed` and never written `Completed`), expect an
+> `SmtRootMismatch` halt on the next operator boot - the consumed nonce
+> is missing from the DB. See
+> [`withdrawal_pipeline_halt_runbook.md`](withdrawal_pipeline_halt_runbook.md).
+> Marking the row `Completed` per Step 2 above also resolves
+> that halt by re-recording the nonce.
+
 ## Path F - corrupt withdrawal row (missing nonce)
 
 `error_message`: `withdrawal row missing nonce`. The recovery worker
@@ -256,7 +266,7 @@ If `withdrawal_nonce IS NOT NULL`, the row was repaired between
 quarantine and triage. Re-arm to `pending`:
 
 ```sql
-UPDATE transactions SET status = 'pending', updated_at = NOW()
+UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
@@ -291,6 +301,66 @@ write-or-classify path has a defect. Capture the row, then delete:
 
 ```sql
 DELETE FROM transactions WHERE id = :transaction_id;
+```
+
+## Path G - requeue cap exhausted (release never landed)
+
+`error_message` contains `recovery requeues without progress`. Each
+recovery pass that finds the row's release signatures all
+finalized-failed or expired (`SigFinality::Dead`) demotes the stuck
+`processing` row back to `pending` for a fresh send. After
+`MAX_RECOVERY_REQUEUE_ATTEMPTS` (3) such requeues with no release ever
+landing, recovery quarantines instead of looping forever. So the
+release-funds transaction was rebroadcast 3 times and every attempt died
+on-chain or expired - none finalized. The row data is valid (distinct
+from Path A/F) and the signatures are conclusively Dead each cycle
+(distinct from Path C's ambiguity).
+
+### Step 1 - verify on-chain
+
+Run [`_verify_onchain_release.md`](_verify_onchain_release.md). Expected
+verdict: `NOT_LANDED` (every attempt died). If `LANDED` -> a landed
+signature was misclassified as Dead; switch to Path C reconciliation and
+[escalate](_escalation.md) (Tier 2) - the classifier has a defect.
+
+### Step 2 - find why every release died
+
+Pull the recorded release signatures (keyed by `transaction_id`) and read
+each on-chain failure:
+
+```sql
+SELECT signature, last_valid_block_height, created_at
+  FROM pending_release_signatures
+ WHERE transaction_id = :transaction_id
+ ORDER BY created_at;
+```
+
+For each, `solana confirm -v <signature> --url <solana-rpc-url>` to read
+the `InstructionError`. A repeating deterministic error (escrow
+underfunded, SMT/proof rejection, account state) means re-sending will not
+help - [escalate](_escalation.md) (Tier 2/3) to engineering. A transient
+cause (blockhash expiry under load, RPC outage during the send window)
+may already have cleared.
+
+### Step 3 - resolve, then re-arm
+
+Fix the root cause first. Then re-arm to `pending` **and reset the requeue
+counter** - re-arming without the reset re-quarantines the row on its next
+stall, since the counter is already at the cap:
+
+```sql
+UPDATE transactions
+   SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+If the release can never land (unrecoverable on-chain rejection), mark the
+row terminal and [escalate](_escalation.md) (Tier 1) for refund
+coordination:
+
+```sql
+UPDATE transactions SET status = 'failed', updated_at = NOW()
+ WHERE id = :transaction_id;
 ```
 
 ## Post-incident artifacts (required)

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -44,6 +44,8 @@ have prefixes.
 | `failed to persist pending remint:` | C - ambiguous (DB lost the sig) | no | `sender/transaction.rs` |
 | `no signatures to verify` | C - ambiguous (RPC may have broadcast) | no | `sender/transaction.rs` |
 | `withdrawal row missing nonce` | F - corrupt withdrawal row | no | recovery worker quarantine |
+| `no broadcast signatures recorded; cannot verify release landed` | C - ambiguous (recovery cannot prove outcome) | no | recovery worker quarantine |
+| `could not verify release landed (` | C - ambiguous (RPC unreachable during recovery) | no | recovery worker quarantine |
 
 ## Path A.halting - build error that halted the pipeline
 
@@ -195,7 +197,21 @@ release and the channel-side remint may have left partial state.
 ## Path C - ambiguous on-chain state
 
 The withdrawal *may* have landed; the operator could not verify before
-committing the row to manual review. Three sub-triggers; same recovery.
+committing the row to manual review. Sub-triggers below; same recovery.
+
+> **Recovery now verifies on-chain before demoting.** The crash-recovery
+> worker persists every broadcast release signature to
+> `pending_release_signatures` at send time and, for a stale `Processing`
+> withdrawal, classifies those signatures on-chain (the same finality check
+> the remint flow uses) *before* deciding. A finalized-success signature is
+> promoted to `Completed` (never re-sent); a dead/expired signature is
+> demoted to `Pending`; a still-live signature is left in `Processing` for
+> the next sweep. It only quarantines when it cannot prove the outcome:
+> either **no broadcast signatures were recorded** (`no broadcast signatures
+> recorded; cannot verify release landed`) or **the RPC could not classify
+> them** (`could not verify release landed (...)`, with the signature list
+> appended). Both land here in Path C — verify on-chain and act on the
+> verdict; never blindly re-arm a row whose release may already be on-chain.
 
 1. **Verify on-chain.** Run
    [`_verify_onchain_release.md`](_verify_onchain_release.md). This is

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -43,6 +43,7 @@ have prefixes.
 | `finality check failed after` | C - ambiguous (RPC unreachable) | no | `sender/remint.rs` |
 | `failed to persist pending remint:` | C - ambiguous (DB lost the sig) | no | `sender/transaction.rs` |
 | `no signatures to verify` | C - ambiguous (RPC may have broadcast) | no | `sender/transaction.rs` |
+| `withdrawal row missing nonce` | F - corrupt withdrawal row | no | recovery worker quarantine |
 
 ## Path A.halting - build error that halted the pipeline
 
@@ -216,6 +217,65 @@ committing the row to manual review. Three sub-triggers; same recovery.
    - Not burned → no user impact; close the alert and re-arm.
 4. **If `AMBIGUOUS`:** stop. [Escalate](_escalation.md) (Tier 2). Wait
    for RPC visibility to recover. Do not act.
+
+## Path F - corrupt withdrawal row (missing nonce)
+
+`error_message`: `withdrawal row missing nonce`. The recovery worker
+found a stale `Processing` withdrawal whose `withdrawal_nonce` is
+`NULL`. The indexer always populates this column for withdrawal rows,
+so a NULL on this row indicates either a manual DB edit, a partial
+schema migration, or a defect in the indexer write path. **Do not
+re-arm.** The processor would reject the row identically on every tick.
+
+### Step 1 - confirm the corruption
+
+```sql
+SELECT id, signature, withdrawal_nonce, mint, amount, recipient,
+       created_at, updated_at
+  FROM transactions
+ WHERE id = :transaction_id;
+```
+
+If `withdrawal_nonce IS NOT NULL`, the row was repaired between
+quarantine and triage. Re-arm to `pending`:
+
+```sql
+UPDATE transactions SET status = 'pending', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+Otherwise proceed.
+
+### Step 2 - check whether the burn landed on the PrivateChannel side
+
+`signature` is the originating PrivateChannel burn signature.
+
+```bash
+solana confirm -v <signature> --url <private-channel-rpc>
+```
+
+### Step 3 - branch on burn verdict
+
+#### Burn landed
+
+The user already burned. Escalate (Tier 1) for refund coordination —
+either a manual `release_funds` to the depositor or a manual remint of
+the burned tokens. Then mark the row terminal:
+
+```sql
+UPDATE transactions SET status = 'failed', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+#### Burn did not land
+
+The indexer wrote a withdrawal row for an instruction that did not
+finalize. [Escalate](_escalation.md) (Tier 3) — the indexer
+write-or-classify path has a defect. Capture the row, then delete:
+
+```sql
+DELETE FROM transactions WHERE id = :transaction_id;
+```
 
 ## Post-incident artifacts (required)
 

--- a/docs/runbooks/withdrawal_pipeline_halt_runbook.md
+++ b/docs/runbooks/withdrawal_pipeline_halt_runbook.md
@@ -1,0 +1,175 @@
+# Runbook - Withdrawal Pipeline Halt
+
+This runbook covers the **SMT-root-mismatch startup halt**. It is a
+deliberate fail-stop: on boot, the first release dispatch finds the local
+SMT root != the on-chain root, and the operator refuses to start the
+withdrawal pipeline rather than consume nonces against a tree it cannot
+reason about.
+
+This halt has **no dedicated "pipeline halted" alert**. It surfaces as
+repeated per-row `failed` webhooks whose `error_message` carries `SMT root
+mismatch` (each withdrawal dispatched after boot is marked `Failed` by
+`send_fatal_error`), plus the operator error logs. You recognize it by
+that pattern, not a single halt event, and it is not routed by the
+dispatch table in [`README.md`](README.md).
+
+As with every runbook here, the recovery `UPDATE` statements are
+**bookkeeping, not fund movement** - see
+[`README.md`](README.md) § "Recovery SQL is bookkeeping; fund restoration
+is human-in-the-loop".
+
+---
+
+## SMT root mismatch on startup
+
+The terminal state of the best-effort release-signature persistence
+tradeoff at `indexer/src/operator/sender/transaction.rs` (the
+`insert_release_signature` site). When a release **lands on-chain** (the
+nonce is consumed and the Instance's `withdrawal_transactions_root`
+advances) but the operator crashes before writing `Completed` - and the
+best-effort signature insert had also failed - recovery correctly
+quarantines the row (`no broadcast signatures recorded; cannot verify
+release landed`), but the DB now has no record of that consumed nonce.
+The next boot rebuilds the local SMT without it and refuses to start the
+withdrawal pipeline.
+
+### Symptom
+
+- New withdrawals stop reaching `completed` - the release pipeline is
+  stalled. (`completed` itself fires no webhook, so the visible signal is
+  the failures below, not a missing success alert.)
+- Each withdrawal dispatched after boot is marked `Failed` and fires a
+  per-row `failed` webhook whose `error_message` contains `SMT root
+  mismatch` (`send_fatal_error` on the lazy `initialize_smt_state`). There
+  is **no dedicated halt-level alert** - recognize the halt by the
+  repeated `failed` + `SMT root mismatch` pattern, not a single event.
+- These rows did **not** actually fail; they are collateral and must be
+  re-armed once the mismatch is resolved (see Resolution).
+
+### Detection
+
+`initialize_smt_state` (`indexer/src/operator/sender/state.rs`) compares
+the local SMT root against the on-chain `withdrawal_transactions_root`
+and, on mismatch, emits these `error!` markers before returning
+`Err(SmtRootMismatch)` (state.rs:122-137):
+
+```
+SMT root mismatch detected! Database out of sync with on-chain state.
+  Instance PDA: <pda>
+  Tree Index: <n>
+  Nonces from DB: [...]
+  Local root:    [...]
+  On-chain root: [...]
+```
+
+```
+This typically means:
+  1. A withdrawal was successfully processed on-chain
+  2. But the operator crashed before updating the database
+  3. The database is now missing transaction records
+```
+
+Grep the operator logs for `SMT root mismatch detected` to confirm.
+
+### Diagnosis - find the consumed-but-unrecorded nonce
+
+The divergence direction is always the same here: a nonce was
+**consumed on-chain** (the on-chain root advanced) but is **missing
+`Completed` in the DB** (the DB is behind the chain). You must identify
+which nonce landed.
+
+1. Read `Tree Index` from the log. The current tree window is
+   `tree_index * MAX_TREE_LEAVES ..< (tree_index + 1) * MAX_TREE_LEAVES`
+   - the same window `initialize_smt_state` rebuilds from
+   `get_completed_withdrawal_nonces` (state.rs:94-102). Only nonces in
+   this window matter.
+2. Pull the withdrawal rows in that window that are NOT `completed`
+   (the candidates whose release may have landed without a `Completed`
+   write). The recovery quarantine reason is the strongest hint:
+
+   ```sql
+   SELECT id, withdrawal_nonce, status, counterpart_signature, updated_at
+     FROM transactions
+    WHERE transaction_type = 'withdrawal'
+      AND withdrawal_nonce >= :min_nonce
+      AND withdrawal_nonce <  :max_nonce
+      AND status <> 'completed'
+    ORDER BY withdrawal_nonce ASC;
+   ```
+
+   A row in `manual_review` whose alert `error_message` was
+   `no broadcast signatures recorded; cannot verify release landed`
+   (recovery-worker quarantine) is the prime suspect.
+3. For each candidate, run
+   [`_verify_onchain_release.md`](_verify_onchain_release.md). Exactly
+   one verdict resolves the mismatch: a `LANDED <sig>` whose
+   `withdrawal_nonce` falls in the tree window is the consumed nonce the
+   DB is missing.
+   - If verification is `AMBIGUOUS`, **stop** and
+     [escalate](_escalation.md) (Tier 2). Do not mark anything
+     `Completed` on a guess - that would re-credit the user's view
+     incorrectly and mask a real divergence.
+
+### Resolution - record the landed nonce, then restart
+
+Once on-chain verification proves a specific nonce landed, mark that row
+`Completed` with the observed signature. This re-inserts the missing
+nonce into the set `initialize_smt_state` rebuilds from, so the local
+root re-matches the on-chain root on the next boot.
+
+```sql
+UPDATE transactions
+   SET status = 'completed',
+       counterpart_signature = :sig,
+       updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+Then restart the withdraw operator. On boot, `initialize_smt_state`
+rebuilds the SMT - now including the recorded nonce - and the root
+verification passes (`SMT root verification passed`).
+
+This `UPDATE` is bookkeeping only: it does not move funds. The release
+already landed on-chain (that is what you verified); this statement only
+makes the operator's record agree with the chain so the pipeline can
+resume. Never run it without a `LANDED` verdict.
+
+**Re-arm the collateral rows.** Withdrawals dispatched during the halt
+were marked `Failed` by `send_fatal_error` but did not actually fail
+on-chain. Their failure reason is only in the alert webhook payload -
+`transactions` has no `error_message` column - so identify them by the
+halt window instead: `failed` withdrawals whose `processed_at` falls
+between the halting boot (the first `SMT root mismatch detected` log line)
+and this fix. Review the list before acting:
+
+```sql
+SELECT id, withdrawal_nonce, processed_at
+  FROM transactions
+ WHERE transaction_type = 'withdrawal'
+   AND status = 'failed'
+   AND processed_at >= :halt_start_ts
+ ORDER BY processed_at ASC;
+```
+
+Confirm each is a halt casualty (not a genuine on-chain failure), then
+re-arm the reviewed ids:
+
+```sql
+UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
+ WHERE id = ANY(:reviewed_ids);
+```
+
+### Escalation
+
+[`_escalation.md`](_escalation.md). Escalate (Tier 2) if on-chain
+verification is `AMBIGUOUS`, if no candidate row's nonce matches the
+advanced on-chain root, or if the mismatch persists after recording the
+verified-landed nonce and restarting.
+
+### Post-incident artifacts (required)
+
+- Tree index and tree-window nonce range.
+- The landed nonce, its `transaction_id`, and the verified signature.
+- On-chain verdict and the RPC endpoint used.
+- Confirmation that `SMT root verification passed` appeared on the
+  post-fix restart.

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -156,6 +156,17 @@ counter_vec!(
     &["program_type", "task"]
 );
 
+// Recovery worker outcome: a stuck-`Processing` row was healed by the
+// stuck-row recovery worker.  `outcome` ∈ {completed, requeued, quarantined};
+// `type` ∈ {deposit, withdrawal}.  All values 0 in steady state — any
+// sustained nonzero is concrete evidence of operator crash-window activity.
+counter_vec!(
+    OPERATOR_STALE_PROCESSING_RECOVERED,
+    "private_channel_operator_stale_processing_recovered_total",
+    "Stale Processing rows healed by the recovery worker",
+    &["program_type", "outcome", "type"]
+);
+
 pub fn init_labels(program_type: &str) {
     INDEXER_MINTS_SAVED.with_label_values(&[program_type]);
     INDEXER_TRANSACTIONS_SAVED.with_label_values(&[program_type]);
@@ -216,8 +227,21 @@ pub fn init_labels(program_type: &str) {
         "storage_writer",
         "reconciliation",
         "feepayer_monitor",
+        "recovery",
     ] {
         OPERATOR_TASK_EXIT.with_label_values(&[program_type, task]);
+    }
+
+    // Pre-register every (outcome, type) combination so dashboards see the
+    // full label space immediately rather than only after the first hit.
+    for outcome in &["completed", "requeued", "quarantined"] {
+        for txn_type in &["deposit", "withdrawal"] {
+            OPERATOR_STALE_PROCESSING_RECOVERED.with_label_values(&[
+                program_type,
+                outcome,
+                txn_type,
+            ]);
+        }
     }
 }
 
@@ -243,6 +267,7 @@ pub fn init() {
         FEEPAYER_BALANCE_LAMPORTS,
         OPERATOR_TRANSACTION_QUARANTINED,
         OPERATOR_TASK_EXIT,
+        OPERATOR_STALE_PROCESSING_RECOVERED,
     );
 }
 
@@ -329,6 +354,7 @@ mod tests {
             "private_channel_feepayer_balance_lamports",
             "private_channel_operator_transaction_quarantined_total",
             "private_channel_operator_task_exit_total",
+            "private_channel_operator_stale_processing_recovered_total",
         ];
 
         let families = prometheus::gather();

--- a/indexer/src/operator/db_transaction_writer.rs
+++ b/indexer/src/operator/db_transaction_writer.rs
@@ -86,12 +86,7 @@ impl DbTransactionWriter {
                     .inc();
             }
             Ok(false) => {
-                // Storage skipped the write: the row was already off
-                // `Processing` (typically the recovery worker moved it
-                // first). Don't count this as a successful DB update,
-                // but DO let the alert webhook below still fire — the
-                // upstream caller deliberately asked us to surface this
-                // status transition.
+                // Row off Processing (recovery moved it); webhook still fires.
                 info!(
                     trace_id = trace_id,
                     "Transaction {} already past Processing; status write skipped",

--- a/indexer/src/operator/db_transaction_writer.rs
+++ b/indexer/src/operator/db_transaction_writer.rs
@@ -66,7 +66,7 @@ impl DbTransactionWriter {
         );
         let trace_id = update.trace_id.as_deref().unwrap_or("none");
         let pt = self.program_type.as_label();
-        if let Err(e) = self
+        match self
             .storage
             .update_transaction_status(
                 update.transaction_id,
@@ -76,24 +76,40 @@ impl DbTransactionWriter {
             )
             .await
         {
-            error!(
-                trace_id = trace_id,
-                "Failed to update transaction {} status: {}", update.transaction_id, e
-            );
-            metrics::OPERATOR_DB_UPDATE_ERRORS
-                .with_label_values(&[pt])
-                .inc();
-            if let Some(err_msg) = &update.error_message {
-                error!(trace_id = trace_id, "Transaction error was: {}", err_msg);
+            Ok(true) => {
+                info!(
+                    trace_id = trace_id,
+                    "Updated transaction {} to status {:?}", update.transaction_id, update.status
+                );
+                metrics::OPERATOR_DB_UPDATES
+                    .with_label_values(&[pt, &format!("{:?}", update.status)])
+                    .inc();
             }
-        } else {
-            info!(
-                trace_id = trace_id,
-                "Updated transaction {} to status {:?}", update.transaction_id, update.status
-            );
-            metrics::OPERATOR_DB_UPDATES
-                .with_label_values(&[pt, &format!("{:?}", update.status)])
-                .inc();
+            Ok(false) => {
+                // Storage skipped the write: the row was already off
+                // `Processing` (typically the recovery worker moved it
+                // first). Don't count this as a successful DB update,
+                // but DO let the alert webhook below still fire — the
+                // upstream caller deliberately asked us to surface this
+                // status transition.
+                info!(
+                    trace_id = trace_id,
+                    "Transaction {} already past Processing; status write skipped",
+                    update.transaction_id
+                );
+            }
+            Err(e) => {
+                error!(
+                    trace_id = trace_id,
+                    "Failed to update transaction {} status: {}", update.transaction_id, e
+                );
+                metrics::OPERATOR_DB_UPDATE_ERRORS
+                    .with_label_values(&[pt])
+                    .inc();
+                if let Some(err_msg) = &update.error_message {
+                    error!(trace_id = trace_id, "Transaction error was: {}", err_msg);
+                }
+            }
         }
 
         if is_alertable {

--- a/indexer/src/operator/fetcher.rs
+++ b/indexer/src/operator/fetcher.rs
@@ -152,6 +152,7 @@ mod tests {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         }
     }
 

--- a/indexer/src/operator/mod.rs
+++ b/indexer/src/operator/mod.rs
@@ -6,6 +6,7 @@ pub mod fetcher;
 pub mod operator;
 pub mod processor;
 pub mod reconciliation;
+pub mod recovery;
 pub mod sender;
 pub mod utils;
 
@@ -14,5 +15,6 @@ pub use db_transaction_writer::DbTransactionWriter;
 pub use fetcher::run_fetcher;
 pub use operator::run;
 pub use processor::run_processor;
+pub use recovery::run_recovery_worker;
 pub use sender::{find_existing_mint_signature, run_sender, TransactionStatusUpdate};
 pub use utils::*;

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -232,8 +232,10 @@ pub async fn run(
     // A task exit increments the OPERATOR_TASK_EXIT metric with a task
     // label so dashboards can tell which one failed without tailing logs.
     //
-    // Non-critical tasks (reconciliation, feepayer monitor) are not watched
-    // here.
+    // The recovery worker is critical: if it dies, stuck-Processing rows stop
+    // being recovered, so an unexpected exit must page and restart like the
+    // pipeline stages. Non-critical tasks (reconciliation, feepayer monitor)
+    // are not watched here.
     //
     // Handles are polled by mutable reference so ownership stays here and
     // they can still be moved into `shutdown_operator` below — awaiting an
@@ -242,6 +244,7 @@ pub async fn run(
     let mut processor_handle = processor_handle;
     let mut sender_handle = sender_handle;
     let mut storage_writer_handle = storage_writer_handle;
+    let mut recovery_handle = recovery_handle;
     let pt_label = program_type.as_label();
 
     // `biased;` makes ctrl-c win on concurrent readiness — avoids a
@@ -263,6 +266,9 @@ pub async fn run(
         }
         _ = &mut storage_writer_handle => {
             critical_exit(pt_label, "storage_writer");
+        }
+        _ = &mut recovery_handle => {
+            critical_exit(pt_label, "recovery");
         }
     }
 

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -2,8 +2,8 @@ use crate::config::OperatorConfig;
 use crate::error::OperatorError;
 use crate::metrics;
 use crate::operator::{
-    feepayer_monitor, fetcher, processor, reconciliation, sender, DbTransactionWriter, RetryConfig,
-    RpcClientWithRetry,
+    feepayer_monitor, fetcher, processor, reconciliation, recovery, sender, DbTransactionWriter,
+    RetryConfig, RpcClientWithRetry, SignerUtil,
 };
 use crate::shutdown_utils::shutdown_operator;
 use crate::storage::Storage;
@@ -123,6 +123,7 @@ pub async fn run(
     let sender_commitment = config.rpc_commitment;
     let sender_source_rpc = source_rpc_client.clone();
     let sender_common_config = common_config.clone();
+    let recovery_storage_tx = storage_tx.clone();
     let sender_handle = tokio::spawn(async move {
         if let Err(e) = sender::run_sender(
             &sender_common_config,
@@ -171,6 +172,35 @@ pub async fn run(
         }
     } else {
         tokio::spawn(async {})
+    };
+
+    // Recovery worker. If the operator crashes between claiming a row
+    // (Pending → Processing) and writing its final status, the row would
+    // sit stuck in Processing forever. This worker periodically finds
+    // those stuck rows and resolves them. Runs on every operator since
+    // every operator has the same crash window.
+    let recovery_handle = {
+        let recovery_storage = storage.clone();
+        let recovery_rpc = source_rpc_client
+            .clone()
+            .unwrap_or_else(|| rpc_client.clone());
+        let recovery_program_type = common_config.program_type;
+        let recovery_token = cancellation_token.clone();
+        let admin_pubkey = SignerUtil::get_admin_pubkey();
+        tokio::spawn(async move {
+            if let Err(e) = recovery::run_recovery_worker(
+                recovery_storage,
+                recovery_rpc,
+                admin_pubkey,
+                recovery_program_type,
+                recovery_storage_tx,
+                recovery_token,
+            )
+            .await
+            {
+                tracing::error!("Recovery worker error: {}", e);
+            }
+        })
     };
 
     // Start feepayer balance monitor for escrow operators only.
@@ -254,6 +284,7 @@ pub async fn run(
         storage_writer_handle,
         reconciliation_handle,
         feepayer_monitor_handle,
+        recovery_handle,
         config.batch_size,
         config.db_poll_interval,
     )

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -174,16 +174,10 @@ pub async fn run(
         tokio::spawn(async {})
     };
 
-    // Recovery worker. If the operator crashes between claiming a row
-    // (Pending → Processing) and writing its final status, the row would
-    // sit stuck in Processing forever. This worker periodically finds
-    // those stuck rows and resolves them. Runs on every operator since
-    // every operator has the same crash window.
+    // Recovery worker: resolves rows stuck in Processing after a crash.
     let recovery_handle = {
         let recovery_storage = storage.clone();
-        let recovery_rpc = source_rpc_client
-            .clone()
-            .unwrap_or_else(|| rpc_client.clone());
+        let recovery_rpc = rpc_client.clone();
         let recovery_program_type = common_config.program_type;
         let recovery_token = cancellation_token.clone();
         let admin_pubkey = SignerUtil::get_admin_pubkey();

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -881,6 +881,7 @@ mod tests {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         }
     }
 
@@ -2203,6 +2204,7 @@ mod tests {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         };
 
         fetcher_tx.send(txn).await.unwrap();
@@ -2306,6 +2308,7 @@ mod tests {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         };
 
         fetcher_tx.send(txn).await.unwrap();

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -1672,7 +1672,9 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         });
         id
     }

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -1675,6 +1675,7 @@ mod tests {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         });
         id
     }

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -1,0 +1,720 @@
+//! Recovers transaction rows that got stuck in `Processing` because the
+//! operator crashed before writing their final status.
+//!
+//! Runs alongside the fetcher / processor / sender. On boot and once per
+//! minute, it picks up rows that have been in `Processing` for too long,
+//! asks the chain whether the operator's intended action already happened,
+//! and updates each row to its true state: `Completed`, `Pending` (so the
+//! fetcher will retry it), or `ManualReview` (so a human can investigate).
+
+use crate::channel_utils::send_guaranteed;
+use crate::config::ProgramType;
+use crate::error::OperatorError;
+use crate::metrics::OPERATOR_STALE_PROCESSING_RECOVERED;
+use crate::operator::sender::find_existing_mint_signature;
+use crate::operator::utils::instruction_util::{MintToBuilder, MintToBuilderWithTxnId};
+use crate::operator::utils::mint_idempotency_memo;
+use crate::operator::utils::rpc_util::RpcClientWithRetry;
+use crate::operator::TransactionStatusUpdate;
+use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
+use crate::storage::common::storage::Storage;
+use chrono::{DateTime, Utc};
+use solana_sdk::pubkey::Pubkey;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+/// How often the recovery loop runs. With the 5-minute age cutoff below,
+/// a stuck row gets resolved within ~6 minutes of getting stuck.
+pub(crate) const RECOVERY_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long a row must sit in `Processing` before we consider it stuck.
+/// Must be safely longer than any legitimate in-flight send (the sender's
+/// shutdown drain is capped at 30s, plus retry headroom). Set too low,
+/// recovery would interfere with a slow but still-alive send. Set too
+/// high, real stuck rows take longer to heal.
+pub(crate) const STALE_THRESHOLD: Duration = Duration::from_secs(5 * 60);
+
+/// Maximum rows handled per loop iteration. Keeps a big backlog from
+/// blocking everything else; remaining rows are picked up on the next tick.
+pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
+
+/// Outcome of checking whether a stuck deposit's mint already landed
+/// on-chain. Three variants are needed (not two), because if we can't tell
+/// for sure, treating that as "didn't land" risks minting a second time.
+enum DepositOutcome {
+    Landed { signature: String },
+    NotLanded,
+    Ambiguous { reason: String },
+}
+
+/// Outcome of looking at a stuck withdrawal. Only two variants because
+/// the on-chain escrow program won't accept a duplicate release anyway,
+/// so unconditionally retrying is safe — we just refuse if the row itself
+/// is malformed.
+enum WithdrawalAction {
+    Demote,
+    Quarantine { reason: String },
+}
+
+/// What recovery should do with a stuck row, regardless of type. The
+/// type-specific outcomes above are mapped into this for the actual write.
+enum RecoveryAction {
+    Complete { signature: String },
+    Demote,
+    Quarantine { reason: String },
+}
+
+/// The recovery loop. The first iteration runs immediately on boot,
+/// because boot right after a crash is the moment stuck rows are most
+/// likely to exist. After that it ticks once a minute to catch rows
+/// orphaned by missed shutdowns or rolling deploys.
+pub async fn run_recovery_worker(
+    storage: Arc<Storage>,
+    rpc_client: Arc<RpcClientWithRetry>,
+    admin_pubkey: Pubkey,
+    program_type: ProgramType,
+    storage_tx: mpsc::Sender<TransactionStatusUpdate>,
+    cancellation_token: CancellationToken,
+) -> Result<(), OperatorError> {
+    info!("Starting recovery worker");
+    let mut interval = tokio::time::interval(RECOVERY_INTERVAL);
+    loop {
+        tokio::select! {
+            _ = cancellation_token.cancelled() => {
+                info!("Recovery worker received cancellation, exiting");
+                break;
+            }
+            _ = interval.tick() => {
+                if let Err(e) = recover_once(
+                    &storage,
+                    &rpc_client,
+                    admin_pubkey,
+                    program_type,
+                    &storage_tx,
+                )
+                .await
+                {
+                    // A single failed tick is fine — each row write is
+                    // independent and conditional, so partial failure can't
+                    // leave the DB inconsistent. Retry next minute.
+                    warn!("Recovery tick failed: {}", e);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn recover_once(
+    storage: &Storage,
+    rpc_client: &RpcClientWithRetry,
+    admin_pubkey: Pubkey,
+    program_type: ProgramType,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) -> Result<(), OperatorError> {
+    let stale = storage
+        .get_stale_processing_transactions(STALE_THRESHOLD, RECOVERY_BATCH_LIMIT)
+        .await?;
+
+    if stale.is_empty() {
+        return Ok(());
+    }
+
+    debug!(
+        count = stale.len(),
+        "Recovery sweep found stale Processing rows"
+    );
+
+    for row in stale {
+        // Read `updated_at` now, before the (possibly slow) RPC call. We
+        // pass it to the write below as a "this row hasn't changed since I
+        // looked" check, if anyone else touches the row in between, the
+        // DB trigger bumps updated_at and our write becomes a no-op.
+        let captured = row.updated_at;
+        let action = decide_action(&row, rpc_client, admin_pubkey).await;
+        route_outcome(storage, &row, captured, action, program_type, storage_tx).await;
+    }
+    Ok(())
+}
+
+async fn decide_action(
+    row: &DbTransaction,
+    rpc_client: &RpcClientWithRetry,
+    admin_pubkey: Pubkey,
+) -> RecoveryAction {
+    match row.transaction_type {
+        TransactionType::Deposit => {
+            match check_deposit_idempotency(row, rpc_client, admin_pubkey).await {
+                DepositOutcome::Landed { signature } => RecoveryAction::Complete { signature },
+                DepositOutcome::NotLanded => RecoveryAction::Demote,
+                DepositOutcome::Ambiguous { reason } => RecoveryAction::Quarantine { reason },
+            }
+        }
+        TransactionType::Withdrawal => match check_withdrawal(row) {
+            WithdrawalAction::Demote => RecoveryAction::Demote,
+            WithdrawalAction::Quarantine { reason } => RecoveryAction::Quarantine { reason },
+        },
+    }
+}
+
+async fn check_deposit_idempotency(
+    row: &DbTransaction,
+    rpc_client: &RpcClientWithRetry,
+    admin_pubkey: Pubkey,
+) -> DepositOutcome {
+    let builder = match reconstruct_mint_builder_for_lookup(row, admin_pubkey) {
+        Ok(b) => b,
+        Err(e) => {
+            return DepositOutcome::Ambiguous {
+                reason: format!("deposit idempotency: rebuild: {e}"),
+            }
+        }
+    };
+    match find_existing_mint_signature(rpc_client, &builder).await {
+        Ok(Some(sig)) => DepositOutcome::Landed {
+            signature: sig.to_string(),
+        },
+        // `find_existing_mint_signature` also returns Ok(None) when the RPC
+        // responds with -32601 MethodNotFound (fail-open at mint.rs:441-442).
+        // That arm is unreachable here because the operator's RPC is the
+        // PrivateChannel node, which implements `getSignaturesForAddress`
+        // (PR #95). So Ok(None) in production means "no prior mint found"
+        // — safe to demote.
+        Ok(None) => DepositOutcome::NotLanded,
+        // Transport / other RPC error. Recovery cannot demote on
+        // uncertainty (a row whose mint already landed would be re-minted
+        // on the next pickup); route to ManualReview instead.
+        Err(e) => DepositOutcome::Ambiguous {
+            reason: format!("deposit idempotency: {e}"),
+        },
+    }
+}
+
+fn check_withdrawal(row: &DbTransaction) -> WithdrawalAction {
+    match row.withdrawal_nonce {
+        Some(_) => WithdrawalAction::Demote,
+        None => WithdrawalAction::Quarantine {
+            reason: "withdrawal row missing nonce".to_string(),
+        },
+    }
+}
+
+/// Rebuild the same mint-builder shape the processor would have produced
+/// for this row (`process_deposit_funds` in processor.rs). We don't send
+/// it — we only need its fields (recipient ATA, memo) so the idempotency
+/// lookup searches the same place the original mint would have targeted.
+fn reconstruct_mint_builder_for_lookup(
+    row: &DbTransaction,
+    admin_pubkey: Pubkey,
+) -> Result<MintToBuilderWithTxnId, String> {
+    let mint = Pubkey::from_str(&row.mint).map_err(|e| format!("invalid mint pubkey: {e}"))?;
+    let recipient =
+        Pubkey::from_str(&row.recipient).map_err(|e| format!("invalid recipient pubkey: {e}"))?;
+    // PrivateChannel is SPL-Token-only today. Hard-coding the program ID
+    // here avoids dragging the MintCache into recovery just to read a
+    // constant. If Token-2022 lands, this and `mint_util.rs` move together.
+    let token_program = spl_token::id();
+    let recipient_ata =
+        get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
+    let amount =
+        u64::try_from(row.amount).map_err(|_| format!("negative amount: {}", row.amount))?;
+
+    let mut builder = MintToBuilder::new();
+    builder
+        .mint(mint)
+        .recipient(recipient)
+        .recipient_ata(recipient_ata)
+        .payer(admin_pubkey)
+        .mint_authority(admin_pubkey)
+        .token_program(token_program)
+        .amount(amount)
+        .idempotency_memo(mint_idempotency_memo(row.id));
+
+    Ok(MintToBuilderWithTxnId {
+        builder,
+        txn_id: row.id,
+        trace_id: row.trace_id.clone(),
+    })
+}
+
+async fn route_outcome(
+    storage: &Storage,
+    row: &DbTransaction,
+    captured_updated_at: DateTime<Utc>,
+    action: RecoveryAction,
+    program_type: ProgramType,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) {
+    let pt_label = match program_type {
+        ProgramType::Escrow => "escrow",
+        ProgramType::Withdraw => "withdraw",
+    };
+    let type_label = match row.transaction_type {
+        TransactionType::Deposit => "deposit",
+        TransactionType::Withdrawal => "withdrawal",
+    };
+
+    match action {
+        RecoveryAction::Complete { signature } => {
+            match storage
+                .try_complete_processing(row.id, captured_updated_at, Some(signature.clone()))
+                .await
+            {
+                Ok(true) => {
+                    info!(
+                        transaction_id = row.id,
+                        signature, "Recovery promoted stale Processing → Completed"
+                    );
+                    OPERATOR_STALE_PROCESSING_RECOVERED
+                        .with_label_values(&[pt_label, "completed", type_label])
+                        .inc();
+                }
+                Ok(false) => {
+                    debug!(
+                        id = row.id,
+                        "recovery skipped — another writer touched the row first"
+                    );
+                }
+                Err(e) => warn!(id = row.id, "recovery write error: {}", e),
+            }
+        }
+        RecoveryAction::Demote => {
+            // The write itself bumps `updated_at` (via the DB trigger), so
+            // the row no longer looks stuck to the next recovery tick. The
+            // fetcher picks it up as a fresh `Pending` job on its next poll.
+            match storage
+                .try_requeue_processing(row.id, captured_updated_at)
+                .await
+            {
+                Ok(true) => {
+                    info!(
+                        transaction_id = row.id,
+                        "Recovery demoted stale Processing → Pending"
+                    );
+                    OPERATOR_STALE_PROCESSING_RECOVERED
+                        .with_label_values(&[pt_label, "requeued", type_label])
+                        .inc();
+                }
+                Ok(false) => {
+                    debug!(
+                        id = row.id,
+                        "recovery skipped — another writer touched the row first"
+                    );
+                }
+                Err(e) => warn!(id = row.id, "recovery write error: {}", e),
+            }
+        }
+        RecoveryAction::Quarantine { reason } => {
+            // Deliberately noisy. We'd rather page on-call for a row we're
+            // unsure about than quietly demote it and risk a double-mint.
+            match storage
+                .try_quarantine_processing(row.id, captured_updated_at, reason.clone())
+                .await
+            {
+                Ok(true) => {
+                    warn!(
+                        transaction_id = row.id,
+                        reason = %reason,
+                        "Recovery quarantined stale Processing → ManualReview"
+                    );
+                    OPERATOR_STALE_PROCESSING_RECOVERED
+                        .with_label_values(&[pt_label, "quarantined", type_label])
+                        .inc();
+                    // Send the same status-update message the rest of the
+                    // operator sends, so the existing webhook + alert log
+                    // fire and on-call gets the reason string the runbook
+                    // expects. Same pattern as `send_recovery_manual_review`
+                    // in sender/state.rs.
+                    let update = TransactionStatusUpdate {
+                        transaction_id: row.id,
+                        trace_id: Some(row.trace_id.clone()),
+                        status: TransactionStatus::ManualReview,
+                        counterpart_signature: None,
+                        processed_at: Some(Utc::now()),
+                        error_message: Some(reason),
+                        remint_signature: None,
+                        remint_attempted: false,
+                    };
+                    let _ = send_guaranteed(storage_tx, update, "recovery manual review").await;
+                }
+                Ok(false) => {
+                    debug!(
+                        id = row.id,
+                        "recovery skipped — another writer touched the row first"
+                    );
+                }
+                Err(e) => warn!(id = row.id, "recovery write error: {}", e),
+            }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-mock-storage"))]
+pub mod test_hooks {
+    //! Test-only entry to drive a single recovery tick deterministically.
+    use super::*;
+
+    pub async fn run_recovery_once(
+        storage: &Storage,
+        rpc_client: &RpcClientWithRetry,
+        admin_pubkey: Pubkey,
+        program_type: ProgramType,
+        storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    ) -> Result<(), OperatorError> {
+        recover_once(storage, rpc_client, admin_pubkey, program_type, storage_tx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operator::utils::rpc_util::RetryConfig;
+    use crate::storage::common::storage::mock::MockStorage;
+    use solana_sdk::commitment_config::CommitmentConfig;
+
+    fn make_deposit_row(id: i64) -> DbTransaction {
+        let now = Utc::now();
+        DbTransaction {
+            id,
+            signature: format!("sig-{id}"),
+            trace_id: format!("trace-{id}"),
+            slot: 100,
+            initiator: Pubkey::new_unique().to_string(),
+            recipient: Pubkey::new_unique().to_string(),
+            mint: Pubkey::new_unique().to_string(),
+            amount: 1_000,
+            memo: None,
+            transaction_type: TransactionType::Deposit,
+            withdrawal_nonce: None,
+            status: TransactionStatus::Processing,
+            created_at: now,
+            updated_at: now,
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            pending_remint_deadline_at: None,
+        }
+    }
+
+    fn make_withdrawal_row(id: i64, nonce: Option<i64>) -> DbTransaction {
+        let mut row = make_deposit_row(id);
+        row.transaction_type = TransactionType::Withdrawal;
+        row.withdrawal_nonce = nonce;
+        row
+    }
+
+    fn make_rpc_client(url: &str) -> RpcClientWithRetry {
+        RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        )
+    }
+
+    // ── check_deposit_idempotency outcome matrix ─────────────────────
+
+    #[tokio::test]
+    async fn check_deposit_idempotency_landed_when_rpc_returns_match() {
+        // Script `getSignaturesForAddress` + `getTransaction` so the helper
+        // finds a confirmed mint with the expected memo. Mirrors the
+        // integration-level fixture but with mockito for unit-scope use.
+        let mut server = mockito::Server::new_async().await;
+
+        let row = make_deposit_row(7_777);
+        let mint = Pubkey::from_str(&row.mint).unwrap();
+        let recipient = Pubkey::from_str(&row.recipient).unwrap();
+        let admin_pubkey = Pubkey::new_unique();
+        let token_program = spl_token::id();
+        let recipient_ata =
+            get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
+        let memo = mint_idempotency_memo(row.id);
+        let signature = solana_sdk::signature::Signature::new_unique();
+        let memo_program_id = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+
+        let _sigs_mock = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignaturesForAddress"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": [
+                        {
+                            "signature": signature.to_string(),
+                            "slot": 100u64,
+                            "err": serde_json::Value::Null,
+                            "memo": format!("[{}] {}", memo.len(), memo),
+                            "blockTime": 1_700_000_000i64,
+                            "confirmationStatus": "finalized",
+                        }
+                    ]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let _tx_mock = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "slot": 100,
+                        "blockTime": 1_700_000_000i64,
+                        "meta": {
+                            "err": null,
+                            "status": { "Ok": null },
+                            "fee": 5000u64,
+                            "innerInstructions": [],
+                            "preBalances": [1_000_000u64],
+                            "postBalances": [999_995u64],
+                            "logMessages": [],
+                            "preTokenBalances": [],
+                            "postTokenBalances": [],
+                            "rewards": [],
+                            "computeUnitsConsumed": 0u64,
+                        },
+                        "transaction": {
+                            "signatures": [signature.to_string()],
+                            "message": {
+                                "accountKeys": [
+                                    {"pubkey": admin_pubkey.to_string(), "signer": true, "writable": true, "source": "transaction"},
+                                    {"pubkey": recipient_ata.to_string(), "signer": false, "writable": true, "source": "transaction"},
+                                    {"pubkey": mint.to_string(), "signer": false, "writable": true, "source": "transaction"},
+                                    {"pubkey": token_program.to_string(), "signer": false, "writable": false, "source": "transaction"},
+                                    {"pubkey": memo_program_id, "signer": false, "writable": false, "source": "transaction"},
+                                ],
+                                "recentBlockhash": "GHtXQBsoZHjzkAm2Sdm6FTyFHBCqBnLanJJhZFCFJXoe",
+                                "instructions": [
+                                    {"program": "spl-memo", "programId": memo_program_id, "parsed": memo},
+                                    {
+                                        "program": "spl-token",
+                                        "programId": token_program.to_string(),
+                                        "parsed": {
+                                            "type": "mintTo",
+                                            "info": {
+                                                "mint": mint.to_string(),
+                                                "account": recipient_ata.to_string(),
+                                                "mintAuthority": admin_pubkey.to_string(),
+                                                "amount": (row.amount as u64).to_string(),
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        let client = make_rpc_client(&server.url());
+        let outcome = check_deposit_idempotency(&row, &client, admin_pubkey).await;
+        match outcome {
+            DepositOutcome::Landed { signature: s } => {
+                assert_eq!(s, signature.to_string());
+            }
+            _ => panic!("expected Landed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn check_deposit_idempotency_not_landed_on_empty_signatures() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignaturesForAddress"
+            })))
+            .with_status(200)
+            .with_body(serde_json::json!({"jsonrpc":"2.0","id":1,"result":[]}).to_string())
+            .create();
+        let client = make_rpc_client(&server.url());
+        let row = make_deposit_row(1);
+        let admin_pubkey = Pubkey::new_unique();
+        let outcome = check_deposit_idempotency(&row, &client, admin_pubkey).await;
+        assert!(matches!(outcome, DepositOutcome::NotLanded));
+    }
+
+    #[tokio::test]
+    async fn check_deposit_idempotency_ambiguous_on_transport_error() {
+        let mut server = mockito::Server::new_async().await;
+        // HTTP 500 → transport error → Err path → Ambiguous.
+        let _m = server
+            .mock("POST", "/")
+            .with_status(500)
+            .with_body("internal server error")
+            .create();
+        let client = make_rpc_client(&server.url());
+        let row = make_deposit_row(1);
+        let admin_pubkey = Pubkey::new_unique();
+        let outcome = check_deposit_idempotency(&row, &client, admin_pubkey).await;
+        match outcome {
+            DepositOutcome::Ambiguous { reason } => {
+                assert!(
+                    reason.starts_with("deposit idempotency:"),
+                    "reason: {reason}"
+                );
+            }
+            _ => panic!("expected Ambiguous"),
+        }
+    }
+
+    // ── check_withdrawal outcome matrix ───────────────────────────────
+
+    #[test]
+    fn check_withdrawal_demotes_when_nonce_present() {
+        let row = make_withdrawal_row(1, Some(42));
+        let action = check_withdrawal(&row);
+        assert!(matches!(action, WithdrawalAction::Demote));
+    }
+
+    #[test]
+    fn check_withdrawal_quarantines_when_nonce_missing() {
+        let row = make_withdrawal_row(1, None);
+        let action = check_withdrawal(&row);
+        match action {
+            WithdrawalAction::Quarantine { reason } => {
+                assert!(reason.contains("withdrawal row missing nonce"));
+            }
+            _ => panic!("expected Quarantine"),
+        }
+    }
+
+    // ── route_outcome calls the right storage helper per variant ─────
+
+    async fn seed_processing_row(mock: &MockStorage, row: DbTransaction) -> DateTime<Utc> {
+        let captured = row.updated_at;
+        mock.pending_transactions.lock().unwrap().push(row);
+        captured
+    }
+
+    #[tokio::test]
+    async fn route_outcome_complete_writes_completed() {
+        let mock = MockStorage::new();
+        let mut row = make_deposit_row(1);
+        row.status = TransactionStatus::Processing;
+        let captured = seed_processing_row(&mock, row.clone()).await;
+        let storage = Storage::Mock(mock.clone());
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        route_outcome(
+            &storage,
+            &row,
+            captured,
+            RecoveryAction::Complete {
+                signature: "sig-abc".to_string(),
+            },
+            ProgramType::Escrow,
+            &storage_tx,
+        )
+        .await;
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Completed);
+        assert_eq!(after[0].counterpart_signature.as_deref(), Some("sig-abc"));
+    }
+
+    #[tokio::test]
+    async fn route_outcome_demote_writes_pending() {
+        let mock = MockStorage::new();
+        let mut row = make_deposit_row(2);
+        row.status = TransactionStatus::Processing;
+        let captured = seed_processing_row(&mock, row.clone()).await;
+        let storage = Storage::Mock(mock.clone());
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        route_outcome(
+            &storage,
+            &row,
+            captured,
+            RecoveryAction::Demote,
+            ProgramType::Escrow,
+            &storage_tx,
+        )
+        .await;
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn route_outcome_quarantine_writes_manual_review_and_sends_alert() {
+        let mock = MockStorage::new();
+        let mut row = make_withdrawal_row(3, None);
+        row.status = TransactionStatus::Processing;
+        let captured = seed_processing_row(&mock, row.clone()).await;
+        let storage = Storage::Mock(mock.clone());
+        let (storage_tx, mut storage_rx) = mpsc::channel(8);
+
+        route_outcome(
+            &storage,
+            &row,
+            captured,
+            RecoveryAction::Quarantine {
+                reason: "withdrawal row missing nonce".to_string(),
+            },
+            ProgramType::Withdraw,
+            &storage_tx,
+        )
+        .await;
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::ManualReview);
+        drop(after);
+
+        let update = storage_rx
+            .try_recv()
+            .expect("expected manual review update");
+        assert_eq!(update.transaction_id, row.id);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert_eq!(
+            update.error_message.as_deref(),
+            Some("withdrawal row missing nonce")
+        );
+    }
+
+    #[tokio::test]
+    async fn route_outcome_demote_noops_when_captured_updated_at_stale() {
+        // The `updated_at` check fails → no metric increment, row unchanged.
+        let mock = MockStorage::new();
+        let mut row = make_deposit_row(4);
+        row.status = TransactionStatus::Processing;
+        mock.pending_transactions.lock().unwrap().push(row.clone());
+        let storage = Storage::Mock(mock.clone());
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        // Captured timestamp that does NOT match the seeded row's updated_at.
+        let stale = row.updated_at - chrono::Duration::seconds(60);
+        route_outcome(
+            &storage,
+            &row,
+            stale,
+            RecoveryAction::Demote,
+            ProgramType::Escrow,
+            &storage_tx,
+        )
+        .await;
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Processing);
+    }
+}

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -176,7 +176,7 @@ async fn decide_action(
     // MAX_RECOVERY_REQUEUE_ATTEMPTS are quarantined (and paged) rather than
     // looping between Pending and Processing indefinitely.
     if matches!(action, RecoveryAction::Demote)
-        && row.recovery_requeue_attempts + 1 >= MAX_RECOVERY_REQUEUE_ATTEMPTS
+        && row.recovery_requeue_attempts >= MAX_RECOVERY_REQUEUE_ATTEMPTS
     {
         return RecoveryAction::Quarantine {
             reason: format!(
@@ -1040,8 +1040,8 @@ mod tests {
         let mock = MockStorage::new();
         let mut row = make_deposit_row(51);
         row.status = TransactionStatus::Processing;
-        // One short of the cap → the next requeue would exceed it.
-        row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS - 1;
+        // At the cap (MAX requeues already done) → the next demote is blocked.
+        row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS;
         // Backdate past STALE_THRESHOLD so the sweep actually selects it.
         row.updated_at = Utc::now() - chrono::Duration::minutes(10);
         mock.pending_transactions.lock().unwrap().push(row.clone());
@@ -1096,10 +1096,18 @@ mod tests {
         let client = make_rpc_client(&server.url());
 
         let mut row = make_deposit_row(52);
+        // One below the cap still demotes (requeues) - pins the off-by-one boundary.
         row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS - 1;
-        let action = decide_action(&row, &storage, &client, Pubkey::new_unique()).await;
+        let below = decide_action(&row, &storage, &client, Pubkey::new_unique()).await;
         assert!(
-            matches!(action, RecoveryAction::Quarantine { .. }),
+            matches!(below, RecoveryAction::Demote),
+            "one below the cap must still Demote (requeue)"
+        );
+        // At the cap, the demote is converted to Quarantine.
+        row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS;
+        let at_cap = decide_action(&row, &storage, &client, Pubkey::new_unique()).await;
+        assert!(
+            matches!(at_cap, RecoveryAction::Quarantine { .. }),
             "demote at the cap must become Quarantine"
         );
     }

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -375,7 +375,9 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         }
     }
 

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -4,7 +4,10 @@ use crate::channel_utils::send_guaranteed;
 use crate::config::ProgramType;
 use crate::error::OperatorError;
 use crate::metrics::OPERATOR_STALE_PROCESSING_RECOVERED;
-use crate::operator::sender::find_existing_mint_signature;
+use crate::operator::sender::types::PendingSig;
+use crate::operator::sender::{
+    classify_release_signatures, find_existing_mint_signature, SigFinality,
+};
 use crate::operator::utils::instruction_util::{MintToBuilder, MintToBuilderWithTxnId};
 use crate::operator::utils::mint_idempotency_memo;
 use crate::operator::utils::rpc_util::RpcClientWithRetry;
@@ -13,6 +16,7 @@ use crate::storage::common::models::{DbTransaction, TransactionStatus, Transacti
 use crate::storage::common::storage::Storage;
 use chrono::{DateTime, Utc};
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signature;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -37,17 +41,32 @@ enum DepositOutcome {
     Ambiguous { reason: String },
 }
 
-/// Two-way outcome: on-chain SMT prevents duplicate release anyway.
+/// Withdrawal recovery outcome. We verify on-chain finality before demoting so
+/// a release that already landed is never re-sent.
 enum WithdrawalAction {
+    /// Release finalized on-chain → mark Completed with that signature.
+    Complete { signature: String },
+    /// Every recorded signature is dead → safe to requeue.
     Demote,
+    /// A recorded signature could still land → re-evaluate next sweep.
+    LeaveProcessing { reason: String },
+    /// Uncertain (no signatures, or RPC could not classify) → page.
     Quarantine { reason: String },
 }
 
 /// Unified action for the storage router.
 enum RecoveryAction {
-    Complete { signature: String },
+    Complete {
+        signature: String,
+    },
     Demote,
-    Quarantine { reason: String },
+    /// Leave the row in Processing this tick (no CAS write).
+    NoAction {
+        reason: String,
+    },
+    Quarantine {
+        reason: String,
+    },
 }
 
 /// Recovery loop. First tick runs on boot (the prime crash-recovery moment).
@@ -95,6 +114,13 @@ async fn recover_once(
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: &CancellationToken,
 ) -> Result<(), OperatorError> {
+    // Best-effort GC of release signatures whose parent is no longer Processing;
+    // a failure here must not block recovery.
+    match storage.gc_stale_release_signatures().await {
+        Ok(removed) => debug!(removed, "Recovery GC'd stale release signatures"),
+        Err(e) => warn!("Recovery release-signature GC failed: {}", e),
+    }
+
     let stale = storage
         .get_stale_processing_transactions(STALE_THRESHOLD, RECOVERY_BATCH_LIMIT)
         .await?;
@@ -116,7 +142,7 @@ async fn recover_once(
         }
         // Capture `updated_at` before the RPC so the write below CAS-checks it.
         let captured = row.updated_at;
-        let action = decide_action(&row, rpc_client, admin_pubkey).await;
+        let action = decide_action(&row, storage, rpc_client, admin_pubkey).await;
         route_outcome(storage, &row, captured, action, program_type, storage_tx).await;
     }
     Ok(())
@@ -124,6 +150,7 @@ async fn recover_once(
 
 async fn decide_action(
     row: &DbTransaction,
+    storage: &Storage,
     rpc_client: &RpcClientWithRetry,
     admin_pubkey: Pubkey,
 ) -> RecoveryAction {
@@ -135,8 +162,10 @@ async fn decide_action(
                 DepositOutcome::Ambiguous { reason } => RecoveryAction::Quarantine { reason },
             }
         }
-        TransactionType::Withdrawal => match check_withdrawal(row) {
+        TransactionType::Withdrawal => match check_withdrawal(row, storage, rpc_client).await {
+            WithdrawalAction::Complete { signature } => RecoveryAction::Complete { signature },
             WithdrawalAction::Demote => RecoveryAction::Demote,
+            WithdrawalAction::LeaveProcessing { reason } => RecoveryAction::NoAction { reason },
             WithdrawalAction::Quarantine { reason } => RecoveryAction::Quarantine { reason },
         },
     }
@@ -167,11 +196,69 @@ async fn check_deposit_idempotency(
     }
 }
 
-fn check_withdrawal(row: &DbTransaction) -> WithdrawalAction {
-    match row.withdrawal_nonce {
-        Some(_) => WithdrawalAction::Demote,
-        None => WithdrawalAction::Quarantine {
+/// Decide a stuck Processing withdrawal's fate by verifying on-chain finality
+/// of the persisted release signatures; never demote one whose release landed.
+async fn check_withdrawal(
+    row: &DbTransaction,
+    storage: &Storage,
+    rpc_client: &RpcClientWithRetry,
+) -> WithdrawalAction {
+    if row.withdrawal_nonce.is_none() {
+        return WithdrawalAction::Quarantine {
             reason: "withdrawal row missing nonce".to_string(),
+        };
+    }
+
+    let stored = match storage.get_release_signatures(row.id).await {
+        Ok(s) => s,
+        // Can't read the durable record → can't prove the release didn't land.
+        Err(e) => {
+            return WithdrawalAction::Quarantine {
+                reason: format!("release signature lookup failed: {e}"),
+            };
+        }
+    };
+
+    // No recorded signatures → can't verify a release landed; demoting risks a
+    // double-payout, so page instead.
+    if stored.is_empty() {
+        return WithdrawalAction::Quarantine {
+            reason: "no broadcast signatures recorded; cannot verify release landed".to_string(),
+        };
+    }
+
+    // Reconstruct PendingSigs for the classifier; a malformed stored signature
+    // is uncertainty, not "dead".
+    let mut pending = Vec::with_capacity(stored.len());
+    for (sig_str, lvbh) in &stored {
+        match Signature::from_str(sig_str) {
+            Ok(signature) => pending.push(PendingSig {
+                signature,
+                last_valid_block_height: *lvbh as u64,
+            }),
+            Err(e) => {
+                return WithdrawalAction::Quarantine {
+                    reason: format!("malformed stored release signature {sig_str}: {e}"),
+                };
+            }
+        }
+    }
+
+    match classify_release_signatures(rpc_client, &pending).await {
+        SigFinality::Landed(sig) => WithdrawalAction::Complete {
+            signature: sig.to_string(),
+        },
+        SigFinality::Dead => WithdrawalAction::Demote,
+        SigFinality::Live(reason) => WithdrawalAction::LeaveProcessing { reason },
+        SigFinality::Uncertain(reason) => WithdrawalAction::Quarantine {
+            reason: format!(
+                "could not verify release landed ({reason}); signatures: {}",
+                stored
+                    .iter()
+                    .map(|(s, _)| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
         },
     }
 }
@@ -273,6 +360,14 @@ async fn route_outcome(
                 }
                 Err(e) => warn!(id = row.id, "recovery write error: {}", e),
             }
+        }
+        RecoveryAction::NoAction { reason } => {
+            // Release could still land; leave Processing untouched (no CAS write).
+            debug!(
+                transaction_id = row.id,
+                reason = %reason,
+                "Recovery left stale Processing withdrawal untouched — release may still land"
+            );
         }
         RecoveryAction::Quarantine { reason } => {
             // Noisy by design — page on uncertainty, never silently demote.
@@ -587,20 +682,182 @@ mod tests {
 
     // ── check_withdrawal outcome matrix ───────────────────────────────
 
-    #[test]
-    fn check_withdrawal_demotes_when_nonce_present() {
-        let row = make_withdrawal_row(1, Some(42));
-        let action = check_withdrawal(&row);
-        assert!(matches!(action, WithdrawalAction::Demote));
-    }
-
-    #[test]
-    fn check_withdrawal_quarantines_when_nonce_missing() {
+    /// Missing nonce → quarantine before any RPC/storage read.
+    #[tokio::test]
+    async fn check_withdrawal_quarantines_when_nonce_missing() {
+        let mock = MockStorage::new();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client("http://localhost:1");
         let row = make_withdrawal_row(1, None);
-        let action = check_withdrawal(&row);
+        let action = check_withdrawal(&row, &storage, &client).await;
         match action {
             WithdrawalAction::Quarantine { reason } => {
                 assert!(reason.contains("withdrawal row missing nonce"));
+            }
+            _ => panic!("expected Quarantine"),
+        }
+    }
+
+    /// No recorded signatures → quarantine, not demote (double-payout risk).
+    #[tokio::test]
+    async fn check_withdrawal_quarantines_when_no_signatures_recorded() {
+        let mock = MockStorage::new();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client("http://localhost:1");
+        let row = make_withdrawal_row(1, Some(42));
+        let action = check_withdrawal(&row, &storage, &client).await;
+        match action {
+            WithdrawalAction::Quarantine { reason } => {
+                assert!(
+                    reason.contains("no broadcast signatures recorded"),
+                    "reason: {reason}"
+                );
+            }
+            _ => panic!("expected Quarantine"),
+        }
+    }
+
+    /// Null-status signature past blockhash validity is dead → demote.
+    #[tokio::test]
+    async fn check_withdrawal_demotes_when_signature_dead() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":1}"#,
+            )
+            .create();
+        let _height = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getBlockHeight""#.into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","result":1000,"id":1}"#)
+            .create();
+
+        let mock = MockStorage::new();
+        let row = make_withdrawal_row(1, Some(42));
+        // current_height (1000) > lvbh (100) → expired/dead.
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        let action = check_withdrawal(&row, &storage, &client).await;
+        assert!(
+            matches!(action, WithdrawalAction::Demote),
+            "expected Demote"
+        );
+    }
+
+    /// Finalized-success signature → Complete with that sig.
+    #[tokio::test]
+    async fn check_withdrawal_completes_when_signature_landed() {
+        let landed_sig = Signature::new_unique();
+        let mut server = mockito::Server::new_async().await;
+        let _status = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":null,"status":{"Ok":null},"confirmationStatus":"finalized"}]},"id":1}"#,
+            )
+            .create();
+
+        let mock = MockStorage::new();
+        let row = make_withdrawal_row(1, Some(42));
+        mock.insert_release_signature(row.id, landed_sig.to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        let action = check_withdrawal(&row, &storage, &client).await;
+        match action {
+            WithdrawalAction::Complete { signature } => {
+                assert_eq!(signature, landed_sig.to_string());
+            }
+            _ => panic!("expected Complete"),
+        }
+    }
+
+    /// Signature still within blockhash validity → leave in Processing.
+    #[tokio::test]
+    async fn check_withdrawal_leaves_processing_when_signature_live() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":1}"#,
+            )
+            .create();
+        let _height = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getBlockHeight""#.into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","result":50,"id":1}"#)
+            .create();
+
+        let mock = MockStorage::new();
+        let row = make_withdrawal_row(1, Some(42));
+        // current_height (50) <= lvbh (1000) → still live.
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 1000)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        let action = check_withdrawal(&row, &storage, &client).await;
+        assert!(
+            matches!(action, WithdrawalAction::LeaveProcessing { .. }),
+            "expected LeaveProcessing"
+        );
+    }
+
+    /// RPC failure during classification is uncertainty → quarantine, never demote.
+    #[tokio::test]
+    async fn check_withdrawal_quarantines_on_rpc_uncertainty() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = server
+            .mock("POST", "/")
+            .with_status(500)
+            .with_body("internal server error")
+            .create();
+
+        let mock = MockStorage::new();
+        let row = make_withdrawal_row(1, Some(42));
+        let recorded_sig = Signature::new_unique().to_string();
+        mock.insert_release_signature(row.id, recorded_sig.clone(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        let action = check_withdrawal(&row, &storage, &client).await;
+        match action {
+            WithdrawalAction::Quarantine { reason } => {
+                assert!(
+                    reason.contains("could not verify release landed"),
+                    "reason: {reason}"
+                );
+                assert!(
+                    reason.contains(&recorded_sig),
+                    "sig should be in reason: {reason}"
+                );
             }
             _ => panic!("expected Quarantine"),
         }

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -1,11 +1,4 @@
-//! Recovers transaction rows that got stuck in `Processing` because the
-//! operator crashed before writing their final status.
-//!
-//! Runs alongside the fetcher / processor / sender. On boot and once per
-//! minute, it picks up rows that have been in `Processing` for too long,
-//! asks the chain whether the operator's intended action already happened,
-//! and updates each row to its true state: `Completed`, `Pending` (so the
-//! fetcher will retry it), or `ManualReview` (so a human can investigate).
+//! Recovers rows stuck in `Processing` after an operator crash.
 
 use crate::channel_utils::send_guaranteed;
 use crate::config::ProgramType;
@@ -28,51 +21,36 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-/// How often the recovery loop runs. With the 5-minute age cutoff below,
-/// a stuck row gets resolved within ~6 minutes of getting stuck.
+/// How often the recovery loop runs.
 pub(crate) const RECOVERY_INTERVAL: Duration = Duration::from_secs(60);
 
-/// How long a row must sit in `Processing` before we consider it stuck.
-/// Must be safely longer than any legitimate in-flight send (the sender's
-/// shutdown drain is capped at 30s, plus retry headroom). Set too low,
-/// recovery would interfere with a slow but still-alive send. Set too
-/// high, real stuck rows take longer to heal.
+/// Age cutoff for "stuck"; must exceed the sender's 30s drain + retries.
 pub(crate) const STALE_THRESHOLD: Duration = Duration::from_secs(5 * 60);
 
-/// Maximum rows handled per loop iteration. Keeps a big backlog from
-/// blocking everything else; remaining rows are picked up on the next tick.
+/// Per-tick batch cap; leftovers are picked up next tick.
 pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 
-/// Outcome of checking whether a stuck deposit's mint already landed
-/// on-chain. Three variants are needed (not two), because if we can't tell
-/// for sure, treating that as "didn't land" risks minting a second time.
+/// Three-way outcome: uncertainty must NOT demote (double-mint risk).
 enum DepositOutcome {
     Landed { signature: String },
     NotLanded,
     Ambiguous { reason: String },
 }
 
-/// Outcome of looking at a stuck withdrawal. Only two variants because
-/// the on-chain escrow program won't accept a duplicate release anyway,
-/// so unconditionally retrying is safe — we just refuse if the row itself
-/// is malformed.
+/// Two-way outcome: on-chain SMT prevents duplicate release anyway.
 enum WithdrawalAction {
     Demote,
     Quarantine { reason: String },
 }
 
-/// What recovery should do with a stuck row, regardless of type. The
-/// type-specific outcomes above are mapped into this for the actual write.
+/// Unified action for the storage router.
 enum RecoveryAction {
     Complete { signature: String },
     Demote,
     Quarantine { reason: String },
 }
 
-/// The recovery loop. The first iteration runs immediately on boot,
-/// because boot right after a crash is the moment stuck rows are most
-/// likely to exist. After that it ticks once a minute to catch rows
-/// orphaned by missed shutdowns or rolling deploys.
+/// Recovery loop. First tick runs on boot (the prime crash-recovery moment).
 pub async fn run_recovery_worker(
     storage: Arc<Storage>,
     rpc_client: Arc<RpcClientWithRetry>,
@@ -100,9 +78,7 @@ pub async fn run_recovery_worker(
                 )
                 .await
                 {
-                    // A single failed tick is fine — each row write is
-                    // independent and conditional, so partial failure can't
-                    // leave the DB inconsistent. Retry next minute.
+                    // Per-row writes are independent; retry next tick.
                     warn!("Recovery tick failed: {}", e);
                 }
             }
@@ -133,20 +109,12 @@ async fn recover_once(
     );
 
     for row in stale {
-        // Cooperate with shutdown between rows. With a batch of up to 100
-        // rows and sequential RPC calls per deposit, a tick can run long
-        // enough to overshoot the shutdown drain budget. Drop the
-        // remaining batch and let the next boot pick up where we left off.
+        // Cooperate with shutdown between rows so long batches exit cleanly.
         if cancellation_token.is_cancelled() {
-            info!(
-                "Recovery sweep interrupted by cancellation; remaining rows deferred to next boot"
-            );
+            info!("Recovery sweep cancelled; remaining rows deferred");
             return Ok(());
         }
-        // Read `updated_at` now, before the (possibly slow) RPC call. We
-        // pass it to the write below as a "this row hasn't changed since I
-        // looked" check, if anyone else touches the row in between, the
-        // DB trigger bumps updated_at and our write becomes a no-op.
+        // Capture `updated_at` before the RPC so the write below CAS-checks it.
         let captured = row.updated_at;
         let action = decide_action(&row, rpc_client, admin_pubkey).await;
         route_outcome(storage, &row, captured, action, program_type, storage_tx).await;
@@ -191,16 +159,9 @@ async fn check_deposit_idempotency(
         Ok(Some(sig)) => DepositOutcome::Landed {
             signature: sig.to_string(),
         },
-        // `find_existing_mint_signature` also returns Ok(None) when the RPC
-        // responds with -32601 MethodNotFound (fail-open at mint.rs:441-442).
-        // That arm is unreachable here because the operator's RPC is the
-        // PrivateChannel node, which implements `getSignaturesForAddress`
-        // (PR #95). So Ok(None) in production means "no prior mint found"
-        // — safe to demote.
+        // PrivateChannel RPC supports getSignaturesForAddress; None = not minted.
         Ok(None) => DepositOutcome::NotLanded,
-        // Transport / other RPC error. Recovery cannot demote on
-        // uncertainty (a row whose mint already landed would be re-minted
-        // on the next pickup); route to ManualReview instead.
+        // Never demote on uncertainty — risks a double-mint on re-pickup.
         Err(e) => DepositOutcome::Ambiguous {
             reason: format!("deposit idempotency: {e}"),
         },
@@ -216,10 +177,7 @@ fn check_withdrawal(row: &DbTransaction) -> WithdrawalAction {
     }
 }
 
-/// Rebuild the same mint-builder shape the processor would have produced
-/// for this row (`process_deposit_funds` in processor.rs). We don't send
-/// it — we only need its fields (recipient ATA, memo) so the idempotency
-/// lookup searches the same place the original mint would have targeted.
+/// Rebuild the processor's mint builder so idempotency lookup keys match.
 fn reconstruct_mint_builder_for_lookup(
     row: &DbTransaction,
     admin_pubkey: Pubkey,
@@ -227,9 +185,7 @@ fn reconstruct_mint_builder_for_lookup(
     let mint = Pubkey::from_str(&row.mint).map_err(|e| format!("invalid mint pubkey: {e}"))?;
     let recipient =
         Pubkey::from_str(&row.recipient).map_err(|e| format!("invalid recipient pubkey: {e}"))?;
-    // PrivateChannel is SPL-Token-only today. Hard-coding the program ID
-    // here avoids dragging the MintCache into recovery just to read a
-    // constant. If Token-2022 lands, this and `mint_util.rs` move together.
+    // PrivateChannel is SPL-Token-only today (mirror `mint_util.rs`).
     let token_program = spl_token::id();
     let recipient_ata =
         get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
@@ -296,9 +252,7 @@ async fn route_outcome(
             }
         }
         RecoveryAction::Demote => {
-            // The write itself bumps `updated_at` (via the DB trigger), so
-            // the row no longer looks stuck to the next recovery tick. The
-            // fetcher picks it up as a fresh `Pending` job on its next poll.
+            // Trigger bumps `updated_at`; the next sweep skips it.
             match storage
                 .try_requeue_processing(row.id, captured_updated_at)
                 .await
@@ -322,8 +276,7 @@ async fn route_outcome(
             }
         }
         RecoveryAction::Quarantine { reason } => {
-            // Deliberately noisy. We'd rather page on-call for a row we're
-            // unsure about than quietly demote it and risk a double-mint.
+            // Noisy by design — page on uncertainty, never silently demote.
             match storage
                 .try_quarantine_processing(row.id, captured_updated_at, reason.clone())
                 .await
@@ -337,11 +290,7 @@ async fn route_outcome(
                     OPERATOR_STALE_PROCESSING_RECOVERED
                         .with_label_values(&[pt_label, "quarantined", type_label])
                         .inc();
-                    // Send the same status-update message the rest of the
-                    // operator sends, so the existing webhook + alert log
-                    // fire and on-call gets the reason string the runbook
-                    // expects. Same pattern as `send_recovery_manual_review`
-                    // in sender/state.rs.
+                    // Fire the existing webhook + alert log (see sender/state.rs).
                     let update = TransactionStatusUpdate {
                         transaction_id: row.id,
                         trace_id: Some(row.trace_id.clone()),
@@ -352,11 +301,7 @@ async fn route_outcome(
                         remint_signature: None,
                         remint_attempted: false,
                     };
-                    // The webhook + alert log are how on-call learns about
-                    // this quarantine. If the storage channel is closed
-                    // (e.g. mid-shutdown the writer exited first), the row
-                    // is still correctly quarantined in the DB, but the
-                    // alert is lost — flag it so the gap is visible.
+                    // Closed channel = on-call alert lost; surface it loudly.
                     if let Err(e) =
                         send_guaranteed(storage_tx, update, "recovery manual review").await
                     {
@@ -390,8 +335,7 @@ pub mod test_hooks {
         program_type: ProgramType,
         storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     ) -> Result<(), OperatorError> {
-        // Tests don't exercise cancellation here — pass a fresh, never-cancelled
-        // token so the sweep runs to completion deterministically.
+        // Fresh, never-cancelled token; tests run to completion.
         let token = CancellationToken::new();
         recover_once(
             storage,
@@ -459,9 +403,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_deposit_idempotency_landed_when_rpc_returns_match() {
-        // Script `getSignaturesForAddress` + `getTransaction` so the helper
-        // finds a confirmed mint with the expected memo. Mirrors the
-        // integration-level fixture but with mockito for unit-scope use.
+        // Scripted mock with memo-matching mint; unit equivalent of the IT fixture.
         let mut server = mockito::Server::new_async().await;
 
         let row = make_deposit_row(7_777);

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -278,7 +278,7 @@ async fn route_outcome(
         RecoveryAction::Quarantine { reason } => {
             // Noisy by design — page on uncertainty, never silently demote.
             match storage
-                .try_quarantine_processing(row.id, captured_updated_at, reason.clone())
+                .try_quarantine_processing(row.id, captured_updated_at)
                 .await
             {
                 Ok(true) => {

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -96,6 +96,7 @@ pub async fn run_recovery_worker(
                     admin_pubkey,
                     program_type,
                     &storage_tx,
+                    &cancellation_token,
                 )
                 .await
                 {
@@ -116,6 +117,7 @@ async fn recover_once(
     admin_pubkey: Pubkey,
     program_type: ProgramType,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    cancellation_token: &CancellationToken,
 ) -> Result<(), OperatorError> {
     let stale = storage
         .get_stale_processing_transactions(STALE_THRESHOLD, RECOVERY_BATCH_LIMIT)
@@ -131,6 +133,16 @@ async fn recover_once(
     );
 
     for row in stale {
+        // Cooperate with shutdown between rows. With a batch of up to 100
+        // rows and sequential RPC calls per deposit, a tick can run long
+        // enough to overshoot the shutdown drain budget. Drop the
+        // remaining batch and let the next boot pick up where we left off.
+        if cancellation_token.is_cancelled() {
+            info!(
+                "Recovery sweep interrupted by cancellation; remaining rows deferred to next boot"
+            );
+            return Ok(());
+        }
         // Read `updated_at` now, before the (possibly slow) RPC call. We
         // pass it to the write below as a "this row hasn't changed since I
         // looked" check, if anyone else touches the row in between, the
@@ -340,7 +352,19 @@ async fn route_outcome(
                         remint_signature: None,
                         remint_attempted: false,
                     };
-                    let _ = send_guaranteed(storage_tx, update, "recovery manual review").await;
+                    // The webhook + alert log are how on-call learns about
+                    // this quarantine. If the storage channel is closed
+                    // (e.g. mid-shutdown the writer exited first), the row
+                    // is still correctly quarantined in the DB, but the
+                    // alert is lost — flag it so the gap is visible.
+                    if let Err(e) =
+                        send_guaranteed(storage_tx, update, "recovery manual review").await
+                    {
+                        warn!(
+                            transaction_id = row.id,
+                            "Recovery quarantined row but failed to deliver alert webhook: {}", e
+                        );
+                    }
                 }
                 Ok(false) => {
                     debug!(
@@ -366,7 +390,18 @@ pub mod test_hooks {
         program_type: ProgramType,
         storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     ) -> Result<(), OperatorError> {
-        recover_once(storage, rpc_client, admin_pubkey, program_type, storage_tx).await
+        // Tests don't exercise cancellation here — pass a fresh, never-cancelled
+        // token so the sweep runs to completion deterministically.
+        let token = CancellationToken::new();
+        recover_once(
+            storage,
+            rpc_client,
+            admin_pubkey,
+            program_type,
+            storage_tx,
+            &token,
+        )
+        .await
     }
 }
 

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -34,6 +34,9 @@ pub(crate) const STALE_THRESHOLD: Duration = Duration::from_secs(5 * 60);
 /// Per-tick batch cap; leftovers are picked up next tick.
 pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 
+/// Max durable Demote requeues before a stuck row is quarantined (paged).
+const MAX_RECOVERY_REQUEUE_ATTEMPTS: i32 = 3;
+
 /// Three-way outcome: uncertainty must NOT demote (double-mint risk).
 enum DepositOutcome {
     Landed { signature: String },
@@ -154,7 +157,7 @@ async fn decide_action(
     rpc_client: &RpcClientWithRetry,
     admin_pubkey: Pubkey,
 ) -> RecoveryAction {
-    match row.transaction_type {
+    let action = match row.transaction_type {
         TransactionType::Deposit => {
             match check_deposit_idempotency(row, rpc_client, admin_pubkey).await {
                 DepositOutcome::Landed { signature } => RecoveryAction::Complete { signature },
@@ -168,7 +171,20 @@ async fn decide_action(
             WithdrawalAction::LeaveProcessing { reason } => RecoveryAction::NoAction { reason },
             WithdrawalAction::Quarantine { reason } => RecoveryAction::Quarantine { reason },
         },
+    };
+    // Cap recovery requeue attempts. Rows that fail to make progress after
+    // MAX_RECOVERY_REQUEUE_ATTEMPTS are quarantined (and paged) rather than
+    // looping between Pending and Processing indefinitely.
+    if matches!(action, RecoveryAction::Demote)
+        && row.recovery_requeue_attempts + 1 >= MAX_RECOVERY_REQUEUE_ATTEMPTS
+    {
+        return RecoveryAction::Quarantine {
+            reason: format!(
+                "exceeded {MAX_RECOVERY_REQUEUE_ATTEMPTS} recovery requeues without progress"
+            ),
+        };
     }
+    action
 }
 
 async fn check_deposit_idempotency(
@@ -473,6 +489,7 @@ mod tests {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         }
     }
 
@@ -953,6 +970,137 @@ mod tests {
         assert_eq!(
             update.error_message.as_deref(),
             Some("withdrawal row missing nonce")
+        );
+    }
+
+    // ── recovery requeue cap ─────────────────────────────────────────
+
+    /// Under the cap: a NotLanded deposit is requeued AND its durable
+    /// counter increments, so the next stale sweep sees the higher count.
+    #[tokio::test]
+    async fn requeue_under_cap_increments_counter_and_requeues() {
+        let mut server = mockito::Server::new_async().await;
+        // Empty signatures → NotLanded → Demote.
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignaturesForAddress"
+            })))
+            .with_status(200)
+            .with_body(serde_json::json!({"jsonrpc":"2.0","id":1,"result":[]}).to_string())
+            .create();
+
+        let mock = MockStorage::new();
+        let mut row = make_deposit_row(50);
+        row.status = TransactionStatus::Processing;
+        row.recovery_requeue_attempts = 0;
+        // Backdate past STALE_THRESHOLD so the sweep actually selects it.
+        row.updated_at = Utc::now() - chrono::Duration::minutes(10);
+        mock.pending_transactions.lock().unwrap().push(row.clone());
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        test_hooks::run_recovery_once(
+            &storage,
+            &client,
+            Pubkey::new_unique(),
+            ProgramType::Escrow,
+            &storage_tx,
+        )
+        .await
+        .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Pending,
+            "under cap → requeued"
+        );
+        assert_eq!(
+            after[0].recovery_requeue_attempts, 1,
+            "durable requeue counter must increment on demote"
+        );
+    }
+
+    /// At the cap: a row that would otherwise Demote is quarantined to
+    /// ManualReview and the alert webhook is sent.
+    #[tokio::test]
+    async fn requeue_at_cap_quarantines_and_alerts() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignaturesForAddress"
+            })))
+            .with_status(200)
+            .with_body(serde_json::json!({"jsonrpc":"2.0","id":1,"result":[]}).to_string())
+            .create();
+
+        let mock = MockStorage::new();
+        let mut row = make_deposit_row(51);
+        row.status = TransactionStatus::Processing;
+        // One short of the cap → the next requeue would exceed it.
+        row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS - 1;
+        // Backdate past STALE_THRESHOLD so the sweep actually selects it.
+        row.updated_at = Utc::now() - chrono::Duration::minutes(10);
+        mock.pending_transactions.lock().unwrap().push(row.clone());
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(8);
+
+        test_hooks::run_recovery_once(
+            &storage,
+            &client,
+            Pubkey::new_unique(),
+            ProgramType::Escrow,
+            &storage_tx,
+        )
+        .await
+        .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::ManualReview,
+            "at cap → quarantined, not requeued"
+        );
+        drop(after);
+
+        let update = storage_rx
+            .try_recv()
+            .expect("cap must fire the manual-review alert webhook");
+        assert_eq!(update.transaction_id, 51);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let reason = update.error_message.as_deref().unwrap_or("");
+        assert!(
+            reason.contains("recovery requeues")
+                && reason.contains(&MAX_RECOVERY_REQUEUE_ATTEMPTS.to_string()),
+            "alert must name the requeue cap and its count: {reason}"
+        );
+    }
+
+    /// `decide_action` caps the Demote arm uniformly regardless of type.
+    #[tokio::test]
+    async fn decide_action_caps_demote_at_threshold() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignaturesForAddress"
+            })))
+            .with_status(200)
+            .with_body(serde_json::json!({"jsonrpc":"2.0","id":1,"result":[]}).to_string())
+            .create();
+        let storage = Storage::Mock(MockStorage::new());
+        let client = make_rpc_client(&server.url());
+
+        let mut row = make_deposit_row(52);
+        row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS - 1;
+        let action = decide_action(&row, &storage, &client, Pubkey::new_unique()).await;
+        assert!(
+            matches!(action, RecoveryAction::Quarantine { .. }),
+            "demote at the cap must become Quarantine"
         );
     }
 

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -159,7 +159,6 @@ async fn check_deposit_idempotency(
         Ok(Some(sig)) => DepositOutcome::Landed {
             signature: sig.to_string(),
         },
-        // PrivateChannel RPC supports getSignaturesForAddress; None = not minted.
         Ok(None) => DepositOutcome::NotLanded,
         // Never demote on uncertainty — risks a double-mint on re-pickup.
         Err(e) => DepositOutcome::Ambiguous {
@@ -553,6 +552,35 @@ mod tests {
             }
             _ => panic!("expected Ambiguous"),
         }
+    }
+
+    #[tokio::test]
+    async fn check_deposit_idempotency_ambiguous_on_method_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        // -32601 must NOT collapse to NotLanded → would demote + double-mint.
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignaturesForAddress"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": { "code": -32601, "message": "Method not found" }
+                })
+                .to_string(),
+            )
+            .create();
+        let client = make_rpc_client(&server.url());
+        let row = make_deposit_row(1);
+        let admin_pubkey = Pubkey::new_unique();
+        let outcome = check_deposit_idempotency(&row, &client, admin_pubkey).await;
+        assert!(
+            matches!(outcome, DepositOutcome::Ambiguous { .. }),
+            "method-not-found must be Ambiguous, never NotLanded"
+        );
     }
 
     // ── check_withdrawal outcome matrix ───────────────────────────────

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -8,8 +8,6 @@ use crate::operator::{
 };
 use serde_json::Value;
 use solana_keychain::SolanaSigner;
-use solana_rpc_client_api::client_error::ErrorKind;
-use solana_rpc_client_api::request::RpcError;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::program_option::COption;
 use solana_sdk::pubkey::Pubkey;
@@ -413,6 +411,7 @@ pub async fn find_existing_mint_signature(
 }
 
 /// Check recent ATA signatures for an already-confirmed mint carrying the given memo.
+/// Any RPC failure (including `-32601`) is returned as `Err` — callers decide.
 pub async fn find_existing_mint_signature_with_memo(
     rpc_client: &RpcClientWithRetry,
     builder_with_txn_id: &MintToBuilderWithTxnId,
@@ -432,14 +431,6 @@ pub async fn find_existing_mint_signature_with_memo(
     {
         Ok(signatures) => signatures,
         Err(e) => {
-            if is_method_not_found_error(e.as_ref()) {
-                warn!(
-                    "Skipping mint idempotency lookup for transaction_id {}: \
-                     RPC endpoint does not support getSignaturesForAddress",
-                    transaction_id
-                );
-                return Ok(None);
-            }
             return Err(format!(
                 "Failed idempotency lookup for transaction_id {} on {}: {}",
                 transaction_id, expected_mint.recipient_ata, e
@@ -488,13 +479,6 @@ pub async fn find_existing_mint_signature_with_memo(
     }
 
     Ok(None)
-}
-
-fn is_method_not_found_error(error: &solana_rpc_client_api::client_error::Error) -> bool {
-    matches!(
-        error.kind(),
-        ErrorKind::RpcError(RpcError::RpcResponseError { code: -32601, .. })
-    )
 }
 
 fn expected_mint_instruction(
@@ -860,17 +844,13 @@ pub(super) fn cleanup_mint_builder(state: &mut SenderState, transaction_id: Opti
 mod tests {
     use super::{
         accounts_and_amount_match, decode_and_check_authority, expected_mint_instruction,
-        instruction_has_expected_mint, instruction_has_memo, is_method_not_found_error,
-        memo_matches, parse_token_instruction_mint_amount,
+        instruction_has_expected_mint, instruction_has_memo, memo_matches,
+        parse_token_instruction_mint_amount,
         partially_decoded_instruction_has_expected_mint, raw_instruction_has_expected_mint,
         strip_memo_length_prefix, transaction_matches_expected_mint, AuthorityCheck,
         ExpectedMintInstruction,
     };
     use crate::operator::utils::instruction_util::{MintToBuilder, MintToBuilderWithTxnId};
-    use solana_rpc_client_api::{
-        client_error::{self, ErrorKind},
-        request::{RpcError, RpcResponseErrorData},
-    };
     use solana_sdk::pubkey::Pubkey;
     use solana_transaction_status::parse_instruction::ParsedInstruction;
     use solana_transaction_status::{
@@ -1530,40 +1510,6 @@ mod tests {
             },
         ));
         assert!(!instruction_has_memo(&ix, memo_text));
-    }
-
-    // ====================================================================
-    // is_method_not_found_error tests
-    // ====================================================================
-
-    /// JSON-RPC error code -32601 is the standard "method not found" code; the helper
-    /// must return true exactly for this value.
-    #[test]
-    fn is_method_not_found_error_returns_true_for_32601() {
-        let error = client_error::Error::new_with_request(
-            ErrorKind::RpcError(RpcError::RpcResponseError {
-                code: -32601,
-                message: "Method not found".to_string(),
-                data: RpcResponseErrorData::Empty,
-            }),
-            solana_rpc_client_api::request::RpcRequest::GetBalance,
-        );
-        assert!(is_method_not_found_error(&error));
-    }
-
-    /// Any other RPC response error code (e.g. -32600 "invalid request") must not be
-    /// confused with method-not-found.
-    #[test]
-    fn is_method_not_found_error_returns_false_for_other_rpc_code() {
-        let error = client_error::Error::new_with_request(
-            ErrorKind::RpcError(RpcError::RpcResponseError {
-                code: -32600,
-                message: "Invalid request".to_string(),
-                data: RpcResponseErrorData::Empty,
-            }),
-            solana_rpc_client_api::request::RpcRequest::GetBalance,
-        );
-        assert!(!is_method_not_found_error(&error));
     }
 
     // ====================================================================

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -845,10 +845,9 @@ mod tests {
     use super::{
         accounts_and_amount_match, decode_and_check_authority, expected_mint_instruction,
         instruction_has_expected_mint, instruction_has_memo, memo_matches,
-        parse_token_instruction_mint_amount,
-        partially_decoded_instruction_has_expected_mint, raw_instruction_has_expected_mint,
-        strip_memo_length_prefix, transaction_matches_expected_mint, AuthorityCheck,
-        ExpectedMintInstruction,
+        parse_token_instruction_mint_amount, partially_decoded_instruction_has_expected_mint,
+        raw_instruction_has_expected_mint, strip_memo_length_prefix,
+        transaction_matches_expected_mint, AuthorityCheck, ExpectedMintInstruction,
     };
     use crate::operator::utils::instruction_util::{MintToBuilder, MintToBuilderWithTxnId};
     use solana_sdk::pubkey::Pubkey;

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -6,6 +6,7 @@ mod transaction;
 pub mod types;
 
 pub use mint::{find_existing_mint_signature, find_existing_mint_signature_with_memo, JitOutcome};
+pub(crate) use remint::{classify_release_signatures, SigFinality};
 pub use types::TransactionStatusUpdate;
 
 #[cfg(any(test, feature = "test-mock-storage"))]

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -477,8 +477,11 @@ mod tests {
     };
     use crate::operator::utils::instruction_util::WithdrawalRemintInfo;
     use crate::operator::MintCache;
+    use crate::operator::RetryConfig;
+    use crate::operator::RpcClientWithRetry;
     use crate::storage::common::storage::mock::MockStorage;
     use crate::storage::Storage;
+    use solana_sdk::commitment_config::CommitmentConfig;
     use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -555,6 +558,7 @@ mod tests {
                 remint_last_valid_block_heights: None,
                 pending_remint_deadline_at: Some(now),
                 finality_check_attempts: attempts,
+                recovery_requeue_attempts: 0,
             });
     }
 
@@ -1235,6 +1239,173 @@ mod tests {
         assert!(
             state.pending_remints.is_empty(),
             "entry consumed after Completed"
+        );
+    }
+
+    // ── classify_release_signatures (multi-sig) ─────────────────
+
+    /// Bare RPC client (1 attempt, fast) for direct classifier tests.
+    fn make_rpc(url: &str) -> RpcClientWithRetry {
+        RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: std::time::Duration::from_millis(1),
+                max_delay: std::time::Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        )
+    }
+
+    /// Finalized success after an earlier finalized failure must win (full-list scan, not first-match).
+    #[tokio::test]
+    async fn classify_release_signatures_finalized_success_wins_over_earlier_failure() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let rpc = make_rpc(&rpc_server.url());
+
+        let failed = Signature::new_unique();
+        let success = Signature::new_unique();
+
+        // value[0] finalized-failed, value[1] finalized-success (positional).
+        let _status = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[
+                {"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"},
+                {"slot":100,"confirmations":null,"err":null,"status":{"Ok":null},"confirmationStatus":"finalized"}
+            ]},"id":0}"#,
+        )
+        .await;
+
+        let sigs = vec![
+            PendingSig {
+                signature: failed,
+                last_valid_block_height: 0,
+            },
+            PendingSig {
+                signature: success,
+                last_valid_block_height: 0,
+            },
+        ];
+
+        match classify_release_signatures(&rpc, &sigs).await {
+            SigFinality::Landed(s) => assert_eq!(
+                s, success,
+                "must return the finalized-success sig, not the failed one"
+            ),
+            _ => panic!("expected Landed(success sig), got a different verdict"),
+        }
+    }
+
+    /// Confirmed success behind a finalized failure must stay Live, never Dead.
+    #[tokio::test]
+    async fn classify_release_signatures_confirmed_success_after_failure_is_live_not_dead() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let rpc = make_rpc(&rpc_server.url());
+
+        // value[0] finalized-failed, value[1] confirmed-success (in a block,
+        // will finalize).
+        let _status = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[
+                {"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"},
+                {"slot":100,"confirmations":10,"err":null,"status":{"Ok":null},"confirmationStatus":"confirmed"}
+            ]},"id":0}"#,
+        )
+        .await;
+
+        let sigs = vec![
+            PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            },
+            PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            },
+        ];
+
+        assert!(
+            matches!(
+                classify_release_signatures(&rpc, &sigs).await,
+                SigFinality::Live(_)
+            ),
+            "confirmed success behind a finalized failure must be Live, not Dead"
+        );
+    }
+
+    /// A still-valid null after an expired null must be Live: nulls are walked fully, not cut at the first.
+    #[tokio::test]
+    async fn classify_release_signatures_live_null_after_expired_null_is_live() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let rpc = make_rpc(&rpc_server.url());
+
+        let _status = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null,null]},"id":0}"#,
+        )
+        .await;
+        // current_height 1000: sig[0] lvbh 100 expired, sig[1] lvbh 2000 live.
+        let _height = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+
+        let sigs = vec![
+            PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 100,
+            },
+            PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 2000,
+            },
+        ];
+
+        assert!(
+            matches!(
+                classify_release_signatures(&rpc, &sigs).await,
+                SigFinality::Live(_)
+            ),
+            "a still-valid null after an expired null must be Live, not Dead"
+        );
+    }
+
+    /// A truncated status list (fewer statuses than sigs) must be Uncertain, never read as "missing = dead".
+    #[tokio::test]
+    async fn classify_release_signatures_status_length_mismatch_is_uncertain() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let rpc = make_rpc(&rpc_server.url());
+
+        // Two sigs requested, one status returned.
+        let _status = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":0}"#,
+        )
+        .await;
+
+        let sigs = vec![
+            PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            },
+            PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            },
+        ];
+
+        assert!(
+            matches!(
+                classify_release_signatures(&rpc, &sigs).await,
+                SigFinality::Uncertain(_)
+            ),
+            "length mismatch must be Uncertain"
         );
     }
 

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -8,12 +8,12 @@ use crate::{
         sender::{
             find_existing_mint_signature_with_memo,
             transaction::FINALITY_SAFETY_DELAY,
-            types::{InstructionWithSigners, PendingRemint},
+            types::{InstructionWithSigners, PendingRemint, PendingSig},
         },
         sign_and_send_transaction,
         utils::instruction_util::WithdrawalRemintInfo,
         ConfirmationResult, ExtraErrorCheckPolicy, MintToBuilder, MintToBuilderWithTxnId,
-        RetryPolicy, SignerUtil, TransactionStatusUpdate,
+        RetryPolicy, RpcClientWithRetry, SignerUtil, TransactionStatusUpdate,
     },
     storage::TransactionStatus,
 };
@@ -180,6 +180,96 @@ pub async fn execute_deferred_remint(
     }
 }
 
+/// On-chain finality verdict for a set of broadcast release signatures. Shared
+/// by the remint gate and recovery so both agree before mutating a withdrawal.
+pub(crate) enum SigFinality {
+    /// A signature finalized successfully — the release landed.
+    Landed(Signature),
+    /// A signature could still land; carries a reason for triage logs.
+    Live(String),
+    /// Every signature is finalized-failed or expired — safe to remint/demote.
+    Dead,
+    /// Could not classify (RPC/length error); callers must NOT treat as Dead.
+    Uncertain(String),
+}
+
+/// Classify `sigs` against on-chain state (see `SigFinality` variants).
+pub(crate) async fn classify_release_signatures(
+    rpc: &RpcClientWithRetry,
+    sigs: &[PendingSig],
+) -> SigFinality {
+    let flat: Vec<Signature> = sigs.iter().map(|p| p.signature).collect();
+
+    let response = match rpc.get_signature_statuses_with_history(&flat).await {
+        Ok(r) => r,
+        Err(e) => {
+            return SigFinality::Uncertain(format!("signature status RPC failed: {}", e));
+        }
+    };
+
+    // RPC returns one status per signature in order; a length mismatch would
+    // silently skip checks below, so treat it as uncertain.
+    if response.value.len() != flat.len() {
+        return SigFinality::Uncertain(format!(
+            "RPC returned {} statuses for {} signatures",
+            response.value.len(),
+            flat.len()
+        ));
+    }
+
+    // Any sig finalized successfully → the release landed.
+    let finalized_success_index = response.value.iter().position(|signature_status| {
+        signature_status.as_ref().is_some_and(|status| {
+            status.satisfies_commitment(CommitmentConfig::finalized()) && status.err.is_none()
+        })
+    });
+    if let Some(index) = finalized_success_index {
+        return SigFinality::Landed(flat[index]);
+    }
+
+    // Fetch block height only for the lvbh check on null-status sigs, so a
+    // transient getBlockHeight outage isn't treated as uncertainty otherwise.
+    let current_height = if response.value.iter().any(|s| s.is_none()) {
+        match rpc.get_block_height().await {
+            Ok(h) => h,
+            Err(e) => {
+                return SigFinality::Uncertain(format!("block height RPC failed: {}", e));
+            }
+        }
+    } else {
+        // Unused: the null-status branch below only fires when some status is None.
+        0
+    };
+
+    // Walk the sigs to see if any could still land (index-aligned with response.value).
+    for (index, pending_sig) in sigs.iter().enumerate() {
+        let signature_status = &response.value[index];
+
+        if let Some(status) = signature_status.as_ref() {
+            // Only `finalized` is definitive; success was handled above, so this is failure.
+            if status.satisfies_commitment(CommitmentConfig::finalized()) {
+                continue;
+            }
+            // confirmed/processed: in a block, will finalize regardless of blockhash validity.
+            return SigFinality::Live(
+                "signature is on-chain (confirmed/processed) and awaiting finalization".to_string(),
+            );
+        }
+
+        // No status entry. lvbh is the only thing keeping it alive.
+        if current_height > pending_sig.last_valid_block_height {
+            continue;
+        }
+        return SigFinality::Live(format!(
+            "signatures still within blockhash validity (current_height={})",
+            current_height
+        ));
+    }
+
+    // Every sig is finalized-failed or expired.
+    SigFinality::Dead
+}
+
 /// Process matured entries in the deferred remint queue. For each matured
 /// entry, classify the stored withdrawal signatures and pick one of:
 ///   1. Any sig finalized + success → report Completed.
@@ -216,149 +306,33 @@ pub async fn process_pending_remints(
             .map(|n| n.to_string())
             .unwrap_or_else(|| "none".to_string());
 
-        // Flatten to a plain Signature slice for the RPC call.
-        let sigs: Vec<Signature> = entry
-            .signatures
-            .iter()
-            .map(|pending_sig| pending_sig.signature)
-            .collect();
-
-        // Ask for the status of every stored signature in one shot.
-        let response = match state
-            .rpc_client
-            .get_signature_statuses_with_history(&sigs)
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                // Couldn't classify. Bump counter and retry next tick, or ManualReview at cap.
+        // Classify the stored signatures against on-chain state.
+        match classify_release_signatures(&state.rpc_client, &entry.signatures).await {
+            // Case 1: a sig finalized successfully — the withdrawal landed.
+            SigFinality::Landed(sig) => {
+                send_completed(storage_tx, &entry, &nonce_label, sig).await;
+            }
+            // Case 2: could still land or unclassifiable → defer, don't remint.
+            SigFinality::Live(reason) | SigFinality::Uncertain(reason) => {
                 defer_or_escalate(
                     &mut remaining,
                     entry,
                     &nonce_label,
-                    &format!("signature status RPC failed: {}", e),
+                    &reason,
                     &state.storage,
                     storage_tx,
                 )
                 .await;
-                continue;
             }
-        };
-
-        // The Solana RPC contract returns one status per input signature in
-        // the same order. If that's violated we'd silently skip checks below.
-        // Treat a length mismatch as a classification failure and defer.
-        if response.value.len() != sigs.len() {
-            defer_or_escalate(
-                &mut remaining,
-                entry,
-                &nonce_label,
-                &format!(
-                    "RPC returned {} statuses for {} signatures",
-                    response.value.len(),
-                    sigs.len()
-                ),
-                &state.storage,
-                storage_tx,
-            )
-            .await;
-            continue;
-        }
-
-        // Case 1: if any sig finalized successfully, the withdrawal landed.
-        // Mark Completed and drop the entry.
-        let finalized_success_index = response.value.iter().position(|signature_status| {
-            signature_status.as_ref().is_some_and(|status| {
-                status.satisfies_commitment(CommitmentConfig::finalized()) && status.err.is_none()
-            })
-        });
-        if let Some(index) = finalized_success_index {
-            send_completed(storage_tx, &entry, &nonce_label, sigs[index]).await;
-            continue;
-        }
-
-        // Block height is only needed for the lvbh check on null-status sigs.
-        // If every sig has a status, the liveness decision is already implied
-        // and we skip the RPC; a transient getBlockHeight outage shouldn't
-        // burn defer attempts when no sig actually needs the height.
-        let current_height = if response.value.iter().any(|s| s.is_none()) {
-            match state.rpc_client.get_block_height().await {
-                Ok(h) => h,
-                Err(e) => {
-                    defer_or_escalate(
-                        &mut remaining,
-                        entry,
-                        &nonce_label,
-                        &format!("block height RPC failed: {}", e),
-                        &state.storage,
-                        storage_tx,
-                    )
-                    .await;
-                    continue;
-                }
-            }
-        } else {
-            // Unreachable below: the null-status branch only fires when at
-            // least one status is None, which we just ruled out.
-            0
-        };
-
-        // Walk the sigs to see if any could still land. Exit early on the
-        // first one that isn't dead. Index-aligned with response.value
-        // (length equality enforced above). Captures a reason describing
-        // why the broadcast could still land so the defer/ManualReview
-        // message can guide operator triage.
-        let mut live_reason: Option<String> = None;
-        for (index, pending_sig) in entry.signatures.iter().enumerate() {
-            let signature_status = &response.value[index];
-
-            if let Some(status) = signature_status.as_ref() {
-                // Status exists. Only `finalized` is a definitive outcome.
-                // (Case 1 above already handled finalized + success, so this
-                // is finalized + error.)
-                if status.satisfies_commitment(CommitmentConfig::finalized()) {
-                    continue;
-                }
-                // `confirmed` or `processed`: already included in a block,
-                // will finalize regardless of blockhash validity.
-                live_reason = Some(
-                    "signature is on-chain (confirmed/processed) and awaiting finalization"
-                        .to_string(),
+            // Case 3: every sig is finalized-failed or expired, safe to remint.
+            SigFinality::Dead => {
+                info!(
+                    "All withdrawal signatures for nonce {} are finalized-failed or expired; attempting remint",
+                    nonce_label
                 );
-                break;
+                execute_deferred_remint(state, &entry, storage_tx).await;
             }
-
-            // No status entry. lvbh is the only thing keeping it alive.
-            if current_height > pending_sig.last_valid_block_height {
-                continue;
-            }
-            live_reason = Some(format!(
-                "signatures still within blockhash validity (current_height={})",
-                current_height
-            ));
-            break;
         }
-
-        // Case 2: at least one broadcast could still land, defer rather than remint.
-        if let Some(reason) = live_reason {
-            defer_or_escalate(
-                &mut remaining,
-                entry,
-                &nonce_label,
-                &reason,
-                &state.storage,
-                storage_tx,
-            )
-            .await;
-            continue;
-        }
-
-        // Case 3: every sig is finalized-failed or expired, safe to remint.
-        info!(
-            "All withdrawal signatures for nonce {} are finalized-failed or expired; attempting remint",
-            nonce_label
-        );
-        execute_deferred_remint(state, &entry, storage_tx).await;
     }
 
     // `remaining` = entries not yet due + entries `defer_or_escalate` re-queued.

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -371,6 +371,11 @@ mod tests {
     use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
     use crate::storage::common::storage::mock::MockStorage;
     use crate::storage::Storage;
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+    use borsh::BorshSerialize;
+    use private_channel_escrow_program_client::Instance;
+    use solana_client::rpc_request::RpcRequest;
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::Signature;
     use std::collections::HashMap;
@@ -436,6 +441,7 @@ mod tests {
             remint_last_valid_block_heights: Some(vec![12_345]),
             pending_remint_deadline_at: Some(deadline),
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         }
     }
 
@@ -1023,5 +1029,90 @@ mod tests {
         let state = result.unwrap();
         assert_eq!(state.instance_pda, Some(instance_pda));
         assert_eq!(state.retry_max_attempts, 5);
+    }
+
+    /// Pins the SmtRootMismatch wedge (see
+    /// `docs/runbooks/withdrawal_pipeline_halt_runbook.md`): a landed release
+    /// whose nonce never reaches `Completed` leaves the DB one nonce behind the
+    /// chain, so next-boot `initialize_smt_state` MUST diverge and halt with
+    /// `Err(SmtRootMismatch)`. A change that silently absorbs it breaks here.
+    #[tokio::test]
+    async fn initialize_smt_state_halts_on_consumed_but_unrecorded_nonce() {
+        let landed_nonce: u64 = 1;
+        let tree_index: u64 = 0;
+
+        // On-chain root = root of an SMT that DOES include the landed nonce.
+        let mut onchain_tree = SmtState::new(tree_index);
+        onchain_tree.insert_nonce(landed_nonce);
+        let onchain_root = onchain_tree.current_root();
+
+        // Craft the Instance account the operator will fetch on boot, carrying
+        // the advanced on-chain root.
+        let instance = Instance {
+            discriminator: 0,
+            bump: 0,
+            version: 0,
+            instance_seed: Pubkey::new_unique(),
+            admin: Pubkey::new_unique(),
+            withdrawal_transactions_root: onchain_root,
+            current_tree_index: tree_index,
+        };
+        let mut instance_bytes = Vec::new();
+        instance.serialize(&mut instance_bytes).unwrap();
+
+        // Mock getAccountInfo to return that crafted Instance account.
+        let account_response = serde_json::json!({
+            "context": {"slot": 1},
+            "value": {
+                "owner": Pubkey::new_unique().to_string(),
+                "lamports": 1_000_000u64,
+                "data": [STANDARD.encode(&instance_bytes), "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        });
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, account_response);
+        let mock_rpc = RpcClientWithRetry {
+            rpc_client: Arc::new(
+                solana_client::nonblocking::rpc_client::RpcClient::new_mock_with_mocks(
+                    "http://127.0.0.1:8899".to_string(),
+                    mocks,
+                ),
+            ),
+            retry_config: RetryConfig::default(),
+        };
+
+        // DB returns NO completed nonces — the landed nonce was never recorded.
+        // This is the divergence: chain has the nonce, DB does not.
+        let mut state = make_sender_state_with_pda(Some(Pubkey::new_unique()));
+        state.rpc_client = Arc::new(mock_rpc);
+
+        let err = state.initialize_smt_state().await.unwrap_err();
+
+        match err {
+            OperatorError::Program(crate::error::ProgramError::SmtRootMismatch {
+                local_root,
+                onchain_root: reported_onchain,
+            }) => {
+                // The local (DB-derived, empty) root must differ from the
+                // advanced on-chain root, and the reported on-chain root must
+                // be the one carrying the consumed nonce.
+                assert_ne!(
+                    local_root, reported_onchain,
+                    "mismatch must show diverging roots"
+                );
+                assert_eq!(
+                    reported_onchain, onchain_root,
+                    "on-chain root must be the one that included the landed nonce"
+                );
+                assert_eq!(
+                    local_root,
+                    SmtState::new(tree_index).current_root(),
+                    "local root must be the empty-tree root (nonce never recorded)"
+                );
+            }
+            other => panic!("expected SmtRootMismatch, got: {other}"),
+        }
     }
 }

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -171,6 +171,8 @@ pub async fn handle_transaction_submission(
                     return;
                 }
                 Ok(None) => {}
+                // Deliberately fail-closed: an unverifiable lookup halts to
+                // manual review rather than risk a blind double-mint. 
                 Err(e) => {
                     error!(
                         "Mint idempotency lookup failed for transaction_id {}: {}",
@@ -316,9 +318,11 @@ pub(super) async fn send_and_confirm(
                         last_valid_block_height,
                     });
 
-                // Record the broadcast signature so recovery can verify finality
-                // before demoting. Best-effort: a failed
-                // insert only makes recovery quarantine later, so never fail the send.
+                // Record the broadcast signature for recovery's finality check.
+                // Best-effort: a failed insert only quarantines later, so never fail
+                // the send. Accepted tradeoff: if the release already landed and we
+                // crash before the Completed write, that gap triggers a next-boot
+                // SmtRootMismatch halt. See docs/runbooks/withdrawal_pipeline_halt_runbook.md.
                 if let Some(txid) = ctx.transaction_id {
                     if let Err(e) = state
                         .storage

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -315,6 +315,23 @@ pub(super) async fn send_and_confirm(
                         signature,
                         last_valid_block_height,
                     });
+
+                // Record the broadcast signature so recovery can verify finality
+                // before demoting. Best-effort: a failed
+                // insert only makes recovery quarantine later, so never fail the send.
+                if let Some(txid) = ctx.transaction_id {
+                    if let Err(e) = state
+                        .storage
+                        .insert_release_signature(
+                            txid,
+                            signature.to_string(),
+                            last_valid_block_height as i64,
+                        )
+                        .await
+                    {
+                        warn!("failed to persist release signature for tx {txid}: {e}");
+                    }
+                }
             }
 
             let commitment_config = CommitmentConfig::confirmed();

--- a/indexer/src/shutdown_utils.rs
+++ b/indexer/src/shutdown_utils.rs
@@ -290,6 +290,7 @@ pub async fn shutdown_operator(
     storage_writer_handle: tokio::task::JoinHandle<()>,
     reconciliation_handle: tokio::task::JoinHandle<()>,
     feepayer_monitor_handle: tokio::task::JoinHandle<()>,
+    recovery_handle: tokio::task::JoinHandle<()>,
     batch_size: u16,
     db_poll_interval: Duration,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -308,6 +309,7 @@ pub async fn shutdown_operator(
             storage_writer_handle,
             reconciliation_handle,
             feepayer_monitor_handle,
+            recovery_handle,
             batch_size,
             db_poll_interval,
             &config,
@@ -360,6 +362,7 @@ async fn perform_operator_shutdown_stages(
     storage_writer_handle: tokio::task::JoinHandle<()>,
     reconciliation_handle: tokio::task::JoinHandle<()>,
     feepayer_monitor_handle: tokio::task::JoinHandle<()>,
+    recovery_handle: tokio::task::JoinHandle<()>,
     batch_size: u16,
     db_poll_interval: Duration,
     config: &ShutdownConfig,
@@ -471,6 +474,24 @@ async fn perform_operator_shutdown_stages(
         Err(_) => {
             warn!(
                 "Feepayer monitor drain timed out after {}s",
+                config.storage_writer_drain_timeout_secs
+            );
+        }
+    }
+
+    info!("Stage 6c: Waiting for recovery worker to drain...");
+    let recovery_result = tokio::time::timeout(
+        Duration::from_secs(config.storage_writer_drain_timeout_secs),
+        recovery_handle,
+    )
+    .await;
+
+    match recovery_result {
+        Ok(Ok(_)) => info!("Recovery worker drained successfully"),
+        Ok(Err(e)) => warn!("Recovery worker error: {:?}", e),
+        Err(_) => {
+            warn!(
+                "Recovery worker drain timed out after {}s",
                 config.storage_writer_drain_timeout_secs
             );
         }

--- a/indexer/src/shutdown_utils.rs
+++ b/indexer/src/shutdown_utils.rs
@@ -423,7 +423,26 @@ async fn perform_operator_shutdown_stages(
         }
     }
 
-    // Stage 5: Drain storage writer
+    // Stage 4b: drain recovery before the storage writer (it's a producer on storage_tx).
+    info!("Stage 4b: Waiting for recovery worker to drain...");
+    let recovery_result = tokio::time::timeout(
+        Duration::from_secs(config.storage_writer_drain_timeout_secs),
+        recovery_handle,
+    )
+    .await;
+
+    match recovery_result {
+        Ok(Ok(_)) => info!("Recovery worker drained successfully"),
+        Ok(Err(e)) => warn!("Recovery worker error: {:?}", e),
+        Err(_) => {
+            warn!(
+                "Recovery worker drain timed out after {}s",
+                config.storage_writer_drain_timeout_secs
+            );
+        }
+    }
+
+    // Stage 5: drain storage writer (consumer); all producers have exited.
     info!("Stage 5: Waiting for storage writer to drain (writing final status updates)...");
     let storage_writer_result = tokio::time::timeout(
         Duration::from_secs(config.storage_writer_drain_timeout_secs),
@@ -474,24 +493,6 @@ async fn perform_operator_shutdown_stages(
         Err(_) => {
             warn!(
                 "Feepayer monitor drain timed out after {}s",
-                config.storage_writer_drain_timeout_secs
-            );
-        }
-    }
-
-    info!("Stage 6c: Waiting for recovery worker to drain...");
-    let recovery_result = tokio::time::timeout(
-        Duration::from_secs(config.storage_writer_drain_timeout_secs),
-        recovery_handle,
-    )
-    .await;
-
-    match recovery_result {
-        Ok(Ok(_)) => info!("Recovery worker drained successfully"),
-        Ok(Err(e)) => warn!("Recovery worker error: {:?}", e),
-        Err(_) => {
-            warn!(
-                "Recovery worker drain timed out after {}s",
                 config.storage_writer_drain_timeout_secs
             );
         }

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -78,6 +78,10 @@ pub struct DbTransaction {
     /// what keeps the `MAX_FINALITY_CHECK_ATTEMPTS` budget honest across
     /// crashes. Non-PendingRemint rows always carry 0 (column DEFAULT).
     pub finality_check_attempts: i32,
+    /// Durable recovery requeue counter. Each `Demote` (stale
+    /// `processing` -> `pending`) bumps this; the cap quarantines a row that
+    /// can never progress instead of looping forever.
+    pub recovery_requeue_attempts: i32,
 }
 
 /// Per-mint balance aggregate used during startup reconciliation.
@@ -217,6 +221,7 @@ impl DbTransactionBuilder {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         }
     }
 }

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -120,14 +120,16 @@ impl Storage {
         update_committed_checkpoint::update_committed_checkpoint(self, program_type, slot).await
     }
 
-    /// Update transaction status after processing
+    /// Update transaction status after processing. Returns `Ok(true)` if
+    /// the row was updated; `Ok(false)` if the write was skipped because
+    /// the row was no longer in `Processing` (recovery already moved it).
     pub async fn update_transaction_status(
         &self,
         transaction_id: i64,
         status: TransactionStatus,
         counterpart_signature: Option<String>,
         processed_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<(), StorageError> {
+    ) -> Result<bool, StorageError> {
         update_transaction_status::update_transaction_status(
             self,
             transaction_id,

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -120,9 +120,7 @@ impl Storage {
         update_committed_checkpoint::update_committed_checkpoint(self, program_type, slot).await
     }
 
-    /// Update transaction status after processing. Returns `Ok(true)` if
-    /// the row was updated; `Ok(false)` if the write was skipped because
-    /// the row was no longer in `Processing` (recovery already moved it).
+    /// Terminal status write; `Ok(false)` if row already off Processing.
     pub async fn update_transaction_status(
         &self,
         transaction_id: i64,
@@ -240,8 +238,7 @@ impl Storage {
         quarantine_all_active_withdrawals::quarantine_all_active_withdrawals(self, exclude_id).await
     }
 
-    /// Rows stuck in `Processing` whose `updated_at` is older than the
-    /// safety threshold. Used by the recovery worker.
+    /// Stale `Processing` rows past the threshold (used by recovery).
     pub async fn get_stale_processing_transactions(
         &self,
         threshold: std::time::Duration,
@@ -251,9 +248,7 @@ impl Storage {
             .await
     }
 
-    /// Move a stuck row from `Processing` back to `Pending` if its
-    /// `updated_at` still matches. Returns `true` if the write happened,
-    /// `false` if another writer touched the row first (which is fine).
+    /// CAS `Processing` → `Pending` on `updated_at`; `Ok(false)` if stale.
     pub async fn try_requeue_processing(
         &self,
         transaction_id: i64,
@@ -263,9 +258,7 @@ impl Storage {
             .await
     }
 
-    /// Mark a stuck row as `Completed` if its `updated_at` still matches.
-    /// Returns `true` if the write happened, `false` if another writer
-    /// touched the row first.
+    /// CAS `Processing` → `Completed` on `updated_at`; `Ok(false)` if stale.
     pub async fn try_complete_processing(
         &self,
         transaction_id: i64,
@@ -281,10 +274,7 @@ impl Storage {
         .await
     }
 
-    /// Mark a stuck row as `ManualReview` if its `updated_at` still
-    /// matches. Returns `true` if the write happened, `false` if another
-    /// writer touched the row first. `reason` is carried only on the
-    /// caller's alert webhook payload; we don't store it.
+    /// CAS `Processing` → `ManualReview`; reason rides on the webhook, not DB.
     pub async fn try_quarantine_processing(
         &self,
         transaction_id: i64,

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -429,6 +429,7 @@ mod tests {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         }
     }
 
@@ -1150,6 +1151,7 @@ mod tests {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
         });
     }
 

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -3,7 +3,9 @@ pub use super::models::*;
 pub mod bump_pending_remint_finality_attempt;
 pub mod close;
 pub mod count_pending_transactions;
+pub mod delete_release_signatures;
 pub mod drop_tables;
+pub mod gc_stale_release_signatures;
 pub mod get_all_db_transactions;
 pub mod get_and_lock_pending_transactions;
 pub mod get_committed_checkpoint;
@@ -15,11 +17,13 @@ pub mod get_mint_status_at_slot;
 pub mod get_orphan_deposit_ids;
 pub mod get_pending_db_transactions;
 pub mod get_pending_remint_transactions;
+pub mod get_release_signatures;
 pub mod get_stale_processing_transactions;
 pub mod init_schema;
 pub mod insert_db_transaction;
 pub mod insert_db_transactions_batch;
 pub mod insert_mint_statuses_batch;
+pub mod insert_release_signature;
 pub mod quarantine_all_active_withdrawals;
 pub mod set_mint_extension_flags;
 pub mod set_pending_remint;
@@ -347,6 +351,42 @@ impl Storage {
             expected_updated_at,
         )
         .await
+    }
+
+    /// Record a broadcast release signature so recovery can verify finality
+    /// before demoting. Idempotent on `signature`.
+    pub async fn insert_release_signature(
+        &self,
+        transaction_id: i64,
+        signature: String,
+        last_valid_block_height: i64,
+    ) -> Result<(), StorageError> {
+        insert_release_signature::insert_release_signature(
+            self,
+            transaction_id,
+            signature,
+            last_valid_block_height,
+        )
+        .await
+    }
+
+    /// Stored release signatures for a transaction as (signature, lvbh).
+    pub async fn get_release_signatures(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Vec<(String, i64)>, StorageError> {
+        get_release_signatures::get_release_signatures(self, transaction_id).await
+    }
+
+    /// Delete all stored release signatures for a transaction.
+    pub async fn delete_release_signatures(&self, transaction_id: i64) -> Result<(), StorageError> {
+        delete_release_signatures::delete_release_signatures(self, transaction_id).await
+    }
+
+    /// Drop release signatures whose parent transaction is no longer
+    /// `Processing`. Returns the number of rows removed.
+    pub async fn gc_stale_release_signatures(&self) -> Result<u64, StorageError> {
+        gc_stale_release_signatures::gc_stale_release_signatures(self).await
     }
 }
 
@@ -1107,7 +1147,9 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         });
     }
 

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -12,12 +12,16 @@ pub mod get_mint;
 pub mod get_mint_balances_for_reconciliation;
 pub mod get_pending_db_transactions;
 pub mod get_pending_remint_transactions;
+pub mod get_stale_processing_transactions;
 pub mod init_schema;
 pub mod insert_db_transaction;
 pub mod insert_db_transactions_batch;
 pub mod quarantine_all_active_withdrawals;
 pub mod set_mint_extension_flags;
 pub mod set_pending_remint;
+pub mod try_complete_processing;
+pub mod try_quarantine_processing;
+pub mod try_requeue_processing;
 pub mod update_committed_checkpoint;
 pub mod update_transaction_status;
 pub mod upsert_mints_batch;
@@ -232,6 +236,66 @@ impl Storage {
         exclude_id: Option<i64>,
     ) -> Result<u64, StorageError> {
         quarantine_all_active_withdrawals::quarantine_all_active_withdrawals(self, exclude_id).await
+    }
+
+    /// Rows stuck in `Processing` whose `updated_at` is older than the
+    /// safety threshold. Used by the recovery worker.
+    pub async fn get_stale_processing_transactions(
+        &self,
+        threshold: std::time::Duration,
+        limit: i64,
+    ) -> Result<Vec<DbTransaction>, StorageError> {
+        get_stale_processing_transactions::get_stale_processing_transactions(self, threshold, limit)
+            .await
+    }
+
+    /// Move a stuck row from `Processing` back to `Pending` if its
+    /// `updated_at` still matches. Returns `true` if the write happened,
+    /// `false` if another writer touched the row first (which is fine).
+    pub async fn try_requeue_processing(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool, StorageError> {
+        try_requeue_processing::try_requeue_processing(self, transaction_id, expected_updated_at)
+            .await
+    }
+
+    /// Mark a stuck row as `Completed` if its `updated_at` still matches.
+    /// Returns `true` if the write happened, `false` if another writer
+    /// touched the row first.
+    pub async fn try_complete_processing(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+        counterpart_signature: Option<String>,
+    ) -> Result<bool, StorageError> {
+        try_complete_processing::try_complete_processing(
+            self,
+            transaction_id,
+            expected_updated_at,
+            counterpart_signature,
+        )
+        .await
+    }
+
+    /// Mark a stuck row as `ManualReview` if its `updated_at` still
+    /// matches. Returns `true` if the write happened, `false` if another
+    /// writer touched the row first. `reason` is carried only on the
+    /// caller's alert webhook payload; we don't store it.
+    pub async fn try_quarantine_processing(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+        reason: String,
+    ) -> Result<bool, StorageError> {
+        try_quarantine_processing::try_quarantine_processing(
+            self,
+            transaction_id,
+            expected_updated_at,
+            reason,
+        )
+        .await
     }
 }
 

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -279,13 +279,11 @@ impl Storage {
         &self,
         transaction_id: i64,
         expected_updated_at: chrono::DateTime<chrono::Utc>,
-        reason: String,
     ) -> Result<bool, StorageError> {
         try_quarantine_processing::try_quarantine_processing(
             self,
             transaction_id,
             expected_updated_at,
-            reason,
         )
         .await
     }

--- a/indexer/src/storage/common/storage/delete_release_signatures.rs
+++ b/indexer/src/storage/common/storage/delete_release_signatures.rs
@@ -1,0 +1,16 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+pub async fn delete_release_signatures(
+    storage: &Storage,
+    transaction_id: i64,
+) -> Result<(), StorageError> {
+    match storage {
+        Storage::Postgres(db) => {
+            db.delete_release_signatures_internal(transaction_id)
+                .await?;
+            Ok(())
+        }
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock) => mock.delete_release_signatures(transaction_id).await,
+    }
+}

--- a/indexer/src/storage/common/storage/gc_stale_release_signatures.rs
+++ b/indexer/src/storage/common/storage/gc_stale_release_signatures.rs
@@ -1,0 +1,9 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+pub async fn gc_stale_release_signatures(storage: &Storage) -> Result<u64, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db.gc_stale_release_signatures_internal().await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock) => mock.gc_stale_release_signatures().await,
+    }
+}

--- a/indexer/src/storage/common/storage/get_release_signatures.rs
+++ b/indexer/src/storage/common/storage/get_release_signatures.rs
@@ -1,0 +1,12 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+pub async fn get_release_signatures(
+    storage: &Storage,
+    transaction_id: i64,
+) -> Result<Vec<(String, i64)>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db.get_release_signatures_internal(transaction_id).await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock) => mock.get_release_signatures(transaction_id).await,
+    }
+}

--- a/indexer/src/storage/common/storage/get_stale_processing_transactions.rs
+++ b/indexer/src/storage/common/storage/get_stale_processing_transactions.rs
@@ -4,9 +4,7 @@ use crate::{
 };
 use std::time::Duration;
 
-/// Rows that have been sitting in `Processing` longer than `threshold`,
-/// oldest first. These are the rows the recovery worker investigates —
-/// they're almost certainly orphans from a crashed operator.
+/// Stale `Processing` rows past the threshold, oldest-first.
 pub async fn get_stale_processing_transactions(
     storage: &Storage,
     threshold: Duration,

--- a/indexer/src/storage/common/storage/get_stale_processing_transactions.rs
+++ b/indexer/src/storage/common/storage/get_stale_processing_transactions.rs
@@ -1,0 +1,26 @@
+use crate::{
+    error::StorageError,
+    storage::common::{models::DbTransaction, storage::Storage},
+};
+use std::time::Duration;
+
+/// Rows that have been sitting in `Processing` longer than `threshold`,
+/// oldest first. These are the rows the recovery worker investigates —
+/// they're almost certainly orphans from a crashed operator.
+pub async fn get_stale_processing_transactions(
+    storage: &Storage,
+    threshold: Duration,
+    limit: i64,
+) -> Result<Vec<DbTransaction>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .get_stale_processing_transactions_internal(threshold, limit)
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .get_stale_processing_transactions(threshold, limit)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/insert_release_signature.rs
+++ b/indexer/src/storage/common/storage/insert_release_signature.rs
@@ -1,0 +1,25 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+pub async fn insert_release_signature(
+    storage: &Storage,
+    transaction_id: i64,
+    signature: String,
+    last_valid_block_height: i64,
+) -> Result<(), StorageError> {
+    match storage {
+        Storage::Postgres(db) => {
+            db.insert_release_signature_internal(
+                transaction_id,
+                signature,
+                last_valid_block_height,
+            )
+            .await?;
+            Ok(())
+        }
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock) => {
+            mock.insert_release_signature(transaction_id, signature, last_valid_block_height)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -353,4 +353,96 @@ impl MockStorage {
         }
         Ok(affected)
     }
+
+    pub async fn get_stale_processing_transactions(
+        &self,
+        threshold: std::time::Duration,
+        limit: i64,
+    ) -> Result<Vec<DbTransaction>, StorageError> {
+        self.check_should_fail("get_stale_processing_transactions")?;
+        let threshold_chrono = chrono::Duration::from_std(threshold).unwrap_or_else(|_| {
+            // Defensive: an overflowing Duration falls back to a 1-day cutoff
+            // which is effectively never-stale for any sane test fixture.
+            chrono::Duration::days(1)
+        });
+        let cutoff = Utc::now() - threshold_chrono;
+        let pending = self.pending_transactions.lock().unwrap();
+        let mut matched: Vec<DbTransaction> = pending
+            .iter()
+            .filter(|t| t.status == TransactionStatus::Processing && t.updated_at < cutoff)
+            .cloned()
+            .collect();
+        matched.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
+        matched.truncate(limit as usize);
+        Ok(matched)
+    }
+
+    pub async fn try_requeue_processing(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: DateTime<Utc>,
+    ) -> Result<bool, StorageError> {
+        self.check_should_fail("try_requeue_processing")?;
+        let mut pending = self.pending_transactions.lock().unwrap();
+        for txn in pending.iter_mut() {
+            if txn.id == transaction_id
+                && txn.status == TransactionStatus::Processing
+                && txn.updated_at == expected_updated_at
+            {
+                txn.status = TransactionStatus::Pending;
+                txn.updated_at = Utc::now();
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    pub async fn try_complete_processing(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: DateTime<Utc>,
+        counterpart_signature: Option<String>,
+    ) -> Result<bool, StorageError> {
+        self.check_should_fail("try_complete_processing")?;
+        let mut pending = self.pending_transactions.lock().unwrap();
+        for txn in pending.iter_mut() {
+            if txn.id == transaction_id
+                && txn.status == TransactionStatus::Processing
+                && txn.updated_at == expected_updated_at
+            {
+                txn.status = TransactionStatus::Completed;
+                if counterpart_signature.is_some() {
+                    txn.counterpart_signature = counterpart_signature;
+                }
+                let now = Utc::now();
+                txn.processed_at = Some(now);
+                txn.updated_at = now;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    pub async fn try_quarantine_processing(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: DateTime<Utc>,
+        _reason: String,
+    ) -> Result<bool, StorageError> {
+        self.check_should_fail("try_quarantine_processing")?;
+        let mut pending = self.pending_transactions.lock().unwrap();
+        for txn in pending.iter_mut() {
+            if txn.id == transaction_id
+                && txn.status == TransactionStatus::Processing
+                && txn.updated_at == expected_updated_at
+            {
+                txn.status = TransactionStatus::ManualReview;
+                let now = Utc::now();
+                txn.processed_at = Some(now);
+                txn.updated_at = now;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
 }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -186,12 +186,15 @@ impl MockStorage {
         processed_at: DateTime<Utc>,
     ) -> Result<bool, StorageError> {
         self.check_should_fail("update_transaction_status")?;
-        // Mirror the Postgres `WHERE status = 'processing'` filter so
-        // tests exercise the same no-op-when-already-moved behavior as
-        // production. A row that's already off Processing is not written.
+        // Mirror the Postgres status filter so tests exercise the same
+        // no-op-when-row-is-terminal behavior as production. Only rows
+        // currently in `Processing` or `PendingRemint` accept writes.
         let mut pending = self.pending_transactions.lock().unwrap();
         let updated = if let Some(txn) = pending.iter_mut().find(|t| t.id == transaction_id) {
-            if txn.status == TransactionStatus::Processing {
+            if matches!(
+                txn.status,
+                TransactionStatus::Processing | TransactionStatus::PendingRemint
+            ) {
                 txn.status = status;
                 if counterpart_signature.is_some() {
                     txn.counterpart_signature = counterpart_signature.clone();

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -13,6 +13,9 @@ pub type StatusUpdateRecord = (i64, TransactionStatus, Option<String>, DateTime<
 /// (transaction_id, signatures, last_valid_block_heights, deadline) persisted on PendingRemint transition.
 pub type PendingRemintRecord = (i64, Vec<String>, Vec<i64>, DateTime<Utc>);
 
+/// In-memory mirror of `pending_release_signatures`: txn_id → (signature, lvbh).
+pub type ReleaseSignatureMap = HashMap<i64, Vec<(String, i64)>>;
+
 #[derive(Clone, Default)]
 pub struct MockStorage {
     pub committed_checkpoints: std::sync::Arc<Mutex<HashMap<String, u64>>>,
@@ -29,6 +32,8 @@ pub struct MockStorage {
     /// Transactions currently in PendingRemint status, used in tests to simulate startup recovery.
     pub pending_remint_transactions: std::sync::Arc<Mutex<Vec<DbTransaction>>>,
     pub mint_status_history: Arc<Mutex<Vec<DbMintStatus>>>,
+    /// Mirrors the `pending_release_signatures` table for verify-before-demote.
+    pub release_signatures: Arc<Mutex<ReleaseSignatureMap>>,
 }
 
 impl MockStorage {
@@ -562,4 +567,76 @@ impl MockStorage {
         }
         Ok(false)
     }
+
+    pub async fn insert_release_signature(
+        &self,
+        transaction_id: i64,
+        signature: String,
+        last_valid_block_height: i64,
+    ) -> Result<(), StorageError> {
+        self.check_should_fail("insert_release_signature")?;
+        let mut map = self.release_signatures.lock().unwrap();
+        // Mirror Postgres `ON CONFLICT (signature) DO NOTHING`.
+        if map_contains_signature(&map, &signature) {
+            return Ok(());
+        }
+        map.entry(transaction_id)
+            .or_default()
+            .push((signature, last_valid_block_height));
+        Ok(())
+    }
+
+    pub async fn get_release_signatures(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Vec<(String, i64)>, StorageError> {
+        self.check_should_fail("get_release_signatures")?;
+        Ok(self
+            .release_signatures
+            .lock()
+            .unwrap()
+            .get(&transaction_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    pub async fn delete_release_signatures(&self, transaction_id: i64) -> Result<(), StorageError> {
+        self.check_should_fail("delete_release_signatures")?;
+        self.release_signatures
+            .lock()
+            .unwrap()
+            .remove(&transaction_id);
+        Ok(())
+    }
+
+    pub async fn gc_stale_release_signatures(&self) -> Result<u64, StorageError> {
+        self.check_should_fail("gc_stale_release_signatures")?;
+        // Mirror the Postgres predicate: drop sigs whose parent is not
+        // `Processing`; an unknown transaction id counts as non-processing.
+        let processing_ids: std::collections::HashSet<i64> = self
+            .pending_transactions
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|t| t.status == TransactionStatus::Processing)
+            .map(|t| t.id)
+            .collect();
+        let mut map = self.release_signatures.lock().unwrap();
+        let mut removed = 0u64;
+        map.retain(|txn_id, sigs| {
+            if processing_ids.contains(txn_id) {
+                true
+            } else {
+                removed += sigs.len() as u64;
+                false
+            }
+        });
+        Ok(removed)
+    }
+}
+
+/// True if `signature` is already recorded for any transaction in the map.
+fn map_contains_signature(map: &ReleaseSignatureMap, signature: &str) -> bool {
+    map.values()
+        .any(|sigs| sigs.iter().any(|(s, _)| s == signature))
 }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -186,9 +186,7 @@ impl MockStorage {
         processed_at: DateTime<Utc>,
     ) -> Result<bool, StorageError> {
         self.check_should_fail("update_transaction_status")?;
-        // Mirror the Postgres status filter so tests exercise the same
-        // no-op-when-row-is-terminal behavior as production. Only rows
-        // currently in `Processing` or `PendingRemint` accept writes.
+        // Mirror the Postgres status filter (Processing or PendingRemint only).
         let mut pending = self.pending_transactions.lock().unwrap();
         let updated = if let Some(txn) = pending.iter_mut().find(|t| t.id == transaction_id) {
             if matches!(
@@ -384,11 +382,9 @@ impl MockStorage {
         limit: i64,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         self.check_should_fail("get_stale_processing_transactions")?;
-        let threshold_chrono = chrono::Duration::from_std(threshold).unwrap_or_else(|_| {
-            // Defensive: an overflowing Duration falls back to a 1-day cutoff
-            // which is effectively never-stale for any sane test fixture.
-            chrono::Duration::days(1)
-        });
+        let threshold_chrono = chrono::Duration::from_std(threshold)
+            // Defensive: an overflowing Duration falls back to a 1-day cutoff.
+            .unwrap_or_else(|_| chrono::Duration::days(1));
         let cutoff = Utc::now() - threshold_chrono;
         let pending = self.pending_transactions.lock().unwrap();
         let mut matched: Vec<DbTransaction> = pending

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -453,7 +453,6 @@ impl MockStorage {
         &self,
         transaction_id: i64,
         expected_updated_at: DateTime<Utc>,
-        _reason: String,
     ) -> Result<bool, StorageError> {
         self.check_should_fail("try_quarantine_processing")?;
         let mut pending = self.pending_transactions.lock().unwrap();

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -184,15 +184,36 @@ impl MockStorage {
         status: TransactionStatus,
         counterpart_signature: Option<String>,
         processed_at: DateTime<Utc>,
-    ) -> Result<(), StorageError> {
+    ) -> Result<bool, StorageError> {
         self.check_should_fail("update_transaction_status")?;
+        // Mirror the Postgres `WHERE status = 'processing'` filter so
+        // tests exercise the same no-op-when-already-moved behavior as
+        // production. A row that's already off Processing is not written.
+        let mut pending = self.pending_transactions.lock().unwrap();
+        let updated = if let Some(txn) = pending.iter_mut().find(|t| t.id == transaction_id) {
+            if txn.status == TransactionStatus::Processing {
+                txn.status = status;
+                if counterpart_signature.is_some() {
+                    txn.counterpart_signature = counterpart_signature.clone();
+                }
+                txn.processed_at = Some(processed_at);
+                txn.updated_at = Utc::now();
+                true
+            } else {
+                false
+            }
+        } else {
+            // Unknown id — record the attempt anyway (tests assert on
+            // `status_updates`), but report no row updated.
+            false
+        };
         self.status_updates.lock().unwrap().push((
             transaction_id,
             status,
             counterpart_signature,
             processed_at,
         ));
-        Ok(())
+        Ok(updated)
     }
 
     pub async fn upsert_mints_batch(&self, mints: &[DbMint]) -> Result<(), StorageError> {

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -513,6 +513,7 @@ impl MockStorage {
                 && txn.updated_at == expected_updated_at
             {
                 txn.status = TransactionStatus::Pending;
+                txn.recovery_requeue_attempts += 1;
                 txn.updated_at = Utc::now();
                 return Ok(true);
             }

--- a/indexer/src/storage/common/storage/try_complete_processing.rs
+++ b/indexer/src/storage/common/storage/try_complete_processing.rs
@@ -1,0 +1,28 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Mark a stuck row as `Completed` after recovery has confirmed the
+/// on-chain action already happened. Only writes if the row's
+/// `updated_at` still matches what the caller read. Returns `true` if
+/// the write happened, `false` if someone else got there first.
+pub async fn try_complete_processing(
+    storage: &Storage,
+    transaction_id: i64,
+    expected_updated_at: chrono::DateTime<chrono::Utc>,
+    counterpart_signature: Option<String>,
+) -> Result<bool, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .try_complete_processing_internal(
+                transaction_id,
+                expected_updated_at,
+                counterpart_signature,
+            )
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .try_complete_processing(transaction_id, expected_updated_at, counterpart_signature)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/try_complete_processing.rs
+++ b/indexer/src/storage/common/storage/try_complete_processing.rs
@@ -1,9 +1,6 @@
 use crate::{error::StorageError, storage::common::storage::Storage};
 
-/// Mark a stuck row as `Completed` after recovery has confirmed the
-/// on-chain action already happened. Only writes if the row's
-/// `updated_at` still matches what the caller read. Returns `true` if
-/// the write happened, `false` if someone else got there first.
+/// CAS `Processing` → `Completed` on `updated_at`; `Ok(false)` if stale.
 pub async fn try_complete_processing(
     storage: &Storage,
     transaction_id: i64,

--- a/indexer/src/storage/common/storage/try_quarantine_processing.rs
+++ b/indexer/src/storage/common/storage/try_quarantine_processing.rs
@@ -1,0 +1,25 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Mark a stuck row as `ManualReview` when recovery can't decide what
+/// happened on-chain. Only writes if the row's `updated_at` still
+/// matches what the caller read. The `reason` is passed only so the
+/// caller can include it in the alert webhook — we don't store it in
+/// the DB.
+pub async fn try_quarantine_processing(
+    storage: &Storage,
+    transaction_id: i64,
+    expected_updated_at: chrono::DateTime<chrono::Utc>,
+    reason: String,
+) -> Result<bool, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .try_quarantine_processing_internal(transaction_id, expected_updated_at, reason)
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .try_quarantine_processing(transaction_id, expected_updated_at, reason)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/try_quarantine_processing.rs
+++ b/indexer/src/storage/common/storage/try_quarantine_processing.rs
@@ -1,10 +1,6 @@
 use crate::{error::StorageError, storage::common::storage::Storage};
 
-/// Mark a stuck row as `ManualReview` when recovery can't decide what
-/// happened on-chain. Only writes if the row's `updated_at` still
-/// matches what the caller read. The `reason` is passed only so the
-/// caller can include it in the alert webhook — we don't store it in
-/// the DB.
+/// CAS `Processing` → `ManualReview`; reason rides on the webhook, not DB.
 pub async fn try_quarantine_processing(
     storage: &Storage,
     transaction_id: i64,

--- a/indexer/src/storage/common/storage/try_quarantine_processing.rs
+++ b/indexer/src/storage/common/storage/try_quarantine_processing.rs
@@ -5,16 +5,15 @@ pub async fn try_quarantine_processing(
     storage: &Storage,
     transaction_id: i64,
     expected_updated_at: chrono::DateTime<chrono::Utc>,
-    reason: String,
 ) -> Result<bool, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
-            .try_quarantine_processing_internal(transaction_id, expected_updated_at, reason)
+            .try_quarantine_processing_internal(transaction_id, expected_updated_at)
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .try_quarantine_processing(transaction_id, expected_updated_at, reason)
+                .try_quarantine_processing(transaction_id, expected_updated_at)
                 .await
         }
     }

--- a/indexer/src/storage/common/storage/try_requeue_processing.rs
+++ b/indexer/src/storage/common/storage/try_requeue_processing.rs
@@ -1,0 +1,24 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Move a stuck row from `Processing` back to `Pending` so the fetcher
+/// will retry it. Only writes if the row's `updated_at` still matches
+/// what the caller read — i.e., nobody else has touched the row since.
+/// Returns `true` if the write happened, `false` if someone else got
+/// there first (which is fine, nothing to do).
+pub async fn try_requeue_processing(
+    storage: &Storage,
+    transaction_id: i64,
+    expected_updated_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .try_requeue_processing_internal(transaction_id, expected_updated_at)
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .try_requeue_processing(transaction_id, expected_updated_at)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/try_requeue_processing.rs
+++ b/indexer/src/storage/common/storage/try_requeue_processing.rs
@@ -1,10 +1,6 @@
 use crate::{error::StorageError, storage::common::storage::Storage};
 
-/// Move a stuck row from `Processing` back to `Pending` so the fetcher
-/// will retry it. Only writes if the row's `updated_at` still matches
-/// what the caller read — i.e., nobody else has touched the row since.
-/// Returns `true` if the write happened, `false` if someone else got
-/// there first (which is fine, nothing to do).
+/// CAS `Processing` → `Pending` on `updated_at`; `Ok(false)` if stale.
 pub async fn try_requeue_processing(
     storage: &Storage,
     transaction_id: i64,

--- a/indexer/src/storage/common/storage/update_transaction_status.rs
+++ b/indexer/src/storage/common/storage/update_transaction_status.rs
@@ -4,24 +4,26 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 
+/// Returns `Ok(true)` if the row was updated, `Ok(false)` if the
+/// underlying write was skipped because the row was no longer in
+/// `Processing` (a benign race with recovery — caller should not count
+/// this as a successful DB update).
 pub async fn update_transaction_status(
     storage: &Storage,
     transaction_id: i64,
     status: TransactionStatus,
     counterpart_signature: Option<String>,
     processed_at: DateTime<Utc>,
-) -> Result<(), StorageError> {
+) -> Result<bool, StorageError> {
     match storage {
-        Storage::Postgres(db) => {
-            db.update_transaction_status_internal(
+        Storage::Postgres(db) => Ok(db
+            .update_transaction_status_internal(
                 transaction_id,
                 status,
                 counterpart_signature,
                 processed_at,
             )
-            .await?;
-            Ok(())
-        }
+            .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db

--- a/indexer/src/storage/common/storage/update_transaction_status.rs
+++ b/indexer/src/storage/common/storage/update_transaction_status.rs
@@ -4,10 +4,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 
-/// Returns `Ok(true)` if the row was updated, `Ok(false)` if the
-/// underlying write was skipped because the row was no longer in
-/// `Processing` (a benign race with recovery — caller should not count
-/// this as a successful DB update).
+/// Terminal status write; `Ok(false)` if row already off Processing.
 pub async fn update_transaction_status(
     storage: &Storage,
     transaction_id: i64,

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -883,7 +883,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = 'processing'
               AND {} < NOW() - make_interval(secs => $1)
@@ -907,7 +907,9 @@ impl PostgresDb {
             transaction_cols::PROCESSED_AT,
             transaction_cols::COUNTERPART_SIGNATURE,
             transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
+            transaction_cols::FINALITY_CHECK_ATTEMPTS,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::UPDATED_AT,

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -801,7 +801,8 @@ impl PostgresDb {
     }
 
     /// Returns `Ok(true)` if the row was updated, `Ok(false)` if it was
-    /// skipped (no longer in `Processing`). Callers branch on the bool to
+    /// skipped because the row is already in a terminal state (recovery
+    /// or another writer moved it first). Callers branch on the bool to
     /// avoid counting no-op writes as successful DB updates.
     pub async fn update_transaction_status_internal(
         &self,
@@ -810,11 +811,17 @@ impl PostgresDb {
         counterpart_signature: Option<String>,
         processed_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool, sqlx::Error> {
-        // The `status = 'processing'` filter protects against this race:
-        // recovery has already moved a stuck row off `Processing`, but a
-        // late confirmation from the original (now-crashed) sender is
-        // still trying to mark it `Completed`. Without the filter, the
-        // late write would overwrite recovery's decision.
+        // The status filter protects against this race: recovery has
+        // already moved a stuck row off `Processing`, but a late
+        // confirmation from the original (now-crashed) sender is still
+        // trying to mark it `Completed`. Without the filter, the late
+        // write would overwrite recovery's decision.
+        //
+        // Both `processing` and `pending_remint` are allowed because the
+        // remint flow writes terminal states (`Completed`,
+        // `FailedReminted`, `ManualReview`) from `pending_remint` —
+        // recovery doesn't touch that status, so there's no race window
+        // to worry about there.
         let result = sqlx::query(
             r#"
             UPDATE transactions
@@ -823,7 +830,7 @@ impl PostgresDb {
                 counterpart_signature = $3,
                 processed_at = $4
             WHERE id = $1
-              AND status = 'processing'
+              AND status IN ('processing', 'pending_remint')
             "#,
         )
         .bind(transaction_id)

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1,6 +1,6 @@
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::time::Duration;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::{
     error::StorageError,
@@ -800,13 +800,16 @@ impl PostgresDb {
         Ok(transactions)
     }
 
+    /// Returns `Ok(true)` if the row was updated, `Ok(false)` if it was
+    /// skipped (no longer in `Processing`). Callers branch on the bool to
+    /// avoid counting no-op writes as successful DB updates.
     pub async fn update_transaction_status_internal(
         &self,
         transaction_id: i64,
         status: TransactionStatus,
         counterpart_signature: Option<String>,
         processed_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<bool, sqlx::Error> {
         // The `status = 'processing'` filter protects against this race:
         // recovery has already moved a stuck row off `Processing`, but a
         // late confirmation from the original (now-crashed) sender is
@@ -830,14 +833,7 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
 
-        if result.rows_affected() == 0 {
-            warn!(
-                transaction_id,
-                "terminal write skipped: row no longer in processing"
-            );
-        }
-
-        Ok(())
+        Ok(result.rows_affected() == 1)
     }
 
     /// Rows stuck in `Processing` whose `updated_at` is older than the

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -930,12 +930,11 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
-    /// CAS `Processing` → `ManualReview`; reason carried on webhook, not DB.
+    /// CAS `Processing` → `ManualReview`; reason rides on the webhook, not DB.
     pub async fn try_quarantine_processing_internal(
         &self,
         transaction_id: i64,
         expected_updated_at: chrono::DateTime<chrono::Utc>,
-        _reason: String,
     ) -> Result<bool, sqlx::Error> {
         let result = sqlx::query(
             r#"

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1,5 +1,6 @@
 use sqlx::{postgres::PgPoolOptions, PgPool};
-use tracing::info;
+use std::time::Duration;
+use tracing::{info, warn};
 
 use crate::{
     error::StorageError,
@@ -806,15 +807,20 @@ impl PostgresDb {
         counterpart_signature: Option<String>,
         processed_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+        // The `status = 'processing'` filter protects against this race:
+        // recovery has already moved a stuck row off `Processing`, but a
+        // late confirmation from the original (now-crashed) sender is
+        // still trying to mark it `Completed`. Without the filter, the
+        // late write would overwrite recovery's decision.
+        let result = sqlx::query(
             r#"
             UPDATE transactions
             SET
                 status = $2,
                 counterpart_signature = $3,
-                processed_at = $4,
-                updated_at = NOW()
+                processed_at = $4
             WHERE id = $1
+              AND status = 'processing'
             "#,
         )
         .bind(transaction_id)
@@ -824,7 +830,152 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
 
+        if result.rows_affected() == 0 {
+            warn!(
+                transaction_id,
+                "terminal write skipped: row no longer in processing"
+            );
+        }
+
         Ok(())
+    }
+
+    /// Rows stuck in `Processing` whose `updated_at` is older than the
+    /// safety threshold. Oldest-first so longest-stuck rows are healed first.
+    pub async fn get_stale_processing_transactions_internal(
+        &self,
+        threshold: Duration,
+        limit: i64,
+    ) -> Result<Vec<DbTransaction>, sqlx::Error> {
+        let threshold_secs = threshold.as_secs() as f64;
+        sqlx::query_as::<_, DbTransaction>(&format!(
+            r#"
+            SELECT
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+                {}, {}, {}, {}, {}, {}, {}, {}
+            FROM transactions
+            WHERE {} = 'processing'
+              AND {} < NOW() - make_interval(secs => $1)
+            ORDER BY {} ASC
+            LIMIT $2
+            "#,
+            transaction_cols::ID,
+            transaction_cols::SIGNATURE,
+            transaction_cols::TRACE_ID,
+            transaction_cols::SLOT,
+            transaction_cols::INITIATOR,
+            transaction_cols::RECIPIENT,
+            transaction_cols::MINT,
+            transaction_cols::AMOUNT,
+            transaction_cols::MEMO,
+            transaction_cols::TRANSACTION_TYPE,
+            transaction_cols::WITHDRAWAL_NONCE,
+            transaction_cols::STATUS,
+            transaction_cols::CREATED_AT,
+            transaction_cols::UPDATED_AT,
+            transaction_cols::PROCESSED_AT,
+            transaction_cols::COUNTERPART_SIGNATURE,
+            transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::PENDING_REMINT_DEADLINE_AT,
+            // Filters
+            transaction_cols::STATUS,
+            transaction_cols::UPDATED_AT,
+            // Ordering (FIFO over stale)
+            transaction_cols::UPDATED_AT,
+        ))
+        .bind(threshold_secs)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Move a stuck row from `Processing` back to `Pending` so the fetcher
+    /// can pick it up again. The `updated_at = $2` condition is what makes
+    /// this safe to call: it only succeeds if nothing else has touched the
+    /// row since the caller read it. Anyone else writing to the row bumps
+    /// `updated_at` via the trigger, so our condition fails and the write
+    /// becomes a no-op.
+    pub async fn try_requeue_processing_internal(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'pending'
+            WHERE id = $1
+              AND status = 'processing'
+              AND updated_at = $2
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(expected_updated_at)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Move a stuck row from `Processing` to `Completed` after recovery
+    /// confirmed the action already happened on-chain. The
+    /// `updated_at = $2` condition makes this a no-op if anyone else has
+    /// touched the row in the meantime. `counterpart_signature` may be
+    /// `None` — withdrawal recovery doesn't always know the exact signature
+    /// that landed, and the on-chain escrow program prevents duplicates
+    /// regardless.
+    pub async fn try_complete_processing_internal(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+        counterpart_signature: Option<String>,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'completed',
+                counterpart_signature = COALESCE($3, counterpart_signature),
+                processed_at = NOW()
+            WHERE id = $1
+              AND status = 'processing'
+              AND updated_at = $2
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(expected_updated_at)
+        .bind(counterpart_signature)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Move a stuck row from `Processing` to `ManualReview` when recovery
+    /// can't tell whether the on-chain action happened — a human needs to
+    /// look. The reason is only carried on the caller's alert webhook
+    /// payload; we don't add a DB column for it.
+    pub async fn try_quarantine_processing_internal(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+        _reason: String,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'manual_review',
+                processed_at = NOW()
+            WHERE id = $1
+              AND status = 'processing'
+              AND updated_at = $2
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(expected_updated_at)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
     }
 
     /// Transitions a withdrawal to PendingRemint status, storing the

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -800,10 +800,7 @@ impl PostgresDb {
         Ok(transactions)
     }
 
-    /// Returns `Ok(true)` if the row was updated, `Ok(false)` if it was
-    /// skipped because the row is already in a terminal state (recovery
-    /// or another writer moved it first). Callers branch on the bool to
-    /// avoid counting no-op writes as successful DB updates.
+    /// Returns true if the row was updated; false if already terminal.
     pub async fn update_transaction_status_internal(
         &self,
         transaction_id: i64,
@@ -811,17 +808,7 @@ impl PostgresDb {
         counterpart_signature: Option<String>,
         processed_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool, sqlx::Error> {
-        // The status filter protects against this race: recovery has
-        // already moved a stuck row off `Processing`, but a late
-        // confirmation from the original (now-crashed) sender is still
-        // trying to mark it `Completed`. Without the filter, the late
-        // write would overwrite recovery's decision.
-        //
-        // Both `processing` and `pending_remint` are allowed because the
-        // remint flow writes terminal states (`Completed`,
-        // `FailedReminted`, `ManualReview`) from `pending_remint` —
-        // recovery doesn't touch that status, so there's no race window
-        // to worry about there.
+        // Only write non-terminal source states — blocks late writes after recovery.
         let result = sqlx::query(
             r#"
             UPDATE transactions
@@ -843,8 +830,7 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
-    /// Rows stuck in `Processing` whose `updated_at` is older than the
-    /// safety threshold. Oldest-first so longest-stuck rows are healed first.
+    /// Stale `Processing` rows older than the threshold, oldest-first.
     pub async fn get_stale_processing_transactions_internal(
         &self,
         threshold: Duration,
@@ -892,12 +878,7 @@ impl PostgresDb {
         .await
     }
 
-    /// Move a stuck row from `Processing` back to `Pending` so the fetcher
-    /// can pick it up again. The `updated_at = $2` condition is what makes
-    /// this safe to call: it only succeeds if nothing else has touched the
-    /// row since the caller read it. Anyone else writing to the row bumps
-    /// `updated_at` via the trigger, so our condition fails and the write
-    /// becomes a no-op.
+    /// CAS `Processing` → `Pending` keyed on `updated_at`; no-op if stale.
     pub async fn try_requeue_processing_internal(
         &self,
         transaction_id: i64,
@@ -920,13 +901,7 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
-    /// Move a stuck row from `Processing` to `Completed` after recovery
-    /// confirmed the action already happened on-chain. The
-    /// `updated_at = $2` condition makes this a no-op if anyone else has
-    /// touched the row in the meantime. `counterpart_signature` may be
-    /// `None` — withdrawal recovery doesn't always know the exact signature
-    /// that landed, and the on-chain escrow program prevents duplicates
-    /// regardless.
+    /// CAS `Processing` → `Completed` keyed on `updated_at`; sig may be `None`.
     pub async fn try_complete_processing_internal(
         &self,
         transaction_id: i64,
@@ -953,10 +928,7 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
-    /// Move a stuck row from `Processing` to `ManualReview` when recovery
-    /// can't tell whether the on-chain action happened — a human needs to
-    /// look. The reason is only carried on the caller's alert webhook
-    /// payload; we don't add a DB column for it.
+    /// CAS `Processing` → `ManualReview`; reason carried on webhook, not DB.
     pub async fn try_quarantine_processing_internal(
         &self,
         transaction_id: i64,

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -32,6 +32,7 @@ mod transaction_cols {
     pub const REMINT_LAST_VALID_BLOCK_HEIGHTS: &str = "remint_last_valid_block_heights";
     pub const PENDING_REMINT_DEADLINE_AT: &str = "pending_remint_deadline_at";
     pub const FINALITY_CHECK_ATTEMPTS: &str = "finality_check_attempts";
+    pub const RECOVERY_REQUEUE_ATTEMPTS: &str = "recovery_requeue_attempts";
 }
 
 #[derive(Clone)]
@@ -218,6 +219,21 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
         info!("finality_check_attempts migration complete");
+
+        // Durable recovery requeue counter so the MAX_RECOVERY_REQUEUE_ATTEMPTS
+        // cap survives operator restarts.
+        info!("Running recovery_requeue_attempts migration if needed...");
+        sqlx::query(
+            r#"
+            DO $$ BEGIN
+                ALTER TABLE transactions
+                ADD COLUMN IF NOT EXISTS recovery_requeue_attempts INTEGER NOT NULL DEFAULT 0;
+            END $$;
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        info!("recovery_requeue_attempts migration complete");
 
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_trace_id ON transactions (trace_id)",
@@ -655,7 +671,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -681,6 +697,7 @@ impl PostgresDb {
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
+            transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -703,7 +720,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -728,6 +745,7 @@ impl PostgresDb {
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
+            transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -750,7 +768,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1
             ORDER BY {} DESC
@@ -776,6 +794,7 @@ impl PostgresDb {
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
+            transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             // Filter
             transaction_cols::TRANSACTION_TYPE,
             // Ordering
@@ -838,7 +857,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -865,6 +884,7 @@ impl PostgresDb {
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
+            transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -938,7 +958,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = 'processing'
               AND {} < NOW() - make_interval(secs => $1)
@@ -965,6 +985,7 @@ impl PostgresDb {
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
+            transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::UPDATED_AT,
@@ -986,7 +1007,8 @@ impl PostgresDb {
         let result = sqlx::query(
             r#"
             UPDATE transactions
-            SET status = 'pending'
+            SET status = 'pending',
+                recovery_requeue_attempts = recovery_requeue_attempts + 1
             WHERE id = $1
               AND status = 'processing'
               AND updated_at = $2

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -424,6 +424,34 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
 
+        // Broadcast release signatures written at send time; recovery reads
+        // them to verify a release landed before demoting (avoids double-payout).
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS pending_release_signatures (
+                id BIGSERIAL PRIMARY KEY,
+                transaction_id BIGINT NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
+                signature TEXT NOT NULL,
+                last_valid_block_height BIGINT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_prs_transaction_id ON pending_release_signatures(transaction_id)",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_prs_signature ON pending_release_signatures(signature)",
+        )
+        .execute(&self.pool)
+        .await?;
+
         info!("Database schema initialized");
         Ok(())
     }
@@ -432,6 +460,10 @@ impl PostgresDb {
         info!("Dropping database tables...");
 
         // Drop tables with CASCADE to handle dependencies
+        sqlx::query("DROP TABLE IF EXISTS pending_release_signatures CASCADE")
+            .execute(&self.pool)
+            .await?;
+
         sqlx::query("DROP TABLE IF EXISTS transactions CASCADE")
             .execute(&self.pool)
             .await?;
@@ -1087,6 +1119,76 @@ impl PostgresDb {
         }
 
         Ok(())
+    }
+
+    /// Persist a broadcast release signature so recovery can verify finality
+    /// before demoting. Idempotent on `signature`.
+    pub async fn insert_release_signature_internal(
+        &self,
+        transaction_id: i64,
+        signature: String,
+        last_valid_block_height: i64,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO pending_release_signatures
+                (transaction_id, signature, last_valid_block_height)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (signature) DO NOTHING
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(signature)
+        .bind(last_valid_block_height)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Return a transaction's release signatures as (signature, lvbh).
+    pub async fn get_release_signatures_internal(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Vec<(String, i64)>, sqlx::Error> {
+        sqlx::query_as::<_, (String, i64)>(
+            r#"
+            SELECT signature, last_valid_block_height
+            FROM pending_release_signatures
+            WHERE transaction_id = $1
+            ORDER BY id ASC
+            "#,
+        )
+        .bind(transaction_id)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Delete all stored release signatures for a transaction.
+    pub async fn delete_release_signatures_internal(
+        &self,
+        transaction_id: i64,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM pending_release_signatures WHERE transaction_id = $1")
+            .bind(transaction_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Drop release signatures whose parent transaction is no longer
+    /// `processing`. Returns the number of rows removed.
+    pub async fn gc_stale_release_signatures_internal(&self) -> Result<u64, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM pending_release_signatures
+            WHERE transaction_id IN (
+                SELECT id FROM transactions WHERE status <> 'processing'
+            )
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
     }
 
     /// Flip every `Pending`/`Processing` withdrawal to `ManualReview`.

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -332,10 +332,7 @@ async fn update_transaction_status_updates_fields() -> Result<(), Box<dyn std::e
     let txn = make_db_transaction("upd_status", TransactionType::Deposit);
     let id = storage.insert_db_transaction(&txn).await?;
 
-    // Mirror the production lifecycle: a row only reaches the terminal
-    // writer after the fetcher has claimed it (`pending` → `processing`).
-    // `update_transaction_status` refuses to write rows still in
-    // `pending` to guard against late writes after recovery moves a row.
+    // Production lifecycle: fetcher must flip to `processing` first.
     sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
         .bind(id)
         .execute(&pool)

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -332,8 +332,17 @@ async fn update_transaction_status_updates_fields() -> Result<(), Box<dyn std::e
     let txn = make_db_transaction("upd_status", TransactionType::Deposit);
     let id = storage.insert_db_transaction(&txn).await?;
 
+    // Mirror the production lifecycle: a row only reaches the terminal
+    // writer after the fetcher has claimed it (`pending` → `processing`).
+    // `update_transaction_status` refuses to write rows still in
+    // `pending` to guard against late writes after recovery moves a row.
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await?;
+
     let now = Utc::now();
-    storage
+    let written = storage
         .update_transaction_status(
             id,
             TransactionStatus::Completed,
@@ -341,6 +350,10 @@ async fn update_transaction_status_updates_fields() -> Result<(), Box<dyn std::e
             now,
         )
         .await?;
+    assert!(
+        written,
+        "row was in Processing, terminal write should report Ok(true)"
+    );
 
     let row: (String, Option<String>) = sqlx::query_as(
         "SELECT status::text, counterpart_signature FROM transactions WHERE id = $1",

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -743,3 +743,125 @@ async fn get_mint_status_at_slot_returns_blocked_after_block_entry(
     assert_eq!(res, MintStatusAtSlot::Blocked);
     Ok(())
 }
+
+// ── pending_release_signatures (verify-before-demote) ─────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn release_signature_insert_get_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    let txn = make_db_transaction("rel_roundtrip", TransactionType::Withdrawal);
+    let id = storage.insert_db_transaction(&txn).await?;
+
+    storage
+        .insert_release_signature(id, "sig-a".to_string(), 100)
+        .await?;
+    storage
+        .insert_release_signature(id, "sig-b".to_string(), 200)
+        .await?;
+
+    let rows = storage.get_release_signatures(id).await?;
+    assert_eq!(
+        rows,
+        vec![("sig-a".to_string(), 100), ("sig-b".to_string(), 200)]
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn release_signature_insert_is_idempotent_on_signature(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    let txn = make_db_transaction("rel_idem", TransactionType::Withdrawal);
+    let id = storage.insert_db_transaction(&txn).await?;
+
+    storage
+        .insert_release_signature(id, "dup-sig".to_string(), 100)
+        .await?;
+    // Same signature again is a no-op (ON CONFLICT DO NOTHING).
+    storage
+        .insert_release_signature(id, "dup-sig".to_string(), 999)
+        .await?;
+
+    let rows = storage.get_release_signatures(id).await?;
+    assert_eq!(rows.len(), 1, "duplicate signature must not double-insert");
+    assert_eq!(rows[0], ("dup-sig".to_string(), 100), "first write wins");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn release_signature_delete_removes_all_for_txn() -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    let txn = make_db_transaction("rel_delete", TransactionType::Withdrawal);
+    let id = storage.insert_db_transaction(&txn).await?;
+
+    storage
+        .insert_release_signature(id, "sig-x".to_string(), 1)
+        .await?;
+    storage
+        .insert_release_signature(id, "sig-y".to_string(), 2)
+        .await?;
+    storage.delete_release_signatures(id).await?;
+    assert!(storage.get_release_signatures(id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn release_signature_gc_only_drops_non_processing() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    let proc_txn = make_db_transaction("rel_gc_proc", TransactionType::Withdrawal);
+    let proc_id = storage.insert_db_transaction(&proc_txn).await?;
+    let done_txn = make_db_transaction("rel_gc_done", TransactionType::Withdrawal);
+    let done_id = storage.insert_db_transaction(&done_txn).await?;
+
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(proc_id)
+        .execute(&pool)
+        .await?;
+    sqlx::query("UPDATE transactions SET status = 'completed'::transaction_status WHERE id = $1")
+        .bind(done_id)
+        .execute(&pool)
+        .await?;
+
+    storage
+        .insert_release_signature(proc_id, "sig-proc".to_string(), 1)
+        .await?;
+    storage
+        .insert_release_signature(done_id, "sig-done".to_string(), 2)
+        .await?;
+
+    let removed = storage.gc_stale_release_signatures().await?;
+    assert_eq!(
+        removed, 1,
+        "GC must drop exactly the non-processing row's sig"
+    );
+    assert_eq!(storage.get_release_signatures(proc_id).await?.len(), 1);
+    assert!(storage.get_release_signatures(done_id).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn release_signature_cascade_on_transaction_delete() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (pool, storage, _pg) = start_postgres().await?;
+    let txn = make_db_transaction("rel_cascade", TransactionType::Withdrawal);
+    let id = storage.insert_db_transaction(&txn).await?;
+    storage
+        .insert_release_signature(id, "sig-cascade".to_string(), 1)
+        .await?;
+
+    sqlx::query("DELETE FROM transactions WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await?;
+
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pending_release_signatures WHERE transaction_id = $1",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(count, 0, "ON DELETE CASCADE must remove orphaned sigs");
+    Ok(())
+}

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -68,6 +68,7 @@ fn make_db_transaction(sig: &str, txn_type: TransactionType) -> DbTransaction {
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     }
 }
 
@@ -863,5 +864,95 @@ async fn release_signature_cascade_on_transaction_delete() -> Result<(), Box<dyn
     .fetch_one(&pool)
     .await?;
     assert_eq!(count, 0, "ON DELETE CASCADE must remove orphaned sigs");
+    Ok(())
+}
+
+// ── recovery requeue counter ─────────────────────────────────────────────────
+
+async fn status_of(pool: &PgPool, id: i64) -> String {
+    sqlx::query_scalar::<_, String>("SELECT status::text FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn updated_at_of(pool: &PgPool, id: i64) -> chrono::DateTime<Utc> {
+    sqlx::query_scalar("SELECT updated_at FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn requeue_attempts_of(pool: &PgPool, id: i64) -> i32 {
+    sqlx::query_scalar("SELECT recovery_requeue_attempts FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_requeue_processing_increments_recovery_counter(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let txn = make_db_transaction("requeue_counter", TransactionType::Deposit);
+    let id = storage.insert_db_transaction(&txn).await?;
+    // Lock flips Pending → Processing (and bumps updated_at via trigger).
+    storage
+        .get_and_lock_pending_transactions(TransactionType::Deposit, 100)
+        .await?;
+    assert_eq!(
+        requeue_attempts_of(&pool, id).await,
+        0,
+        "starts at default 0"
+    );
+
+    let captured = updated_at_of(&pool, id).await;
+    let requeued = storage.try_requeue_processing(id, captured).await?;
+    assert!(
+        requeued,
+        "CAS requeue must succeed for the captured timestamp"
+    );
+
+    assert_eq!(
+        status_of(&pool, id).await,
+        "pending",
+        "requeue must demote back to pending"
+    );
+    assert_eq!(
+        requeue_attempts_of(&pool, id).await,
+        1,
+        "successful requeue must increment the durable counter by exactly 1"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_requeue_processing_stale_cas_leaves_counter_unchanged(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let txn = make_db_transaction("requeue_stale", TransactionType::Deposit);
+    let id = storage.insert_db_transaction(&txn).await?;
+    storage
+        .get_and_lock_pending_transactions(TransactionType::Deposit, 100)
+        .await?;
+
+    // A timestamp that does NOT match the row's updated_at → CAS no-op.
+    let stale = updated_at_of(&pool, id).await - chrono::Duration::seconds(60);
+    let requeued = storage.try_requeue_processing(id, stale).await?;
+    assert!(!requeued, "stale CAS must no-op");
+
+    assert_eq!(
+        status_of(&pool, id).await,
+        "processing",
+        "no-op CAS must leave status untouched"
+    );
+    assert_eq!(
+        requeue_attempts_of(&pool, id).await,
+        0,
+        "no-op CAS must NOT bump the counter"
+    );
     Ok(())
 }

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -1459,17 +1459,7 @@ fn walkdir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     out
 }
 
-// ── Drill 15: deposit_manual_review.md § Path E ────────────────────────────
-//
-// Pins three contracts for the recovery-worker idempotency-failure path:
-//   1. The triage substring `deposit idempotency:` is present in
-//      `indexer/src/operator/recovery.rs` so future contributors cannot
-//      silently rename it.
-//   2. The re-arm SQL flips a single `manual_review` deposit to `pending`
-//      and is targeted by id (not by error_message), so it is fungible
-//      across any future Path-E substring variants.
-//   3. A `manual_review` row that was never armed cannot be re-armed by
-//      mistake into another row's identity (the SQL is single-row).
+// Drill 15: pins Path E triage substring + row-scoped re-arm SQL.
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
@@ -1519,15 +1509,7 @@ async fn drill_15_deposit_manual_review_recovery_idempotency_failure_flow(
     Ok(())
 }
 
-// ── Drill 16: withdrawal_manual_review.md § Path F ─────────────────────────
-//
-// Pins three contracts for the recovery-worker missing-nonce path:
-//   1. Triage substring `withdrawal row missing nonce` is present in
-//      `indexer/src/operator/recovery.rs`.
-//   2. The runbook has zero "re-arm to pending" SQL for Path F — the
-//      `manual_review` row stays `manual_review` until a human resolves
-//      it (the row is structurally corrupt).
-//   3. The terminal-write SQL is row-scoped by id.
+// Drill 16: pins Path F triage substring + row-scoped terminal SQL.
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -1458,3 +1458,127 @@ fn walkdir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     }
     out
 }
+
+// ── Drill 15: deposit_manual_review.md § Path E ────────────────────────────
+//
+// Pins three contracts for the recovery-worker idempotency-failure path:
+//   1. The triage substring `deposit idempotency:` is present in
+//      `indexer/src/operator/recovery.rs` so future contributors cannot
+//      silently rename it.
+//   2. The re-arm SQL flips a single `manual_review` deposit to `pending`
+//      and is targeted by id (not by error_message), so it is fungible
+//      across any future Path-E substring variants.
+//   3. A `manual_review` row that was never armed cannot be re-armed by
+//      mistake into another row's identity (the SQL is single-row).
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_15_deposit_manual_review_recovery_idempotency_failure_flow(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "deposit_manual_review.md",
+        "Path E — recovery-worker idempotency lookup failed",
+    );
+
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+    let recovery_path = workspace_root.join("indexer/src/operator/recovery.rs");
+    let recovery = std::fs::read_to_string(&recovery_path)
+        .unwrap_or_else(|e| panic!("read {recovery_path:?}: {e}"));
+    assert!(
+        recovery.contains("deposit idempotency:"),
+        "Path E dispatch substring missing from recovery.rs"
+    );
+    eprintln!("OK   recovery.rs: \"deposit idempotency:\"");
+
+    // ── Re-arm SQL is row-scoped and fungible across Path-E substrings ──
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    let trigger_id = seed_deposit(&pool, "manual_review").await?;
+    let collateral_id = seed_deposit(&pool, "manual_review").await?;
+
+    sqlx::query("UPDATE transactions SET status='pending', updated_at=NOW() WHERE id=$1")
+        .bind(trigger_id)
+        .execute(&pool)
+        .await?;
+
+    assert_eq!(
+        status_of(&pool, trigger_id).await?,
+        "pending",
+        "Path E re-arm must flip the trigger row to pending"
+    );
+    assert_eq!(
+        status_of(&pool, collateral_id).await?,
+        "manual_review",
+        "Path E re-arm must NOT touch sibling manual_review rows"
+    );
+
+    eprintln!("Path E triage substring + re-arm SQL verified.");
+    Ok(())
+}
+
+// ── Drill 16: withdrawal_manual_review.md § Path F ─────────────────────────
+//
+// Pins three contracts for the recovery-worker missing-nonce path:
+//   1. Triage substring `withdrawal row missing nonce` is present in
+//      `indexer/src/operator/recovery.rs`.
+//   2. The runbook has zero "re-arm to pending" SQL for Path F — the
+//      `manual_review` row stays `manual_review` until a human resolves
+//      it (the row is structurally corrupt).
+//   3. The terminal-write SQL is row-scoped by id.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_16_withdrawal_manual_review_recovery_missing_nonce_flow(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "withdrawal_manual_review.md",
+        "Path F — corrupt withdrawal row (missing nonce)",
+    );
+
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+    let recovery_path = workspace_root.join("indexer/src/operator/recovery.rs");
+    let recovery = std::fs::read_to_string(&recovery_path)
+        .unwrap_or_else(|e| panic!("read {recovery_path:?}: {e}"));
+    assert!(
+        recovery.contains("withdrawal row missing nonce"),
+        "Path F dispatch substring missing from recovery.rs"
+    );
+    eprintln!("OK   recovery.rs: \"withdrawal row missing nonce\"");
+
+    // ── Terminal SQL is row-scoped, ManualReview → Failed ──
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    let trigger_id = seed_withdrawal(&pool, "manual_review", 1, None).await?;
+    // Force-null the nonce to mirror the recovery-worker quarantine condition.
+    sqlx::query("UPDATE transactions SET withdrawal_nonce = NULL WHERE id = $1")
+        .bind(trigger_id)
+        .execute(&pool)
+        .await?;
+    let sibling_id = seed_withdrawal(&pool, "manual_review", 2, None).await?;
+
+    // Step 3 → Burn landed → mark failed (terminal).
+    sqlx::query("UPDATE transactions SET status='failed', updated_at=NOW() WHERE id=$1")
+        .bind(trigger_id)
+        .execute(&pool)
+        .await?;
+
+    assert_eq!(
+        status_of(&pool, trigger_id).await?,
+        "failed",
+        "Path F § Step 3 burn-landed branch must terminalize the row to failed"
+    );
+    assert_eq!(
+        status_of(&pool, sibling_id).await?,
+        "manual_review",
+        "Path F terminal SQL must NOT touch sibling manual_review rows"
+    );
+
+    eprintln!("Path F triage substring + terminal SQL verified.");
+    Ok(())
+}

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -60,6 +60,10 @@ name = "remint_recovery"
 path = "tests/indexer/remint_recovery.rs"
 
 [[test]]
+name = "stuck_processing_recovery"
+path = "tests/indexer/stuck_processing_recovery.rs"
+
+[[test]]
 name = "test_rpc_http_malformed"
 path = "tests/private-channel/rpc/test_rpc_http_malformed.rs"
 

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -52,6 +52,7 @@ integration-test:
 	@cargo test --test mock_rpc_retry -- --nocapture
 	@cargo test --test checkpoint_partial_flush -- --nocapture
 	@cargo test --test remint_recovery -- --nocapture
+	@cargo test --test stuck_processing_recovery -- --nocapture
 	@cargo test --test bootstrap_validation -- --nocapture
 	@cargo test --test yellowstone_wiring -- --nocapture
 	@cargo test --test malformed_yellowstone_update -- --nocapture
@@ -250,6 +251,8 @@ integration-coverage-indexer:
 	@cargo llvm-cov test --no-report --workspace --test checkpoint_partial_flush -- --nocapture
 	@echo "Running remint recovery tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test remint_recovery -- --nocapture
+	@echo "Running stuck-Processing recovery tests with coverage instrumentation..."
+	@cargo llvm-cov test --no-report --workspace --test stuck_processing_recovery -- --nocapture
 	@echo "Running indexer bootstrap validation tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test bootstrap_validation -- --nocapture
 	@echo "Running Yellowstone wiring tests with coverage instrumentation..."

--- a/integration/tests/indexer/harness_sanity.rs
+++ b/integration/tests/indexer/harness_sanity.rs
@@ -68,6 +68,7 @@ fn pending_deposit_row(id: i64, mint: Pubkey, recipient: Pubkey) -> DbTransactio
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -228,6 +228,7 @@ fn make_withdrawal_transaction(
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/pausable_mint.rs
+++ b/integration/tests/indexer/pausable_mint.rs
@@ -241,6 +241,7 @@ fn make_withdrawal_transaction(
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/permanent_delegate_mint.rs
+++ b/integration/tests/indexer/permanent_delegate_mint.rs
@@ -272,6 +272,7 @@ fn make_withdrawal_transaction(
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/processor_quarantine.rs
+++ b/integration/tests/indexer/processor_quarantine.rs
@@ -54,6 +54,7 @@ fn make_bad_deposit(id: i64) -> DbTransaction {
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/remint_flow.rs
+++ b/integration/tests/indexer/remint_flow.rs
@@ -128,6 +128,7 @@ fn seed_pending_remint_row(mock: &MockStorage, id: i64, attempts: i32) {
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: Some(now),
             finality_check_attempts: attempts,
+            recovery_requeue_attempts: 0,
         });
 }
 

--- a/integration/tests/indexer/remint_recovery.rs
+++ b/integration/tests/indexer/remint_recovery.rs
@@ -70,6 +70,7 @@ fn make_row(
         remint_last_valid_block_heights: Some(vec![0]),
         pending_remint_deadline_at: Some(deadline),
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/sender_mint_signature_failures.rs
+++ b/integration/tests/indexer/sender_mint_signature_failures.rs
@@ -74,12 +74,11 @@ fn complete_builder(
 }
 
 /// Backends that don't implement `getSignaturesForAddress` reply with
-/// JSON-RPC error code `-32601 Method not found`. The helper must
-/// degrade gracefully — log + return `Ok(None)` — so the sender keeps
-/// submitting (the alternative would freeze every withdrawal flow on
-/// such a backend).
+/// `-32601 Method not found`. The idempotency check fails closed and
+/// returns `Err` so callers refuse to blind-mint (sender → fatal,
+/// recovery → quarantine) rather than risk a double-mint.
 #[tokio::test]
-async fn method_not_found_returns_none_without_hard_failure() {
+async fn method_not_found_surfaces_as_error() {
     let mock = MockRpcServer::start().await;
     let client = test_client(mock.url());
 
@@ -105,13 +104,11 @@ async fn method_not_found_returns_none_without_hard_failure() {
         token_program,
         1_000,
     );
-    let result = find_existing_mint_signature_with_memo(&client, &bwt, &memo)
-        .await
-        .expect("method-not-found must NOT bubble up as a hard error");
+    let result = find_existing_mint_signature_with_memo(&client, &bwt, &memo).await;
 
     assert!(
-        result.is_none(),
-        "graceful-degradation contract: -32601 yields Ok(None)"
+        result.is_err(),
+        "fail-closed contract: -32601 yields Err so callers don't blind-mint"
     );
     mock.shutdown().await;
 }

--- a/integration/tests/indexer/state_recovery_malformed.rs
+++ b/integration/tests/indexer/state_recovery_malformed.rs
@@ -66,6 +66,7 @@ fn make_row(
         remint_last_valid_block_heights: Some(lvbhs),
         pending_remint_deadline_at: Some(deadline),
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -488,13 +488,11 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
     mock.shutdown().await;
 }
 
-// IT-6 omitted: -32601 arm is unreachable on the PrivateChannel RPC (PR #95).
-
-// IT-7: fresh row is untouched (no RPC, no DB write).
+// IT-6: fresh row is untouched (no RPC, no DB write).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it7_fresh_processing_row_untouched() {
-    let (db, url, _container) = start_pg("it7_fresh").await;
+async fn it6_fresh_processing_row_untouched() {
+    let (db, url, _container) = start_pg("it6_fresh").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -545,11 +543,11 @@ async fn it7_fresh_processing_row_untouched() {
     mock.shutdown().await;
 }
 
-// IT-8: conditional write is a no-op if the row moved between SELECT and write.
+// IT-7: conditional write is a no-op if the row moved between SELECT and write.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it8_conditional_write_noops_when_row_moved() {
-    let (db, url, _container) = start_pg("it8_cond").await;
+async fn it7_conditional_write_noops_when_row_moved() {
+    let (db, url, _container) = start_pg("it7_cond").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
 
@@ -583,11 +581,11 @@ async fn it8_conditional_write_noops_when_row_moved() {
     );
 }
 
-// IT-9: lagging terminal write cannot stomp a recovery demote.
+// IT-8: lagging terminal write cannot stomp a recovery demote.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
-    let (db, url, _container) = start_pg("it9_lagging").await;
+async fn it8_lagging_terminal_write_no_ops_after_recovery_demote() {
+    let (db, url, _container) = start_pg("it8_lagging").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -636,11 +634,11 @@ async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
     mock.shutdown().await;
 }
 
-// IT-10: 250-row backlog drained across multiple ticks.
+// IT-9: 250-row backlog drained across multiple ticks.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it10_backlog_batched_across_ticks() {
-    let (db, url, _container) = start_pg("it10_batched").await;
+async fn it9_backlog_batched_across_ticks() {
+    let (db, url, _container) = start_pg("it9_batched").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -737,11 +735,11 @@ async fn it10_backlog_batched_across_ticks() {
     mock.shutdown().await;
 }
 
-// IT-11: PendingRemint rows are NOT touched by recovery.
+// IT-10: PendingRemint rows are NOT touched by recovery.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it11_pending_remint_rows_untouched() {
-    let (db, url, _container) = start_pg("it11_pending_remint").await;
+async fn it10_pending_remint_rows_untouched() {
+    let (db, url, _container) = start_pg("it10_pending_remint").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -799,11 +797,11 @@ async fn it11_pending_remint_rows_untouched() {
     mock.shutdown().await;
 }
 
-// IT-12: withdrawal with NULL nonce → ManualReview (runbook reason string).
+// IT-11: withdrawal with NULL nonce → ManualReview (runbook reason string).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it12_withdrawal_missing_nonce_quarantines() {
-    let (db, url, _container) = start_pg("it12_missing_nonce").await;
+async fn it11_withdrawal_missing_nonce_quarantines() {
+    let (db, url, _container) = start_pg("it11_missing_nonce").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -847,7 +845,7 @@ async fn it12_withdrawal_missing_nonce_quarantines() {
         "quarantined",
         "withdrawal",
         metric_before,
-        "IT-12",
+        "IT-11",
     );
     mock.shutdown().await;
 }

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -816,6 +816,7 @@ async fn it11_pending_remint_rows_untouched() {
     db.set_pending_remint_internal(
         tx_id,
         vec!["fake-sig".to_string()],
+        vec![1],
         Utc::now() + ChronoDuration::minutes(30),
     )
     .await

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1,0 +1,984 @@
+//! End-to-end tests for the stuck-`Processing` recovery worker.
+//!
+//! Each test reproduces a concrete operator-crash window described in the
+//! recovery design plan, then drives one `test_hooks::run_recovery_once`
+//! tick against a real Postgres + a scripted Solana RPC. Assertions verify
+//! both DB final state AND observable side effects (the
+//! `OPERATOR_STALE_PROCESSING_RECOVERED` metric, ManualReview webhook
+//! messages, and absence of spurious re-sends).
+
+use {
+    chrono::{Duration as ChronoDuration, Utc},
+    private_channel_indexer::{
+        config::ProgramType,
+        metrics::OPERATOR_STALE_PROCESSING_RECOVERED,
+        operator::{
+            recovery::test_hooks,
+            utils::{
+                instruction_util::mint_idempotency_memo,
+                rpc_util::{RetryConfig, RpcClientWithRetry},
+            },
+            TransactionStatusUpdate,
+        },
+        storage::{common::models::DbTransactionBuilder, PostgresDb, Storage, TransactionType},
+        PostgresConfig,
+    },
+    serde_json::json,
+    solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature},
+    spl_associated_token_account::get_associated_token_address_with_program_id,
+    std::{sync::Arc, time::Duration},
+    test_utils::mock_rpc::{MockRpcServer, Reply},
+    tokio::sync::mpsc,
+};
+
+/// Snapshot a single recovery-metric cell.  Returned value is the counter's
+/// pre-test reading; callers assert `counter.get() > snapshot` after running
+/// recovery.  We use a >-delta rather than exact equality because the metric
+/// is process-global and other concurrent integration tests may also be
+/// incrementing the same (program, outcome, type) cell — the assertion only
+/// proves that *this* test's row produced a hit, which is the property we
+/// care about.
+fn snapshot_recovered(program: &str, outcome: &str, txn_type: &str) -> f64 {
+    OPERATOR_STALE_PROCESSING_RECOVERED
+        .with_label_values(&[program, outcome, txn_type])
+        .get()
+}
+
+fn assert_recovered_increment(
+    program: &str,
+    outcome: &str,
+    txn_type: &str,
+    before: f64,
+    label: &str,
+) {
+    let after = OPERATOR_STALE_PROCESSING_RECOVERED
+        .with_label_values(&[program, outcome, txn_type])
+        .get();
+    assert!(
+        after > before,
+        "{label}: OPERATOR_STALE_PROCESSING_RECOVERED{{program={program},outcome={outcome},type={txn_type}}} \
+         should have incremented (before={before}, after={after})"
+    );
+}
+
+// ── fixture helpers ─────────────────────────────────────────────────────────
+
+async fn start_pg(
+    db_name: &str,
+) -> (
+    PostgresDb,
+    String,
+    testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+) {
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    let container = Postgres::default()
+        .with_db_name(db_name)
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("postgres container");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:password@{}:{}/{}", host, port, db_name);
+    let db = PostgresDb::new(&PostgresConfig {
+        database_url: url.clone(),
+        max_connections: 10,
+    })
+    .await
+    .unwrap();
+    (db, url, container)
+}
+
+fn make_deposit(
+    sig: &str,
+    mint: Pubkey,
+    recipient: Pubkey,
+    amount: u64,
+) -> private_channel_indexer::storage::common::models::DbTransaction {
+    DbTransactionBuilder::new(sig.to_string(), 1, mint.to_string(), amount)
+        .initiator(recipient.to_string())
+        .recipient(recipient.to_string())
+        .transaction_type(TransactionType::Deposit)
+        .build()
+}
+
+fn make_withdrawal(
+    sig: &str,
+    nonce: i64,
+) -> private_channel_indexer::storage::common::models::DbTransaction {
+    let mint = Pubkey::new_unique().to_string();
+    let recipient = Pubkey::new_unique().to_string();
+    let mut tx = DbTransactionBuilder::new(sig.to_string(), 1, mint, 10_000u64)
+        .initiator(recipient.clone())
+        .recipient(recipient)
+        .transaction_type(TransactionType::Withdrawal)
+        .build();
+    tx.withdrawal_nonce = Some(nonce);
+    tx
+}
+
+/// Insert a row, flip it to `processing`, then backdate `updated_at` past the
+/// BEFORE-UPDATE trigger. The trigger is temporarily disabled around the
+/// backdate so the explicit timestamp wins.
+async fn seed_backdated_processing(
+    pool: &sqlx::PgPool,
+    tx_id: i64,
+    age: ChronoDuration,
+) -> chrono::DateTime<Utc> {
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(tx_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+    let backdated = Utc::now() - age;
+    sqlx::query("ALTER TABLE transactions DISABLE TRIGGER update_transactions_updated_at")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE transactions SET updated_at = $1 WHERE id = $2")
+        .bind(backdated)
+        .bind(tx_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE transactions ENABLE TRIGGER update_transactions_updated_at")
+        .execute(pool)
+        .await
+        .unwrap();
+    backdated
+}
+
+async fn status_of(pool: &sqlx::PgPool, id: i64) -> String {
+    sqlx::query_scalar::<_, String>("SELECT status::text FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn counterpart_sig_of(pool: &sqlx::PgPool, id: i64) -> Option<String> {
+    sqlx::query_scalar::<_, Option<String>>(
+        "SELECT counterpart_signature FROM transactions WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn updated_at_of(pool: &sqlx::PgPool, id: i64) -> chrono::DateTime<Utc> {
+    sqlx::query_scalar("SELECT updated_at FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+fn test_client(url: String) -> RpcClientWithRetry {
+    RpcClientWithRetry::with_retry_config(
+        url,
+        RetryConfig {
+            max_attempts: 2,
+            base_delay: Duration::from_millis(5),
+            max_delay: Duration::from_millis(50),
+        },
+        CommitmentConfig::confirmed(),
+    )
+}
+
+/// Scripted `getTransaction` reply whose parsed JSON satisfies
+/// `transaction_matches_expected_mint`. Mirrors the helper in
+/// `sender_mint_idempotency.rs` exactly.
+fn get_transaction_reply(
+    signature: &Signature,
+    mint: &Pubkey,
+    recipient_ata: &Pubkey,
+    mint_authority: &Pubkey,
+    token_program: &Pubkey,
+    amount: u64,
+    memo: &str,
+) -> Reply {
+    let memo_program_id = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+    Reply::result(json!({
+        "slot": 100,
+        "blockTime": 1_700_000_000i64,
+        "meta": {
+            "err": null,
+            "status": { "Ok": null },
+            "fee": 5000u64,
+            "innerInstructions": [],
+            "preBalances": [1_000_000u64],
+            "postBalances": [999_995u64],
+            "logMessages": [],
+            "preTokenBalances": [],
+            "postTokenBalances": [],
+            "rewards": [],
+            "computeUnitsConsumed": 0u64,
+        },
+        "transaction": {
+            "signatures": [signature.to_string()],
+            "message": {
+                "accountKeys": [
+                    {"pubkey": mint_authority.to_string(), "signer": true, "writable": true, "source": "transaction"},
+                    {"pubkey": recipient_ata.to_string(), "signer": false, "writable": true, "source": "transaction"},
+                    {"pubkey": mint.to_string(), "signer": false, "writable": true, "source": "transaction"},
+                    {"pubkey": token_program.to_string(), "signer": false, "writable": false, "source": "transaction"},
+                    {"pubkey": memo_program_id, "signer": false, "writable": false, "source": "transaction"},
+                ],
+                "recentBlockhash": "GHtXQBsoZHjzkAm2Sdm6FTyFHBCqBnLanJJhZFCFJXoe",
+                "instructions": [
+                    {"program": "spl-memo", "programId": memo_program_id, "parsed": memo},
+                    {
+                        "program": "spl-token",
+                        "programId": token_program.to_string(),
+                        "parsed": {
+                            "type": "mintTo",
+                            "info": {
+                                "mint": mint.to_string(),
+                                "account": recipient_ata.to_string(),
+                                "mintAuthority": mint_authority.to_string(),
+                                "amount": amount.to_string(),
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+    }))
+}
+
+// ── IT-1 ────────────────────────────────────────────────────────────────────
+//
+// Deposit crashes mid-Processing, mint already landed → recovery promotes to
+// Completed with the on-chain signature.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it1_deposit_landed_promoted_to_completed() {
+    let (db, url, _container) = start_pg("it1_landed").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let admin_pubkey = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let amount: u64 = 12_345;
+    let token_program = spl_token::id();
+    let recipient_ata =
+        get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
+
+    let deposit_sig = Signature::new_unique();
+    let tx = make_deposit(&deposit_sig.to_string(), mint, recipient, amount);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    let _ = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let memo = mint_idempotency_memo(tx_id);
+    let prior_sig = Signature::new_unique();
+
+    let mock = MockRpcServer::start().await;
+    mock.enqueue(
+        "getSignaturesForAddress",
+        Reply::result(json!([{
+            "signature": prior_sig.to_string(),
+            "slot": 100u64,
+            "err": serde_json::Value::Null,
+            "memo": format!("[{}] {}", memo.len(), memo),
+            "blockTime": 1_700_000_000i64,
+            "confirmationStatus": "finalized",
+        }])),
+    );
+    mock.enqueue(
+        "getTransaction",
+        get_transaction_reply(
+            &prior_sig,
+            &mint,
+            &recipient_ata,
+            &admin_pubkey,
+            &token_program,
+            amount,
+            &memo,
+        ),
+    );
+
+    let client = test_client(mock.url());
+    let (storage_tx, _storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("escrow", "completed", "deposit");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        admin_pubkey,
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "completed");
+    assert_eq!(
+        counterpart_sig_of(&pool, tx_id).await,
+        Some(prior_sig.to_string())
+    );
+    // Recovery never sends transactions.
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    assert_recovered_increment("escrow", "completed", "deposit", metric_before, "IT-1");
+    mock.shutdown().await;
+}
+
+// ── IT-2 ────────────────────────────────────────────────────────────────────
+//
+// Deposit crashes mid-Processing, mint did NOT land → recovery demotes to
+// Pending. (The full re-pickup loop is exercised by IT-2.5 below where the
+// fetcher re-claims the demoted row; here we pin the demote step itself.)
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it2_deposit_not_landed_demoted_to_pending() {
+    let (db, url, _container) = start_pg("it2_demote").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 100);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
+    let client = test_client(mock.url());
+    let (storage_tx, _storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("escrow", "requeued", "deposit");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "pending");
+    // The fetcher will pick this up on its next tick (covered by the live
+    // operator path, not the recovery worker itself).
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    assert_recovered_increment("escrow", "requeued", "deposit", metric_before, "IT-2");
+    mock.shutdown().await;
+}
+
+// ── IT-3 ────────────────────────────────────────────────────────────────────
+//
+// Withdrawal crashes mid-Processing, release NOT landed → recovery demotes.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it3_withdrawal_demoted_unconditionally() {
+    let (db, url, _container) = start_pg("it3_wd_demote").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 7);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    // The withdrawal path makes no RPC calls. Script nothing.
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("withdraw", "requeued", "withdrawal");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Withdraw,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "pending");
+    let fresh = updated_at_of(&pool, tx_id).await;
+    assert!(
+        fresh > Utc::now() - ChronoDuration::seconds(5),
+        "updated_at should be fresh"
+    );
+    assert_recovered_increment("withdraw", "requeued", "withdrawal", metric_before, "IT-3");
+    mock.shutdown().await;
+}
+
+// ── IT-4 ────────────────────────────────────────────────────────────────────
+//
+// Path purity: withdrawal recovery makes ZERO RPC calls.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it4_withdrawal_recovery_zero_rpc_calls() {
+    let (db, url, _container) = start_pg("it4_zero_rpc").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 1);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Withdraw,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    // Every method should have zero calls — the recovery path took no RPC.
+    for method in &[
+        "getSignaturesForAddress",
+        "getTransaction",
+        "sendTransaction",
+        "getLatestBlockhash",
+        "getSignatureStatuses",
+    ] {
+        assert_eq!(mock.call_count(method), 0, "{method} should have 0 calls");
+    }
+    assert_eq!(status_of(&pool, tx_id).await, "pending");
+    mock.shutdown().await;
+}
+
+// ── IT-5 ────────────────────────────────────────────────────────────────────
+//
+// RPC down on deposit recovery → ManualReview, NOT pending.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
+    let (db, url, _container) = start_pg("it5_rpc_down").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 500);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    // Always return a generic JSON-RPC error → transport / RPC error path.
+    mock.enqueue_sequence(
+        "getSignaturesForAddress",
+        vec![
+            Reply::error(-32000, "internal"),
+            Reply::error(-32000, "internal"),
+            Reply::error(-32000, "internal"),
+        ],
+    );
+    let client = test_client(mock.url());
+    let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "manual_review",
+        "RPC failure must NOT silently demote — fail-loud is the contract"
+    );
+    let update = storage_rx
+        .try_recv()
+        .expect("manual_review update should be sent");
+    assert_eq!(update.transaction_id, tx_id);
+    let err = update.error_message.as_deref().unwrap_or("");
+    assert!(
+        err.starts_with("deposit idempotency:"),
+        "reason should match runbook substring: {err}"
+    );
+    assert_recovered_increment("escrow", "quarantined", "deposit", metric_before, "IT-5");
+    mock.shutdown().await;
+}
+
+// Note: there is no IT-6. The original plan included a test for the
+// JSON-RPC `-32601 MethodNotFound` failure mode, but the operator's
+// `rpc_client` always points at the PrivateChannel node (Contra's own
+// RPC), which implements `getSignaturesForAddress` (PR #95). The
+// `-32601` fail-open arm in `find_existing_mint_signature_with_memo`
+// (mint.rs:441-442) is dead code under any production configuration,
+// so testing it would assert against an unreachable code path. The
+// only reachable Ambiguous case on the deposit path is transport
+// error, covered by IT-5.
+
+// ── IT-7 ────────────────────────────────────────────────────────────────────
+//
+// Fresh row: recovery does NOT touch it; no RPC, no DB write.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it7_fresh_processing_row_untouched() {
+    let (db, url, _container) = start_pg("it7_fresh").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 100);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    // Flip to processing without backdating — updated_at is "now".
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let pre_updated = updated_at_of(&pool, tx_id).await;
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "processing",
+        "fresh row must not be picked up by recovery"
+    );
+    assert_eq!(
+        updated_at_of(&pool, tx_id).await,
+        pre_updated,
+        "fresh row's updated_at must not change"
+    );
+    for method in &["getSignaturesForAddress", "getTransaction"] {
+        assert_eq!(
+            mock.call_count(method),
+            0,
+            "{method} should have 0 calls for fresh row"
+        );
+    }
+    mock.shutdown().await;
+}
+
+// ── IT-8 ────────────────────────────────────────────────────────────────────
+//
+// The conditional write becomes a no-op when the row has moved between
+// SELECT and the write. Simulated by directly mutating the row between
+// the captured timestamp and the try_* call.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it8_conditional_write_noops_when_row_moved() {
+    let (db, url, _container) = start_pg("it8_cond").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 100);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+    let _captured = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    // Race: caller already moved the row off Processing → try_requeue must
+    // return false because both `status = processing` and the captured
+    // `updated_at` no longer match.
+    sqlx::query("UPDATE transactions SET status = 'completed'::transaction_status WHERE id = $1")
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Call the conditional write directly with the original captured timestamp.
+    let moved = storage
+        .try_requeue_processing(tx_id, _captured)
+        .await
+        .unwrap();
+    assert!(
+        !moved,
+        "conditional write must no-op when row moved off Processing"
+    );
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "completed",
+        "row must remain at the new status"
+    );
+}
+
+// ── IT-9 ────────────────────────────────────────────────────────────────────
+//
+// Tightened terminal write — lagging completion cannot stomp a recovery
+// demote.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
+    let (db, url, _container) = start_pg("it9_lagging").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 100);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+    assert_eq!(status_of(&pool, tx_id).await, "pending");
+
+    // Simulate a lagging in-flight completion from the dead operator. Should
+    // no-op due to the tightened `AND status = 'processing'` predicate.
+    db.update_transaction_status_internal(
+        tx_id,
+        private_channel_indexer::storage::common::models::TransactionStatus::Completed,
+        Some("lagging-sig".to_string()),
+        Utc::now(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "pending",
+        "tightened terminal write must NOT overwrite a recovery demote"
+    );
+    assert_eq!(
+        counterpart_sig_of(&pool, tx_id).await,
+        None,
+        "lagging sig must NOT be persisted"
+    );
+    mock.shutdown().await;
+}
+
+// ── IT-10 ───────────────────────────────────────────────────────────────────
+//
+// Backlog batching — 250 stuck rows are recovered across multiple ticks.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it10_backlog_batched_across_ticks() {
+    let (db, url, _container) = start_pg("it10_batched").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mut ids: Vec<i64> = Vec::with_capacity(250);
+    for _ in 0..250 {
+        let mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 100);
+        let id = db.insert_transaction_internal(&tx).await.unwrap();
+        ids.push(id);
+    }
+    // Bulk: flip all to processing then backdate once.
+    sqlx::query(
+        "UPDATE transactions SET status = 'processing'::transaction_status WHERE id = ANY($1)",
+    )
+    .bind(&ids)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("ALTER TABLE transactions DISABLE TRIGGER update_transactions_updated_at")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE transactions SET updated_at = $1 WHERE id = ANY($2)")
+        .bind(Utc::now() - ChronoDuration::minutes(10))
+        .bind(&ids)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE transactions ENABLE TRIGGER update_transactions_updated_at")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    // Every getSignaturesForAddress returns empty → demote-all path.
+    for _ in 0..300 {
+        mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
+    }
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    // Tick 1: should heal exactly RECOVERY_BATCH_LIMIT (100) rows.
+    let t0 = std::time::Instant::now();
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+    assert!(
+        t0.elapsed() < Duration::from_secs(20),
+        "single tick should not starve the live path"
+    );
+    let pending_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE status = 'pending'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(pending_count, 100, "tick 1 must heal exactly the batch cap");
+
+    // Tick 2 + 3: drain the rest. The healed rows now have a fresh
+    // `updated_at` (post-trigger bump) and are excluded from subsequent
+    // sweeps because they're either now Pending OR still Processing but
+    // freshly stamped — for the remaining still-Processing rows, the
+    // original backdate still holds.
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+    let pending_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE status = 'pending'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        pending_count, 250,
+        "all 250 rows must be healed across 3 ticks"
+    );
+    mock.shutdown().await;
+}
+
+// ── IT-11 ───────────────────────────────────────────────────────────────────
+//
+// PendingRemint rows are NOT touched by stuck-Processing recovery.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it11_pending_remint_rows_untouched() {
+    let (db, url, _container) = start_pg("it11_pending_remint").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 42);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    // Set up as pending_remint with backdated updated_at.
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    db.set_pending_remint_internal(
+        tx_id,
+        vec!["fake-sig".to_string()],
+        Utc::now() + ChronoDuration::minutes(30),
+    )
+    .await
+    .unwrap();
+
+    sqlx::query("ALTER TABLE transactions DISABLE TRIGGER update_transactions_updated_at")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE transactions SET updated_at = $1 WHERE id = $2")
+        .bind(Utc::now() - ChronoDuration::minutes(10))
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE transactions ENABLE TRIGGER update_transactions_updated_at")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Withdraw,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "pending_remint",
+        "pending_remint rows must not be touched by stuck-Processing recovery"
+    );
+    mock.shutdown().await;
+}
+
+// ── IT-12 ───────────────────────────────────────────────────────────────────
+//
+// Withdrawal row missing `withdrawal_nonce` → ManualReview with the runbook
+// reason string.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it12_withdrawal_missing_nonce_quarantines() {
+    let (db, url, _container) = start_pg("it12_missing_nonce").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 99);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    // Force-null the nonce after insert (simulates a corrupt row).
+    sqlx::query("UPDATE transactions SET withdrawal_nonce = NULL WHERE id = $1")
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Withdraw,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "manual_review");
+    let update = storage_rx
+        .try_recv()
+        .expect("manual_review update should be sent");
+    assert_eq!(
+        update.error_message.as_deref(),
+        Some("withdrawal row missing nonce")
+    );
+    assert_recovered_increment(
+        "withdraw",
+        "quarantined",
+        "withdrawal",
+        metric_before,
+        "IT-12",
+    );
+    mock.shutdown().await;
+}
+
+// ── Threshold boundary (extra) ──────────────────────────────────────────────
+//
+// `get_stale_processing_transactions_internal` boundary: three rows at
+// `now - 4:59`, `now - 5:00`, `now - 5:01`. Threshold = 5min. Assert two
+// returned (the two with `updated_at < now - threshold`).
+
+#[tokio::test(flavor = "multi_thread")]
+async fn threshold_boundary_returns_only_strictly_older_rows() {
+    let (db, url, _container) = start_pg("it_boundary").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mut ids = Vec::new();
+    for _ in 0..3 {
+        let mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 1);
+        ids.push(db.insert_transaction_internal(&tx).await.unwrap());
+    }
+    sqlx::query(
+        "UPDATE transactions SET status = 'processing'::transaction_status WHERE id = ANY($1)",
+    )
+    .bind(&ids)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let ages = [
+        ChronoDuration::seconds(4 * 60 + 59),
+        ChronoDuration::seconds(5 * 60),
+        ChronoDuration::seconds(5 * 60 + 1),
+    ];
+    sqlx::query("ALTER TABLE transactions DISABLE TRIGGER update_transactions_updated_at")
+        .execute(&pool)
+        .await
+        .unwrap();
+    for (id, age) in ids.iter().zip(ages.iter()) {
+        sqlx::query("UPDATE transactions SET updated_at = $1 WHERE id = $2")
+            .bind(Utc::now() - *age)
+            .bind(id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+    sqlx::query("ALTER TABLE transactions ENABLE TRIGGER update_transactions_updated_at")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let stale = db
+        .get_stale_processing_transactions_internal(Duration::from_secs(5 * 60), 100)
+        .await
+        .unwrap();
+    // The 4:59 row is younger than 5min → excluded.
+    // The 5:00 row is NOT strictly older — postgres `<` is strict, so
+    // depending on timing fence it may or may not be returned. Assert the
+    // 5:01 row is always present, and the 4:59 row is always excluded.
+    let returned_ids: std::collections::HashSet<i64> = stale.iter().map(|r| r.id).collect();
+    assert!(
+        !returned_ids.contains(&ids[0]),
+        "4:59-old row must NOT be returned (younger than threshold)"
+    );
+    assert!(
+        returned_ids.contains(&ids[2]),
+        "5:01-old row MUST be returned (older than threshold)"
+    );
+}

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -488,11 +488,11 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
     mock.shutdown().await;
 }
 
-// IT-6: idempotency RPC -32601 → not-minted → demote
-// Locks mint.rs's defensive branch; unreachable in prod.
+// IT-6: idempotency RPC -32601 (method not found) → Ambiguous → quarantine,
+// NOT demote. A demote would re-mint a deposit we couldn't verify (double-mint).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it6_method_not_found_demotes_deposit_to_pending() {
+async fn it6_method_not_found_quarantines_deposit() {
     let (db, url, _container) = start_pg("it6_method_not_found").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
@@ -505,7 +505,7 @@ async fn it6_method_not_found_demotes_deposit_to_pending() {
     seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
 
     let mock = MockRpcServer::start().await;
-    // -32601 is permanent (no retry) → mint.rs returns Ok(None) → NotLanded.
+    // -32601 is permanent (no retry) → strict lookup returns Err → Ambiguous.
     mock.enqueue(
         "getSignaturesForAddress",
         Reply::error(-32601, "Method not found"),
@@ -513,7 +513,7 @@ async fn it6_method_not_found_demotes_deposit_to_pending() {
     let client = test_client(mock.url());
     let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    let metric_before = snapshot_recovered("escrow", "requeued", "deposit");
+    let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
 
     test_hooks::run_recovery_once(
         &storage,
@@ -525,7 +525,7 @@ async fn it6_method_not_found_demotes_deposit_to_pending() {
     .await
     .unwrap();
 
-    // Proves the RPC was actually reached (not a pre-RPC bail)
+    // Proves the RPC was actually reached (not a pre-RPC bail) and not retried.
     assert_eq!(
         mock.call_count("getSignaturesForAddress"),
         1,
@@ -533,15 +533,19 @@ async fn it6_method_not_found_demotes_deposit_to_pending() {
     );
     assert_eq!(
         status_of(&pool, tx_id).await,
-        "pending",
-        "method-not-found is treated as not-landed → demote, not quarantine"
+        "manual_review",
+        "method-not-found is uncertainty → quarantine, never silent demote"
     );
-    // Demote is a direct DB CAS — no manual_review webhook update is emitted.
+    let update = storage_rx
+        .try_recv()
+        .expect("manual_review update should be sent");
+    assert_eq!(update.transaction_id, tx_id);
+    let err = update.error_message.as_deref().unwrap_or("");
     assert!(
-        storage_rx.try_recv().is_err(),
-        "demote must not emit a status update"
+        err.starts_with("deposit idempotency:"),
+        "reason should match runbook substring: {err}"
     );
-    assert_recovered_increment("escrow", "requeued", "deposit", metric_before, "IT-6");
+    assert_recovered_increment("escrow", "quarantined", "deposit", metric_before, "IT-6");
     mock.shutdown().await;
 }
 

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -488,11 +488,68 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
     mock.shutdown().await;
 }
 
-// IT-6: fresh row is untouched (no RPC, no DB write).
+// IT-6: idempotency RPC -32601 → not-minted → demote
+// Locks mint.rs's defensive branch; unreachable in prod.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it6_fresh_processing_row_untouched() {
-    let (db, url, _container) = start_pg("it6_fresh").await;
+async fn it6_method_not_found_demotes_deposit_to_pending() {
+    let (db, url, _container) = start_pg("it6_method_not_found").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 700);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    // -32601 is permanent (no retry) → mint.rs returns Ok(None) → NotLanded.
+    mock.enqueue(
+        "getSignaturesForAddress",
+        Reply::error(-32601, "Method not found"),
+    );
+    let client = test_client(mock.url());
+    let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("escrow", "requeued", "deposit");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    // Proves the RPC was actually reached (not a pre-RPC bail)
+    assert_eq!(
+        mock.call_count("getSignaturesForAddress"),
+        1,
+        "the -32601 branch must be reached via exactly one RPC call"
+    );
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "pending",
+        "method-not-found is treated as not-landed → demote, not quarantine"
+    );
+    // Demote is a direct DB CAS — no manual_review webhook update is emitted.
+    assert!(
+        storage_rx.try_recv().is_err(),
+        "demote must not emit a status update"
+    );
+    assert_recovered_increment("escrow", "requeued", "deposit", metric_before, "IT-6");
+    mock.shutdown().await;
+}
+
+// IT-7: fresh row is untouched (no RPC, no DB write).
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it7_fresh_processing_row_untouched() {
+    let (db, url, _container) = start_pg("it7_fresh").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -543,11 +600,11 @@ async fn it6_fresh_processing_row_untouched() {
     mock.shutdown().await;
 }
 
-// IT-7: conditional write is a no-op if the row moved between SELECT and write.
+// IT-8: conditional write is a no-op if the row moved between SELECT and write.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it7_conditional_write_noops_when_row_moved() {
-    let (db, url, _container) = start_pg("it7_cond").await;
+async fn it8_conditional_write_noops_when_row_moved() {
+    let (db, url, _container) = start_pg("it8_cond").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
 
@@ -581,11 +638,11 @@ async fn it7_conditional_write_noops_when_row_moved() {
     );
 }
 
-// IT-8: lagging terminal write cannot stomp a recovery demote.
+// IT-9: lagging terminal write cannot stomp a recovery demote.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it8_lagging_terminal_write_no_ops_after_recovery_demote() {
-    let (db, url, _container) = start_pg("it8_lagging").await;
+async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
+    let (db, url, _container) = start_pg("it9_lagging").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -634,11 +691,11 @@ async fn it8_lagging_terminal_write_no_ops_after_recovery_demote() {
     mock.shutdown().await;
 }
 
-// IT-9: 250-row backlog drained across multiple ticks.
+// IT-10: 250-row backlog drained across multiple ticks.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it9_backlog_batched_across_ticks() {
-    let (db, url, _container) = start_pg("it9_batched").await;
+async fn it10_backlog_batched_across_ticks() {
+    let (db, url, _container) = start_pg("it10_batched").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -735,11 +792,11 @@ async fn it9_backlog_batched_across_ticks() {
     mock.shutdown().await;
 }
 
-// IT-10: PendingRemint rows are NOT touched by recovery.
+// IT-11: PendingRemint rows are NOT touched by recovery.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it10_pending_remint_rows_untouched() {
-    let (db, url, _container) = start_pg("it10_pending_remint").await;
+async fn it11_pending_remint_rows_untouched() {
+    let (db, url, _container) = start_pg("it11_pending_remint").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -797,11 +854,11 @@ async fn it10_pending_remint_rows_untouched() {
     mock.shutdown().await;
 }
 
-// IT-11: withdrawal with NULL nonce → ManualReview (runbook reason string).
+// IT-12: withdrawal with NULL nonce → ManualReview (runbook reason string).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it11_withdrawal_missing_nonce_quarantines() {
-    let (db, url, _container) = start_pg("it11_missing_nonce").await;
+async fn it12_withdrawal_missing_nonce_quarantines() {
+    let (db, url, _container) = start_pg("it12_missing_nonce").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -845,7 +902,7 @@ async fn it11_withdrawal_missing_nonce_quarantines() {
         "quarantined",
         "withdrawal",
         metric_before,
-        "IT-11",
+        "IT-12",
     );
     mock.shutdown().await;
 }

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1,11 +1,4 @@
-//! End-to-end tests for the stuck-`Processing` recovery worker.
-//!
-//! Each test reproduces a concrete operator-crash window described in the
-//! recovery design plan, then drives one `test_hooks::run_recovery_once`
-//! tick against a real Postgres + a scripted Solana RPC. Assertions verify
-//! both DB final state AND observable side effects (the
-//! `OPERATOR_STALE_PROCESSING_RECOVERED` metric, ManualReview webhook
-//! messages, and absence of spurious re-sends).
+//! E2E tests for the stuck-`Processing` recovery worker.
 
 use {
     chrono::{Duration as ChronoDuration, Utc},
@@ -31,13 +24,7 @@ use {
     tokio::sync::mpsc,
 };
 
-/// Snapshot a single recovery-metric cell.  Returned value is the counter's
-/// pre-test reading; callers assert `counter.get() > snapshot` after running
-/// recovery.  We use a >-delta rather than exact equality because the metric
-/// is process-global and other concurrent integration tests may also be
-/// incrementing the same (program, outcome, type) cell — the assertion only
-/// proves that *this* test's row produced a hit, which is the property we
-/// care about.
+/// Pre-test reading of a recovery-metric cell; assert `>snapshot` after.
 fn snapshot_recovered(program: &str, outcome: &str, txn_type: &str) -> f64 {
     OPERATOR_STALE_PROCESSING_RECOVERED
         .with_label_values(&[program, outcome, txn_type])
@@ -120,9 +107,7 @@ fn make_withdrawal(
     tx
 }
 
-/// Insert a row, flip it to `processing`, then backdate `updated_at` past the
-/// BEFORE-UPDATE trigger. The trigger is temporarily disabled around the
-/// backdate so the explicit timestamp wins.
+/// Insert + flip to `processing` + backdate `updated_at` past the trigger.
 async fn seed_backdated_processing(
     pool: &sqlx::PgPool,
     tx_id: i64,
@@ -190,9 +175,7 @@ fn test_client(url: String) -> RpcClientWithRetry {
     )
 }
 
-/// Scripted `getTransaction` reply whose parsed JSON satisfies
-/// `transaction_matches_expected_mint`. Mirrors the helper in
-/// `sender_mint_idempotency.rs` exactly.
+/// Scripted `getTransaction` reply satisfying `transaction_matches_expected_mint`.
 fn get_transaction_reply(
     signature: &Signature,
     mint: &Pubkey,
@@ -251,10 +234,7 @@ fn get_transaction_reply(
     }))
 }
 
-// ── IT-1 ────────────────────────────────────────────────────────────────────
-//
-// Deposit crashes mid-Processing, mint already landed → recovery promotes to
-// Completed with the on-chain signature.
+// IT-1: deposit landed → Completed (with on-chain sig).
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it1_deposit_landed_promoted_to_completed() {
@@ -330,11 +310,7 @@ async fn it1_deposit_landed_promoted_to_completed() {
     mock.shutdown().await;
 }
 
-// ── IT-2 ────────────────────────────────────────────────────────────────────
-//
-// Deposit crashes mid-Processing, mint did NOT land → recovery demotes to
-// Pending. (The full re-pickup loop is exercised by IT-2.5 below where the
-// fetcher re-claims the demoted row; here we pin the demote step itself.)
+// IT-2: deposit not landed → Pending (demote step).
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it2_deposit_not_landed_demoted_to_pending() {
@@ -367,16 +343,13 @@ async fn it2_deposit_not_landed_demoted_to_pending() {
     .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "pending");
-    // The fetcher will pick this up on its next tick (covered by the live
-    // operator path, not the recovery worker itself).
+    // Live fetcher picks it up on the next tick (out of scope here).
     assert_eq!(mock.call_count("sendTransaction"), 0);
     assert_recovered_increment("escrow", "requeued", "deposit", metric_before, "IT-2");
     mock.shutdown().await;
 }
 
-// ── IT-3 ────────────────────────────────────────────────────────────────────
-//
-// Withdrawal crashes mid-Processing, release NOT landed → recovery demotes.
+// IT-3: withdrawal not landed → demote.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it3_withdrawal_demoted_unconditionally() {
@@ -416,9 +389,7 @@ async fn it3_withdrawal_demoted_unconditionally() {
     mock.shutdown().await;
 }
 
-// ── IT-4 ────────────────────────────────────────────────────────────────────
-//
-// Path purity: withdrawal recovery makes ZERO RPC calls.
+// IT-4: withdrawal recovery makes ZERO RPC calls.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it4_withdrawal_recovery_zero_rpc_calls() {
@@ -459,9 +430,7 @@ async fn it4_withdrawal_recovery_zero_rpc_calls() {
     mock.shutdown().await;
 }
 
-// ── IT-5 ────────────────────────────────────────────────────────────────────
-//
-// RPC down on deposit recovery → ManualReview, NOT pending.
+// IT-5: deposit RPC failure → ManualReview (never silent demote).
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
@@ -519,19 +488,9 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
     mock.shutdown().await;
 }
 
-// Note: there is no IT-6. The original plan included a test for the
-// JSON-RPC `-32601 MethodNotFound` failure mode, but the operator's
-// `rpc_client` always points at the PrivateChannel node (Contra's own
-// RPC), which implements `getSignaturesForAddress` (PR #95). The
-// `-32601` fail-open arm in `find_existing_mint_signature_with_memo`
-// (mint.rs:441-442) is dead code under any production configuration,
-// so testing it would assert against an unreachable code path. The
-// only reachable Ambiguous case on the deposit path is transport
-// error, covered by IT-5.
+// IT-6 omitted: -32601 arm is unreachable on the PrivateChannel RPC (PR #95).
 
-// ── IT-7 ────────────────────────────────────────────────────────────────────
-//
-// Fresh row: recovery does NOT touch it; no RPC, no DB write.
+// IT-7: fresh row is untouched (no RPC, no DB write).
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it7_fresh_processing_row_untouched() {
@@ -586,11 +545,7 @@ async fn it7_fresh_processing_row_untouched() {
     mock.shutdown().await;
 }
 
-// ── IT-8 ────────────────────────────────────────────────────────────────────
-//
-// The conditional write becomes a no-op when the row has moved between
-// SELECT and the write. Simulated by directly mutating the row between
-// the captured timestamp and the try_* call.
+// IT-8: conditional write is a no-op if the row moved between SELECT and write.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it8_conditional_write_noops_when_row_moved() {
@@ -605,9 +560,7 @@ async fn it8_conditional_write_noops_when_row_moved() {
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
     let _captured = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
 
-    // Race: caller already moved the row off Processing → try_requeue must
-    // return false because both `status = processing` and the captured
-    // `updated_at` no longer match.
+    // Race: row already moved off Processing → try_requeue returns false.
     sqlx::query("UPDATE transactions SET status = 'completed'::transaction_status WHERE id = $1")
         .bind(tx_id)
         .execute(&pool)
@@ -630,10 +583,7 @@ async fn it8_conditional_write_noops_when_row_moved() {
     );
 }
 
-// ── IT-9 ────────────────────────────────────────────────────────────────────
-//
-// Tightened terminal write — lagging completion cannot stomp a recovery
-// demote.
+// IT-9: lagging terminal write cannot stomp a recovery demote.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
@@ -664,8 +614,7 @@ async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
     .unwrap();
     assert_eq!(status_of(&pool, tx_id).await, "pending");
 
-    // Simulate a lagging in-flight completion from the dead operator. Should
-    // no-op due to the tightened `AND status = 'processing'` predicate.
+    // Lagging in-flight write from dead operator — must no-op.
     db.update_transaction_status_internal(
         tx_id,
         private_channel_indexer::storage::common::models::TransactionStatus::Completed,
@@ -687,9 +636,7 @@ async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
     mock.shutdown().await;
 }
 
-// ── IT-10 ───────────────────────────────────────────────────────────────────
-//
-// Backlog batching — 250 stuck rows are recovered across multiple ticks.
+// IT-10: 250-row backlog drained across multiple ticks.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it10_backlog_batched_across_ticks() {
@@ -759,11 +706,7 @@ async fn it10_backlog_batched_across_ticks() {
             .unwrap();
     assert_eq!(pending_count, 100, "tick 1 must heal exactly the batch cap");
 
-    // Tick 2 + 3: drain the rest. The healed rows now have a fresh
-    // `updated_at` (post-trigger bump) and are excluded from subsequent
-    // sweeps because they're either now Pending OR still Processing but
-    // freshly stamped — for the remaining still-Processing rows, the
-    // original backdate still holds.
+    // Ticks 2-3: drain the rest. Healed rows are excluded (trigger bumped updated_at).
     test_hooks::run_recovery_once(
         &storage,
         &client,
@@ -794,9 +737,7 @@ async fn it10_backlog_batched_across_ticks() {
     mock.shutdown().await;
 }
 
-// ── IT-11 ───────────────────────────────────────────────────────────────────
-//
-// PendingRemint rows are NOT touched by stuck-Processing recovery.
+// IT-11: PendingRemint rows are NOT touched by recovery.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it11_pending_remint_rows_untouched() {
@@ -858,10 +799,7 @@ async fn it11_pending_remint_rows_untouched() {
     mock.shutdown().await;
 }
 
-// ── IT-12 ───────────────────────────────────────────────────────────────────
-//
-// Withdrawal row missing `withdrawal_nonce` → ManualReview with the runbook
-// reason string.
+// IT-12: withdrawal with NULL nonce → ManualReview (runbook reason string).
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it12_withdrawal_missing_nonce_quarantines() {
@@ -914,11 +852,7 @@ async fn it12_withdrawal_missing_nonce_quarantines() {
     mock.shutdown().await;
 }
 
-// ── Threshold boundary (extra) ──────────────────────────────────────────────
-//
-// `get_stale_processing_transactions_internal` boundary: three rows at
-// `now - 4:59`, `now - 5:00`, `now - 5:01`. Threshold = 5min. Assert two
-// returned (the two with `updated_at < now - threshold`).
+// Threshold boundary: three rows at -4:59 / -5:00 / -5:01, expect the two older returned.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn threshold_boundary_returns_only_strictly_older_rows() {
@@ -968,10 +902,7 @@ async fn threshold_boundary_returns_only_strictly_older_rows() {
         .get_stale_processing_transactions_internal(Duration::from_secs(5 * 60), 100)
         .await
         .unwrap();
-    // The 4:59 row is younger than 5min → excluded.
-    // The 5:00 row is NOT strictly older — postgres `<` is strict, so
-    // depending on timing fence it may or may not be returned. Assert the
-    // 5:01 row is always present, and the 4:59 row is always excluded.
+    // 4:59 excluded; 5:00 is timing-dependent (Postgres `<` is strict).
     let returned_ids: std::collections::HashSet<i64> = stale.iter().map(|r| r.id).collect();
     assert!(
         !returned_ids.contains(&ids[0]),

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1167,6 +1167,76 @@ async fn it12_withdrawal_missing_nonce_quarantines() {
     mock.shutdown().await;
 }
 
+// IT-13: a deposit that keeps coming back NotLanded is quarantined once it hits
+// the requeue cap instead of looping pending→processing→pending forever.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it13_recovery_requeue_cap_quarantines_after_max() {
+    let (db, url, _container) = start_pg("it13_requeue_cap").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 100);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    // Seed the durable counter to MAX_RECOVERY_REQUEUE_ATTEMPTS - 1 (= 2); the
+    // next would-be demote crosses the cap → quarantine, not requeue.
+    sqlx::query("ALTER TABLE transactions DISABLE TRIGGER update_transactions_updated_at")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE transactions SET recovery_requeue_attempts = 2 WHERE id = $1")
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE transactions ENABLE TRIGGER update_transactions_updated_at")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    // Empty signatures → NotLanded → would Demote, but the cap intercepts it.
+    mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
+    let client = test_client(mock.url());
+    let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Escrow,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "manual_review",
+        "row at the requeue cap must quarantine, not loop back to pending"
+    );
+    let update = storage_rx
+        .try_recv()
+        .expect("cap must fire the manual_review alert webhook");
+    assert_eq!(update.transaction_id, tx_id);
+    let err = update.error_message.as_deref().unwrap_or("");
+    // Count tracks MAX_RECOVERY_REQUEUE_ATTEMPTS (= 3, see the seed above); pin it to catch an off-by-one cap.
+    assert!(
+        err.contains("3 recovery requeues"),
+        "alert must name the requeue cap and its count: {err}"
+    );
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    assert_recovered_increment("escrow", "quarantined", "deposit", metric_before, "IT-13");
+    mock.shutdown().await;
+}
+
 // Threshold boundary: three rows at -4:59 / -5:00 / -5:01, expect the two older returned.
 
 #[tokio::test(flavor = "multi_thread")]

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -349,10 +349,10 @@ async fn it2_deposit_not_landed_demoted_to_pending() {
     mock.shutdown().await;
 }
 
-// IT-3: withdrawal not landed → demote.
+// IT-3: withdrawal whose recorded release signature is dead (null status, blockhash expired) → demote.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it3_withdrawal_demoted_unconditionally() {
+async fn it3_withdrawal_dead_signature_demoted() {
     let (db, url, _container) = start_pg("it3_wd_demote").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
@@ -361,9 +361,17 @@ async fn it3_withdrawal_demoted_unconditionally() {
     let tx = make_withdrawal(&Signature::new_unique().to_string(), 7);
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
     seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    db.insert_release_signature_internal(tx_id, Signature::new_unique().to_string(), 100)
+        .await
+        .unwrap();
 
     let mock = MockRpcServer::start().await;
-    // The withdrawal path makes no RPC calls. Script nothing.
+    // Status null + current height (1000) > lvbh (100) → expired/dead.
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
+    );
+    mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
@@ -385,15 +393,16 @@ async fn it3_withdrawal_demoted_unconditionally() {
         fresh > Utc::now() - ChronoDuration::seconds(5),
         "updated_at should be fresh"
     );
+    assert_eq!(mock.call_count("sendTransaction"), 0);
     assert_recovered_increment("withdraw", "requeued", "withdrawal", metric_before, "IT-3");
     mock.shutdown().await;
 }
 
-// IT-4: withdrawal recovery makes ZERO RPC calls.
+// IT-4: withdrawal whose recorded release signature finalized → Completed, no re-send.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it4_withdrawal_recovery_zero_rpc_calls() {
-    let (db, url, _container) = start_pg("it4_zero_rpc").await;
+async fn it4_withdrawal_landed_signature_completed_no_resend() {
+    let (db, url, _container) = start_pg("it4_landed").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -401,8 +410,73 @@ async fn it4_withdrawal_recovery_zero_rpc_calls() {
     let tx = make_withdrawal(&Signature::new_unique().to_string(), 1);
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
     seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    let landed_sig = Signature::new_unique();
+    db.insert_release_signature_internal(tx_id, landed_sig.to_string(), 100)
+        .await
+        .unwrap();
 
     let mock = MockRpcServer::start().await;
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": {"slot": 200},
+            "value": [{
+                "slot": 100,
+                "confirmations": null,
+                "err": null,
+                "status": {"Ok": null},
+                "confirmationStatus": "finalized"
+            }]
+        })),
+    );
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("withdraw", "completed", "withdrawal");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Withdraw,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "completed");
+    assert_eq!(
+        counterpart_sig_of(&pool, tx_id).await,
+        Some(landed_sig.to_string())
+    );
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    assert_recovered_increment("withdraw", "completed", "withdrawal", metric_before, "IT-4");
+    mock.shutdown().await;
+}
+
+// IT-4b: withdrawal whose recorded signature is still live → left in Processing (no CAS write).
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it4b_withdrawal_live_signature_left_processing() {
+    let (db, url, _container) = start_pg("it4b_live").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 2);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    let _captured = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    db.insert_release_signature_internal(tx_id, Signature::new_unique().to_string(), 1000)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    // Status null + current height (50) <= lvbh (1000) → still live.
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
+    );
+    mock.enqueue("getBlockHeight", Reply::result(json!(50)));
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
@@ -416,17 +490,198 @@ async fn it4_withdrawal_recovery_zero_rpc_calls() {
     .await
     .unwrap();
 
-    // Every method should have zero calls — the recovery path took no RPC.
-    for method in &[
-        "getSignaturesForAddress",
-        "getTransaction",
-        "sendTransaction",
-        "getLatestBlockhash",
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "processing",
+        "live signature must leave the row in Processing for the next sweep"
+    );
+    // No CAS write → updated_at stays backdated, not refreshed to "now".
+    assert!(
+        updated_at_of(&pool, tx_id).await < Utc::now() - ChronoDuration::minutes(5),
+        "no CAS write means updated_at must stay backdated, not refreshed"
+    );
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    mock.shutdown().await;
+}
+
+// IT-4c: withdrawal with no recorded signatures → quarantine (can't verify, double-payout risk).
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it4c_withdrawal_no_signatures_quarantined() {
+    let (db, url, _container) = start_pg("it4c_no_sigs").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 3);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Withdraw,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "manual_review");
+    // No RPC needed — empty signature set short-circuits before classification.
+    assert_eq!(mock.call_count("getSignatureStatuses"), 0);
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    let update = storage_rx
+        .try_recv()
+        .expect("manual_review update should be sent");
+    let err = update.error_message.as_deref().unwrap_or("");
+    assert!(
+        err.contains("no broadcast signatures recorded"),
+        "reason: {err}"
+    );
+    assert_recovered_increment(
+        "withdraw",
+        "quarantined",
+        "withdrawal",
+        metric_before,
+        "IT-4c",
+    );
+    mock.shutdown().await;
+}
+
+// IT-4d: RPC uncertainty during classification → quarantine, never demote.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it4d_withdrawal_rpc_uncertain_quarantined() {
+    let (db, url, _container) = start_pg("it4d_uncertain").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 4);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    db.insert_release_signature_internal(tx_id, Signature::new_unique().to_string(), 100)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    // getSignatureStatuses fails on every retry → Uncertain.
+    mock.enqueue_sequence(
         "getSignatureStatuses",
-    ] {
-        assert_eq!(mock.call_count(method), 0, "{method} should have 0 calls");
-    }
-    assert_eq!(status_of(&pool, tx_id).await, "pending");
+        vec![
+            Reply::error(-32000, "internal"),
+            Reply::error(-32000, "internal"),
+            Reply::error(-32000, "internal"),
+        ],
+    );
+    let client = test_client(mock.url());
+    let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Withdraw,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "manual_review",
+        "RPC uncertainty must quarantine, never silently demote"
+    );
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    let update = storage_rx
+        .try_recv()
+        .expect("manual_review update should be sent");
+    let err = update.error_message.as_deref().unwrap_or("");
+    assert!(
+        err.contains("could not verify release landed"),
+        "reason: {err}"
+    );
+    assert_recovered_increment(
+        "withdraw",
+        "quarantined",
+        "withdrawal",
+        metric_before,
+        "IT-4d",
+    );
+    mock.shutdown().await;
+}
+
+// IT-4e: GC backstop reclaims release sigs whose parent left Processing.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it4e_gc_reclaims_non_processing_release_sigs() {
+    let (db, url, _container) = start_pg("it4e_gc").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    // One processing withdrawal (sig retained) and one completed (sig GC'd).
+    let proc = make_withdrawal(&Signature::new_unique().to_string(), 10);
+    let proc_id = db.insert_transaction_internal(&proc).await.unwrap();
+    let done = make_withdrawal(&Signature::new_unique().to_string(), 11);
+    let done_id = db.insert_transaction_internal(&done).await.unwrap();
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(proc_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE transactions SET status = 'completed'::transaction_status WHERE id = $1")
+        .bind(done_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    db.insert_release_signature_internal(proc_id, Signature::new_unique().to_string(), 1)
+        .await
+        .unwrap();
+    db.insert_release_signature_internal(done_id, Signature::new_unique().to_string(), 2)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    // recover_once runs gc_stale_release_signatures at the top of the sweep.
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        Pubkey::new_unique(),
+        ProgramType::Withdraw,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    let remaining_done: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pending_release_signatures WHERE transaction_id = $1",
+    )
+    .bind(done_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(remaining_done, 0, "completed txn's sig must be GC'd");
+    let remaining_proc: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pending_release_signatures WHERE transaction_id = $1",
+    )
+    .bind(proc_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(remaining_proc, 1, "processing txn's sig must be retained");
     mock.shutdown().await;
 }
 

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1183,13 +1183,13 @@ async fn it13_recovery_requeue_cap_quarantines_after_max() {
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
     seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
 
-    // Seed the durable counter to MAX_RECOVERY_REQUEUE_ATTEMPTS - 1 (= 2); the
-    // next would-be demote crosses the cap → quarantine, not requeue.
+    // Seed the durable counter to MAX_RECOVERY_REQUEUE_ATTEMPTS (= 3); the row
+    // has already used its requeue budget, so the next demote is quarantined.
     sqlx::query("ALTER TABLE transactions DISABLE TRIGGER update_transactions_updated_at")
         .execute(&pool)
         .await
         .unwrap();
-    sqlx::query("UPDATE transactions SET recovery_requeue_attempts = 2 WHERE id = $1")
+    sqlx::query("UPDATE transactions SET recovery_requeue_attempts = 3 WHERE id = $1")
         .bind(tx_id)
         .execute(&pool)
         .await

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -212,6 +212,7 @@ async fn null_withdrawal_nonce_is_quarantined_to_manual_review(
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
+        recovery_requeue_attempts: 0,
     };
     storage.insert_db_transaction(&withdrawal).await?;
 


### PR DESCRIPTION
## Summary

Addresses SOLA2-12 finding. When the fetcher flipped a row from `pending` to `processing` and the operator died before the row reached a terminal status (`completed` / `failed` / `manual_review` / `pending_remint`), the row sat in `processing` forever. The fetcher's next loop only selects `pending` rows. For deposits this meant tokens locked on Mainnet with the private-channel mint never happening; for withdrawals, the user's burned private-channel tokens with no matching escrow release.

This PR adds a peer recovery worker that runs on boot and on a 60 s interval, picks up rows that have sat in `processing` past a 5 min stale threshold, asks the chain whether the operator's intended action already happened, and updates each row to its true state.

## What's added

- **Recovery worker.** New `operator/recovery.rs`, spawned as a peer task next to fetcher/processor/sender. Per type: deposits go through an RPC idempotency check (three-way `Landed` / `NotLanded` / `Ambiguous`); withdrawals demote unconditionally and rely on the escrow program's exclusion-proof check to prevent double-release.
- **Storage helpers.** `get_stale_processing_transactions` plus three conditional writes (`try_complete_processing`, `try_requeue_processing`, `try_quarantine_processing`) gated on `updated_at = $expected`. Returns `Ok(false)` instead of erroring when another writer/operator moved the row first.
- **Tightened terminal write.** `update_transaction_status_internal` now carries `AND status = 'processing'` so a lagging in-flight completion cannot stomp a recovery demote. Mirrors `set_pending_remint_internal`.
- **Webhook integration.** Quarantine outcomes emit a `TransactionStatusUpdate` through the shared `storage_tx` channel so the existing `DbTransactionWriter` fires the alert webhook with a runbook-keyed reason string.
- **Metric.** New `OPERATOR_STALE_PROCESSING_RECOVERED{program,outcome,type}` counter. 
- **Runbooks + drills.** Adds Path E to `deposit_manual_review.md` (RPC unreachable) and Path F to `withdrawal_manual_review.md` (corrupt withdrawal row). 
- **Tests.** One new integration suite covering 12 IT scenarios + 8 unit tests inside `recovery.rs`. IT-5 and IT-12 also assert the metric increments.



### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,735 | 11,231 | 86.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27134188494) |
| Indexer | 18,753 | 21,734 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27134188494) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27134188494) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27134188494) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 10,989 | 13,564 | 81.0% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27134188494) |
| **Total** | **41,188** | **48,524** | **84.9%** | |

> Last updated: 2026-06-08 11:50:44 UTC by E2E Integration