### PR TITLE
fix(core): repair address_signatures index on startup, fail closed on…

### DIFF
--- a/core/src/accounts/address_index_repair.rs
+++ b/core/src/accounts/address_index_repair.rs
@@ -5,6 +5,7 @@ use {
                 get_address_signatures_flushed_slot, upsert_address_signatures_flushed_slot_in_tx,
                 ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY,
             },
+            get_latest_slot::get_latest_slot,
             traits::{AccountsDB, BlockInfo},
             types::StoredTransaction,
             write_batch::{upsert_address_signature_rows, AddressSignatureRow},
@@ -35,15 +36,14 @@ pub async fn repair_address_signatures(db: &AccountsDB, _metrics: SharedMetrics)
         .context("Failed to read address_signatures watermark")?
         .unwrap_or(-1);
 
-    let max_block: Option<i64> = sqlx::query_scalar("SELECT MAX(slot) FROM blocks")
-        .fetch_one(pool.as_ref())
+    let Some(max_block_u64) = get_latest_slot(db)
         .await
-        .context("Failed to query max block slot")?;
-
-    let Some(max_block) = max_block else {
+        .context("Failed to query max block slot")?
+    else {
         info!("address_signatures repair: no blocks present, nothing to do");
         return Ok(());
     };
+    let max_block = max_block_u64 as i64;
 
     if max_block <= watermark {
         info!(

--- a/core/src/accounts/address_index_repair.rs
+++ b/core/src/accounts/address_index_repair.rs
@@ -1,0 +1,428 @@
+use {
+    crate::{
+        accounts::{
+            address_index_watermark::{
+                get_address_signatures_flushed_slot, upsert_address_signatures_flushed_slot_in_tx,
+                ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY,
+            },
+            traits::{AccountsDB, BlockInfo},
+            types::StoredTransaction,
+            write_batch::{upsert_address_signature_rows, AddressSignatureRow},
+        },
+        stage_metrics::SharedMetrics,
+    },
+    anyhow::{anyhow, Context, Result},
+    solana_sdk::signature::Signature,
+    sqlx::{PgPool, Row},
+    std::sync::Arc,
+    tracing::{info, warn},
+};
+
+/// Re-derive missing rows. Idempotent.
+pub async fn repair_address_signatures(db: &AccountsDB, _metrics: SharedMetrics) -> Result<()> {
+    let postgres_db = match db {
+        AccountsDB::Postgres(p) => p,
+        AccountsDB::Redis(_) => {
+            info!("address_signatures repair skipped (Redis backend)");
+            return Ok(());
+        }
+    };
+
+    let pool = Arc::clone(&postgres_db.pool);
+
+    let watermark = get_address_signatures_flushed_slot(&pool)
+        .await
+        .context("Failed to read address_signatures watermark")?
+        .unwrap_or(-1);
+
+    let max_block: Option<i64> = sqlx::query_scalar("SELECT MAX(slot) FROM blocks")
+        .fetch_one(pool.as_ref())
+        .await
+        .context("Failed to query max block slot")?;
+
+    let Some(max_block) = max_block else {
+        info!("address_signatures repair: no blocks present, nothing to do");
+        return Ok(());
+    };
+
+    if max_block <= watermark {
+        info!(
+            watermark,
+            max_block, "address_signatures repair: already consistent"
+        );
+        return Ok(());
+    }
+
+    info!(
+        watermark,
+        max_block, "address_signatures repair: scanning slot range"
+    );
+
+    let mut repaired_rows: u64 = 0;
+    let mut repaired_slots: u64 = 0;
+    let mut cursor: i64 = watermark;
+    const SLOT_PAGE: i64 = 256;
+
+    while cursor < max_block {
+        let upper = std::cmp::min(cursor.saturating_add(SLOT_PAGE), max_block);
+        let rows = sqlx::query(
+            "SELECT slot, data FROM blocks
+             WHERE slot > $1 AND slot <= $2
+             ORDER BY slot ASC",
+        )
+        .bind(cursor)
+        .bind(upper)
+        .fetch_all(pool.as_ref())
+        .await
+        .context("Failed to fetch blocks for repair")?;
+
+        if rows.is_empty() {
+            cursor = upper;
+            continue;
+        }
+
+        for row in rows {
+            let slot: i64 = row.get("slot");
+            let data: Vec<u8> = row.get("data");
+            let block: BlockInfo = bincode::deserialize(&data)
+                .with_context(|| format!("Failed to deserialize block at slot {}", slot))?;
+
+            let derived = derive_rows_for_block(pool.as_ref(), slot, &block).await?;
+            let n = derived.len();
+
+            let mut pg_tx = pool
+                .begin()
+                .await
+                .context("Failed to begin repair transaction")?;
+
+            upsert_address_signature_rows(&mut pg_tx, &derived)
+                .await
+                .with_context(|| format!("Repair insert failed for slot {}", slot))?;
+
+            upsert_address_signatures_flushed_slot_in_tx(&mut pg_tx, slot)
+                .await
+                .with_context(|| format!("Repair watermark update failed for slot {}", slot))?;
+
+            pg_tx
+                .commit()
+                .await
+                .with_context(|| format!("Repair commit failed for slot {}", slot))?;
+
+            repaired_rows = repaired_rows.saturating_add(n as u64);
+            repaired_slots = repaired_slots.saturating_add(1);
+            cursor = slot;
+        }
+
+        if cursor < upper {
+            cursor = upper;
+        }
+    }
+
+    info!(
+        watermark,
+        max_block,
+        repaired_slots,
+        repaired_rows,
+        ?ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY,
+        "address_signatures repair complete"
+    );
+    Ok(())
+}
+
+async fn derive_rows_for_block(
+    pool: &PgPool,
+    slot: i64,
+    block: &BlockInfo,
+) -> Result<Vec<AddressSignatureRow>> {
+    if block.transaction_signatures.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let sig_bytes: Vec<Vec<u8>> = block
+        .transaction_signatures
+        .iter()
+        .map(|s| s.as_ref().to_vec())
+        .collect();
+    let sig_refs: Vec<&[u8]> = sig_bytes.iter().map(|v| v.as_slice()).collect();
+
+    let rows = sqlx::query(
+        "SELECT signature, data FROM transactions
+         WHERE signature = ANY($1::bytea[])",
+    )
+    .bind(&sig_refs)
+    .fetch_all(pool)
+    .await
+    .with_context(|| format!("Failed to fetch transactions for slot {}", slot))?;
+
+    let mut out: Vec<AddressSignatureRow> = Vec::with_capacity(rows.len() * 7);
+    for row in rows {
+        let sig_bytes: Vec<u8> = row.get("signature");
+        let data: Vec<u8> = row.get("data");
+        let stored: StoredTransaction = match bincode::deserialize(&data) {
+            Ok(t) => t,
+            Err(e) => {
+                let sig = Signature::try_from(sig_bytes.as_slice())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|_| "<unparseable>".to_string());
+                return Err(anyhow!(
+                    "Repair: failed to deserialize transaction {} at slot {}: {}",
+                    sig,
+                    slot,
+                    e
+                ));
+            }
+        };
+
+        let keys = stored.transaction.message.static_account_keys();
+        for pk in keys {
+            out.push(AddressSignatureRow {
+                address: pk.to_bytes().to_vec(),
+                slot,
+                signature: sig_bytes.clone(),
+            });
+        }
+    }
+
+    if out.is_empty() && !block.transaction_signatures.is_empty() {
+        warn!(
+            slot,
+            block_sigs = block.transaction_signatures.len(),
+            "address_signatures repair: block lists txs but transactions table has none"
+        );
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        accounts::write_batch::AddressSignatureRow,
+        stage_metrics::NoopMetrics,
+        test_helpers::{
+            create_test_block_info, create_test_sanitized_transaction, start_test_postgres,
+        },
+    };
+    use solana_sdk::{hash::Hash, signature::Keypair};
+    use solana_svm::{
+        account_loader::LoadedTransaction,
+        transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
+        transaction_processing_result::ProcessedTransaction,
+    };
+    use std::collections::HashMap;
+
+    async fn count_addr_sig_rows(db: &AccountsDB) -> i64 {
+        let pg = match db {
+            AccountsDB::Postgres(p) => p,
+            _ => panic!("expected Postgres"),
+        };
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM address_signatures")
+            .fetch_one(pg.pool.as_ref())
+            .await
+            .unwrap()
+    }
+
+    async fn fetch_addr_sig_rows(db: &AccountsDB) -> Vec<(Vec<u8>, i64, Vec<u8>)> {
+        let pg = match db {
+            AccountsDB::Postgres(p) => p,
+            _ => panic!("expected Postgres"),
+        };
+        let rows = sqlx::query("SELECT address, slot, signature FROM address_signatures")
+            .fetch_all(pg.pool.as_ref())
+            .await
+            .unwrap();
+        let mut out: Vec<(Vec<u8>, i64, Vec<u8>)> = rows
+            .into_iter()
+            .map(|r| (r.get("address"), r.get("slot"), r.get("signature")))
+            .collect();
+        out.sort();
+        out
+    }
+
+    fn expected_rows_for(
+        tx: &solana_sdk::transaction::SanitizedTransaction,
+        slot: i64,
+    ) -> Vec<(Vec<u8>, i64, Vec<u8>)> {
+        let sig = tx.signature().as_ref().to_vec();
+        let mut out: Vec<(Vec<u8>, i64, Vec<u8>)> = tx
+            .message()
+            .account_keys()
+            .iter()
+            .map(|pk| (pk.to_bytes().to_vec(), slot, sig.clone()))
+            .collect();
+        out.sort();
+        out
+    }
+
+    async fn clear_address_signatures(db: &AccountsDB) {
+        let pg = match db {
+            AccountsDB::Postgres(p) => p,
+            _ => panic!("expected Postgres"),
+        };
+        sqlx::query("DELETE FROM address_signatures")
+            .execute(pg.pool.as_ref())
+            .await
+            .unwrap();
+    }
+
+    fn make_processed() -> ProcessedTransaction {
+        ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                accounts: vec![],
+                ..Default::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status: Ok(()),
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: HashMap::new(),
+        }))
+    }
+
+    /// Repair derives rows + advances watermark.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn repair_derives_missing_rows_and_advances_watermark() {
+        let (mut db, _pg) = start_test_postgres().await;
+
+        let from_a = Keypair::new();
+        let to_a = solana_sdk::pubkey::Pubkey::new_unique();
+        let tx_a = create_test_sanitized_transaction(&from_a, &to_a, 1);
+        let sig_a = *tx_a.signature();
+        let from_b = Keypair::new();
+        let to_b = solana_sdk::pubkey::Pubkey::new_unique();
+        let tx_b = create_test_sanitized_transaction(&from_b, &to_b, 1);
+        let sig_b = *tx_b.signature();
+
+        let _: Vec<AddressSignatureRow> = db
+            .write_batch(
+                &[],
+                vec![(sig_a, &tx_a, 100, 1_700_000_000, &make_processed())],
+                Some(create_test_block_info(100, Hash::new_unique())),
+            )
+            .await
+            .unwrap();
+        let _: Vec<AddressSignatureRow> = db
+            .write_batch(
+                &[],
+                vec![(sig_b, &tx_b, 101, 1_700_000_000, &make_processed())],
+                Some(create_test_block_info(101, Hash::new_unique())),
+            )
+            .await
+            .unwrap();
+
+        // Block must list the tx signatures.
+        let pg = match &db {
+            AccountsDB::Postgres(p) => p.pool.clone(),
+            _ => panic!("expected Postgres"),
+        };
+        for (slot, sig) in [(100i64, sig_a), (101, sig_b)] {
+            let mut block = create_test_block_info(slot as u64, Hash::new_unique());
+            block.transaction_signatures = vec![sig];
+            let data = bincode::serialize(&block).unwrap();
+            sqlx::query("UPDATE blocks SET data = $1 WHERE slot = $2")
+                .bind(&data)
+                .bind(slot)
+                .execute(pg.as_ref())
+                .await
+                .unwrap();
+        }
+
+        // Simulate the crash gap.
+        clear_address_signatures(&db).await;
+        assert_eq!(count_addr_sig_rows(&db).await, 0);
+
+        repair_address_signatures(&db, Arc::new(NoopMetrics) as SharedMetrics)
+            .await
+            .unwrap();
+
+        let mut expected = expected_rows_for(&tx_a, 100);
+        expected.extend(expected_rows_for(&tx_b, 101));
+        expected.sort();
+        assert!(!expected.is_empty(), "test setup produced no expected rows");
+
+        let actual = fetch_addr_sig_rows(&db).await;
+        assert_eq!(
+            actual, expected,
+            "repaired rows must match the (address, slot, signature) triples \
+             derived from tx_a@100 and tx_b@101 exactly"
+        );
+
+        let wm = get_address_signatures_flushed_slot(&pg).await.unwrap();
+        assert_eq!(
+            wm,
+            Some(101),
+            "watermark must advance to the max repaired slot"
+        );
+    }
+
+    /// Second run inserts no new rows.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn repair_is_idempotent_on_rerun() {
+        let (mut db, _pg) = start_test_postgres().await;
+
+        let from = Keypair::new();
+        let to = solana_sdk::pubkey::Pubkey::new_unique();
+        let tx = create_test_sanitized_transaction(&from, &to, 1);
+        let sig = *tx.signature();
+
+        db.write_batch(
+            &[],
+            vec![(sig, &tx, 50, 1_700_000_000, &make_processed())],
+            Some(create_test_block_info(50, Hash::new_unique())),
+        )
+        .await
+        .unwrap();
+
+        let pg = match &db {
+            AccountsDB::Postgres(p) => p.pool.clone(),
+            _ => panic!("expected Postgres"),
+        };
+        let mut block = create_test_block_info(50, Hash::new_unique());
+        block.transaction_signatures = vec![sig];
+        let data = bincode::serialize(&block).unwrap();
+        sqlx::query("UPDATE blocks SET data = $1 WHERE slot = $2")
+            .bind(&data)
+            .bind(50i64)
+            .execute(pg.as_ref())
+            .await
+            .unwrap();
+
+        clear_address_signatures(&db).await;
+
+        let expected = expected_rows_for(&tx, 50);
+        assert!(!expected.is_empty(), "test setup produced no expected rows");
+
+        repair_address_signatures(&db, Arc::new(NoopMetrics) as SharedMetrics)
+            .await
+            .unwrap();
+        let rows_first = fetch_addr_sig_rows(&db).await;
+        let wm_first = get_address_signatures_flushed_slot(&pg).await.unwrap();
+
+        assert_eq!(
+            rows_first, expected,
+            "first repair must produce the exact expected row set"
+        );
+        assert_eq!(
+            wm_first,
+            Some(50),
+            "watermark must advance to slot 50 after first repair"
+        );
+
+        repair_address_signatures(&db, Arc::new(NoopMetrics) as SharedMetrics)
+            .await
+            .unwrap();
+        let rows_second = fetch_addr_sig_rows(&db).await;
+        let wm_second = get_address_signatures_flushed_slot(&pg).await.unwrap();
+
+        assert_eq!(
+            rows_second, rows_first,
+            "rerun must not add, remove, or alter any row"
+        );
+        assert_eq!(wm_second, wm_first, "rerun must not change the watermark");
+    }
+}

