### PR TITLE
fix(indexer): close two data-loss windows in Yellowstone and RPC polling

### DIFF
--- a/indexer/src/indexer/datasource/rpc_polling/source.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/source.rs
@@ -248,7 +248,11 @@ mod tests {
             .create()
     }
 
-    fn mock_get_block_success(server: &mut Server, slot: u64, expect_at_least: usize) -> mockito::Mock {
+    fn mock_get_block_success(
+        server: &mut Server,
+        slot: u64,
+        expect_at_least: usize,
+    ) -> mockito::Mock {
         server
             .mock("POST", "/")
             .match_body(mockito::Matcher::PartialJson(json!({
@@ -272,7 +276,11 @@ mod tests {
             .create()
     }
 
-    fn mock_get_block_error(server: &mut Server, slot: u64, expect_at_least: usize) -> mockito::Mock {
+    fn mock_get_block_error(
+        server: &mut Server,
+        slot: u64,
+        expect_at_least: usize,
+    ) -> mockito::Mock {
         server
             .mock("POST", "/")
             .match_body(mockito::Matcher::PartialJson(json!({
@@ -374,14 +382,10 @@ mod tests {
 
         // Collect SlotCompletes until we see 100,101,102 or time out.
         let mut seen = std::collections::HashSet::new();
-        let deadline =
-            tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(500);
         while seen.len() < 3 && tokio::time::Instant::now() < deadline {
-            if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) = tokio::time::timeout(
-                std::time::Duration::from_millis(50),
-                rx.recv(),
-            )
-            .await
+            if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
+                tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await
             {
                 seen.insert(slot);
             }

--- a/indexer/src/indexer/datasource/rpc_polling/source.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/source.rs
@@ -181,6 +181,12 @@ impl DataSource for RpcPollingSource {
                             metrics::INDEXER_RPC_ERRORS
                                 .with_label_values(&[program_type.as_label(), "get_block"])
                                 .inc();
+                            // Don't emit SlotComplete or advance — that would
+                            // checkpoint past an unparsed slot and lose anything in it.
+                            // Break so the next poll re-fetches from `current_slot`.
+                            tokio::time::sleep(Duration::from_millis(error_retry_interval_ms))
+                                .await;
+                            break;
                         }
                     }
 
@@ -220,5 +226,173 @@ impl DataSource for RpcPollingSource {
     async fn shutdown(&mut self) -> Result<(), DataSourceError> {
         info!("RPC polling source shutdown requested (no additional cleanup needed)");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+    use serde_json::json;
+    use tokio::sync::mpsc;
+
+    fn mock_get_slot(server: &mut Server, slot: u64) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(
+                json!({ "method": "getSlot" }),
+            ))
+            .with_status(200)
+            .with_body(json!({ "jsonrpc": "2.0", "result": slot, "id": 1 }).to_string())
+            .expect_at_least(1)
+            .create()
+    }
+
+    fn mock_get_block_success(server: &mut Server, slot: u64, expect_at_least: usize) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [slot]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "blockhash": "TestBlockHash11111111111111111111111111111",
+                        "parentSlot": slot - 1,
+                        "transactions": []
+                    },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .expect_at_least(expect_at_least)
+            .create()
+    }
+
+    fn mock_get_block_error(server: &mut Server, slot: u64, expect_at_least: usize) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [slot]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32600, "message": "Invalid request" },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .expect_at_least(expect_at_least)
+            .create()
+    }
+
+    /// getBlock failure must not emit SlotComplete or advance.
+    /// The failed slot is re-fetched on the next poll.
+    #[tokio::test]
+    async fn fetch_error_does_not_emit_slot_complete_and_retries() {
+        let mut server = Server::new_async().await;
+
+        // Chain tip stays ahead so get_slots_to_process always returns [100].
+        let _m_slot = mock_get_slot(&mut server, 105);
+        // Slot 100 always fails; expect ≥2 retries proving no advance past it.
+        let m_block_err = mock_get_block_error(&mut server, 100, 2);
+
+        let mut source = RpcPollingSource::new(
+            server.url(),
+            Some(100), // from_slot — start exactly at the failing slot
+            10,        // poll_interval_ms — tight loop for the test
+            10,        // error_retry_interval_ms — quick retry on error
+            10,
+            solana_transaction_status::UiTransactionEncoding::Json,
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+            ProgramType::Escrow,
+            None,
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+        // Allow at least a couple of poll iterations against the failing slot.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        cancel.cancel();
+        let _ = handle.await;
+
+        // Assert: at least two attempts on slot 100 (proves it didn't advance past it).
+        m_block_err.assert();
+
+        // Assert: no SlotComplete was emitted for slot 100 — checkpoint must not move.
+        let mut messages = vec![];
+        while let Ok(msg) = rx.try_recv() {
+            messages.push(msg);
+        }
+        let advanced_past_100 = messages.iter().any(|m| {
+            matches!(
+                m,
+                ProcessorMessage::SlotComplete { slot, .. } if *slot == 100
+            )
+        });
+        assert!(
+            !advanced_past_100,
+            "SlotComplete{{slot:100}} must not be emitted on fetch failure"
+        );
+    }
+
+    /// Happy path: a successful getBlock emits SlotComplete and
+    /// advances `current_slot`, so subsequent polls request later slots.
+    #[tokio::test]
+    async fn fetch_success_emits_slot_complete_and_advances() {
+        let mut server = Server::new_async().await;
+
+        // Chain tip 103 → get_slots_to_process(100, 10) returns [100,101,102].
+        let _m_slot = mock_get_slot(&mut server, 103);
+        let _m_b100 = mock_get_block_success(&mut server, 100, 1);
+        let _m_b101 = mock_get_block_success(&mut server, 101, 1);
+        let _m_b102 = mock_get_block_success(&mut server, 102, 1);
+
+        let mut source = RpcPollingSource::new(
+            server.url(),
+            Some(100),
+            10,
+            10,
+            10,
+            solana_transaction_status::UiTransactionEncoding::Json,
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+            ProgramType::Escrow,
+            None,
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+        // Collect SlotCompletes until we see 100,101,102 or time out.
+        let mut seen = std::collections::HashSet::new();
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+        while seen.len() < 3 && tokio::time::Instant::now() < deadline {
+            if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) = tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                rx.recv(),
+            )
+            .await
+            {
+                seen.insert(slot);
+            }
+        }
+        cancel.cancel();
+        let _ = handle.await;
+
+        assert!(
+            seen.contains(&100) && seen.contains(&101) && seen.contains(&102),
+            "expected SlotComplete for 100,101,102; got {:?}",
+            seen
+        );
     }
 }

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -107,7 +107,7 @@ impl YellowstoneSource {
 
 #[cfg(feature = "datasource-rpc")]
 async fn try_fill_reconnect_gap(
-    last_seen_slot: u64,
+    checkpoint: u64,
     rpc_poller: &RpcPoller,
     max_gap_slots: u64,
     batch_size: usize,
@@ -123,22 +123,25 @@ async fn try_fill_reconnect_gap(
                 reason: format!("Failed to get latest slot: {}", e),
             })?;
 
-    match validate_gap(current_slot, last_seen_slot, max_gap_slots) {
+    // Validate against the real checkpoint distance; the boundary slot is
+    // included only when handing off to fill_slot_range below.
+    match validate_gap(current_slot, checkpoint, max_gap_slots) {
         Ok(None) => {
             info!(
-                "No gap detected on reconnect. Current slot: {}, last seen: {}",
-                current_slot, last_seen_slot
+                "No gap detected on reconnect. Current slot: {}, checkpoint: {}",
+                current_slot, checkpoint
             );
             Ok(0)
         }
         Ok(Some(gap)) => {
+            let replay_anchor = checkpoint.saturating_sub(1);
             info!(
-                "Gap detected on reconnect: {} slots (from {} to {}). Backfilling...",
-                gap, last_seen_slot, current_slot
+                "Gap detected on reconnect: {} slots (replaying from {} to {}). Backfilling...",
+                gap, replay_anchor, current_slot
             );
             fill_slot_range(
                 rpc_poller,
-                last_seen_slot,
+                replay_anchor,
                 current_slot,
                 batch_size,
                 program_type,
@@ -235,7 +238,7 @@ impl DataSource for YellowstoneSource {
                 #[cfg(feature = "datasource-rpc")]
                 {
                     // Anchor on the durable checkpoint, not an in-memory watermark.
-                    // BlockMeta(S) can race partial tx delivery, so replay must include S itself
+                    // BlockMeta(S) can race partial tx delivery, so replay must include S itself.
                     // Tx/mint inserts are idempotent, so replaying the boundary slot is safe.
                     if let (Some(ref poller), Some(ref storage)) = (&rpc_poller, &storage) {
                         let checkpoint = match get_last_checkpoint(storage, program_type).await {
@@ -245,6 +248,9 @@ impl DataSource for YellowstoneSource {
                                     "Reconnect gap-fill skipped: failed to read checkpoint: {}",
                                     e
                                 );
+                                // Backoff so a persistent storage outage paired with a
+                                // fast-failing Yellowstone endpoint can't spin the loop.
+                                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                                 continue;
                             }
                         };
@@ -254,9 +260,8 @@ impl DataSource for YellowstoneSource {
                             continue;
                         }
 
-                        let anchor = checkpoint.saturating_sub(1);
                         match try_fill_reconnect_gap(
-                            anchor,
+                            checkpoint,
                             poller,
                             max_gap_slots,
                             batch_size,
@@ -574,7 +579,10 @@ mod tests {
     async fn try_fill_reconnect_gap_fills_gap() {
         let mut server = Server::new_async().await;
 
+        // checkpoint = 100, current_slot = 103 → replay anchor = 99,
+        // fill_slot_range emits slots 100..=103 (boundary slot included).
         let _m_slot = mock_get_slot(&mut server, 103);
+        let _m0 = mock_get_block_success(&mut server, 100);
         let _m1 = mock_get_block_success(&mut server, 101);
         let _m2 = mock_get_block_success(&mut server, 102);
         let _m3 = mock_get_block_success(&mut server, 103);
@@ -589,7 +597,7 @@ mod tests {
         let result =
             try_fill_reconnect_gap(100, &poller, 1000, 10, ProgramType::Escrow, None, &tx).await;
 
-        assert_eq!(result.unwrap(), 3);
+        assert_eq!(result.unwrap(), 4);
         drop(tx);
 
         let mut slots = vec![];
@@ -599,7 +607,7 @@ mod tests {
             }
         }
 
-        assert_eq!(slots, vec![101, 102, 103]);
+        assert_eq!(slots, vec![100, 101, 102, 103]);
     }
 
     #[tokio::test]

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -7,7 +7,7 @@ use private_channel_metrics::MetricLabel;
 use solana_sdk::message::VersionedMessage;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "datasource-rpc")]
 use tracing::warn;
@@ -25,13 +25,12 @@ use crate::indexer::datasource::common::parser::escrow::parse_escrow_instruction
 use crate::indexer::datasource::common::parser::withdraw::parse_withdraw_instruction;
 use crate::indexer::datasource::common::{datasource::DataSource, types::*};
 use crate::indexer::datasource::rpc_polling::types::InnerInstructions;
-
-#[cfg(feature = "datasource-rpc")]
-use std::sync::Arc;
+use crate::storage::Storage;
 
 #[cfg(feature = "datasource-rpc")]
 use crate::indexer::{
     backfill::{fill_slot_range, validate_gap},
+    checkpoint::get_last_checkpoint,
     datasource::rpc_polling::rpc::RpcPoller,
 };
 
@@ -48,6 +47,8 @@ pub struct YellowstoneSource {
     max_gap_slots: u64,
     #[cfg(feature = "datasource-rpc")]
     batch_size: usize,
+    #[cfg(feature = "datasource-rpc")]
+    storage: Option<Arc<Storage>>,
     health: Option<Arc<private_channel_metrics::HealthState>>,
 }
 
@@ -71,6 +72,8 @@ impl YellowstoneSource {
             max_gap_slots: 0,
             #[cfg(feature = "datasource-rpc")]
             batch_size: 0,
+            #[cfg(feature = "datasource-rpc")]
+            storage: None,
             health: None,
         }
     }
@@ -90,6 +93,14 @@ impl YellowstoneSource {
         self.rpc_poller = Some(rpc_poller);
         self.max_gap_slots = max_gap_slots;
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Storage holds the durable checkpoint that anchors reconnect backfill.
+    /// Without it, reconnect gap-fill is a no-op.
+    #[cfg(feature = "datasource-rpc")]
+    pub fn with_storage(mut self, storage: Arc<Storage>) -> Self {
+        self.storage = Some(storage);
         self
     }
 }
@@ -177,10 +188,10 @@ impl DataSource for YellowstoneSource {
         let max_gap_slots = self.max_gap_slots;
         #[cfg(feature = "datasource-rpc")]
         let batch_size = self.batch_size;
+        #[cfg(feature = "datasource-rpc")]
+        let storage = self.storage.clone();
 
         let handle = tokio::spawn(async move {
-            let last_seen_slot = AtomicU64::new(0);
-
             loop {
                 if cancellation_token.is_cancelled() {
                     info!("Yellowstone source received cancellation signal, stopping...");
@@ -195,7 +206,6 @@ impl DataSource for YellowstoneSource {
                     escrow_instance_id,
                     tx.clone(),
                     cancellation_token.clone(),
-                    &last_seen_slot,
                     health.as_ref(),
                 )
                 .await
@@ -224,43 +234,61 @@ impl DataSource for YellowstoneSource {
 
                 #[cfg(feature = "datasource-rpc")]
                 {
-                    let seen = last_seen_slot.load(Ordering::Relaxed);
-                    if seen > 0 {
-                        if let Some(ref poller) = rpc_poller {
-                            match try_fill_reconnect_gap(
-                                seen,
-                                poller,
-                                max_gap_slots,
-                                batch_size,
-                                program_type,
-                                escrow_instance_id,
-                                &tx,
-                            )
-                            .await
+                    // Anchor on the durable checkpoint, not an in-memory watermark.
+                    // BlockMeta(S) can race partial tx delivery, so replay must include S itself
+                    // Tx/mint inserts are idempotent, so replaying the boundary slot is safe.
+                    if let (Some(ref poller), Some(ref storage)) = (&rpc_poller, &storage) {
+                        let checkpoint = match get_last_checkpoint(storage, program_type).await {
+                            Ok(slot) => slot,
+                            Err(e) => {
+                                warn!(
+                                    "Reconnect gap-fill skipped: failed to read checkpoint: {}",
+                                    e
+                                );
+                                continue;
+                            }
+                        };
+
+                        if checkpoint == 0 {
+                            // Fresh system, startup backfill handles initial catch-up.
+                            continue;
+                        }
+
+                        let anchor = checkpoint.saturating_sub(1);
+                        match try_fill_reconnect_gap(
+                            anchor,
+                            poller,
+                            max_gap_slots,
+                            batch_size,
+                            program_type,
+                            escrow_instance_id,
+                            &tx,
+                        )
+                        .await
+                        {
+                            Ok(filled) => {
+                                if filled > 0 {
+                                    info!(
+                                        "Reconnect gap-fill complete: {} slots backfilled \
+                                         (from checkpoint {})",
+                                        filled, checkpoint
+                                    );
+                                }
+                            }
+                            Err(DataSourceError::GapFillFailed { ref reason })
+                                if reason.contains("Gap too large") =>
                             {
-                                Ok(filled) => {
-                                    if filled > 0 {
-                                        info!(
-                                            "Reconnect gap-fill complete: {} slots backfilled",
-                                            filled
-                                        );
-                                    }
-                                }
-                                Err(DataSourceError::GapFillFailed { ref reason })
-                                    if reason.contains("Gap too large") =>
-                                {
-                                    error!(
-                                        "Reconnect gap too large (last seen: {}): {}. \
-                                         Operator should investigate; next startup backfill will catch it.",
-                                        seen, reason
-                                    );
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        "Reconnect gap-fill failed (last seen: {}): {}. Continuing reconnect.",
-                                        seen, e
-                                    );
-                                }
+                                error!(
+                                    "Reconnect gap too large (checkpoint: {}): {}. \
+                                     Operator should investigate; next startup backfill will catch it.",
+                                    checkpoint, reason
+                                );
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Reconnect gap-fill failed (checkpoint: {}): {}. Continuing reconnect.",
+                                    checkpoint, e
+                                );
                             }
                         }
                     }
@@ -288,7 +316,6 @@ async fn connect_and_stream(
     escrow_instance_id: Option<Pubkey>,
     tx: InstructionSender,
     cancellation_token: CancellationToken,
-    last_seen_slot: &AtomicU64,
     health: Option<&Arc<private_channel_metrics::HealthState>>,
 ) -> Result<(), DataSourceError> {
     let mut client = GeyserGrpcClient::build_from_shared(endpoint.to_string())
@@ -391,7 +418,6 @@ async fn connect_and_stream(
                     }
                 }
                 Some(UpdateOneof::BlockMeta(block_meta)) => {
-                    last_seen_slot.store(block_meta.slot, Ordering::Relaxed);
                     metrics::INDEXER_CHAIN_TIP_SLOT
                         .with_label_values(&[program_type.as_label()])
                         .set(block_meta.slot as f64);

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -227,11 +227,13 @@ pub async fn run(
                     indexer_config.backfill.max_gap_slots, indexer_config.backfill.batch_size
                 );
 
-                source.with_gap_detection(
-                    gap_rpc_poller,
-                    indexer_config.backfill.max_gap_slots,
-                    indexer_config.backfill.batch_size,
-                )
+                source
+                    .with_gap_detection(
+                        gap_rpc_poller,
+                        indexer_config.backfill.max_gap_slots,
+                        indexer_config.backfill.batch_size,
+                    )
+                    .with_storage(storage.clone())
             };
 
             let source = if let Some(h) = health.clone() {

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -171,10 +171,16 @@ impl MockStorage {
         slot: u64,
     ) -> Result<(), StorageError> {
         self.check_should_fail(program_type)?;
-        self.committed_checkpoints
-            .lock()
-            .unwrap()
-            .insert(program_type.to_string(), slot);
+        // Mirrors postgres GREATEST(): monotonic, lower writes are ignored.
+        // Use `set_checkpoint` to seed arbitrary values in tests.
+        let mut map = self.committed_checkpoints.lock().unwrap();
+        map.entry(program_type.to_string())
+            .and_modify(|existing| {
+                if slot > *existing {
+                    *existing = slot;
+                }
+            })
+            .or_insert(slot);
         Ok(())
     }
 

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -711,13 +711,15 @@ impl PostgresDb {
         program_type: &str,
         slot: u64,
     ) -> Result<(), sqlx::Error> {
+        // Monotonic guard: GREATEST() prevents a lower slot (e.g. backfill
+        // replay after a flushed Yellowstone update) from regressing the cursor.
         sqlx::query(
             r#"
             INSERT INTO indexer_state (program_type, last_committed_slot, updated_at)
             VALUES ($1, $2, NOW())
             ON CONFLICT (program_type)
             DO UPDATE SET
-                last_committed_slot = EXCLUDED.last_committed_slot,
+                last_committed_slot = GREATEST(indexer_state.last_committed_slot, EXCLUDED.last_committed_slot),
                 updated_at = NOW()
             "#,
         )

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -387,6 +387,23 @@ async fn checkpoint_update_higher_slot() -> Result<(), Box<dyn std::error::Error
     Ok(())
 }
 
+/// Monotonic guard: lower slot never overwrites a higher one.
+#[tokio::test(flavor = "multi_thread")]
+async fn checkpoint_update_lower_slot_is_noop() -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+
+    storage.update_committed_checkpoint("prog", 500).await?;
+    storage.update_committed_checkpoint("prog", 100).await?;
+
+    let cp = storage.get_committed_checkpoint("prog").await?;
+    assert_eq!(
+        cp,
+        Some(500),
+        "lower-slot write must not regress the persisted checkpoint"
+    );
+    Ok(())
+}
+
 // ── 8. Mint operations ───────────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread")]

--- a/integration/tests/indexer/yellowstone_reconnect_gap.rs
+++ b/integration/tests/indexer/yellowstone_reconnect_gap.rs
@@ -1,19 +1,9 @@
 //! Reconnect-gap recovery for `YellowstoneSource`.
 //!
-//! Exercises the production contract documented at `source.rs::start`:
-//! after a Yellowstone disconnect, when
-//! configured with `.with_gap_detection(rpc_poller, max_gap_slots,
-//! batch_size)`, the source should
-//!
-//!   1. detect the gap between the last streamed slot and the current
-//!      chain tip (via `RpcPoller::get_latest_slot`),
-//!   2. call `fill_slot_range` to fetch missed blocks via RPC, and
-//!   3. emit `ProcessorMessage::SlotComplete` markers for every slot in
-//!      the gap before the new streaming subscription resumes.
-//!
-//! The mock Yellowstone server provides a `drop_stream()` helper that
-//! simulates a mid-subscription disconnect; an in-process `mockito` RPC
-//! server stands in for the backfill RPC endpoint.
+//! After a Yellowstone disconnect, the source reads the durable checkpoint
+//! from storage and passes `checkpoint - 1`
+//! to `fill_slot_range` so the boundary slot is replayed via RPC. Tx/mint
+//! inserts are idempotent, so replaying is safe.
 
 use mockito::{Matcher, Server as MockitoServer};
 use private_channel_indexer::config::ProgramType;
@@ -21,6 +11,8 @@ use private_channel_indexer::indexer::datasource::common::datasource::DataSource
 use private_channel_indexer::indexer::datasource::common::types::ProcessorMessage;
 use private_channel_indexer::indexer::datasource::rpc_polling::rpc::RpcPoller;
 use private_channel_indexer::indexer::datasource::yellowstone::YellowstoneSource;
+use private_channel_indexer::storage::common::storage::mock::MockStorage;
+use private_channel_indexer::storage::Storage;
 use serde_json::json;
 use solana_sdk::commitment_config::CommitmentLevel;
 use solana_transaction_status::UiTransactionEncoding;
@@ -54,10 +46,8 @@ fn empty_block_json() -> serde_json::Value {
     })
 }
 
-/// End-to-end reconnect-gap: stream N, N+1 → drop stream → after reconnect
-/// the source should backfill N+2..=N+6 via the RpcPoller and then resume
-/// streaming. Asserts every slot in [N, N+6] shows up on the processor
-/// channel.
+/// Happy-path: checkpoint=101 → stream 100,101 → drop → backfill 101..=106
+/// inclusive (anchor = checkpoint-1 = 100) → resume streaming 107,108.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gap_fill_runs_after_drop_stream() {
     let _ = tracing_subscriber::fmt()
@@ -68,8 +58,7 @@ async fn gap_fill_runs_after_drop_stream() {
     // In-process mockito RPC backend for the RpcPoller backfill path.
     let mut rpc_mock = MockitoServer::new_async().await;
 
-    // getSlot → current chain tip = 106. The reconnect-gap logic will see
-    // last_seen_slot = 101 and ask for slots 102..=106.
+    // Chain tip = 106. Anchor = checkpoint-1 = 100 → backfill 101..=106.
     let _slot_mock = rpc_mock
         .mock("POST", "/")
         .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
@@ -79,10 +68,10 @@ async fn gap_fill_runs_after_drop_stream() {
         .create_async()
         .await;
 
-    // getBlock for each slot in the gap — empty blocks so parse_block emits
-    // no instructions, only SlotComplete markers.
+    // Empty blocks → only SlotComplete markers. Slot 101 was also streamed;
+    // replay is harmless thanks to idempotent inserts in prod.
     let mut block_mocks = Vec::new();
-    for slot in 102u64..=106u64 {
+    for slot in 101u64..=106u64 {
         let m = rpc_mock
             .mock("POST", "/")
             .match_body(Matcher::PartialJson(
@@ -111,6 +100,11 @@ async fn gap_fill_runs_after_drop_stream() {
         CommitmentLevel::Confirmed,
     ));
 
+    // Pre-seed durable checkpoint = 101. In prod the processor advances it.
+    let mock_storage = MockStorage::new();
+    mock_storage.set_checkpoint("escrow", 101);
+    let storage: Arc<Storage> = Arc::new(Storage::Mock(mock_storage));
+
     let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(256);
     let cancel = CancellationToken::new();
 
@@ -121,7 +115,8 @@ async fn gap_fill_runs_after_drop_stream() {
         ProgramType::Escrow,
         None,
     )
-    .with_gap_detection(rpc_poller, 1_000, 16);
+    .with_gap_detection(rpc_poller, 1_000, 16)
+    .with_storage(storage);
 
     let handle = source
         .start(tx, cancel.clone())
@@ -147,20 +142,16 @@ async fn gap_fill_runs_after_drop_stream() {
         }
     }
 
-    // Phase 2: kill the stream. The source will break out of
-    // connect_and_stream with Ok(()), enter the reconnect-gap block, and
-    // call RpcPoller to backfill.
+    // Phase 2: drop the stream → source reads checkpoint and backfills 101..=106.
     server.drop_stream();
 
-    // Phase 3: enqueue slots 107, 108 so that once the source reconnects
-    // post-backfill, streaming resumes cleanly (and we can assert on it).
+    // Phase 3: queue 107,108 to prove streaming resumes post-backfill.
     server.enqueue(UpdateMatcher, Update::ok(block_meta(107)));
     server.enqueue(UpdateMatcher, Update::ok(block_meta(108)));
 
-    // Collect the remaining SlotCompletes. Expect 102..=106 from backfill
-    // plus 107, 108 from the resumed stream.
+    // Expect 101..=106 from inclusive backfill + 107,108 from resumed stream.
     let deadline_phase2 = tokio::time::Instant::now() + Duration::from_secs(20);
-    let wanted: HashSet<u64> = (102u64..=108u64).collect();
+    let wanted: HashSet<u64> = (101u64..=108u64).collect();
     while !wanted.is_subset(&seen) {
         let remaining = deadline_phase2.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
@@ -191,6 +182,85 @@ async fn gap_fill_runs_after_drop_stream() {
     );
 
     // Teardown.
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    server.shutdown().await;
+}
+
+/// Error path: fresh system (checkpoint=0) must skip reconnect gap-fill —
+/// no RPC backfill calls, no spurious SlotCompletes. Startup backfill (when
+/// configured) is responsible for initial catch-up, not the reconnect path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fresh_system_reconnect_does_not_gap_fill() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+
+    let mut rpc_mock = MockitoServer::new_async().await;
+
+    // No getBlock mocks — any call would panic mockito's matcher. getSlot is
+    // tolerated (the reconnect path may probe it before checking checkpoint).
+    let _slot_mock = rpc_mock
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": 200, "id": 1}).to_string())
+        .expect_at_most(1)
+        .create_async()
+        .await;
+
+    let server = MockYellowstoneServer::start().await;
+
+    let rpc_poller = Arc::new(RpcPoller::new(
+        rpc_mock.url(),
+        UiTransactionEncoding::Json,
+        CommitmentLevel::Confirmed,
+    ));
+
+    // No checkpoint seeded → get_last_checkpoint returns 0 → skip path.
+    let storage: Arc<Storage> = Arc::new(Storage::Mock(MockStorage::new()));
+
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(64);
+    let cancel = CancellationToken::new();
+
+    let mut source = YellowstoneSource::new(
+        server.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(rpc_poller, 1_000, 16)
+    .with_storage(storage);
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    // Stream one slot, drop, give the reconnect path time to run.
+    server.enqueue(UpdateMatcher, Update::ok(block_meta(100)));
+    let _ = tokio::time::timeout(Duration::from_secs(2), rx.recv()).await;
+    server.drop_stream();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Drain the channel — only the streamed slot 100 should appear, never
+    // any backfill SlotCompletes (which would mean we contacted the RPC).
+    let mut all_slots = vec![];
+    while let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
+        tokio::time::timeout(Duration::from_millis(50), rx.recv()).await
+    {
+        all_slots.push(slot);
+    }
+
+    let unexpected: Vec<_> = all_slots.iter().filter(|&&s| s != 100).collect();
+    assert!(
+        unexpected.is_empty(),
+        "fresh system must NOT trigger gap-fill; unexpected slots: {:?}",
+        unexpected
+    );
+
     cancel.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
     server.shutdown().await;


### PR DESCRIPTION
## Summary

Addresses SOLA2-22 and SOLA2-7 from v1 scan.
Closes two correctness bugs in the indexer's slot-completion pipeline that could permanently drop a real deposit or withdrawal, plus a latent checkpoint-regression at the DB layer that the primary fix would otherwise expose more frequently.

"slot complete" was being inferred from metadata or cursor progress rather than from data actually being durably persisted. Each fix moves the source of truth to the durable checkpoint and relies on the existing idempotency of tx/mint inserts to absorb safe replays.

## Scope

**Yellowstone reconnect anchor: durable checkpoint, not in-memory watermark**

The old reconnect path advanced `last_seen_slot` on `BlockMeta(S)` arrival and replayed `S+1..tip` on reconnect. But `BlockMeta(S)` is not proof all filtered transactions for `S` were delivered because Yellowstone treats meta and transaction updates as separate per-slot inputs. A disconnect after meta but before all txs will leave deposits stranded.

**RPC polling: don't advance on fetch failure**

The polling loop previously logged `getBlock(slot)` errors then fell through to emit `SlotComplete { slot }` and advance `current_slot`. A single transient RPC error checkpointed past an unparsed slot. Real deposits in that slot were lost forever.

The `Err` arm now backs off and `break`s the inner for-loop without emitting `SlotComplete` or advancing. The outer loop's next iteration calls `get_slots_to_process(current_slot, ...)` which returns the same failed slot and retries until success.

**Adjacent fix: monotonic checkpoint at the DB layer**

`CheckpointWriter`'s pending map merges to per-program max within a flush batch but is cleared after each flush. A lower slot arriving in a later batch could regress the persisted cursor.

One-line SQL change in `update_committed_checkpoint_internal`:

## Tests

- **Yellowstone reconnect (integration):** fresh-system (checkpoint=0) error path.
- **RPC polling (unit):** persistent-fetch-error retry path.
- **Checkpoint monotonicity (postgres integration):** write 500 then 100, expect 500.
- Existing yellowstone wiring / inner-instruction / malformed-update suites unchanged.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,620 | 11,100 | 86.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26167726520) |
| Indexer | 15,346 | 17,998 | 85.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26167726520) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26167726520) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26167726520) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 10,002 | 12,376 | 80.8% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26167726520) |
| **Total** | **36,679** | **43,469** | **84.4%** | |

> Last updated: 2026-05-20 14:26:59 UTC by E2E Integration