### PR TITLE
fix(indexer): use history-searching RPC for post-restart finality check (SOLA3-9)

### DIFF
--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -207,7 +207,7 @@ pub async fn process_pending_remints(
 
         match state
             .rpc_client
-            .get_signature_statuses(&entry.signatures)
+            .get_signature_statuses_with_history(&entry.signatures)
             .await
         {
             Ok(response) => {
@@ -582,6 +582,10 @@ mod tests {
 
         let _mock = rpc_server
             .mock("POST", "/")
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex(r#""method"\s*:\s*"getSignatureStatuses""#.into()),
+                mockito::Matcher::Regex(r#""searchTransactionHistory"\s*:\s*true"#.into()),
+            ]))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -656,6 +660,10 @@ mod tests {
         // Finality check: null means the tx was dropped — proceed to remint.
         let _mock = rpc_server
             .mock("POST", "/")
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex(r#""method"\s*:\s*"getSignatureStatuses""#.into()),
+                mockito::Matcher::Regex(r#""searchTransactionHistory"\s*:\s*true"#.into()),
+            ]))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -263,9 +263,9 @@ impl SenderState {
             };
 
             // Parse all stored withdrawal signatures. These are passed to
-            // get_signature_statuses() by process_pending_remints to verify the
-            // withdrawal did not finalize before we remint. A single bad entry
-            // means we cannot safely do that check — escalate to ManualReview.
+            // get_signature_statuses_with_history() by process_pending_remints to verify
+            // the withdrawal did not finalize before we remint. A single bad entry means
+            // we cannot safely do that check — escalate to ManualReview.
             let sig_strings = tx.remint_signatures.unwrap_or_default();
             let Some(signatures) = Self::or_manual_review(
                 sig_strings

--- a/indexer/src/operator/utils/rpc_util.rs
+++ b/indexer/src/operator/utils/rpc_util.rs
@@ -210,6 +210,32 @@ impl RpcClientWithRetry {
         .await
     }
 
+    /// Like `get_signature_statuses`, but sets `searchTransactionHistory: true` so the
+    /// validator consults long-term ledger storage when the recent status cache misses.
+    /// Use for authoritative finality checks where the signature may have aged out of
+    /// cache (e.g. recovery after operator downtime); an `Ok` response with all `None`
+    /// means the signature is genuinely not on-chain.
+    pub async fn get_signature_statuses_with_history(
+        &self,
+        signatures: &[Signature],
+    ) -> Result<
+        solana_client::rpc_response::Response<
+            Vec<Option<solana_transaction_status::TransactionStatus>>,
+        >,
+        Box<client_error::Error>,
+    > {
+        self.with_retry(
+            "get_signature_statuses_with_history",
+            RetryPolicy::Idempotent,
+            || async {
+                self.rpc_client
+                    .get_signature_statuses_with_history(signatures)
+                    .await
+            },
+        )
+        .await
+    }
+
     /// Get recent signatures that touched an address (read-only, safe to retry)
     pub async fn get_signatures_for_address(
         &self,


### PR DESCRIPTION
## Summary
Fixes SOLA3-9: post-restart finality check used the cache-only `getSignatureStatuses` RPC, so a withdrawal that finalized on-chain could come back as `null` once its signature aged out of the validator's status cache. `process_pending_remints` then reminted, double-paying the user.

Swaps the finality check to `get_signature_statuses_with_history` (sets `searchTransactionHistory: true`), so the validator consults long-term ledger storage. An `Ok` response with all `None` is now authoritative "did not land" rather than "maybe aged out." Existing branches already cover the rest of the audit's requirements:
  - `Ok` finalized → `Completed`, skip remint
  - `Ok` all `None` (history-searched) → safe to remint
  - `Err` → retry up to 3 then `ManualReview` — never optimistic mint
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,620 | 11,100 | 86.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26176605573) |
| Indexer | 15,177 | 17,878 | 84.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26176605573) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26176605573) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26176605573) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 10,022 | 12,381 | 80.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26176605573) |
| **Total** | **36,530** | **43,354** | **84.3%** | |

> Last updated: 2026-05-20 17:09:31 UTC by E2E Integration