--- a/core/src/accounts/address_index_repair.rs
+++ b/core/src/accounts/address_index_repair.rs
@@ -511,7 +511,10 @@ mod tests {
         // a pre-existing DB rather than a crash gap.
         clear_address_signatures(&db).await;
         assert_eq!(count_addr_sig_rows(&db).await, 0);
-        assert_eq!(get_address_signatures_flushed_slot(&pg).await.unwrap(), None);
+        assert_eq!(
+            get_address_signatures_flushed_slot(&pg).await.unwrap(),
+            None
+        );
 
         repair_address_signatures(&db, Arc::new(NoopMetrics) as SharedMetrics)
             .await

--- a/core/src/accounts/address_index_repair.rs
+++ b/core/src/accounts/address_index_repair.rs
@@ -173,8 +173,16 @@ async fn derive_rows_for_block(
             }
         };
 
-        let keys = stored.transaction.message.static_account_keys();
-        for pk in keys {
+        let tx_with_meta = stored.transaction_with_status_meta();
+        let solana_transaction_status::TransactionWithStatusMeta::Complete(versioned) =
+            tx_with_meta
+        else {
+            return Err(anyhow!(
+                "Repair: transaction_with_status_meta returned non-Complete at slot {}",
+                slot
+            ));
+        };
+        for pk in versioned.account_keys().iter() {
             out.push(AddressSignatureRow {
                 address: pk.to_bytes().to_vec(),
                 slot,

--- a/core/src/accounts/address_index_repair.rs
+++ b/core/src/accounts/address_index_repair.rs
@@ -31,10 +31,9 @@ pub async fn repair_address_signatures(db: &AccountsDB, _metrics: SharedMetrics)
 
     let pool = Arc::clone(&postgres_db.pool);
 
-    let watermark = get_address_signatures_flushed_slot(&pool)
+    let watermark_opt = get_address_signatures_flushed_slot(&pool)
         .await
-        .context("Failed to read address_signatures watermark")?
-        .unwrap_or(-1);
+        .context("Failed to read address_signatures watermark")?;
 
     let Some(max_block_u64) = get_latest_slot(db)
         .await
@@ -43,7 +42,31 @@ pub async fn repair_address_signatures(db: &AccountsDB, _metrics: SharedMetrics)
         info!("address_signatures repair: no blocks present, nothing to do");
         return Ok(());
     };
-    let max_block = max_block_u64 as i64;
+    let max_block = i64::try_from(max_block_u64).context("max block slot exceeds i64::MAX")?;
+
+    // No watermark row yet: first run against an existing DB. Re-deriving the
+    // entire block history would block startup for the full slot range, so
+    // instead trust the existing index up to the current tip and seed the
+    // watermark. Every later crash is then bounded to (watermark, max_block] by
+    // the watermark the live writer advances.
+    let Some(watermark) = watermark_opt else {
+        info!(
+            max_block,
+            "address_signatures repair: no watermark, seeding to current tip"
+        );
+        let mut pg_tx = pool
+            .begin()
+            .await
+            .context("Failed to begin watermark seed transaction")?;
+        upsert_address_signatures_flushed_slot_in_tx(&mut pg_tx, max_block)
+            .await
+            .context("Failed to seed address_signatures watermark")?;
+        pg_tx
+            .commit()
+            .await
+            .context("Failed to commit watermark seed")?;
+        return Ok(());
+    };
 
     if max_block <= watermark {
         info!(
@@ -274,6 +297,20 @@ mod tests {
             .unwrap();
     }
 
+    /// Seed the watermark below the gap, simulating a writer that crashed after
+    /// progressing to `slot`. Repair only scans `(watermark, max_block]`.
+    async fn set_watermark(db: &AccountsDB, slot: i64) {
+        let pg = match db {
+            AccountsDB::Postgres(p) => p,
+            _ => panic!("expected Postgres"),
+        };
+        let mut tx = pg.pool.begin().await.unwrap();
+        upsert_address_signatures_flushed_slot_in_tx(&mut tx, slot)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+    }
+
     fn make_processed() -> ProcessedTransaction {
         ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
             loaded_transaction: LoadedTransaction {
@@ -340,9 +377,11 @@ mod tests {
                 .unwrap();
         }
 
-        // Simulate the crash gap.
+        // Simulate the crash gap: writer had flushed through slot 99, then
+        // crashed leaving slots 100-101 unindexed.
         clear_address_signatures(&db).await;
         assert_eq!(count_addr_sig_rows(&db).await, 0);
+        set_watermark(&db, 99).await;
 
         repair_address_signatures(&db, Arc::new(NoopMetrics) as SharedMetrics)
             .await
@@ -401,6 +440,7 @@ mod tests {
             .unwrap();
 
         clear_address_signatures(&db).await;
+        set_watermark(&db, 49).await;
 
         let expected = expected_rows_for(&tx, 50);
         assert!(!expected.is_empty(), "test setup produced no expected rows");
@@ -432,5 +472,61 @@ mod tests {
             "rerun must not add, remove, or alter any row"
         );
         assert_eq!(wm_second, wm_first, "rerun must not change the watermark");
+    }
+
+    /// First run against an existing DB (no watermark) seeds to the tip and does
+    /// NOT re-derive history — avoids an unbounded startup scan over all blocks.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn repair_seeds_watermark_to_tip_when_unset() {
+        let (mut db, _pg) = start_test_postgres().await;
+
+        let from = Keypair::new();
+        let to = solana_sdk::pubkey::Pubkey::new_unique();
+        let tx = create_test_sanitized_transaction(&from, &to, 1);
+        let sig = *tx.signature();
+
+        db.write_batch(
+            &[],
+            vec![(sig, &tx, 70, 1_700_000_000, &make_processed())],
+            Some(create_test_block_info(70, Hash::new_unique())),
+        )
+        .await
+        .unwrap();
+
+        let pg = match &db {
+            AccountsDB::Postgres(p) => p.pool.clone(),
+            _ => panic!("expected Postgres"),
+        };
+        let mut block = create_test_block_info(70, Hash::new_unique());
+        block.transaction_signatures = vec![sig];
+        let data = bincode::serialize(&block).unwrap();
+        sqlx::query("UPDATE blocks SET data = $1 WHERE slot = $2")
+            .bind(&data)
+            .bind(70i64)
+            .execute(pg.as_ref())
+            .await
+            .unwrap();
+
+        // No watermark set, address_signatures empty: simulates first run against
+        // a pre-existing DB rather than a crash gap.
+        clear_address_signatures(&db).await;
+        assert_eq!(count_addr_sig_rows(&db).await, 0);
+        assert_eq!(get_address_signatures_flushed_slot(&pg).await.unwrap(), None);
+
+        repair_address_signatures(&db, Arc::new(NoopMetrics) as SharedMetrics)
+            .await
+            .unwrap();
+
+        // Must NOT backfill history; must seed the watermark to the current tip.
+        assert_eq!(
+            count_addr_sig_rows(&db).await,
+            0,
+            "unset watermark must not trigger a full-history backfill"
+        );
+        assert_eq!(
+            get_address_signatures_flushed_slot(&pg).await.unwrap(),
+            Some(70),
+            "watermark must be seeded to the current tip"
+        );
     }
 }

--- a/core/src/accounts/address_index_watermark.rs
+++ b/core/src/accounts/address_index_watermark.rs
@@ -3,14 +3,23 @@ use sqlx::{PgPool, Postgres, Transaction};
 pub const ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY: &str = "address_signatures_flushed_slot";
 
 pub async fn get_address_signatures_flushed_slot(pool: &PgPool) -> sqlx::Result<Option<i64>> {
-    let bytes: Option<Vec<u8>> = sqlx::query_scalar("SELECT value FROM metadata WHERE key = $1")
-        .bind(ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY)
-        .fetch_optional(pool)
-        .await?;
+    let result =
+        sqlx::query_scalar::<_, Option<Vec<u8>>>("SELECT value FROM metadata WHERE key = $1")
+            .bind(ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY)
+            .fetch_optional(pool)
+            .await;
+
+    let bytes = match result {
+        Ok(Some(Some(b))) => Some(b),
+        Ok(Some(None)) | Ok(None) => None,
+        // 42P01 = undefined_table; schema not yet created.
+        Err(sqlx::Error::Database(e)) if e.code().as_deref() == Some("42P01") => return Ok(None),
+        Err(e) => return Err(e),
+    };
 
     Ok(bytes.and_then(|b| {
         let arr: [u8; 8] = b.as_slice().try_into().ok()?;
-        Some(i64::from_le_bytes(arr))
+        Some(i64::from_be_bytes(arr))
     }))
 }
 
@@ -26,7 +35,7 @@ pub async fn upsert_address_signatures_flushed_slot_in_tx(
          WHERE metadata.value < EXCLUDED.value",
     )
     .bind(ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY)
-    .bind(slot.to_le_bytes().to_vec())
+    .bind(slot.to_be_bytes().to_vec())
     .execute(&mut **tx)
     .await?;
     Ok(())
@@ -36,12 +45,40 @@ pub async fn upsert_address_signatures_flushed_slot_in_tx(
 mod tests {
     use super::*;
     use crate::test_helpers::start_test_postgres_raw;
+    use sqlx::postgres::PgPoolOptions;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_watermark_returns_none_when_unset() {
         let (db, _pg) = start_test_postgres_raw().await;
         let v = get_address_signatures_flushed_slot(&db.pool).await.unwrap();
         assert!(v.is_none());
+    }
+
+    /// Fresh DB with no schema must yield None, not an error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_watermark_tolerates_missing_metadata_table() {
+        use testcontainers::runners::AsyncRunner;
+        use testcontainers_modules::postgres::Postgres;
+        let container = Postgres::default()
+            .with_db_name("pg_no_schema")
+            .with_user("postgres")
+            .with_password("password")
+            .start()
+            .await
+            .unwrap();
+        let host = container.get_host().await.unwrap();
+        let port = container.get_host_port_ipv4(5432).await.unwrap();
+        let url = format!(
+            "postgres://postgres:password@{}:{}/pg_no_schema",
+            host, port
+        );
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .unwrap();
+        let v = get_address_signatures_flushed_slot(&pool).await.unwrap();
+        assert!(v.is_none(), "fresh DB must not error on missing schema");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -55,6 +92,31 @@ mod tests {
 
         let v = get_address_signatures_flushed_slot(&db.pool).await.unwrap();
         assert_eq!(v, Some(42));
+    }
+
+    /// Bytea lexicographic compare must match integer compare across 256.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn upsert_advances_across_256_byte_boundary() {
+        let (db, _pg) = start_test_postgres_raw().await;
+
+        let mut tx = db.pool.begin().await.unwrap();
+        upsert_address_signatures_flushed_slot_in_tx(&mut tx, 255)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let mut tx = db.pool.begin().await.unwrap();
+        upsert_address_signatures_flushed_slot_in_tx(&mut tx, 256)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let v = get_address_signatures_flushed_slot(&db.pool).await.unwrap();
+        assert_eq!(
+            v,
+            Some(256),
+            "watermark must advance from 255 to 256 under bytea < comparison"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/core/src/accounts/address_index_watermark.rs
+++ b/core/src/accounts/address_index_watermark.rs
@@ -1,0 +1,88 @@
+use sqlx::{PgPool, Postgres, Transaction};
+
+pub const ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY: &str = "address_signatures_flushed_slot";
+
+pub async fn get_address_signatures_flushed_slot(pool: &PgPool) -> sqlx::Result<Option<i64>> {
+    let bytes: Option<Vec<u8>> = sqlx::query_scalar("SELECT value FROM metadata WHERE key = $1")
+        .bind(ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY)
+        .fetch_optional(pool)
+        .await?;
+
+    Ok(bytes.and_then(|b| {
+        let arr: [u8; 8] = b.as_slice().try_into().ok()?;
+        Some(i64::from_le_bytes(arr))
+    }))
+}
+
+/// Monotonic UPSERT; never rewinds.
+pub async fn upsert_address_signatures_flushed_slot_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    slot: i64,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO metadata (key, value) VALUES ($1, $2)
+         ON CONFLICT (key) DO UPDATE
+         SET value = EXCLUDED.value
+         WHERE metadata.value < EXCLUDED.value",
+    )
+    .bind(ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY)
+    .bind(slot.to_le_bytes().to_vec())
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::start_test_postgres_raw;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_watermark_returns_none_when_unset() {
+        let (db, _pg) = start_test_postgres_raw().await;
+        let v = get_address_signatures_flushed_slot(&db.pool).await.unwrap();
+        assert!(v.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn upsert_then_get_roundtrip() {
+        let (db, _pg) = start_test_postgres_raw().await;
+        let mut tx = db.pool.begin().await.unwrap();
+        upsert_address_signatures_flushed_slot_in_tx(&mut tx, 42)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let v = get_address_signatures_flushed_slot(&db.pool).await.unwrap();
+        assert_eq!(v, Some(42));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn upsert_is_monotonic() {
+        let (db, _pg) = start_test_postgres_raw().await;
+
+        let mut tx = db.pool.begin().await.unwrap();
+        upsert_address_signatures_flushed_slot_in_tx(&mut tx, 100)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let mut tx = db.pool.begin().await.unwrap();
+        upsert_address_signatures_flushed_slot_in_tx(&mut tx, 50)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let v = get_address_signatures_flushed_slot(&db.pool).await.unwrap();
+        assert_eq!(v, Some(100), "watermark must not rewind");
+
+        let mut tx = db.pool.begin().await.unwrap();
+        upsert_address_signatures_flushed_slot_in_tx(&mut tx, 200)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let v = get_address_signatures_flushed_slot(&db.pool).await.unwrap();
+        assert_eq!(v, Some(200));
+    }
+}

--- a/core/src/accounts/address_index_watermark.rs
+++ b/core/src/accounts/address_index_watermark.rs
@@ -28,6 +28,10 @@ pub async fn upsert_address_signatures_flushed_slot_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     slot: i64,
 ) -> sqlx::Result<()> {
+    debug_assert!(
+        slot >= 0,
+        "watermark slot must be non-negative; a negative slot breaks the big-endian bytea monotonic compare"
+    );
     sqlx::query(
         "INSERT INTO metadata (key, value) VALUES ($1, $2)
          ON CONFLICT (key) DO UPDATE

--- a/core/src/accounts/mod.rs
+++ b/core/src/accounts/mod.rs
@@ -1,4 +1,6 @@
 pub mod account_matches_owners;
+pub mod address_index_repair;
+pub mod address_index_watermark;
 pub mod bob;
 pub mod constants;
 pub mod error;

--- a/core/src/accounts/truncate.rs
+++ b/core/src/accounts/truncate.rs
@@ -1,5 +1,6 @@
 use {
     super::{postgres::PostgresAccountsDB, traits::BlockInfo},
+    crate::accounts::address_index_watermark::ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY,
     anyhow::{anyhow, Context, Result},
     sqlx::{Executor, PgPool, Postgres, QueryBuilder, Row},
     std::{
@@ -350,6 +351,12 @@ async fn set_first_available_block_metadata(
                 .execute(pool)
                 .await
                 .context("Failed to clear first_available_block metadata")?;
+            // Wiped DB must not look consistent to repair.
+            sqlx::query("DELETE FROM metadata WHERE key = $1")
+                .bind(ADDRESS_SIGNATURES_FLUSHED_SLOT_KEY)
+                .execute(pool)
+                .await
+                .context("Failed to clear address_signatures_flushed_slot metadata")?;
             Ok(None)
         }
     }

--- a/core/src/accounts/write_batch.rs
+++ b/core/src/accounts/write_batch.rs
@@ -27,6 +27,30 @@ pub struct AddressSignatureRow {
     pub signature: Vec<u8>,
 }
 
+/// Bulk-insert into address_signatures inside an active PG tx.
+pub(crate) async fn upsert_address_signature_rows(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    rows: &[AddressSignatureRow],
+) -> Result<(), sqlx::Error> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let addresses: Vec<&[u8]> = rows.iter().map(|r| r.address.as_slice()).collect();
+    let slots: Vec<i64> = rows.iter().map(|r| r.slot).collect();
+    let sigs: Vec<&[u8]> = rows.iter().map(|r| r.signature.as_slice()).collect();
+    sqlx::query(
+        "INSERT INTO address_signatures (address, slot, signature)
+         SELECT * FROM UNNEST($1::bytea[], $2::int8[], $3::bytea[])
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(&addresses)
+    .bind(&slots)
+    .bind(&sigs)
+    .execute(&mut **tx)
+    .await
+    .map(|_| ())
+}
+
 pub async fn write_batch(
     db: &mut AccountsDB,
     account_settlements: &[(Pubkey, AccountSettlement)],

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts::AccountsDB,
+        accounts::{address_index_repair::repair_address_signatures, AccountsDB},
         rpc::{
             server::{start_rpc_service, RpcServiceConfig},
             ReadDeps, WriteDeps,
@@ -163,6 +163,7 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
             // Failure here is fatal: starting with an empty cache could allow
             // duplicate transactions to execute after a restart.
             let db = AccountsDB::new(&config.accountsdb_connection_url, true).await?;
+            repair_address_signatures(&db, Arc::clone(&config.metrics)).await?;
             let (initial_live_blockhashes, initial_dedup_cache) =
                 load_dedup_state(&db, config.max_blockhashes()).await?;
 
@@ -284,20 +285,25 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
             (None, Arc::new(RwLock::new(LinkedList::new())))
         };
 
-    // Start RPC service based on node mode
+    let read_deps = match config.mode {
+        NodeMode::Read | NodeMode::Aio => {
+            let accounts_db = AccountsDB::new(&config.accountsdb_connection_url, true).await?;
+            if matches!(config.mode, NodeMode::Read) {
+                repair_address_signatures(&accounts_db, Arc::clone(&config.metrics)).await?;
+            }
+            Some(ReadDeps {
+                admin_keys: config.admin_keys,
+                accounts_db,
+                live_blockhashes: live_blockhashes_arc,
+            })
+        }
+        NodeMode::Write => None,
+    };
+
     let rpc_config = RpcServiceConfig {
         port: config.port,
         max_connections: config.max_connections,
-        read_deps: match config.mode {
-            NodeMode::Read | NodeMode::Aio => Some(ReadDeps {
-                admin_keys: config.admin_keys,
-                accounts_db: AccountsDB::new(&config.accountsdb_connection_url, true)
-                    .await
-                    .unwrap(),
-                live_blockhashes: live_blockhashes_arc,
-            }),
-            NodeMode::Write => None,
-        },
+        read_deps,
         write_deps,
         heartbeats,
         shutdown_token: shutdown_token.clone(),

--- a/core/src/stages/address_index_writer.rs
+++ b/core/src/stages/address_index_writer.rs
@@ -1,10 +1,15 @@
 use {
     crate::{
-        accounts::write_batch::AddressSignatureRow, health::StageHeartbeat,
-        nodes::node::WorkerHandle, stage_metrics::SharedMetrics,
+        accounts::{
+            address_index_watermark::upsert_address_signatures_flushed_slot_in_tx,
+            write_batch::{upsert_address_signature_rows, AddressSignatureRow},
+        },
+        health::StageHeartbeat,
+        nodes::node::WorkerHandle,
+        stage_metrics::SharedMetrics,
     },
     sqlx::{postgres::PgPoolOptions, PgPool},
-    std::sync::Arc,
+    std::{sync::Arc, time::Duration},
     tokio::{sync::mpsc, time::Instant},
     tokio_util::sync::CancellationToken,
     tracing::{debug, error, info, warn},
@@ -15,6 +20,8 @@ use {
 /// One connection is enough for sequential bulk inserts; the second slot is
 /// just headroom for sqlx's own bookkeeping connection-resets.
 const WRITER_POOL_SIZE: u32 = 2;
+
+const FLUSH_RETRY_BACKOFF_MS: [u64; 3] = [100, 500, 2000];
 
 pub struct AddressIndexWriterArgs {
     pub rows_rx: mpsc::Receiver<Vec<AddressSignatureRow>>,
@@ -55,9 +62,7 @@ pub async fn start_address_index_writer(args: AddressIndexWriterArgs) -> WorkerH
             }
         };
 
-        // Buffer accumulates whatever recv_many delivers per tick. Capacity is
-        // a hint; recv_many caps at flush_chunk_size so the buffer never grows
-        // unbounded during steady state.
+        // Buffer accumulates whatever recv_many delivers per tick.
         let mut buf: Vec<Vec<AddressSignatureRow>> = Vec::with_capacity(64);
         let mut flat: Vec<AddressSignatureRow> = Vec::with_capacity(flush_chunk_size * 2);
 
@@ -85,28 +90,36 @@ pub async fn start_address_index_writer(args: AddressIndexWriterArgs) -> WorkerH
                         while flat.len() >= flush_chunk_size {
                             let take = flat.split_off(flush_chunk_size);
                             let chunk = std::mem::replace(&mut flat, take);
-                            flush_chunk(&pool, &chunk, &metrics).await;
-                            heartbeat.record_progress();
+                            if let Err(e) =
+                                flush_and_record(&pool, &chunk, &flat, &metrics, &heartbeat).await
+                            {
+                                error!(?e, "address_signatures flush failed; exiting");
+                                return;
+                            }
                         }
                     }
                     if !flat.is_empty() {
                         let chunk = std::mem::take(&mut flat);
-                        flush_chunk(&pool, &chunk, &metrics).await;
-                        heartbeat.record_progress();
+                        if let Err(e) =
+                            flush_and_record(&pool, &chunk, &flat, &metrics, &heartbeat).await
+                        {
+                            error!(?e, "address_signatures flush failed; exiting");
+                            return;
+                        }
                     }
                 }
             }
         }
 
-        // Drain anything still buffered after shutdown / channel close so we
-        // don't drop addr_sig rows whose transactions row is already durable.
+        // Drain anything still buffered after shutdown / channel close.
         while let Ok(batch) = rows_rx.try_recv() {
             flat.extend(batch);
         }
         if !flat.is_empty() {
-            flush_chunk(&pool, &flat, &metrics).await;
-            heartbeat.record_progress();
-            flat.clear();
+            if let Err(e) = flush_and_record(&pool, &flat, &[], &metrics, &heartbeat).await {
+                error!(?e, "address_signatures final flush failed; exiting");
+                return;
+            }
         }
 
         info!("Address-index writer stopped");
@@ -115,53 +128,106 @@ pub async fn start_address_index_writer(args: AddressIndexWriterArgs) -> WorkerH
     WorkerHandle::new("AddressIndexWriter".to_string(), handle)
 }
 
-async fn flush_chunk(pool: &PgPool, rows: &[AddressSignatureRow], metrics: &SharedMetrics) {
-    if rows.is_empty() {
-        return;
+async fn flush_and_record(
+    pool: &PgPool,
+    chunk: &[AddressSignatureRow],
+    remaining: &[AddressSignatureRow],
+    metrics: &SharedMetrics,
+    heartbeat: &StageHeartbeat,
+) -> Result<(), sqlx::Error> {
+    let watermark = pick_watermark(chunk, remaining);
+    flush_chunk_with_retry(pool, chunk, watermark, metrics).await?;
+    heartbeat.record_progress();
+    Ok(())
+}
+
+/// Watermark advance; assumes monotonic slots.
+fn pick_watermark(chunk: &[AddressSignatureRow], remaining: &[AddressSignatureRow]) -> Option<i64> {
+    if chunk.is_empty() {
+        return None;
+    }
+    match remaining.first() {
+        Some(r) => Some(r.slot - 1),
+        None => chunk.last().map(|r| r.slot),
+    }
+}
+
+async fn flush_chunk_with_retry(
+    pool: &PgPool,
+    rows: &[AddressSignatureRow],
+    watermark: Option<i64>,
+    metrics: &SharedMetrics,
+) -> Result<(), sqlx::Error> {
+    let mut last_err: Option<sqlx::Error> = None;
+    for (i, ms) in FLUSH_RETRY_BACKOFF_MS.iter().enumerate() {
+        match flush_chunk_once(pool, rows, watermark, metrics).await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                if i + 1 < FLUSH_RETRY_BACKOFF_MS.len() {
+                    warn!(error = %e, attempt = i, "address_signatures flush retry");
+                    tokio::time::sleep(Duration::from_millis(*ms)).await;
+                    last_err = Some(e);
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+    Err(last_err.expect("retry loop must have observed at least one error"))
+}
+
+async fn flush_chunk_once(
+    pool: &PgPool,
+    rows: &[AddressSignatureRow],
+    watermark: Option<i64>,
+    metrics: &SharedMetrics,
+) -> Result<(), sqlx::Error> {
+    if rows.is_empty() && watermark.is_none() {
+        return Ok(());
     }
     let n = rows.len();
-    let mut addresses: Vec<&[u8]> = Vec::with_capacity(n);
-    let mut slots: Vec<i64> = Vec::with_capacity(n);
-    let mut signatures: Vec<&[u8]> = Vec::with_capacity(n);
-    for r in rows {
-        addresses.push(&r.address);
-        slots.push(r.slot);
-        signatures.push(&r.signature);
-    }
 
     let t0 = Instant::now();
-    let result = sqlx::query(
-        "INSERT INTO address_signatures (address, slot, signature)
-         SELECT * FROM UNNEST($1::bytea[], $2::int8[], $3::bytea[])
-         ON CONFLICT DO NOTHING",
-    )
-    .bind(&addresses)
-    .bind(&slots)
-    .bind(&signatures)
-    .execute(pool)
+    let result: Result<(), sqlx::Error> = async {
+        let mut tx = pool.begin().await?;
+        upsert_address_signature_rows(&mut tx, rows).await?;
+        if let Some(slot) = watermark {
+            upsert_address_signatures_flushed_slot_in_tx(&mut tx, slot).await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
     .await;
+
     let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
     metrics.address_signatures_flush_duration_ms(elapsed_ms);
 
-    match result {
-        Ok(_) => {
+    match &result {
+        Ok(()) => {
             metrics.address_signatures_rows_flushed(n);
-            debug!(rows = n, elapsed_ms, "address_signatures flush complete");
+            debug!(
+                rows = n,
+                elapsed_ms,
+                ?watermark,
+                "address_signatures flush complete"
+            );
         }
         Err(e) => {
             metrics.address_signatures_flush_errors_total();
             warn!(
                 rows = n,
-                elapsed_ms, "address_signatures flush failed (worker continues): {}", e
+                elapsed_ms, "address_signatures flush failed: {}", e
             );
         }
     }
+    result
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
+        accounts::address_index_watermark::get_address_signatures_flushed_slot,
         stage_metrics::NoopMetrics,
         test_helpers::{postgres_container_url, start_test_postgres},
     };
@@ -185,6 +251,16 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap()
+    }
+
+    async fn read_watermark(url: &str) -> Option<i64> {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(url)
+            .await
+            .unwrap();
+        let pool = Arc::new(pool);
+        get_address_signatures_flushed_slot(&pool).await.unwrap()
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -284,14 +360,12 @@ mod tests {
         assert!(join.is_ok(), "writer must not hang on bad PG URL");
     }
 
+    /// Permanent flush failure must exit the task.
     #[tokio::test(flavor = "multi_thread")]
-    async fn writer_continues_after_transient_pg_error() {
+    async fn writer_exits_when_retries_exhausted() {
         let (_db, pg) = start_test_postgres().await;
         let url = postgres_container_url(&pg, "test_db").await;
 
-        // Drop the address_signatures table out from under the writer to
-        // induce a PG error on the first flush, then recreate it. The worker
-        // must keep running and successfully flush the second batch.
         let admin = PgPoolOptions::new()
             .max_connections(1)
             .connect(&url)
@@ -314,33 +388,13 @@ mod tests {
         })
         .await;
 
-        // First batch hits the missing table → flush error logged, worker survives.
         tx.send(vec![make_row(1, 0, 1)]).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(500)).await;
 
-        // Recreate the table, send a second batch — must land.
-        sqlx::query(
-            "CREATE TABLE address_signatures (
-                address BYTEA NOT NULL,
-                slot BIGINT NOT NULL,
-                signature BYTEA NOT NULL,
-                PRIMARY KEY (address, slot, signature)
-            )",
-        )
-        .execute(&admin)
-        .await
-        .unwrap();
+        let join = tokio::time::timeout(Duration::from_secs(15), handle.handle).await;
+        assert!(join.is_ok(), "writer should exit after retries exhaust");
 
-        tx.send(vec![make_row(2, 1, 2), make_row(3, 2, 3)])
-            .await
-            .unwrap();
-        drop(tx);
-
-        let join = tokio::time::timeout(Duration::from_secs(10), handle.handle).await;
-        assert!(join.is_ok(), "writer should exit cleanly after recovery");
-
-        let n = count_rows(&url).await;
-        assert_eq!(n, 2, "rows from the second batch should be persisted");
+        let send_after = tx.send(vec![make_row(2, 1, 2)]).await;
+        assert!(send_after.is_err(), "writer receiver should be closed");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -383,5 +437,75 @@ mod tests {
             "at least the in-flight buffer must be flushed on shutdown, got {}",
             n
         );
+    }
+
+    /// Watermark = max flushed slot when buffer drains.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_advances_watermark_in_same_commit() {
+        let (_db, pg) = start_test_postgres().await;
+        let url = postgres_container_url(&pg, "test_db").await;
+
+        let (tx, rx) = mpsc::channel(8);
+        let shutdown = CancellationToken::new();
+        let handle = start_address_index_writer(AddressIndexWriterArgs {
+            rows_rx: rx,
+            accountsdb_connection_url: url.clone(),
+            flush_chunk_size: 100,
+            shutdown_token: shutdown.clone(),
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: StageHeartbeat::new(),
+        })
+        .await;
+
+        for slot in 10i64..=12 {
+            tx.send(vec![
+                make_row(slot as u8, slot, slot as u8),
+                make_row((slot + 100) as u8, slot, (slot + 1) as u8),
+            ])
+            .await
+            .unwrap();
+        }
+        drop(tx);
+
+        let join = tokio::time::timeout(Duration::from_secs(10), handle.handle).await;
+        assert!(join.is_ok(), "writer should exit after channel close");
+
+        let rows = count_rows(&url).await;
+        assert_eq!(rows, 6, "expected 6 rows across slots 10..=12");
+
+        let wm = read_watermark(&url).await;
+        assert_eq!(wm, Some(12), "watermark should advance to max flushed slot");
+    }
+
+    #[test]
+    fn pick_watermark_no_remaining_returns_chunk_max() {
+        let chunk = vec![
+            AddressSignatureRow {
+                address: vec![1; 32],
+                slot: 5,
+                signature: vec![1; 64],
+            },
+            AddressSignatureRow {
+                address: vec![2; 32],
+                slot: 7,
+                signature: vec![2; 64],
+            },
+        ];
+        assert_eq!(pick_watermark(&chunk, &[]), Some(7));
+    }
+
+    #[test]
+    fn pick_watermark_with_remaining_uses_min_minus_one() {
+        let chunk = vec![AddressSignatureRow {
+            address: vec![1; 32],
+            slot: 5,
+            signature: vec![1; 64],
+        }];
+        let remaining = vec![AddressSignatureRow {
+            address: vec![3; 32],
+            slot: 8,
+            signature: vec![3; 64],
+        }];
+        assert_eq!(pick_watermark(&chunk, &remaining), Some(7));
     }
 }

--- a/core/src/stages/address_index_writer.rs
+++ b/core/src/stages/address_index_writer.rs
@@ -21,7 +21,8 @@ use {
 /// just headroom for sqlx's own bookkeeping connection-resets.
 const WRITER_POOL_SIZE: u32 = 2;
 
-const FLUSH_RETRY_BACKOFF_MS: [u64; 3] = [100, 500, 2000];
+/// Sleep before each next attempt; total attempts = len + 1.
+const FLUSH_RETRY_BACKOFF_MS: [u64; 2] = [100, 500];
 
 pub struct AddressIndexWriterArgs {
     pub rows_rx: mpsc::Receiver<Vec<AddressSignatureRow>>,
@@ -158,22 +159,16 @@ async fn flush_chunk_with_retry(
     watermark: Option<i64>,
     metrics: &SharedMetrics,
 ) -> Result<(), sqlx::Error> {
-    let mut last_err: Option<sqlx::Error> = None;
     for (i, ms) in FLUSH_RETRY_BACKOFF_MS.iter().enumerate() {
         match flush_chunk_once(pool, rows, watermark, metrics).await {
             Ok(()) => return Ok(()),
             Err(e) => {
-                if i + 1 < FLUSH_RETRY_BACKOFF_MS.len() {
-                    warn!(error = %e, attempt = i, "address_signatures flush retry");
-                    tokio::time::sleep(Duration::from_millis(*ms)).await;
-                    last_err = Some(e);
-                } else {
-                    return Err(e);
-                }
+                warn!(error = %e, attempt = i, "address_signatures flush retry");
+                tokio::time::sleep(Duration::from_millis(*ms)).await;
             }
         }
     }
-    Err(last_err.expect("retry loop must have observed at least one error"))
+    flush_chunk_once(pool, rows, watermark, metrics).await
 }
 
 async fn flush_chunk_once(

--- a/core/src/stages/address_index_writer.rs
+++ b/core/src/stages/address_index_writer.rs
@@ -21,8 +21,10 @@ use {
 /// just headroom for sqlx's own bookkeeping connection-resets.
 const WRITER_POOL_SIZE: u32 = 2;
 
-/// Sleep before each next attempt; total attempts = len + 1.
-const FLUSH_RETRY_BACKOFF_MS: [u64; 2] = [100, 500];
+/// Delays (ms) before each retry; total attempts = len + 1. Sized to ride out a
+/// typical managed-Postgres failover / replica promotion (a few seconds) rather
+/// than tearing the node down on a transient blip.
+const FLUSH_RETRY_BACKOFF_MS: [u64; 4] = [250, 1000, 3000, 5000];
 
 pub struct AddressIndexWriterArgs {
     pub rows_rx: mpsc::Receiver<Vec<AddressSignatureRow>>,
@@ -148,7 +150,11 @@ fn pick_watermark(chunk: &[AddressSignatureRow], remaining: &[AddressSignatureRo
         return None;
     }
     match remaining.first() {
-        Some(r) => Some(r.slot - 1),
+        // Slots below `remaining`'s first are fully flushed. Guard slot 0: a
+        // negative watermark sorts above all positives under big-endian bytea
+        // compare and would pin it permanently.
+        Some(r) if r.slot > 0 => Some(r.slot - 1),
+        Some(_) => None,
         None => chunk.last().map(|r| r.slot),
     }
 }

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -47,6 +47,29 @@ struct SettleResult {
     account_settlements: Vec<(Pubkey, AccountSettlement)>,
 }
 
+#[derive(Debug)]
+enum SettleError {
+    AddressIndexWriterGone,
+    Other(String),
+}
+
+impl std::fmt::Display for SettleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AddressIndexWriterGone => f.write_str("address_signatures writer dropped"),
+            Self::Other(s) => f.write_str(s),
+        }
+    }
+}
+
+impl std::error::Error for SettleError {}
+
+impl From<String> for SettleError {
+    fn from(s: String) -> Self {
+        Self::Other(s)
+    }
+}
+
 #[derive(Clone)]
 struct LastBlock {
     slot: u64,
@@ -309,8 +332,13 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                                     break;
                                 }
                             }
-                            Err(_) => {
-                                error!("Failed to settle transactions");
+                            Err(SettleError::AddressIndexWriterGone) => {
+                                anyhow::bail!(
+                                    "address_signatures writer dropped, aborting settler"
+                                );
+                            }
+                            Err(SettleError::Other(msg)) => {
+                                error!("Failed to settle transactions: {}", msg);
                                 break;
                             }
                         }
@@ -432,7 +460,7 @@ async fn settle_transactions(
     processing_results: &[(TransactionProcessingResult, SanitizedTransaction)],
     metrics: &crate::stage_metrics::SharedMetrics,
     address_signatures_tx: Option<&mpsc::Sender<Vec<AddressSignatureRow>>>,
-) -> Result<SettleResult, Box<dyn std::error::Error>> {
+) -> Result<SettleResult, SettleError> {
     let t_total = tokio::time::Instant::now();
     // Preallocate per-tick collections from the known result count so the hot
     // path doesn't pay the geometric-growth realloc tax on every tick. The 4×
@@ -563,16 +591,7 @@ async fn settle_transactions(
         .await?;
     let t_db_ms = t_db_start.elapsed().as_secs_f64() * 1000.0;
 
-    // Send-after-commit: address_signatures rows are durable in
-    // `transactions` already; the index writer fills in the read view with
-    // an eventually-consistent gap of <1 writer-flush interval. .send().await
-    // applies backpressure when the bounded channel fills.
-    //
-    // A closed channel (writer task exited) is logged and tolerated: the
-    // atomic commit has already succeeded, so the only consequence is that
-    // `address_signatures` is missing this tick's entries. That's the same
-    // eventually-consistent contract `getSignaturesForAddress` already
-    // tolerates — not a reason to tear down the settler.
+    // Closed channel = writer gone; escalate to exit.
     if let Some(tx) = address_signatures_tx {
         if !addr_sig_rows.is_empty() {
             let send_t0 = tokio::time::Instant::now();
@@ -583,9 +602,7 @@ async fn settle_transactions(
                     );
                 }
                 Err(_) => {
-                    warn!(
-                        "address_signatures writer dropped; index entries for this tick will not be written"
-                    );
+                    return Err(SettleError::AddressIndexWriterGone);
                 }
             }
         }
@@ -1609,5 +1626,58 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
         shutdown.cancel();
+    }
+
+    /// Writer-dropped must exit settler.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settler_aborts_when_address_index_writer_dropped() {
+        let (_db, pg) = start_test_postgres().await;
+        let url = postgres_container_url(&pg, "test_db").await;
+
+        let (exec_tx, exec_rx) = mpsc::unbounded_channel();
+        let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
+        let (settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
+        let (address_signatures_tx, address_signatures_rx) = mpsc::channel(8);
+        let shutdown = CancellationToken::new();
+
+        let handle = start_settle_worker(SettleArgs {
+            execution_results_rx: exec_rx,
+            settled_accounts_tx,
+            settled_blockhashes_tx,
+            address_signatures_tx,
+            accountsdb_connection_url: url,
+            blocktime_ms: 50,
+            perf_sample_period_secs: 3600,
+            shutdown_token: shutdown.clone(),
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: crate::health::StageHeartbeat::new(),
+        })
+        .await;
+
+        // Simulate the writer task exiting.
+        drop(address_signatures_rx);
+
+        // Tick triggers send-Err.
+        let from = Keypair::new();
+        let to = Pubkey::new_unique();
+        let tx = create_test_sanitized_transaction(&from, &to, 100);
+        let pk = Pubkey::new_unique();
+        let executed = make_executed(vec![(
+            pk,
+            AccountSharedData::new(500, 0, &Pubkey::new_unique()),
+        )]);
+        let output = LoadAndExecuteSanitizedTransactionsOutput {
+            processing_results: vec![Ok(executed)],
+            error_metrics: Default::default(),
+            execute_timings: Default::default(),
+            balance_collector: None,
+        };
+        exec_tx.send((output, vec![tx])).unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(10), handle.handle).await;
+        assert!(
+            result.is_ok(),
+            "settle worker must exit when address-index writer is gone"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes the durability gap between `transactions` and `address_signatures` that lets remint recovery miss confirmed remints and double-mint after a crash. The two tables were committed in different SQL transactions: `transactions` atomically with the settle batch, `address_signatures` later by a background writer. A crash (or any silent drop from the writer's send/flush paths) left durable transactions invisible to `getSignaturesForAddress`, which the operator uses as its remint idempotency oracle.

State truth from DB and the read surface now reconverge before any read from RPC is served, and the running-process silent-drop paths can no longer accumulate gaps.

## Scope

**Startup repair pass**

`repair_address_signatures()` scans `blocks` for `slot > watermark`, re-derives `(address, slot, signature)` rows from the durable `transactions` table, upserts them and advances the watermark per-slot atomically. Wired into `run_node` before `start_rpc_service` binds, for both Write/Aio (against the write pool) and Read (against the read pool). Idempotent under concurrent runs.

**Watermark in `metadata`: on-disk source of truth**

New key `address_signatures_flushed_slot` advanced inside the writer's flush COMMIT, in the same SQL transaction as the INSERT. Monotonic UPDATE prevents rewinds from concurrent repair runs.

**Fatal escalation on silent-drop paths**

Settler send-failure now returns `SettleError::AddressIndexWriterGone`, which the tick handler escalates. Writer flush errors retry on bounded backoff and then exit the task. Either path closes the channel and trips `wait_for_any_worker_quit`, taking the node down; restart triggers repair.

**Truncate handles the watermark**

Full DB wipe also deletes `address_signatures_flushed_slot`

## Tests

- **Repair correctness (unit):** asserts exact `(address, slot, signature)` row set derived from test transactions matches what repair produces, watermark advances to the max repaired slot.
- **Repair idempotency (unit):** baseline + rerun comparison; second run leaves both row set and watermark unchanged.
- **Watermark roundtrip + monotonicity (unit):** read-after-write, refuse-to-rewind on lower slot, accept higher slot.
- **Writer watermark advance in COMMIT (integration):** in-process worker flushes rows; both `address_signatures` and `metadata.address_signatures_flushed_slot` are visible together.
- **Writer fatal on permanent flush error (integration):** dropped `address_signatures` table forces retry exhaustion; worker task exits and channel receiver is closed.
- **Settler aborts on writer-gone (integration):** receiver dropped before first tick; `run_settle_worker` returns Err, task exits.
- **`pick_watermark` rules (unit):** chunk-only and chunk-plus-pending cases.


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 10,246 | 11,809 | 86.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27023338769) |
| Indexer | 17,232 | 20,061 | 85.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27023338769) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27023338769) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27023338769) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 10,581 | 13,239 | 79.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27023338769) |
| **Total** | **39,770** | **47,104** | **84.4%** | |

> Last updated: 2026-06-05 15:49:31 UTC by E2E Integration