### PR TITLE
fix(indexer): harden pending-remint gate against double payouts and restart resets   (SOLA3-19, SOLA3-1)

### DIFF
--- a/indexer/src/operator/fetcher.rs
+++ b/indexer/src/operator/fetcher.rs
@@ -151,6 +151,7 @@ mod tests {
             remint_signatures: None,
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         }
     }
 

--- a/indexer/src/operator/fetcher.rs
+++ b/indexer/src/operator/fetcher.rs
@@ -149,6 +149,7 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
         }
     }

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -836,6 +836,7 @@ mod tests {
             remint_signatures: None,
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         }
     }
 
@@ -2140,6 +2141,7 @@ mod tests {
             remint_signatures: None,
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         };
 
         fetcher_tx.send(txn).await.unwrap();
@@ -2242,6 +2244,7 @@ mod tests {
             remint_signatures: None,
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         };
 
         fetcher_tx.send(txn).await.unwrap();

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -834,6 +834,7 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
         }
     }
@@ -2137,6 +2138,7 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
         };
 
@@ -2238,6 +2240,7 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
         };
 

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -235,7 +235,7 @@ pub(super) async fn try_jit_mint_initialization(
     )
     .await
     {
-        Ok(s) => s,
+        Ok((s, _)) => s,
         Err(e) => {
             error!("Failed to send InitializeMint transaction: {}", e);
             return JitOutcome::PermanentFailure(format!(

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -294,8 +294,10 @@ pub async fn process_pending_remints(
 
         // Walk the sigs to see if any could still land. Exit early on the
         // first one that isn't dead. Index-aligned with response.value
-        // (length equality enforced above).
-        let mut any_still_live = false;
+        // (length equality enforced above). Captures a reason describing
+        // why the broadcast could still land so the defer/ManualReview
+        // message can guide operator triage.
+        let mut live_reason: Option<String> = None;
         for (index, pending_sig) in entry.signatures.iter().enumerate() {
             let signature_status = &response.value[index];
 
@@ -306,9 +308,12 @@ pub async fn process_pending_remints(
                 if status.satisfies_commitment(CommitmentConfig::finalized()) {
                     continue;
                 }
-                // `confirmed` or `processed` — already included in a block,
+                // `confirmed` or `processed`: already included in a block,
                 // will finalize regardless of blockhash validity.
-                any_still_live = true;
+                live_reason = Some(
+                    "signature is on-chain (confirmed/processed) and awaiting finalization"
+                        .to_string(),
+                );
                 break;
             }
 
@@ -316,23 +321,16 @@ pub async fn process_pending_remints(
             if current_height > pending_sig.last_valid_block_height {
                 continue;
             }
-            any_still_live = true;
+            live_reason = Some(format!(
+                "signatures still within blockhash validity (current_height={})",
+                current_height
+            ));
             break;
         }
 
         // Case 2: at least one broadcast could still land, defer rather than remint.
-        if any_still_live {
-            defer_or_escalate(
-                &mut remaining,
-                entry,
-                &nonce_label,
-                &format!(
-                    "signatures still within blockhash validity (current_height={})",
-                    current_height
-                ),
-                storage_tx,
-            )
-            .await;
+        if let Some(reason) = live_reason {
+            defer_or_escalate(&mut remaining, entry, &nonce_label, &reason, storage_tx).await;
             continue;
         }
 

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -237,6 +237,7 @@ pub async fn process_pending_remints(
                     entry,
                     &nonce_label,
                     &format!("signature status RPC failed: {}", e),
+                    &state.storage,
                     storage_tx,
                 )
                 .await;
@@ -257,6 +258,7 @@ pub async fn process_pending_remints(
                     response.value.len(),
                     sigs.len()
                 ),
+                &state.storage,
                 storage_tx,
             )
             .await;
@@ -285,6 +287,7 @@ pub async fn process_pending_remints(
                     entry,
                     &nonce_label,
                     &format!("block height RPC failed: {}", e),
+                    &state.storage,
                     storage_tx,
                 )
                 .await;
@@ -330,7 +333,15 @@ pub async fn process_pending_remints(
 
         // Case 2: at least one broadcast could still land, defer rather than remint.
         if let Some(reason) = live_reason {
-            defer_or_escalate(&mut remaining, entry, &nonce_label, &reason, storage_tx).await;
+            defer_or_escalate(
+                &mut remaining,
+                entry,
+                &nonce_label,
+                &reason,
+                &state.storage,
+                storage_tx,
+            )
+            .await;
             continue;
         }
 
@@ -387,6 +398,7 @@ async fn defer_or_escalate(
     entry: PendingRemint,
     nonce_label: &str,
     reason: &str,
+    storage: &crate::storage::Storage,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
 ) {
     let attempt = entry.finality_check_attempts + 1;
@@ -420,13 +432,50 @@ async fn defer_or_escalate(
         return;
     }
 
+    let new_deadline = Utc::now() + chrono::Duration::from_std(FINALITY_SAFETY_DELAY).unwrap();
+
+    // Fail-closed: an inability to persist the bumped counter is itself
+    // ambiguity. Escalate to ManualReview rather than continue deferring with
+    // a counter we can't trust to survive a restart.
+    if let Some(transaction_id) = entry.ctx.transaction_id {
+        if let Err(persist_err) = storage
+            .bump_pending_remint_finality_attempt(transaction_id, attempt as i32, new_deadline)
+            .await
+        {
+            error!(
+                "Pending remint for nonce {} counter persist failed, escalating to ManualReview: {}",
+                nonce_label, persist_err
+            );
+            send_guaranteed(
+                storage_tx,
+                TransactionStatusUpdate {
+                    transaction_id,
+                    trace_id: entry.ctx.trace_id.clone(),
+                    status: TransactionStatus::ManualReview,
+                    counterpart_signature: None,
+                    processed_at: Some(Utc::now()),
+                    error_message: Some(format!(
+                        "{} | counter persist failed at attempt {}: {}",
+                        entry.original_error, attempt, persist_err
+                    )),
+                    remint_signature: None,
+                    remint_attempted: false,
+                },
+                "transaction status update",
+            )
+            .await
+            .ok();
+            return;
+        }
+    }
+
     warn!(
         "Pending remint for nonce {} deferred (attempt {}/{}): {}",
         nonce_label, attempt, MAX_FINALITY_CHECK_ATTEMPTS, reason
     );
     remaining.push(PendingRemint {
         finality_check_attempts: attempt,
-        deadline: Utc::now() + chrono::Duration::from_std(FINALITY_SAFETY_DELAY).unwrap(),
+        deadline: new_deadline,
         ..entry
     });
 }
@@ -441,6 +490,7 @@ mod tests {
     use crate::operator::MintCache;
     use crate::storage::common::storage::mock::MockStorage;
     use crate::storage::Storage;
+    use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::Once;
@@ -456,15 +506,15 @@ mod tests {
         });
     }
 
-    fn make_sender_state() -> SenderState {
+    fn make_sender_state() -> (SenderState, MockStorage) {
         let mock = MockStorage::new();
-        let storage = Arc::new(Storage::Mock(mock));
+        let storage = Arc::new(Storage::Mock(mock.clone()));
         let rpc = Arc::new(crate::operator::RpcClientWithRetry::with_retry_config(
             "http://localhost:8899".to_string(),
             crate::operator::RetryConfig::default(),
             solana_sdk::commitment_config::CommitmentConfig::confirmed(),
         ));
-        SenderState {
+        let state = SenderState {
             rpc_client: rpc,
             storage: storage.clone(),
             instance_pda: None,
@@ -482,7 +532,41 @@ mod tests {
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
             semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
-        }
+        };
+        (state, mock)
+    }
+
+    /// Push a stub PendingRemint row into the mock so a subsequent
+    /// `bump_pending_remint_finality_attempt(id, ...)` can find a row to update.
+    /// Only the id and attempts fields matter for the bump path.
+    fn seed_pending_remint_row(mock: &MockStorage, id: i64, attempts: i32) {
+        use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
+        let now = Utc::now();
+        mock.pending_remint_transactions
+            .lock()
+            .unwrap()
+            .push(DbTransaction {
+                id,
+                signature: Signature::new_unique().to_string(),
+                trace_id: format!("trace-{id}"),
+                slot: 0,
+                initiator: Pubkey::new_unique().to_string(),
+                recipient: Pubkey::new_unique().to_string(),
+                mint: Pubkey::new_unique().to_string(),
+                amount: 0,
+                memo: None,
+                transaction_type: TransactionType::Withdrawal,
+                withdrawal_nonce: Some(id),
+                status: TransactionStatus::PendingRemint,
+                created_at: now,
+                updated_at: now,
+                processed_at: None,
+                counterpart_signature: None,
+                remint_signatures: None,
+                remint_last_valid_block_heights: None,
+                pending_remint_deadline_at: Some(now),
+                finality_check_attempts: attempts,
+            });
     }
 
     fn make_remint_info(txn_id: i64) -> WithdrawalRemintInfo {
@@ -497,9 +581,9 @@ mod tests {
         }
     }
 
-    fn make_sender_state_with_rpc(rpc_url: &str) -> SenderState {
+    fn make_sender_state_with_rpc(rpc_url: &str) -> (SenderState, MockStorage) {
         let mock = MockStorage::new();
-        let storage = Arc::new(Storage::Mock(mock));
+        let storage = Arc::new(Storage::Mock(mock.clone()));
         let rpc = Arc::new(crate::operator::RpcClientWithRetry::with_retry_config(
             rpc_url.to_string(),
             crate::operator::RetryConfig {
@@ -509,7 +593,7 @@ mod tests {
             },
             solana_sdk::commitment_config::CommitmentConfig::confirmed(),
         ));
-        SenderState {
+        let state = SenderState {
             rpc_client: rpc,
             storage: storage.clone(),
             instance_pda: None,
@@ -527,7 +611,8 @@ mod tests {
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
             semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
-        }
+        };
+        (state, mock)
     }
 
     /// Register a mockito response for a specific Solana RPC method.
@@ -547,8 +632,12 @@ mod tests {
 
     #[tokio::test]
     async fn process_pending_remints_requeues_on_rpc_error() {
-        let mut state = make_sender_state();
+        let (mut state, mock) = make_sender_state();
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // The defer path persists the bumped counter; the row must exist in the
+        // mock for that write to succeed (otherwise the counter is held).
+        seed_pending_remint_row(&mock, 20, 0);
 
         // Push a matured entry — RPC will fail (no real endpoint)
         state.pending_remints.push(PendingRemint {
@@ -580,11 +669,74 @@ mod tests {
             "should re-queue entry after RPC error"
         );
         assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
+
+        // The bumped counter must also be persisted so it survives a restart.
+        let persisted = mock
+            .pending_remint_transactions
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|t| t.id == 20)
+            .map(|t| t.finality_check_attempts);
+        assert_eq!(persisted, Some(1));
+    }
+
+    /// Fail-closed on persist failure: if the counter bump can't be written,
+    /// the safety fuse is no longer trustworthy, so the entry must escalate
+    /// to ManualReview rather than continue deferring on shaky state.
+    #[tokio::test]
+    async fn process_pending_remints_escalates_when_bump_persist_fails() {
+        let (mut state, mock) = make_sender_state();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        seed_pending_remint_row(&mock, 30, 1);
+        mock.set_should_fail("bump_pending_remint_finality_attempt", true);
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(30),
+                withdrawal_nonce: Some(9),
+                trace_id: Some("trace-30".to_string()),
+            },
+            remint_info: make_remint_info(30),
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 1,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        // Entry dropped from in-memory queue, not re-queued.
+        assert!(state.pending_remints.is_empty());
+
+        // ManualReview update was sent with the persist error in the message.
+        let update = storage_rx
+            .try_recv()
+            .expect("persist failure must produce a ManualReview update");
+        assert_eq!(update.transaction_id, 30);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let err = update.error_message.as_deref().unwrap();
+        assert!(err.contains("counter persist failed"), "got: {err}");
+        assert!(err.contains("release_funds failed"), "got: {err}");
+
+        // DB row was not modified by the failed bump.
+        let persisted = mock
+            .pending_remint_transactions
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|t| t.id == 30)
+            .map(|t| t.finality_check_attempts);
+        assert_eq!(persisted, Some(1));
     }
 
     #[tokio::test]
     async fn process_pending_remints_manual_review_after_max_rpc_failures() {
-        let mut state = make_sender_state();
+        let (mut state, _mock) = make_sender_state();
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         // Push entry already at max attempts — next RPC failure triggers ManualReview
@@ -643,8 +795,11 @@ mod tests {
     /// the finality window guarantee that prevents double-minting.
     #[tokio::test]
     async fn process_pending_remints_handles_mixed_matured_and_immature() {
-        let mut state = make_sender_state();
+        let (mut state, mock) = make_sender_state();
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // The matured entry (id 10) defers, which now persists the bump.
+        seed_pending_remint_row(&mock, 10, 0);
 
         let future_deadline = Utc::now() + chrono::Duration::seconds(600);
 
@@ -732,7 +887,7 @@ mod tests {
     #[tokio::test]
     async fn process_pending_remints_marks_completed_when_withdrawal_finalized() {
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         let sig = Signature::new_unique();
@@ -812,7 +967,7 @@ mod tests {
     async fn process_pending_remints_not_finalized_remint_fails_sends_manual_review() {
         ensure_test_signer();
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         let sig = Signature::new_unique();
@@ -883,7 +1038,7 @@ mod tests {
     async fn process_pending_remints_finalized_with_onchain_error_proceeds_to_remint() {
         ensure_test_signer();
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         let sig = Signature::new_unique();
@@ -952,7 +1107,7 @@ mod tests {
     #[tokio::test]
     async fn process_pending_remints_second_of_two_sigs_finalized_marks_completed() {
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         let sig1 = Signature::new_unique(); // first attempt — dropped
@@ -1032,7 +1187,7 @@ mod tests {
     async fn process_pending_remints_all_sigs_expired_proceeds_to_remint() {
         ensure_test_signer();
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         let sig = Signature::new_unique();
@@ -1095,8 +1250,10 @@ mod tests {
     #[tokio::test]
     async fn process_pending_remints_one_sig_still_live_defers() {
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        seed_pending_remint_row(&mock, 101, 0);
 
         let sig = Signature::new_unique();
 
@@ -1150,7 +1307,7 @@ mod tests {
     #[tokio::test]
     async fn process_pending_remints_live_sig_at_cap_escalates_to_manual_review() {
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         let sig = Signature::new_unique();
@@ -1207,8 +1364,10 @@ mod tests {
     #[tokio::test]
     async fn process_pending_remints_block_height_rpc_failure_defers() {
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        seed_pending_remint_row(&mock, 103, 0);
 
         let sig = Signature::new_unique();
 
@@ -1262,8 +1421,10 @@ mod tests {
     async fn process_pending_remints_confirmed_not_finalized_past_lvbh_defers() {
         ensure_test_signer();
         let mut rpc_server = mockito::Server::new_async().await;
-        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        seed_pending_remint_row(&mock, 105, 0);
 
         let sig = Signature::new_unique();
 

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -265,13 +265,11 @@ pub async fn process_pending_remints(
 
         // Case 1: if any sig finalized successfully, the withdrawal landed.
         // Mark Completed and drop the entry.
-        let finalized_success_index =
-            response.value.iter().position(|signature_status| {
-                signature_status.as_ref().is_some_and(|status| {
-                    status.satisfies_commitment(CommitmentConfig::finalized())
-                        && status.err.is_none()
-                })
-            });
+        let finalized_success_index = response.value.iter().position(|signature_status| {
+            signature_status.as_ref().is_some_and(|status| {
+                status.satisfies_commitment(CommitmentConfig::finalized()) && status.err.is_none()
+            })
+        });
         if let Some(index) = finalized_success_index {
             send_completed(storage_tx, &entry, &nonce_label, sigs[index]).await;
             continue;
@@ -535,11 +533,7 @@ mod tests {
     }
 
     /// Register a mockito response for a specific Solana RPC method.
-    async fn mock_rpc(
-        server: &mut mockito::Server,
-        method: &str,
-        body: &str,
-    ) -> mockito::Mock {
+    async fn mock_rpc(server: &mut mockito::Server, method: &str, body: &str) -> mockito::Mock {
         server
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex(format!(
@@ -566,7 +560,10 @@ mod tests {
                 trace_id: Some("trace-20".to_string()),
             },
             remint_info: make_remint_info(20),
-            signatures: vec![PendingSig { signature: Signature::new_unique(), last_valid_block_height: 0 }],
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
             original_error: "max retries".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -600,7 +597,10 @@ mod tests {
                 trace_id: Some("trace-20".to_string()),
             },
             remint_info: make_remint_info(20),
-            signatures: vec![PendingSig { signature: Signature::new_unique(), last_valid_block_height: 0 }],
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
             original_error: "max retries".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 2, // MAX_FINALITY_CHECK_ATTEMPTS - 1
@@ -660,7 +660,10 @@ mod tests {
                 trace_id: Some("trace-10".to_string()),
             },
             remint_info: make_remint_info(10),
-            signatures: vec![PendingSig { signature: Signature::new_unique(), last_valid_block_height: 0 }],
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
             original_error: "release_funds failed".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -674,7 +677,10 @@ mod tests {
                 trace_id: Some("trace-20".to_string()),
             },
             remint_info: make_remint_info(20),
-            signatures: vec![PendingSig { signature: Signature::new_unique(), last_valid_block_height: 0 }],
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
             original_error: "release_funds failed".to_string(),
             deadline: future_deadline,
             finality_check_attempts: 0,
@@ -767,7 +773,10 @@ mod tests {
                 trace_id: Some("trace-99".to_string()),
             },
             remint_info: make_remint_info(99),
-            signatures: vec![PendingSig { signature: sig, last_valid_block_height: 0 }],
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 0,
+            }],
             original_error: "release_funds failed".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -841,7 +850,10 @@ mod tests {
                 trace_id: Some("trace-77".to_string()),
             },
             remint_info: make_remint_info(77),
-            signatures: vec![PendingSig { signature: sig, last_valid_block_height: 0 }],
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 0,
+            }],
             original_error: "release_funds failed".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -914,7 +926,10 @@ mod tests {
                 trace_id: Some("trace-88".to_string()),
             },
             remint_info: make_remint_info(88),
-            signatures: vec![PendingSig { signature: sig, last_valid_block_height: 0 }],
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 0,
+            }],
             original_error: "timeout".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -979,8 +994,14 @@ mod tests {
             },
             remint_info: make_remint_info(55),
             signatures: vec![
-                PendingSig { signature: sig1, last_valid_block_height: 0 },
-                PendingSig { signature: sig2, last_valid_block_height: 0 },
+                PendingSig {
+                    signature: sig1,
+                    last_valid_block_height: 0,
+                },
+                PendingSig {
+                    signature: sig2,
+                    last_valid_block_height: 0,
+                },
             ],
             original_error: "release_funds failed".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -366,7 +366,7 @@ pub async fn process_pending_remints(
 }
 
 /// Report a pending-remint entry as Completed because one of its withdrawal
-/// signatures landed on Solana.
+/// signatures finalized on Solana.
 async fn send_completed(
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     entry: &PendingRemint,

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -23,12 +23,15 @@ use solana_sdk::{commitment_config::CommitmentConfig, signature::Signature};
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-/// Maximum number of finality-check retries before giving up and sending to ManualReview.
+/// Cap on total deferrals of a single pending remint. Covers both transient
+/// RPC errors during the finality check AND liveness extensions when a stored
+/// signature is still within blockhash validity. Past this cap we escalate
+/// to ManualReview rather than loop indefinitely.
 const MAX_FINALITY_CHECK_ATTEMPTS: u32 = 3;
 
 /// Attempt to remint burned PrivateChannel tokens back to user after permanent withdrawal failure.
 /// Builds a MintTo instruction with an idempotency memo (same pattern as deposits).
-/// No sender-level retry — RPC-level retries may still occur via RpcClientWithRetry.
+/// No sender-level retry; RPC-level retries may still occur via RpcClientWithRetry.
 async fn attempt_remint(
     state: &SenderState,
     info: &WithdrawalRemintInfo,
@@ -69,7 +72,7 @@ async fn attempt_remint(
         Ok(None) => {}
         Err(e) => {
             warn!(
-                "Remint idempotency lookup failed for transaction {}: {} — proceeding with send",
+                "Remint idempotency lookup failed for transaction {}: {}; proceeding with send",
                 info.transaction_id, e
             );
         }
@@ -87,7 +90,7 @@ async fn attempt_remint(
         compute_budget: None,
     };
 
-    let signature = sign_and_send_transaction(state.rpc_client.clone(), ix, RetryPolicy::None)
+    let (signature, _) = sign_and_send_transaction(state.rpc_client.clone(), ix, RetryPolicy::None)
         .await
         .map_err(|e| format!("Failed to send remint transaction: {}", e))?;
 
@@ -177,17 +180,24 @@ pub async fn execute_deferred_remint(
     }
 }
 
-/// Process matured entries in the deferred remint queue.
-/// Called from the sender loop tick. For each matured entry, checks whether any
-/// previously sent withdrawal signature reached finalized commitment. If so, the
-/// withdrawal actually succeeded and we report Completed. Otherwise we attempt remint.
+/// Process matured entries in the deferred remint queue. For each matured
+/// entry, classify the stored withdrawal signatures and pick one of:
+///   1. Any sig finalized + success → report Completed.
+///   2. Any sig still live (has a non-finalized status entry, OR has no
+///      status entry but still within blockhash validity)
+///      → defer with extended deadline.
+///   3. Every sig finalized-failed, or null-status with expired blockhash
+///      → remint.
+///
+/// RPC failures during classification fall through the same defer-or-escalate
+/// path as case 2.
 pub async fn process_pending_remints(
     state: &mut SenderState,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
 ) {
     let now = Utc::now();
 
-    // Partition: matured entries get processed, immature stay in the queue
+    // Drain the queue and split: due now vs. wait longer.
     let mut remaining = Vec::new();
     let mut matured = Vec::new();
     for entry in state.pending_remints.drain(..) {
@@ -198,6 +208,7 @@ pub async fn process_pending_remints(
         }
     }
 
+    // Each matured entry leaves the queue unless we push it back into `remaining`.
     for entry in matured {
         let nonce_label = entry
             .ctx
@@ -205,111 +216,230 @@ pub async fn process_pending_remints(
             .map(|n| n.to_string())
             .unwrap_or_else(|| "none".to_string());
 
-        match state
+        // Flatten to a plain Signature slice for the RPC call.
+        let sigs: Vec<Signature> = entry
+            .signatures
+            .iter()
+            .map(|pending_sig| pending_sig.signature)
+            .collect();
+
+        // Ask for the status of every stored signature in one shot.
+        let response = match state
             .rpc_client
-            .get_signature_statuses_with_history(&entry.signatures)
+            .get_signature_statuses_with_history(&sigs)
             .await
         {
-            Ok(response) => {
-                let mut found_finalized = false;
-                for (i, status_opt) in response.value.iter().enumerate() {
-                    if let Some(status) = status_opt {
-                        if status.satisfies_commitment(CommitmentConfig::finalized())
-                            && status.err.is_none()
-                        {
-                            info!(
-                                "Withdrawal nonce {} actually finalized (sig: {}) — skipping remint",
-                                nonce_label, entry.signatures[i]
-                            );
-                            if let Some(transaction_id) = entry.ctx.transaction_id {
-                                send_guaranteed(
-                                    storage_tx,
-                                    TransactionStatusUpdate {
-                                        transaction_id,
-                                        trace_id: entry.ctx.trace_id.clone(),
-                                        status: TransactionStatus::Completed,
-                                        counterpart_signature: Some(
-                                            entry.signatures[i].to_string(),
-                                        ),
-                                        processed_at: Some(Utc::now()),
-                                        error_message: None,
-                                        remint_signature: None,
-                                        remint_attempted: false,
-                                    },
-                                    "transaction status update",
-                                )
-                                .await
-                                .ok();
-                            }
-                            found_finalized = true;
-                            break;
-                        }
-                    }
-                }
-                if found_finalized {
+            Ok(r) => r,
+            Err(e) => {
+                // Couldn't classify. Bump counter and retry next tick, or ManualReview at cap.
+                defer_or_escalate(
+                    &mut remaining,
+                    entry,
+                    &nonce_label,
+                    &format!("signature status RPC failed: {}", e),
+                    storage_tx,
+                )
+                .await;
+                continue;
+            }
+        };
+
+        // The Solana RPC contract returns one status per input signature in
+        // the same order. If that's violated we'd silently skip checks below.
+        // Treat a length mismatch as a classification failure and defer.
+        if response.value.len() != sigs.len() {
+            defer_or_escalate(
+                &mut remaining,
+                entry,
+                &nonce_label,
+                &format!(
+                    "RPC returned {} statuses for {} signatures",
+                    response.value.len(),
+                    sigs.len()
+                ),
+                storage_tx,
+            )
+            .await;
+            continue;
+        }
+
+        // Case 1: if any sig finalized successfully, the withdrawal landed.
+        // Mark Completed and drop the entry.
+        let finalized_success_index =
+            response.value.iter().position(|signature_status| {
+                signature_status.as_ref().is_some_and(|status| {
+                    status.satisfies_commitment(CommitmentConfig::finalized())
+                        && status.err.is_none()
+                })
+            });
+        if let Some(index) = finalized_success_index {
+            send_completed(storage_tx, &entry, &nonce_label, sigs[index]).await;
+            continue;
+        }
+
+        // Case 2 setup: fetch the cluster's current block height for the liveness check.
+        let current_height = match state.rpc_client.get_block_height().await {
+            Ok(h) => h,
+            Err(e) => {
+                // Same handling as the sig-status RPC failure above.
+                defer_or_escalate(
+                    &mut remaining,
+                    entry,
+                    &nonce_label,
+                    &format!("block height RPC failed: {}", e),
+                    storage_tx,
+                )
+                .await;
+                continue;
+            }
+        };
+
+        // Walk the sigs to see if any could still land. Exit early on the
+        // first one that isn't dead. Index-aligned with response.value
+        // (length equality enforced above).
+        let mut any_still_live = false;
+        for (index, pending_sig) in entry.signatures.iter().enumerate() {
+            let signature_status = &response.value[index];
+
+            if let Some(status) = signature_status.as_ref() {
+                // Status exists. Only `finalized` is a definitive outcome.
+                // (Case 1 above already handled finalized + success, so this
+                // is finalized + error.)
+                if status.satisfies_commitment(CommitmentConfig::finalized()) {
                     continue;
                 }
-                // No sig finalized → proceed to remint
-                info!(
-                    "No finalized withdrawal for nonce {} — attempting remint",
-                    nonce_label
-                );
-                execute_deferred_remint(state, &entry, storage_tx).await;
+                // `confirmed` or `processed` — already included in a block,
+                // will finalize regardless of blockhash validity.
+                any_still_live = true;
+                break;
             }
-            Err(e) => {
-                let attempt = entry.finality_check_attempts + 1;
-                if attempt >= MAX_FINALITY_CHECK_ATTEMPTS {
-                    error!(
-                        "Finality check for nonce {} failed after {} attempts — \
-                         cannot verify withdrawal status, sending to ManualReview: {}",
-                        nonce_label, attempt, e
-                    );
-                    if let Some(transaction_id) = entry.ctx.transaction_id {
-                        send_guaranteed(
-                            storage_tx,
-                            TransactionStatusUpdate {
-                                transaction_id,
-                                trace_id: entry.ctx.trace_id.clone(),
-                                status: TransactionStatus::ManualReview,
-                                counterpart_signature: None,
-                                processed_at: Some(Utc::now()),
-                                error_message: Some(format!(
-                                    "{} | finality check failed after {} attempts: {}",
-                                    entry.original_error, attempt, e
-                                )),
-                                remint_signature: None,
-                                remint_attempted: false,
-                            },
-                            "transaction status update",
-                        )
-                        .await
-                        .ok();
-                    }
-                } else {
-                    warn!(
-                        "Finality check for nonce {} failed (attempt {}/{}) — \
-                         re-queuing with extended deadline: {}",
-                        nonce_label, attempt, MAX_FINALITY_CHECK_ATTEMPTS, e
-                    );
-                    remaining.push(PendingRemint {
-                        finality_check_attempts: attempt,
-                        deadline: Utc::now()
-                            + chrono::Duration::from_std(FINALITY_SAFETY_DELAY).unwrap(),
-                        ..entry
-                    });
-                }
+
+            // No status entry. lvbh is the only thing keeping it alive.
+            if current_height > pending_sig.last_valid_block_height {
+                continue;
             }
+            any_still_live = true;
+            break;
         }
+
+        // Case 2: at least one broadcast could still land, defer rather than remint.
+        if any_still_live {
+            defer_or_escalate(
+                &mut remaining,
+                entry,
+                &nonce_label,
+                &format!(
+                    "signatures still within blockhash validity (current_height={})",
+                    current_height
+                ),
+                storage_tx,
+            )
+            .await;
+            continue;
+        }
+
+        // Case 3: every sig is finalized-failed or expired, safe to remint.
+        info!(
+            "All withdrawal signatures for nonce {} are finalized-failed or expired; attempting remint",
+            nonce_label
+        );
+        execute_deferred_remint(state, &entry, storage_tx).await;
     }
 
+    // `remaining` = entries not yet due + entries `defer_or_escalate` re-queued.
     state.pending_remints = remaining;
+}
+
+/// Report a pending-remint entry as Completed because one of its withdrawal
+/// signatures landed on Solana.
+async fn send_completed(
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    entry: &PendingRemint,
+    nonce_label: &str,
+    sig: Signature,
+) {
+    info!(
+        "Withdrawal nonce {} finalized on-chain (sig: {}); skipping remint",
+        nonce_label, sig
+    );
+    let Some(transaction_id) = entry.ctx.transaction_id else {
+        return;
+    };
+    send_guaranteed(
+        storage_tx,
+        TransactionStatusUpdate {
+            transaction_id,
+            trace_id: entry.ctx.trace_id.clone(),
+            status: TransactionStatus::Completed,
+            counterpart_signature: Some(sig.to_string()),
+            processed_at: Some(Utc::now()),
+            error_message: None,
+            remint_signature: None,
+            remint_attempted: false,
+        },
+        "transaction status update",
+    )
+    .await
+    .ok();
+}
+
+/// Bump the entry's deferral counter and either re-queue with an extended
+/// deadline or escalate to ManualReview when the cap is hit. Used by every
+/// "couldn't classify this entry as ready-to-remint" branch.
+async fn defer_or_escalate(
+    remaining: &mut Vec<PendingRemint>,
+    entry: PendingRemint,
+    nonce_label: &str,
+    reason: &str,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) {
+    let attempt = entry.finality_check_attempts + 1;
+
+    if attempt >= MAX_FINALITY_CHECK_ATTEMPTS {
+        error!(
+            "Pending remint for nonce {} reached attempt cap ({}); escalating to ManualReview: {}",
+            nonce_label, attempt, reason
+        );
+        if let Some(transaction_id) = entry.ctx.transaction_id {
+            send_guaranteed(
+                storage_tx,
+                TransactionStatusUpdate {
+                    transaction_id,
+                    trace_id: entry.ctx.trace_id.clone(),
+                    status: TransactionStatus::ManualReview,
+                    counterpart_signature: None,
+                    processed_at: Some(Utc::now()),
+                    error_message: Some(format!(
+                        "{} | escalated to ManualReview after {} attempts: {}",
+                        entry.original_error, attempt, reason
+                    )),
+                    remint_signature: None,
+                    remint_attempted: false,
+                },
+                "transaction status update",
+            )
+            .await
+            .ok();
+        }
+        return;
+    }
+
+    warn!(
+        "Pending remint for nonce {} deferred (attempt {}/{}): {}",
+        nonce_label, attempt, MAX_FINALITY_CHECK_ATTEMPTS, reason
+    );
+    remaining.push(PendingRemint {
+        finality_check_attempts: attempt,
+        deadline: Utc::now() + chrono::Duration::from_std(FINALITY_SAFETY_DELAY).unwrap(),
+        ..entry
+    });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::operator::sender::types::{
-        PendingRemint, SenderState, TransactionContext, MAX_IN_FLIGHT,
+        PendingRemint, PendingSig, SenderState, TransactionContext, MAX_IN_FLIGHT,
     };
     use crate::operator::utils::instruction_util::WithdrawalRemintInfo;
     use crate::operator::MintCache;
@@ -404,6 +534,25 @@ mod tests {
         }
     }
 
+    /// Register a mockito response for a specific Solana RPC method.
+    async fn mock_rpc(
+        server: &mut mockito::Server,
+        method: &str,
+        body: &str,
+    ) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(format!(
+                r#""method"\s*:\s*"{}""#,
+                method
+            )))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create_async()
+            .await
+    }
+
     #[tokio::test]
     async fn process_pending_remints_requeues_on_rpc_error() {
         let mut state = make_sender_state();
@@ -417,7 +566,7 @@ mod tests {
                 trace_id: Some("trace-20".to_string()),
             },
             remint_info: make_remint_info(20),
-            signatures: vec![Signature::new_unique()],
+            signatures: vec![PendingSig { signature: Signature::new_unique(), last_valid_block_height: 0 }],
             original_error: "max retries".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -451,7 +600,7 @@ mod tests {
                 trace_id: Some("trace-20".to_string()),
             },
             remint_info: make_remint_info(20),
-            signatures: vec![Signature::new_unique()],
+            signatures: vec![PendingSig { signature: Signature::new_unique(), last_valid_block_height: 0 }],
             original_error: "max retries".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 2, // MAX_FINALITY_CHECK_ATTEMPTS - 1
@@ -469,8 +618,12 @@ mod tests {
 
         let err = update.error_message.as_deref().unwrap();
         assert!(
-            err.contains("finality check failed"),
-            "should mention finality check failure: {err}"
+            err.contains("escalated to ManualReview"),
+            "should mention ManualReview escalation: {err}"
+        );
+        assert!(
+            err.contains("signature status RPC failed"),
+            "should mention the underlying failure: {err}"
         );
         assert!(
             err.contains("max retries"),
@@ -507,7 +660,7 @@ mod tests {
                 trace_id: Some("trace-10".to_string()),
             },
             remint_info: make_remint_info(10),
-            signatures: vec![Signature::new_unique()],
+            signatures: vec![PendingSig { signature: Signature::new_unique(), last_valid_block_height: 0 }],
             original_error: "release_funds failed".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -521,7 +674,7 @@ mod tests {
                 trace_id: Some("trace-20".to_string()),
             },
             remint_info: make_remint_info(20),
-            signatures: vec![Signature::new_unique()],
+            signatures: vec![PendingSig { signature: Signature::new_unique(), last_valid_block_height: 0 }],
             original_error: "release_funds failed".to_string(),
             deadline: future_deadline,
             finality_check_attempts: 0,
@@ -614,7 +767,7 @@ mod tests {
                 trace_id: Some("trace-99".to_string()),
             },
             remint_info: make_remint_info(99),
-            signatures: vec![sig],
+            signatures: vec![PendingSig { signature: sig, last_valid_block_height: 0 }],
             original_error: "release_funds failed".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -657,8 +810,8 @@ mod tests {
 
         let sig = Signature::new_unique();
 
-        // Finality check: null means the tx was dropped — proceed to remint.
-        let _mock = rpc_server
+        // Finality check: null means the tx was dropped, proceed to remint.
+        let _status_mock = rpc_server
             .mock("POST", "/")
             .match_body(mockito::Matcher::AllOf(vec![
                 mockito::Matcher::Regex(r#""method"\s*:\s*"getSignatureStatuses""#.into()),
@@ -672,6 +825,15 @@ mod tests {
             .create_async()
             .await;
 
+        // Block height ahead of the stored lvbh (0) so every sig is treated as
+        // expired and the gate falls through to Case 3 (remint).
+        let _block_height_mock = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+
         state.pending_remints.push(PendingRemint {
             ctx: TransactionContext {
                 transaction_id: Some(77),
@@ -679,7 +841,7 @@ mod tests {
                 trace_id: Some("trace-77".to_string()),
             },
             remint_info: make_remint_info(77),
-            signatures: vec![sig],
+            signatures: vec![PendingSig { signature: sig, last_valid_block_height: 0 }],
             original_error: "release_funds failed".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -716,28 +878,34 @@ mod tests {
 
         let sig = Signature::new_unique();
 
-        let _mock = rpc_server
-            .mock("POST", "/")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                r#"{
-                    "jsonrpc": "2.0",
-                    "result": {
-                        "context": {"slot": 200},
-                        "value": [{
-                            "slot": 100,
-                            "confirmations": null,
-                            "err": {"InstructionError": [0, {"Custom": 1}]},
-                            "status": {"Err": {"InstructionError": [0, {"Custom": 1}]}},
-                            "confirmationStatus": "finalized"
-                        }]
-                    },
-                    "id": 0
-                }"#,
-            )
-            .create_async()
-            .await;
+        let _status_mock = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{
+                "jsonrpc": "2.0",
+                "result": {
+                    "context": {"slot": 200},
+                    "value": [{
+                        "slot": 100,
+                        "confirmations": null,
+                        "err": {"InstructionError": [0, {"Custom": 1}]},
+                        "status": {"Err": {"InstructionError": [0, {"Custom": 1}]}},
+                        "confirmationStatus": "finalized"
+                    }]
+                },
+                "id": 0
+            }"#,
+        )
+        .await;
+
+        // Block height ahead of the stored lvbh (0) so the finalized-failed sig
+        // counts as dead and the gate falls through to Case 3 (remint).
+        let _block_height_mock = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
 
         state.pending_remints.push(PendingRemint {
             ctx: TransactionContext {
@@ -746,7 +914,7 @@ mod tests {
                 trace_id: Some("trace-88".to_string()),
             },
             remint_info: make_remint_info(88),
-            signatures: vec![sig],
+            signatures: vec![PendingSig { signature: sig, last_valid_block_height: 0 }],
             original_error: "timeout".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -810,7 +978,10 @@ mod tests {
                 trace_id: Some("trace-55".to_string()),
             },
             remint_info: make_remint_info(55),
-            signatures: vec![sig1, sig2],
+            signatures: vec![
+                PendingSig { signature: sig1, last_valid_block_height: 0 },
+                PendingSig { signature: sig2, last_valid_block_height: 0 },
+            ],
             original_error: "release_funds failed".to_string(),
             deadline: Utc::now() - chrono::Duration::seconds(1),
             finality_check_attempts: 0,
@@ -832,5 +1003,303 @@ mod tests {
             state.pending_remints.is_empty(),
             "entry consumed after Completed"
         );
+    }
+
+    // ── liveness gate paths ────────────────────────────────────────────
+
+    /// Sig has no on-chain record AND its blockhash is past validity. Dead.
+    /// The gate must proceed to remint.
+    #[tokio::test]
+    async fn process_pending_remints_all_sigs_expired_proceeds_to_remint() {
+        ensure_test_signer();
+        let mut rpc_server = mockito::Server::new_async().await;
+        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let sig = Signature::new_unique();
+
+        let _status_mock = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":0}"#,
+        )
+        .await;
+
+        // current_height (1000) > lvbh (100): sig is expired.
+        let _block_height_mock = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(100),
+                withdrawal_nonce: Some(20),
+                trace_id: Some("trace-100".to_string()),
+            },
+            remint_info: make_remint_info(100),
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 100,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        // Reaching Case 3 triggers execute_deferred_remint, whose RPC calls
+        // have no matching mocks; the remint fails and writes ManualReview
+        // with "remint failed" in the error message.
+        let update = storage_rx
+            .try_recv()
+            .expect("should receive ManualReview from execute_deferred_remint");
+        assert_eq!(update.transaction_id, 100);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert!(
+            update
+                .error_message
+                .as_deref()
+                .unwrap_or("")
+                .contains("remint failed"),
+            "reaching Case 3 means execute_deferred_remint ran"
+        );
+        assert!(state.pending_remints.is_empty());
+    }
+
+    /// Sig has no on-chain record but its blockhash is still within validity.
+    /// Could still land. The gate must defer (no remint, no status update)
+    /// and bump the counter.
+    #[tokio::test]
+    async fn process_pending_remints_one_sig_still_live_defers() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let sig = Signature::new_unique();
+
+        let _status_mock = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":0}"#,
+        )
+        .await;
+
+        // current_height (50) <= lvbh (1000): sig still within validity.
+        let _block_height_mock = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":50,"id":0}"#,
+        )
+        .await;
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(101),
+                withdrawal_nonce: Some(21),
+                trace_id: Some("trace-101".to_string()),
+            },
+            remint_info: make_remint_info(101),
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 1000,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update: row must stay PendingRemint while the broadcast could still land"
+        );
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(
+            state.pending_remints[0].finality_check_attempts, 1,
+            "counter must be bumped after a liveness deferral"
+        );
+    }
+
+    /// Entry already at the deferral cap on the liveness branch must escalate
+    /// to ManualReview, and the error message must identify the cause as the
+    /// liveness check (not an RPC failure).
+    #[tokio::test]
+    async fn process_pending_remints_live_sig_at_cap_escalates_to_manual_review() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let sig = Signature::new_unique();
+
+        let _status_mock = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":0}"#,
+        )
+        .await;
+
+        // Sig still live: lvbh (1000) > current_height (50).
+        let _block_height_mock = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":50,"id":0}"#,
+        )
+        .await;
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(102),
+                withdrawal_nonce: Some(22),
+                trace_id: Some("trace-102".to_string()),
+            },
+            remint_info: make_remint_info(102),
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 1000,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 2, // one more attempt hits the cap
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        let update = storage_rx
+            .try_recv()
+            .expect("should receive ManualReview at the cap");
+        assert_eq!(update.transaction_id, 102);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let err = update.error_message.as_deref().unwrap_or("");
+        assert!(
+            err.contains("signatures still within blockhash validity"),
+            "escalation message must identify the liveness cause: {err}"
+        );
+        assert!(state.pending_remints.is_empty());
+    }
+
+    /// getBlockHeight RPC fails. The gate cannot evaluate liveness, so it
+    /// must defer (not remint blindly). Same shape as the existing
+    /// sig-status RPC failure handling.
+    #[tokio::test]
+    async fn process_pending_remints_block_height_rpc_failure_defers() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let sig = Signature::new_unique();
+
+        let _status_mock = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":0}"#,
+        )
+        .await;
+
+        // getBlockHeight returns an RPC-level error.
+        let _block_height_mock = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","error":{"code":-32600,"message":"server error"},"id":0}"#,
+        )
+        .await;
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(103),
+                withdrawal_nonce: Some(23),
+                trace_id: Some("trace-103".to_string()),
+            },
+            remint_info: make_remint_info(103),
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 100,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update: RPC failure under cap just defers the entry"
+        );
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
+    }
+
+    /// Sig is already on-chain at `confirmed` (in a block, awaiting
+    /// finalization) but its blockhash has expired. The tx will finalize
+    /// regardless of blockhash validity, so the gate must defer rather than
+    /// remint. Reminting here would cause a double-payout once the tx
+    /// finalizes a few slots later.
+    #[tokio::test]
+    async fn process_pending_remints_confirmed_not_finalized_past_lvbh_defers() {
+        ensure_test_signer();
+        let mut rpc_server = mockito::Server::new_async().await;
+        let mut state = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let sig = Signature::new_unique();
+
+        // Status: confirmed (in a block) but not yet finalized, no error.
+        let _status_mock = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{
+                "jsonrpc": "2.0",
+                "result": {
+                    "context": {"slot": 200},
+                    "value": [{
+                        "slot": 100,
+                        "confirmations": 1,
+                        "err": null,
+                        "status": {"Ok": null},
+                        "confirmationStatus": "confirmed"
+                    }]
+                },
+                "id": 0
+            }"#,
+        )
+        .await;
+
+        // current_height (1000) > lvbh (100): blockhash validity has passed.
+        let _block_height_mock = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(105),
+                withdrawal_nonce: Some(25),
+                trace_id: Some("trace-105".to_string()),
+            },
+            remint_info: make_remint_info(105),
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 100,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update: a confirmed-but-not-finalized sig must defer the remint"
+        );
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
     }
 }

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -377,7 +377,14 @@ async fn send_completed(
         "Withdrawal nonce {} finalized on-chain (sig: {}); skipping remint",
         nonce_label, sig
     );
+    // Always Some in practice: entries are only queued for withdrawals, which
+    // carry a DB id. A None here drops a finalized withdrawal with no DB trace,
+    // so log it instead of returning silently.
     let Some(transaction_id) = entry.ctx.transaction_id else {
+        error!(
+            "send_completed for nonce {} has no transaction_id; finalized withdrawal (sig: {}) cannot be marked Completed",
+            nonce_label, sig
+        );
         return;
     };
     send_guaranteed(

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -277,22 +277,30 @@ pub async fn process_pending_remints(
             continue;
         }
 
-        // Case 2 setup: fetch the cluster's current block height for the liveness check.
-        let current_height = match state.rpc_client.get_block_height().await {
-            Ok(h) => h,
-            Err(e) => {
-                // Same handling as the sig-status RPC failure above.
-                defer_or_escalate(
-                    &mut remaining,
-                    entry,
-                    &nonce_label,
-                    &format!("block height RPC failed: {}", e),
-                    &state.storage,
-                    storage_tx,
-                )
-                .await;
-                continue;
+        // Block height is only needed for the lvbh check on null-status sigs.
+        // If every sig has a status, the liveness decision is already implied
+        // and we skip the RPC; a transient getBlockHeight outage shouldn't
+        // burn defer attempts when no sig actually needs the height.
+        let current_height = if response.value.iter().any(|s| s.is_none()) {
+            match state.rpc_client.get_block_height().await {
+                Ok(h) => h,
+                Err(e) => {
+                    defer_or_escalate(
+                        &mut remaining,
+                        entry,
+                        &nonce_label,
+                        &format!("block height RPC failed: {}", e),
+                        &state.storage,
+                        storage_tx,
+                    )
+                    .await;
+                    continue;
+                }
             }
+        } else {
+            // Unreachable below: the null-status branch only fires when at
+            // least one status is None, which we just ruled out.
+            0
         };
 
         // Walk the sigs to see if any could still land. Exit early on the
@@ -1099,6 +1107,76 @@ mod tests {
             "finalized-with-error must NOT produce Completed — funds never left escrow"
         );
         assert_eq!(update.transaction_id, 88);
+    }
+
+    /// Regression: when every stored signature already has a status entry, the
+    /// liveness decision is already implied (finalized-failed) and no block
+    /// height RPC is needed. A transient `getBlockHeight` outage in that
+    /// scenario must NOT consume defer attempts.
+    #[tokio::test]
+    async fn process_pending_remints_skips_block_height_when_all_sigs_classifiable() {
+        ensure_test_signer();
+        let mut rpc_server = mockito::Server::new_async().await;
+        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let sig = Signature::new_unique();
+
+        // Finalized-failed: status present, finalized commitment, error set.
+        let _status_mock = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{
+                "jsonrpc": "2.0",
+                "result": {
+                    "context": {"slot": 200},
+                    "value": [{
+                        "slot": 100,
+                        "confirmations": null,
+                        "err": {"InstructionError": [0, {"Custom": 1}]},
+                        "status": {"Err": {"InstructionError": [0, {"Custom": 1}]}},
+                        "confirmationStatus": "finalized"
+                    }]
+                },
+                "id": 0
+            }"#,
+        )
+        .await;
+
+        // Deliberately NOT mocking getBlockHeight: if the code reaches that
+        // call mockito returns 501, the call errors, and defer_or_escalate
+        // fires with "block height RPC failed" instead of execute_deferred_remint.
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(89),
+                withdrawal_nonce: Some(13),
+                trace_id: Some("trace-89".to_string()),
+            },
+            remint_info: make_remint_info(89),
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 100,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        let update = storage_rx
+            .try_recv()
+            .expect("should receive a status update");
+        assert_eq!(update.transaction_id, 89);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let err = update.error_message.as_deref().unwrap_or("");
+        assert!(
+            err.contains("remint failed"),
+            "must reach execute_deferred_remint; if this contains 'block height' \
+             the pre-check regressed: {err}"
+        );
+        assert!(state.pending_remints.is_empty());
     }
 
     /// When a withdrawal was retried and produced multiple signatures, one of the

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -284,9 +284,11 @@ impl SenderState {
                     .map(|(sig_string, &lvbh)| {
                         let signature = Signature::from_str(sig_string)
                             .map_err(|e| format!("invalid withdrawal signature: {e}"))?;
+                        let last_valid_block_height = u64::try_from(lvbh)
+                            .map_err(|_| format!("negative last_valid_block_height: {lvbh}"))?;
                         Ok(PendingSig {
                             signature,
-                            last_valid_block_height: lvbh as u64,
+                            last_valid_block_height,
                         })
                     })
                     .collect()

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -330,6 +330,24 @@ impl SenderState {
                 deadline,
             );
 
+            // A corrupt negative value would wrap to a huge u32 and skip the
+            // attempt cap, defeating the whole point of persisting it.
+            let Some(finality_check_attempts) = Self::or_manual_review(
+                u32::try_from(tx.finality_check_attempts).map_err(|_| {
+                    format!(
+                        "negative finality_check_attempts: {}",
+                        tx.finality_check_attempts
+                    )
+                }),
+                storage_tx,
+                tx.id,
+                &tx.trace_id,
+            )
+            .await
+            else {
+                continue;
+            };
+
             self.pending_remints.push(PendingRemint {
                 ctx,
                 remint_info,
@@ -338,7 +356,7 @@ impl SenderState {
                 // combined error messages if the remint itself also fails.
                 original_error: "recovered from persistent storage".to_string(),
                 deadline,
-                finality_check_attempts: 0,
+                finality_check_attempts,
             });
         }
 
@@ -417,6 +435,7 @@ mod tests {
             remint_signatures: Some(vec![sig.to_string()]),
             remint_last_valid_block_heights: Some(vec![12_345]),
             pending_remint_deadline_at: Some(deadline),
+            finality_check_attempts: 0,
         }
     }
 
@@ -431,7 +450,8 @@ mod tests {
     /// - withdrawal signatures (needed for the finality check)
     /// - the original deadline (not a fresh 32s window — the clock keeps
     ///   ticking across restarts)
-    /// - finality_check_attempts reset to 0 (not stored in DB)
+    /// - finality_check_attempts round-trips from the DB so the
+    ///   MAX_FINALITY_CHECK_ATTEMPTS budget survives restarts
     ///
     /// No channel messages should be sent — there is nothing wrong with
     /// these rows, they just need to be re-queued.
@@ -443,13 +463,12 @@ mod tests {
         let sig = Signature::new_unique();
         let deadline = Utc::now() + chrono::Duration::seconds(20);
 
-        // Simulate the row that would exist in the DB after a crash.
-        mock.pending_remint_transactions
-            .lock()
-            .unwrap()
-            .push(make_pending_remint_row(
-                42, &mint, &recipient, &sig, deadline,
-            ));
+        // Mid-budget value so the round-trip assertion is meaningful: a reset
+        // to 0 on recovery would re-arm the cap and let an ambiguous row
+        // outlive the intended ManualReview escalation.
+        let mut row = make_pending_remint_row(42, &mint, &recipient, &sig, deadline);
+        row.finality_check_attempts = 2;
+        mock.pending_remint_transactions.lock().unwrap().push(row);
 
         let mut state = make_sender_state(mock);
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
@@ -486,8 +505,9 @@ mod tests {
             entry.deadline
         );
 
-        // Attempt counter always resets — it is in-memory only.
-        assert_eq!(entry.finality_check_attempts, 0);
+        // The counter must survive the round-trip. A reset would re-arm the
+        // attempt cap on every restart.
+        assert_eq!(entry.finality_check_attempts, 2);
 
         // Standard recovery marker so combined error messages are meaningful.
         assert_eq!(entry.original_error, "recovered from persistent storage");
@@ -497,6 +517,35 @@ mod tests {
             storage_rx.try_recv().is_err(),
             "no channel message expected for a valid recovery row"
         );
+    }
+
+    /// A negative `finality_check_attempts` should never appear (the column is
+    /// `INTEGER NOT NULL DEFAULT 0`, only ever written to non-negative values),
+    /// but a corrupt row must escalate rather than wrap silently into a huge
+    /// `u32` that bypasses the attempt cap.
+    #[tokio::test]
+    async fn recover_pending_remints_escalates_negative_attempt_counter() {
+        let mock = MockStorage::new();
+        let mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let sig = Signature::new_unique();
+        let deadline = Utc::now() + chrono::Duration::seconds(20);
+
+        let mut row = make_pending_remint_row(7, &mint, &recipient, &sig, deadline);
+        row.finality_check_attempts = -1;
+        mock.pending_remint_transactions.lock().unwrap().push(row);
+
+        let mut state = make_sender_state(mock);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        state.recover_pending_remints(&storage_tx).await.unwrap();
+
+        assert!(state.pending_remints.is_empty());
+        let update = storage_rx
+            .try_recv()
+            .expect("corrupt row must produce a ManualReview update");
+        assert_eq!(update.transaction_id, 7);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
     }
 
     // ── recover_pending_remints: parse error escalations ─────────────

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -1,7 +1,7 @@
 use crate::channel_utils::send_guaranteed;
 use crate::error::account::AccountError;
 use crate::error::OperatorError;
-use crate::operator::sender::types::{PendingRemint, TransactionContext};
+use crate::operator::sender::types::{PendingRemint, PendingSig, TransactionContext};
 use crate::operator::tree_constants::MAX_TREE_LEAVES;
 use crate::operator::utils::smt_util::SmtState;
 use crate::operator::{parse_instance, RetryConfig, RpcClientWithRetry};
@@ -262,22 +262,38 @@ impl SenderState {
                 continue;
             };
 
-            // Parse all stored withdrawal signatures. These are passed to
-            // get_signature_statuses_with_history() by process_pending_remints to verify
-            // the withdrawal did not finalize before we remint. A single bad entry means
-            // we cannot safely do that check — escalate to ManualReview.
+            // Pair each stored signature with its last_valid_block_height. The
+            // remint gate needs both to verify the withdrawal cannot still land.
+            // An empty array, a bad signature, or an array-length mismatch means
+            // we cannot safely run that check, so we escalate to ManualReview.
             let sig_strings = tx.remint_signatures.unwrap_or_default();
-            let Some(signatures) = Self::or_manual_review(
+            let lvbhs = tx.remint_last_valid_block_heights.unwrap_or_default();
+
+            let parsed: Result<Vec<PendingSig>, String> = if sig_strings.is_empty() {
+                Err("no withdrawal signatures stored; cannot verify finality".to_string())
+            } else if sig_strings.len() != lvbhs.len() {
+                Err(format!(
+                    "lvbh length {} != signatures length {}",
+                    lvbhs.len(),
+                    sig_strings.len()
+                ))
+            } else {
                 sig_strings
                     .iter()
-                    .map(|s| Signature::from_str(s))
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| format!("invalid withdrawal signature: {e}")),
-                storage_tx,
-                tx.id,
-                &tx.trace_id,
-            )
-            .await
+                    .zip(&lvbhs)
+                    .map(|(sig_string, &lvbh)| {
+                        let signature = Signature::from_str(sig_string)
+                            .map_err(|e| format!("invalid withdrawal signature: {e}"))?;
+                        Ok(PendingSig {
+                            signature,
+                            last_valid_block_height: lvbh as u64,
+                        })
+                    })
+                    .collect()
+            };
+
+            let Some(signatures) =
+                Self::or_manual_review(parsed, storage_tx, tx.id, &tx.trace_id).await
             else {
                 continue;
             };
@@ -397,6 +413,7 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: Some(vec![sig.to_string()]),
+            remint_last_valid_block_heights: Some(vec![12_345]),
             pending_remint_deadline_at: Some(deadline),
         }
     }
@@ -453,8 +470,11 @@ mod tests {
         assert_eq!(entry.remint_info.user, recipient);
 
         // Signatures must be parsed back — they drive the finality check.
+        // lvbh must round-trip too: the gate needs it to prove a broadcast
+        // can no longer land.
         assert_eq!(entry.signatures.len(), 1);
-        assert_eq!(entry.signatures[0], sig);
+        assert_eq!(entry.signatures[0].signature, sig);
+        assert_eq!(entry.signatures[0].last_valid_block_height, 12_345);
 
         // Deadline must be the stored one, not a fresh window.
         // Allows up to 1s of clock skew between DB write and assertion.
@@ -668,6 +688,55 @@ mod tests {
         assert!(
             state.pending_remints.is_empty(),
             "row with invalid signature must not be queued"
+        );
+        assert!(storage_rx.try_recv().is_err());
+    }
+
+    /// A PendingRemint row whose `remint_signatures` and
+    /// `remint_last_valid_block_heights` arrays have different lengths cannot
+    /// be turned into a coherent `Vec<PendingSig>`. Index-pairing would be
+    /// undefined, so the remint gate cannot reliably check liveness.
+    ///
+    /// Escalate to ManualReview rather than guessing which sig got which lvbh.
+    #[tokio::test]
+    async fn recover_pending_remints_escalates_lvbh_length_mismatch_to_manual_review() {
+        let mock = MockStorage::new();
+        let mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let deadline = Utc::now() + chrono::Duration::seconds(20);
+
+        let mut bad_row =
+            make_pending_remint_row(50, &mint, &recipient, &Signature::new_unique(), deadline);
+        bad_row.remint_signatures = Some(vec![
+            Signature::new_unique().to_string(),
+            Signature::new_unique().to_string(),
+        ]);
+        bad_row.remint_last_valid_block_heights = Some(vec![100]);
+
+        mock.pending_remint_transactions
+            .lock()
+            .unwrap()
+            .push(bad_row);
+
+        let mut state = make_sender_state(mock);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        state.recover_pending_remints(&storage_tx).await.unwrap();
+
+        let update = storage_rx
+            .try_recv()
+            .expect("should receive ManualReview for length mismatch");
+        assert_eq!(update.transaction_id, 50);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let err = update.error_message.as_deref().unwrap_or("");
+        assert!(
+            err.contains("lvbh length"),
+            "error message should describe the length mismatch: {err}"
+        );
+
+        assert!(
+            state.pending_remints.is_empty(),
+            "row with mismatched array lengths must not be queued"
         );
         assert!(storage_rx.try_recv().is_err());
     }

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -25,8 +25,8 @@ use super::mint::{
 };
 use super::proof::{cleanup_failed_transaction, rebuild_with_regenerated_proof};
 use super::types::{
-    InFlightQueue, InFlightTx, InstructionWithSigners, PendingRemint, PollTaskResult, SenderState,
-    TransactionContext, TransactionStatusUpdate, MAX_IN_FLIGHT,
+    InFlightQueue, InFlightTx, InstructionWithSigners, PendingRemint, PendingSig, PollTaskResult,
+    SenderState, TransactionContext, TransactionStatusUpdate, MAX_IN_FLIGHT,
 };
 
 use std::sync::Arc;
@@ -302,7 +302,7 @@ pub(super) async fn send_and_confirm(
     match sign_and_send_transaction(state.rpc_client.clone(), instruction.clone(), retry_policy)
         .await
     {
-        Ok(signature) => {
+        Ok((signature, last_valid_block_height)) => {
             info!("Transaction sent with signature: {}", signature);
 
             // Stash signature for finality check on withdrawal failure path
@@ -311,7 +311,10 @@ pub(super) async fn send_and_confirm(
                     .pending_signatures
                     .entry(nonce)
                     .or_default()
-                    .push(signature);
+                    .push(PendingSig {
+                        signature,
+                        last_valid_block_height,
+                    });
             }
 
             let commitment_config = CommitmentConfig::confirmed();
@@ -684,11 +687,18 @@ pub(super) async fn handle_permanent_failure(
     // keeping status as Processing until the remint resolves avoids partial state
     // if the operator crashes during the finality window.
     if let Some(transaction_id) = ctx.transaction_id {
-        let sig_strings: Vec<String> = signatures.iter().map(|sig| sig.to_string()).collect();
+        let sig_strings: Vec<String> = signatures
+            .iter()
+            .map(|pending_sig| pending_sig.signature.to_string())
+            .collect();
+        let lvbhs: Vec<i64> = signatures
+            .iter()
+            .map(|pending_sig| pending_sig.last_valid_block_height as i64)
+            .collect();
 
         if let Err(e) = state
             .storage
-            .set_pending_remint(transaction_id, sig_strings, deadline)
+            .set_pending_remint(transaction_id, sig_strings, lvbhs, deadline)
             .await
         {
             error!(
@@ -776,7 +786,7 @@ pub(super) async fn fire_and_store(
     match sign_and_send_transaction(state.rpc_client.clone(), instruction.clone(), retry_policy)
         .await
     {
-        Ok(signature) => {
+        Ok((signature, _last_valid_block_height)) => {
             metrics::OPERATOR_RPC_SEND_DURATION
                 .with_label_values(&[pt, "in_flight"])
                 .observe(send_start.elapsed().as_secs_f64());
@@ -850,7 +860,7 @@ pub(super) fn spawn_fire_and_store(
     tokio::spawn(async move {
         let send_start = std::time::Instant::now();
         match sign_and_send_transaction(rpc_client, instruction.clone(), retry_policy).await {
-            Ok(signature) => {
+            Ok((signature, _last_valid_block_height)) => {
                 metrics::OPERATOR_RPC_SEND_DURATION
                     .with_label_values(&[program_type.as_label(), "in_flight"])
                     .observe(send_start.elapsed().as_secs_f64());
@@ -1376,7 +1386,13 @@ mod tests {
         // Populate remint cache and some pending signatures
         state.remint_cache.insert(5, make_remint_info(10));
         let sig = Signature::new_unique();
-        state.pending_signatures.insert(5, vec![sig]);
+        state.pending_signatures.insert(
+            5,
+            vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 0,
+            }],
+        );
 
         let ctx = TransactionContext {
             transaction_id: Some(10),
@@ -1398,7 +1414,7 @@ mod tests {
         let entry = &state.pending_remints[0];
         assert_eq!(entry.ctx.transaction_id, Some(10));
         assert_eq!(entry.signatures.len(), 1);
-        assert_eq!(entry.signatures[0], sig);
+        assert_eq!(entry.signatures[0].signature, sig);
         assert_eq!(entry.original_error, "release_funds failed");
         assert_eq!(entry.finality_check_attempts, 0);
 
@@ -1465,9 +1481,13 @@ mod tests {
         state.smt_state = Some(smt);
         state.retry_counts.insert(3, 2);
         state.remint_cache.insert(3, make_remint_info(50));
-        state
-            .pending_signatures
-            .insert(3, vec![Signature::new_unique()]);
+        state.pending_signatures.insert(
+            3,
+            vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+        );
 
         let sig = solana_sdk::signature::Signature::new_unique();
         handle_success(&mut state, &ctx, sig, &storage_tx).await;
@@ -1498,11 +1518,18 @@ mod tests {
 
         // Simulate what send_and_confirm does: stash a signature
         let sig = Signature::new_unique();
-        state.pending_signatures.entry(nonce).or_default().push(sig);
+        state
+            .pending_signatures
+            .entry(nonce)
+            .or_default()
+            .push(PendingSig {
+                signature: sig,
+                last_valid_block_height: 0,
+            });
 
         assert!(state.pending_signatures.contains_key(&nonce));
         assert_eq!(state.pending_signatures[&nonce].len(), 1);
-        assert_eq!(state.pending_signatures[&nonce][0], sig);
+        assert_eq!(state.pending_signatures[&nonce][0].signature, sig);
 
         // Stash another (simulating a retry)
         let sig2 = Signature::new_unique();
@@ -1510,7 +1537,10 @@ mod tests {
             .pending_signatures
             .entry(nonce)
             .or_default()
-            .push(sig2);
+            .push(PendingSig {
+                signature: sig2,
+                last_valid_block_height: 0,
+            });
         assert_eq!(state.pending_signatures[&nonce].len(), 2);
     }
 
@@ -1536,7 +1566,19 @@ mod tests {
         let sig1 = Signature::new_unique();
         let sig2 = Signature::new_unique();
         state.remint_cache.insert(5, make_remint_info(10));
-        state.pending_signatures.insert(5, vec![sig1, sig2]);
+        state.pending_signatures.insert(
+            5,
+            vec![
+                PendingSig {
+                    signature: sig1,
+                    last_valid_block_height: 100,
+                },
+                PendingSig {
+                    signature: sig2,
+                    last_valid_block_height: 200,
+                },
+            ],
+        );
 
         let ctx = TransactionContext {
             transaction_id: Some(10),
@@ -1560,7 +1602,7 @@ mod tests {
             "set_pending_remint should be called exactly once"
         );
 
-        let (stored_id, stored_sigs, stored_deadline) = &calls[0];
+        let (stored_id, stored_sigs, stored_lvbhs, stored_deadline) = &calls[0];
         assert_eq!(*stored_id, 10, "wrong transaction_id persisted");
 
         assert_eq!(
@@ -1576,6 +1618,25 @@ mod tests {
             stored_sigs.contains(&sig2.to_string()),
             "sig2 must be persisted"
         );
+
+        // lvbh array must be index-paired with sig array and carry the values
+        // we stashed at send time. Otherwise the remint gate can't tell a still-
+        // live broadcast from a dead one.
+        assert_eq!(
+            stored_sigs.len(),
+            stored_lvbhs.len(),
+            "sig array and lvbh array must be the same length"
+        );
+        let sig1_idx = stored_sigs
+            .iter()
+            .position(|stored_sig| stored_sig == &sig1.to_string())
+            .unwrap();
+        let sig2_idx = stored_sigs
+            .iter()
+            .position(|stored_sig| stored_sig == &sig2.to_string())
+            .unwrap();
+        assert_eq!(stored_lvbhs[sig1_idx], 100, "sig1's lvbh must be persisted");
+        assert_eq!(stored_lvbhs[sig2_idx], 200, "sig2's lvbh must be persisted");
 
         // Deadline must be ~FINALITY_SAFETY_DELAY (32s) from now.
         // We allow a ±3s window to absorb test execution time.
@@ -1608,9 +1669,13 @@ mod tests {
         mock.set_should_fail("set_pending_remint", true);
 
         state.remint_cache.insert(5, make_remint_info(10));
-        state
-            .pending_signatures
-            .insert(5, vec![Signature::new_unique()]);
+        state.pending_signatures.insert(
+            5,
+            vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+        );
 
         let ctx = TransactionContext {
             transaction_id: Some(10),

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1565,17 +1565,19 @@ mod tests {
         // failing permanently. Both must be persisted for a complete finality check.
         let sig1 = Signature::new_unique();
         let sig2 = Signature::new_unique();
+        let sig1_lvbh: u64 = 100;
+        let sig2_lvbh: u64 = 200;
         state.remint_cache.insert(5, make_remint_info(10));
         state.pending_signatures.insert(
             5,
             vec![
                 PendingSig {
                     signature: sig1,
-                    last_valid_block_height: 100,
+                    last_valid_block_height: sig1_lvbh,
                 },
                 PendingSig {
                     signature: sig2,
-                    last_valid_block_height: 200,
+                    last_valid_block_height: sig2_lvbh,
                 },
             ],
         );
@@ -1635,8 +1637,14 @@ mod tests {
             .iter()
             .position(|stored_sig| stored_sig == &sig2.to_string())
             .unwrap();
-        assert_eq!(stored_lvbhs[sig1_idx], 100, "sig1's lvbh must be persisted");
-        assert_eq!(stored_lvbhs[sig2_idx], 200, "sig2's lvbh must be persisted");
+        assert_eq!(
+            stored_lvbhs[sig1_idx], sig1_lvbh as i64,
+            "sig1's lvbh must be persisted"
+        );
+        assert_eq!(
+            stored_lvbhs[sig2_idx], sig2_lvbh as i64,
+            "sig2's lvbh must be persisted"
+        );
 
         // Deadline must be ~FINALITY_SAFETY_DELAY (32s) from now.
         // We allow a ±3s window to absorb test execution time.

--- a/indexer/src/operator/sender/types.rs
+++ b/indexer/src/operator/sender/types.rs
@@ -157,8 +157,8 @@ pub struct SenderState {
     /// Cached remint info for withdrawal transactions, keyed by nonce.
     /// Extracted before cleanup_failed_transaction removes builder from SMT cache.
     pub remint_cache: HashMap<u64, WithdrawalRemintInfo>,
-    /// Signatures sent per withdrawal nonce, used for finality checks before reminting.
-    pub pending_signatures: HashMap<u64, Vec<Signature>>,
+    /// Signatures sent per withdrawal nonce (with lvbh), used for finality checks before reminting.
+    pub pending_signatures: HashMap<u64, Vec<PendingSig>>,
     /// Deferred remint queue — entries are processed after their deadline matures.
     pub pending_remints: Vec<PendingRemint>,
     /// Mint/InitializeMint transactions sent but awaiting on-chain confirmation.
@@ -172,12 +172,20 @@ pub struct SenderState {
     pub semaphore: Arc<Semaphore>,
 }
 
+/// Withdrawal signature + its blockhash's `last_valid_block_height`, so the
+/// remint gate can prove the signature can no longer land.
+#[derive(Debug, Clone, Copy)]
+pub struct PendingSig {
+    pub signature: Signature,
+    pub last_valid_block_height: u64,
+}
+
 /// A remint deferred until Solana finality window passes, allowing us to verify
 /// that the original withdrawal definitively did not land before reminting.
 pub struct PendingRemint {
     pub ctx: TransactionContext,
     pub remint_info: WithdrawalRemintInfo,
-    pub signatures: Vec<Signature>,
+    pub signatures: Vec<PendingSig>,
     pub original_error: String,
     /// UTC timestamp after which the finality check runs. Using DateTime<Utc> instead of
     /// Instant allows the deadline to be persisted to the database and restored on restart.

--- a/indexer/src/operator/utils/rpc_util.rs
+++ b/indexer/src/operator/utils/rpc_util.rs
@@ -137,14 +137,18 @@ impl RpcClientWithRetry {
     }
 
     /// Get recent blockhash + last_valid_block_height with retry.
-    pub async fn get_latest_blockhash_with_lvbh(
+    pub async fn get_latest_blockhash_with_commitment(
         &self,
     ) -> Result<(Hash, u64), Box<client_error::Error>> {
-        self.with_retry("get_latest_blockhash", RetryPolicy::Idempotent, || async {
-            self.rpc_client
-                .get_latest_blockhash_with_commitment(self.rpc_client.commitment())
-                .await
-        })
+        self.with_retry(
+            "get_latest_blockhash_with_commitment",
+            RetryPolicy::Idempotent,
+            || async {
+                self.rpc_client
+                    .get_latest_blockhash_with_commitment(self.rpc_client.commitment())
+                    .await
+            },
+        )
         .await
     }
 

--- a/indexer/src/operator/utils/rpc_util.rs
+++ b/indexer/src/operator/utils/rpc_util.rs
@@ -136,6 +136,28 @@ impl RpcClientWithRetry {
         .await
     }
 
+    /// Get recent blockhash + last_valid_block_height with retry.
+    pub async fn get_latest_blockhash_with_lvbh(
+        &self,
+    ) -> Result<(Hash, u64), Box<client_error::Error>> {
+        self.with_retry("get_latest_blockhash", RetryPolicy::Idempotent, || async {
+            self.rpc_client
+                .get_latest_blockhash_with_commitment(self.rpc_client.commitment())
+                .await
+        })
+        .await
+    }
+
+    /// Get the current block height with retry. Used by the pending-remint gate
+    /// to compare against each stored signature's `last_valid_block_height` and
+    /// decide whether a broadcast can still land.
+    pub async fn get_block_height(&self) -> Result<u64, Box<client_error::Error>> {
+        self.with_retry("get_block_height", RetryPolicy::Idempotent, || async {
+            self.rpc_client.get_block_height().await
+        })
+        .await
+    }
+
     /// Send transaction with configurable retry policy
     ///
     /// # Arguments

--- a/indexer/src/operator/utils/transaction_util.rs
+++ b/indexer/src/operator/utils/transaction_util.rs
@@ -57,7 +57,7 @@ pub async fn sign_and_send_transaction(
     }
 
     let (recent_blockhash, last_valid_block_height) = rpc_client
-        .get_latest_blockhash_with_lvbh()
+        .get_latest_blockhash_with_commitment()
         .await
         .map_err(TransactionError::Rpc)?;
 

--- a/indexer/src/operator/utils/transaction_util.rs
+++ b/indexer/src/operator/utils/transaction_util.rs
@@ -43,7 +43,7 @@ pub async fn sign_and_send_transaction(
     rpc_client: Arc<RpcClientWithRetry>,
     mut ix_with_signers: InstructionWithSigners,
     retry_policy: RetryPolicy,
-) -> Result<Signature, TransactionError> {
+) -> Result<(Signature, u64), TransactionError> {
     if let Some(compute_unit_price) = ix_with_signers.compute_unit_price {
         let compute_budget_ix =
             ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price);
@@ -56,8 +56,8 @@ pub async fn sign_and_send_transaction(
         ix_with_signers.instructions.insert(0, compute_budget_ix);
     }
 
-    let recent_blockhash = rpc_client
-        .get_latest_blockhash()
+    let (recent_blockhash, last_valid_block_height) = rpc_client
+        .get_latest_blockhash_with_lvbh()
         .await
         .map_err(TransactionError::Rpc)?;
 
@@ -81,7 +81,7 @@ pub async fn sign_and_send_transaction(
         .await
         .map_err(TransactionError::Rpc)?;
 
-    Ok(signature)
+    Ok((signature, last_valid_block_height))
 }
 
 /// Check transaction status with polling.
@@ -547,7 +547,7 @@ mod tests {
 
         let result = sign_and_send_transaction(rpc_client, ix, RetryPolicy::None).await;
 
-        let sig = result.unwrap();
+        let (sig, _) = result.unwrap();
         assert_eq!(sig.to_string(), expected_sig);
     }
 

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -73,6 +73,11 @@ pub struct DbTransaction {
     /// UTC timestamp of when the finality check deadline expires for PendingRemint transactions.
     /// Set when transitioning to PendingRemint, used to restore the exact wait time on restart.
     pub pending_remint_deadline_at: Option<DateTime<Utc>>,
+    /// Persisted defer counter for PendingRemint rows. Each finality-check
+    /// failure or liveness deferral bumps this; restoring it on restart is
+    /// what keeps the `MAX_FINALITY_CHECK_ATTEMPTS` budget honest across
+    /// crashes. Non-PendingRemint rows always carry 0 (column DEFAULT).
+    pub finality_check_attempts: i32,
 }
 
 /// Per-mint balance aggregate used during startup reconciliation.
@@ -193,6 +198,7 @@ impl DbTransactionBuilder {
             remint_signatures: None,
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         }
     }
 }

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -68,8 +68,10 @@ pub struct DbTransaction {
     /// PendingRemint. Used on restart to verify whether the original withdrawal
     /// finalized before attempting to remint.
     pub remint_signatures: Option<Vec<String>>,
-    /// UTC timestamp of when the finality check deadline expires for PendingRemint transactions.                                                                           
-    /// Set when transitioning to PendingRemint, used to restore the exact wait time on restart.                                                                            
+    /// `last_valid_block_height` per stored signature, index-paired with `remint_signatures`.
+    pub remint_last_valid_block_heights: Option<Vec<i64>>,
+    /// UTC timestamp of when the finality check deadline expires for PendingRemint transactions.
+    /// Set when transitioning to PendingRemint, used to restore the exact wait time on restart.
     pub pending_remint_deadline_at: Option<DateTime<Utc>>,
 }
 
@@ -189,6 +191,7 @@ impl DbTransactionBuilder {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
         }
     }

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -200,15 +200,22 @@ impl Storage {
     }
 
     /// Transitions a withdrawal to PendingRemint, storing withdrawal
-    /// signatures for the finality check on restart.
+    /// signatures + lvbh for the finality check on restart.
     pub async fn set_pending_remint(
         &self,
         transaction_id: i64,
         remint_signatures: Vec<String>,
+        remint_last_valid_block_heights: Vec<i64>,
         deadline_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<(), StorageError> {
-        set_pending_remint::set_pending_remint(self, transaction_id, remint_signatures, deadline_at)
-            .await
+        set_pending_remint::set_pending_remint(
+            self,
+            transaction_id,
+            remint_signatures,
+            remint_last_valid_block_heights,
+            deadline_at,
+        )
+        .await
     }
 
     /// Returns all withdrawal transactions in PendingRemint status.
@@ -271,6 +278,7 @@ mod tests {
             processed_at: None,
             counterpart_signature: None,
             remint_signatures: None,
+            remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
         }
     }

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -1,5 +1,6 @@
 pub use super::models::*;
 
+pub mod bump_pending_remint_finality_attempt;
 pub mod close;
 pub mod count_pending_transactions;
 pub mod drop_tables;
@@ -218,6 +219,25 @@ impl Storage {
         .await
     }
 
+    /// Persist an incremented defer counter and extended deadline for a
+    /// PendingRemint row. Called from the sender loop each time
+    /// `process_pending_remints` defers an entry, so the
+    /// `MAX_FINALITY_CHECK_ATTEMPTS` budget survives restarts.
+    pub async fn bump_pending_remint_finality_attempt(
+        &self,
+        transaction_id: i64,
+        attempts: i32,
+        new_deadline: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), StorageError> {
+        bump_pending_remint_finality_attempt::bump_pending_remint_finality_attempt(
+            self,
+            transaction_id,
+            attempts,
+            new_deadline,
+        )
+        .await
+    }
+
     /// Returns all withdrawal transactions in PendingRemint status.
     /// Called on startup to re-hydrate the remint queue after a crash.
     pub async fn get_pending_remint_transactions(
@@ -280,6 +300,7 @@ mod tests {
             remint_signatures: None,
             remint_last_valid_block_heights: None,
             pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
         }
     }
 

--- a/indexer/src/storage/common/storage/bump_pending_remint_finality_attempt.rs
+++ b/indexer/src/storage/common/storage/bump_pending_remint_finality_attempt.rs
@@ -1,0 +1,26 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+pub async fn bump_pending_remint_finality_attempt(
+    storage: &Storage,
+    transaction_id: i64,
+    attempts: i32,
+    new_deadline: chrono::DateTime<chrono::Utc>,
+) -> Result<(), StorageError> {
+    match storage {
+        Storage::Postgres(db) => {
+            db.bump_pending_remint_finality_attempt_internal(
+                transaction_id,
+                attempts,
+                new_deadline,
+            )
+            .await?;
+            Ok(())
+        }
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .bump_pending_remint_finality_attempt(transaction_id, attempts, new_deadline)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -9,8 +9,8 @@ use std::sync::Mutex;
 /// Recorded status update from `update_transaction_status`.
 pub type StatusUpdateRecord = (i64, TransactionStatus, Option<String>, DateTime<Utc>);
 
-/// Tuple of (transaction_id, withdrawal_signature_strings, deadline) — the data persisted when a withdrawal transitions to PendingRemint status.
-pub type PendingRemintRecord = (i64, Vec<String>, DateTime<Utc>);
+/// (transaction_id, signatures, last_valid_block_heights, deadline) persisted on PendingRemint transition.
+pub type PendingRemintRecord = (i64, Vec<String>, Vec<i64>, DateTime<Utc>);
 
 #[derive(Clone, Default)]
 pub struct MockStorage {
@@ -310,6 +310,7 @@ impl MockStorage {
         &self,
         transaction_id: i64,
         remint_signatures: Vec<String>,
+        remint_last_valid_block_heights: Vec<i64>,
         deadline_at: DateTime<Utc>,
     ) -> Result<(), StorageError> {
         if self
@@ -327,6 +328,7 @@ impl MockStorage {
         self.pending_remint_signatures.lock().unwrap().push((
             transaction_id,
             remint_signatures,
+            remint_last_valid_block_heights,
             deadline_at,
         ));
         Ok(())

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -334,6 +334,29 @@ impl MockStorage {
         Ok(())
     }
 
+    /// Update the in-memory pending_remint row for `transaction_id` with the
+    /// new attempt counter and deadline. Returns `RowNotFound` if no row
+    /// exists, matching the Postgres semantics so a test can observe a
+    /// missing-row failure. Honors `should_fail("bump_pending_remint_finality_attempt")`.
+    pub async fn bump_pending_remint_finality_attempt(
+        &self,
+        transaction_id: i64,
+        attempts: i32,
+        new_deadline: DateTime<Utc>,
+    ) -> Result<(), StorageError> {
+        self.check_should_fail("bump_pending_remint_finality_attempt")?;
+        let mut rows = self.pending_remint_transactions.lock().unwrap();
+        let row = rows
+            .iter_mut()
+            .find(|t| t.id == transaction_id)
+            .ok_or_else(|| StorageError::DatabaseError {
+                message: format!("no PendingRemint row for id {transaction_id}"),
+            })?;
+        row.finality_check_attempts = attempts;
+        row.pending_remint_deadline_at = Some(new_deadline);
+        Ok(())
+    }
+
     pub async fn get_pending_remint_transactions(
         &self,
     ) -> Result<Vec<DbTransaction>, StorageError> {

--- a/indexer/src/storage/common/storage/set_pending_remint.rs
+++ b/indexer/src/storage/common/storage/set_pending_remint.rs
@@ -4,19 +4,30 @@ pub async fn set_pending_remint(
     storage: &Storage,
     transaction_id: i64,
     remint_signatures: Vec<String>,
+    remint_last_valid_block_heights: Vec<i64>,
     deadline_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<(), StorageError> {
     match storage {
         Storage::Postgres(db) => {
-            db.set_pending_remint_internal(transaction_id, remint_signatures, deadline_at)
-                .await?;
+            db.set_pending_remint_internal(
+                transaction_id,
+                remint_signatures,
+                remint_last_valid_block_heights,
+                deadline_at,
+            )
+            .await?;
 
             Ok(())
         }
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .set_pending_remint(transaction_id, remint_signatures, deadline_at)
+                .set_pending_remint(
+                    transaction_id,
+                    remint_signatures,
+                    remint_last_valid_block_heights,
+                    deadline_at,
+                )
                 .await
         }
     }

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -27,6 +27,7 @@ mod transaction_cols {
     pub const COUNTERPART_SIGNATURE: &str = "counterpart_signature";
     pub const TRACE_ID: &str = "trace_id";
     pub const REMINT_SIGNATURES: &str = "remint_signatures";
+    pub const REMINT_LAST_VALID_BLOCK_HEIGHTS: &str = "remint_last_valid_block_heights";
     pub const PENDING_REMINT_DEADLINE_AT: &str = "pending_remint_deadline_at";
 }
 
@@ -175,15 +176,30 @@ impl PostgresDb {
         info!("Running pending_remint_deadline_at migration if needed...");
         sqlx::query(
             r#"
-            DO $$ BEGIN                                                                         
-                ALTER TABLE transactions ADD COLUMN IF NOT EXISTS pending_remint_deadline_at    
-        TIMESTAMPTZ;                                                                            
-            END $$;                                                                             
+            DO $$ BEGIN
+                ALTER TABLE transactions ADD COLUMN IF NOT EXISTS pending_remint_deadline_at
+        TIMESTAMPTZ;
+            END $$;
             "#,
         )
         .execute(&self.pool)
         .await?;
         info!("pending_remint_deadline_at migration complete");
+
+        // Parallel array to remint_signatures: last_valid_block_height per stored
+        // signature so the remint gate can prove a broadcast can no longer land.
+        info!("Running remint_last_valid_block_heights migration if needed...");
+        sqlx::query(
+            r#"
+            DO $$ BEGIN
+                ALTER TABLE transactions
+                ADD COLUMN IF NOT EXISTS remint_last_valid_block_heights BIGINT[];
+            END $$;
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        info!("remint_last_valid_block_heights migration complete");
 
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_trace_id ON transactions (trace_id)",
@@ -613,7 +629,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -635,6 +651,7 @@ impl PostgresDb {
             transaction_cols::PROCESSED_AT,
             transaction_cols::COUNTERPART_SIGNATURE,
             transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             // Filters
             transaction_cols::STATUS,
@@ -835,6 +852,7 @@ impl PostgresDb {
         &self,
         transaction_id: i64,
         remint_signatures: Vec<String>,
+        remint_last_valid_block_heights: Vec<i64>,
         deadline_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<(), sqlx::Error> {
         let result = sqlx::query(
@@ -843,7 +861,8 @@ impl PostgresDb {
             SET
                 status = $2,
                 remint_signatures = $3,
-                pending_remint_deadline_at = $4,
+                remint_last_valid_block_heights = $4,
+                pending_remint_deadline_at = $5,
                 updated_at = NOW()
             WHERE id = $1
                 AND status = 'processing'
@@ -852,6 +871,7 @@ impl PostgresDb {
         .bind(transaction_id)
         .bind(TransactionStatus::PendingRemint)
         .bind(remint_signatures)
+        .bind(remint_last_valid_block_heights)
         .bind(deadline_at)
         .execute(&self.pool)
         .await?;

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -29,6 +29,7 @@ mod transaction_cols {
     pub const REMINT_SIGNATURES: &str = "remint_signatures";
     pub const REMINT_LAST_VALID_BLOCK_HEIGHTS: &str = "remint_last_valid_block_heights";
     pub const PENDING_REMINT_DEADLINE_AT: &str = "pending_remint_deadline_at";
+    pub const FINALITY_CHECK_ATTEMPTS: &str = "finality_check_attempts";
 }
 
 #[derive(Clone)]
@@ -200,6 +201,21 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
         info!("remint_last_valid_block_heights migration complete");
+
+        // Persisted defer-counter for pending remints so the
+        // MAX_FINALITY_CHECK_ATTEMPTS budget survives operator restarts.
+        info!("Running finality_check_attempts migration if needed...");
+        sqlx::query(
+            r#"
+            DO $$ BEGIN
+                ALTER TABLE transactions
+                ADD COLUMN IF NOT EXISTS finality_check_attempts INTEGER NOT NULL DEFAULT 0;
+            END $$;
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        info!("finality_check_attempts migration complete");
 
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_trace_id ON transactions (trace_id)",
@@ -583,7 +599,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -608,6 +624,7 @@ impl PostgresDb {
             transaction_cols::REMINT_SIGNATURES,
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
+            transaction_cols::FINALITY_CHECK_ATTEMPTS,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -630,7 +647,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -654,6 +671,7 @@ impl PostgresDb {
             transaction_cols::REMINT_SIGNATURES,
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
+            transaction_cols::FINALITY_CHECK_ATTEMPTS,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -676,7 +694,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1
             ORDER BY {} DESC
@@ -701,6 +719,7 @@ impl PostgresDb {
             transaction_cols::REMINT_SIGNATURES,
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
+            transaction_cols::FINALITY_CHECK_ATTEMPTS,
             // Filter
             transaction_cols::TRANSACTION_TYPE,
             // Ordering
@@ -763,7 +782,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -789,6 +808,7 @@ impl PostgresDb {
             transaction_cols::REMINT_SIGNATURES,
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
+            transaction_cols::FINALITY_CHECK_ATTEMPTS,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -876,6 +896,39 @@ impl PostgresDb {
         .bind(remint_signatures)
         .bind(remint_last_valid_block_heights)
         .bind(deadline_at)
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(sqlx::Error::RowNotFound);
+        }
+
+        Ok(())
+    }
+
+    /// Persists an incremented defer counter and the extended deadline for an
+    /// already-PendingRemint row. The status guard prevents resurrecting a
+    /// terminal row (Completed / FailedReminted / ManualReview).
+    pub async fn bump_pending_remint_finality_attempt_internal(
+        &self,
+        transaction_id: i64,
+        attempts: i32,
+        new_deadline: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET
+                finality_check_attempts = $2,
+                pending_remint_deadline_at = $3,
+                updated_at = NOW()
+            WHERE id = $1
+                AND status = 'pending_remint'
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(attempts)
+        .bind(new_deadline)
         .execute(&self.pool)
         .await?;
 

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -583,7 +583,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -606,6 +606,7 @@ impl PostgresDb {
             transaction_cols::PROCESSED_AT,
             transaction_cols::COUNTERPART_SIGNATURE,
             transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             // Filters
             transaction_cols::STATUS,
@@ -674,7 +675,7 @@ impl PostgresDb {
         sqlx::query_as::<_, DbTransaction>(&format!(
             r#"
             SELECT
-                {}, {}, {}, {}, {}, {}, {}, {}, {},
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
                 {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1
@@ -698,6 +699,7 @@ impl PostgresDb {
             transaction_cols::PROCESSED_AT,
             transaction_cols::COUNTERPART_SIGNATURE,
             transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             // Filter
             transaction_cols::TRANSACTION_TYPE,
@@ -761,7 +763,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -785,6 +787,7 @@ impl PostgresDb {
             transaction_cols::PROCESSED_AT,
             transaction_cols::COUNTERPART_SIGNATURE,
             transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             // Filters
             transaction_cols::STATUS,

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -65,6 +65,7 @@ fn make_db_transaction(sig: &str, txn_type: TransactionType) -> DbTransaction {
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: None,
+        remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
     }
 }
@@ -553,7 +554,7 @@ async fn set_pending_remint_succeeds_when_processing() -> Result<(), Box<dyn std
 
     let deadline = Utc::now() + chrono::Duration::seconds(32);
     storage
-        .set_pending_remint(id, vec!["sig1".to_string()], deadline)
+        .set_pending_remint(id, vec!["sig1".to_string()], vec![0], deadline)
         .await?;
 
     Ok(())
@@ -573,7 +574,7 @@ async fn set_pending_remint_fails_when_not_processing() -> Result<(), Box<dyn st
 
     let deadline = Utc::now() + chrono::Duration::seconds(32);
     let result = storage
-        .set_pending_remint(id, vec!["sig1".to_string()], deadline)
+        .set_pending_remint(id, vec!["sig1".to_string()], vec![0], deadline)
         .await;
 
     assert!(result.is_err(), "should fail when status is not processing");

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -67,6 +67,7 @@ fn make_db_transaction(sig: &str, txn_type: TransactionType) -> DbTransaction {
         remint_signatures: None,
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
+        finality_check_attempts: 0,
     }
 }
 

--- a/indexer/tests/remint_e2e_test.rs
+++ b/indexer/tests/remint_e2e_test.rs
@@ -147,9 +147,17 @@ async fn test_pending_remint_persisted_and_recovered() -> Result<(), Box<dyn std
 
     // Simulate handle_permanent_failure persisting the remint state.
     // Deadline is 32s from now — the finality safety window.
+    // Distinct lvbh values per sig so we can verify index-aligned roundtrip.
+    let lvbh_sig1: i64 = 1_000;
+    let lvbh_sig2: i64 = 2_000;
     let deadline = Utc::now() + chrono::Duration::seconds(32);
     storage
-        .set_pending_remint(tx_id, vec![sig1.to_string(), sig2.to_string()], deadline)
+        .set_pending_remint(
+            tx_id,
+            vec![sig1.to_string(), sig2.to_string()],
+            vec![lvbh_sig1, lvbh_sig2],
+            deadline,
+        )
         .await?;
 
     // Simulate restart: fetch all PendingRemint rows as recover_pending_remints would.
@@ -181,6 +189,35 @@ async fn test_pending_remint_persisted_and_recovered() -> Result<(), Box<dyn std
     assert!(
         stored_sigs.contains(&sig2.to_string()),
         "sig2 must be stored"
+    );
+
+    // last_valid_block_height per sig must be stored index-aligned with the
+    // sig array. The gate uses this to determine whether a broadcast can
+    // still land, so reordering or losing it would re-open the audit hole.
+    let stored_lvbhs = row
+        .remint_last_valid_block_heights
+        .as_ref()
+        .expect("last_valid_block_heights must be stored");
+    assert_eq!(
+        stored_lvbhs.len(),
+        stored_sigs.len(),
+        "lvbh array must be the same length as the signature array"
+    );
+    let sig1_index = stored_sigs
+        .iter()
+        .position(|stored_sig| stored_sig == &sig1.to_string())
+        .expect("sig1 must be in stored array");
+    let sig2_index = stored_sigs
+        .iter()
+        .position(|stored_sig| stored_sig == &sig2.to_string())
+        .expect("sig2 must be in stored array");
+    assert_eq!(
+        stored_lvbhs[sig1_index], lvbh_sig1,
+        "sig1's lvbh must round-trip in the same slot as sig1"
+    );
+    assert_eq!(
+        stored_lvbhs[sig2_index], lvbh_sig2,
+        "sig2's lvbh must round-trip in the same slot as sig2"
     );
 
     // Deadline must be stored and within 2s of what we wrote (Postgres
@@ -221,7 +258,7 @@ async fn test_resolved_remint_not_returned_by_recovery_query(
     // Insert and transition to PendingRemint.
     let tx_id = insert_withdrawal(&pool, &mint, &recipient, 5_000).await?;
     storage
-        .set_pending_remint(tx_id, vec![sig.to_string()], deadline)
+        .set_pending_remint(tx_id, vec![sig.to_string()], vec![0], deadline)
         .await?;
 
     // Confirm it shows up in recovery before resolution.
@@ -267,7 +304,7 @@ async fn test_failed_reminted_row_not_returned_by_recovery_query(
     // 1. Insert withdrawal and transition to PendingRemint.
     let tx_id = insert_withdrawal(&pool, &mint, &recipient, 5_000).await?;
     storage
-        .set_pending_remint(tx_id, vec![sig.to_string()], deadline)
+        .set_pending_remint(tx_id, vec![sig.to_string()], vec![0], deadline)
         .await?;
 
     // Confirm it appears in recovery before resolution.
@@ -331,7 +368,7 @@ async fn test_withdrawal_failure_remint_restores_balance() -> Result<(), Box<dyn
     let deadline = Utc::now() + chrono::Duration::seconds(32);
     let tx_id = insert_withdrawal(&pool, &mint, &recipient, withdrawal_amount).await?;
     storage
-        .set_pending_remint(tx_id, vec![withdrawal_sig.to_string()], deadline)
+        .set_pending_remint(tx_id, vec![withdrawal_sig.to_string()], vec![0], deadline)
         .await?;
 
     // Step 3: while the row is in PendingRemint the balance must reflect the
@@ -409,7 +446,12 @@ async fn test_multiple_pending_remints_excluded_from_balance(
     for amount in [10_000i64, 8_000, 12_000] {
         let tx_id = insert_withdrawal(&pool, &mint, &Pubkey::new_unique(), amount).await?;
         storage
-            .set_pending_remint(tx_id, vec![Signature::new_unique().to_string()], deadline)
+            .set_pending_remint(
+                tx_id,
+                vec![Signature::new_unique().to_string()],
+                vec![0],
+                deadline,
+            )
             .await?;
     }
 
@@ -456,7 +498,7 @@ async fn test_manual_review_not_returned_by_recovery_query(
 
     let tx_id = insert_withdrawal(&pool, &mint, &recipient, 5_000).await?;
     storage
-        .set_pending_remint(tx_id, vec![sig.to_string()], deadline)
+        .set_pending_remint(tx_id, vec![sig.to_string()], vec![0], deadline)
         .await?;
 
     // Confirm it appears before resolution.

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -645,20 +645,20 @@ async fn drill_6_recovery_query_skips_terminal_statuses() -> Result<(), Box<dyn 
     // resolved by recovery actions per the runbook.
     let to_completed = seed_withdrawal(&pool, "processing", 100, None).await?;
     storage
-        .set_pending_remint(to_completed, vec![sig.clone()], deadline)
+        .set_pending_remint(to_completed, vec![sig.clone()], vec![0], deadline)
         .await?;
     let to_failed_reminted = seed_withdrawal(&pool, "processing", 101, None).await?;
     storage
-        .set_pending_remint(to_failed_reminted, vec![sig.clone()], deadline)
+        .set_pending_remint(to_failed_reminted, vec![sig.clone()], vec![0], deadline)
         .await?;
     let to_manual_review = seed_withdrawal(&pool, "processing", 102, None).await?;
     storage
-        .set_pending_remint(to_manual_review, vec![sig.clone()], deadline)
+        .set_pending_remint(to_manual_review, vec![sig.clone()], vec![0], deadline)
         .await?;
     // Plus one that stays in pending_remint — the only one recovery should return.
     let still_pending = seed_withdrawal(&pool, "processing", 103, None).await?;
     storage
-        .set_pending_remint(still_pending, vec![sig.clone()], deadline)
+        .set_pending_remint(still_pending, vec![sig.clone()], vec![0], deadline)
         .await?;
 
     // Apply the recovery actions the runbook prescribes.

--- a/integration/tests/indexer/harness_sanity.rs
+++ b/integration/tests/indexer/harness_sanity.rs
@@ -67,6 +67,7 @@ fn pending_deposit_row(id: i64, mint: Pubkey, recipient: Pubkey) -> DbTransactio
         remint_signatures: None,
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
+        finality_check_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/harness_sanity.rs
+++ b/integration/tests/indexer/harness_sanity.rs
@@ -65,6 +65,7 @@ fn pending_deposit_row(id: i64, mint: Pubkey, recipient: Pubkey) -> DbTransactio
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: None,
+        remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
     }
 }

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -209,6 +209,7 @@ fn make_withdrawal_transaction(
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: None,
+        remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
     }
 }

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -211,6 +211,7 @@ fn make_withdrawal_transaction(
         remint_signatures: None,
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
+        finality_check_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/pausable_mint.rs
+++ b/integration/tests/indexer/pausable_mint.rs
@@ -238,6 +238,7 @@ fn make_withdrawal_transaction(
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: None,
+        remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
     }
 }

--- a/integration/tests/indexer/pausable_mint.rs
+++ b/integration/tests/indexer/pausable_mint.rs
@@ -240,6 +240,7 @@ fn make_withdrawal_transaction(
         remint_signatures: None,
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
+        finality_check_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/pending_remint_storage.rs
+++ b/integration/tests/indexer/pending_remint_storage.rs
@@ -182,3 +182,72 @@ async fn test_pending_remint_query_filters_by_status() {
     assert_eq!(rows.len(), 1, "only the pending_remint row must return");
     assert_eq!(rows[0].id, ids[0]);
 }
+
+// ── Case D ──────────────────────────────────────────────────────────────────
+/// `finality_check_attempts` must persist and round-trip so the safety cap
+/// survives operator restarts. A row written with `attempts = 0` and then
+/// bumped twice must read back as 2; the WHERE-clause on the bump must reject
+/// non-PendingRemint rows so a terminal row can't be silently resurrected.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_finality_check_attempts_persisted_across_restart() {
+    let (db, url, _container) = start_pg("t12_attempts").await;
+    let storage = Storage::Postgres(db.clone());
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let sig = Signature::new_unique().to_string();
+    let tx = make_withdrawal(&sig, 0);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+
+    // Move to processing so set_pending_remint_internal's status guard passes.
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let initial_deadline = Utc::now() + ChronoDuration::seconds(32);
+    db.set_pending_remint_internal(
+        tx_id,
+        vec![Signature::new_unique().to_string()],
+        vec![0],
+        initial_deadline,
+    )
+    .await
+    .unwrap();
+
+    // Fresh PendingRemint rows start at 0.
+    let rows = db.get_pending_remint_transactions_internal().await.unwrap();
+    assert_eq!(rows[0].finality_check_attempts, 0);
+
+    // Two consecutive bumps mirror the defer path advancing through the cap.
+    let bumped_deadline_1 = Utc::now() + ChronoDuration::seconds(64);
+    db.bump_pending_remint_finality_attempt_internal(tx_id, 1, bumped_deadline_1)
+        .await
+        .unwrap();
+    let bumped_deadline_2 = Utc::now() + ChronoDuration::seconds(96);
+    db.bump_pending_remint_finality_attempt_internal(tx_id, 2, bumped_deadline_2)
+        .await
+        .unwrap();
+
+    // Restart-equivalent read sees the persisted counter, not 0.
+    let rows = db.get_pending_remint_transactions_internal().await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].finality_check_attempts, 2);
+
+    // Status guard: a terminal row must not be resurrectable by bump.
+    sqlx::query(
+        "UPDATE transactions SET status = 'manual_review'::transaction_status WHERE id = $1",
+    )
+    .bind(tx_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let result = db
+        .bump_pending_remint_finality_attempt_internal(tx_id, 3, Utc::now())
+        .await;
+    assert!(
+        matches!(result, Err(sqlx::Error::RowNotFound)),
+        "bump must reject non-PendingRemint rows, got {result:?}"
+    );
+}

--- a/integration/tests/indexer/pending_remint_storage.rs
+++ b/integration/tests/indexer/pending_remint_storage.rs
@@ -97,7 +97,8 @@ async fn test_pending_remint_round_trip_preserves_signatures_and_deadline() {
     ];
     let deadline = Utc::now() + ChronoDuration::minutes(30);
 
-    db.set_pending_remint_internal(tx_id, remint_sigs.clone(), deadline)
+    let remint_lvbhs = vec![0; remint_sigs.len()];
+    db.set_pending_remint_internal(tx_id, remint_sigs.clone(), remint_lvbhs, deadline)
         .await
         .expect("set_pending_remint must succeed");
 
@@ -157,6 +158,7 @@ async fn test_pending_remint_query_filters_by_status() {
     db.set_pending_remint_internal(
         ids[0],
         vec!["fake".to_string()],
+        vec![0],
         Utc::now() + ChronoDuration::minutes(10),
     )
     .await

--- a/integration/tests/indexer/permanent_delegate_mint.rs
+++ b/integration/tests/indexer/permanent_delegate_mint.rs
@@ -269,6 +269,7 @@ fn make_withdrawal_transaction(
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: None,
+        remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
     }
 }

--- a/integration/tests/indexer/permanent_delegate_mint.rs
+++ b/integration/tests/indexer/permanent_delegate_mint.rs
@@ -271,6 +271,7 @@ fn make_withdrawal_transaction(
         remint_signatures: None,
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
+        finality_check_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/processor_quarantine.rs
+++ b/integration/tests/indexer/processor_quarantine.rs
@@ -51,6 +51,7 @@ fn make_bad_deposit(id: i64) -> DbTransaction {
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: None,
+        remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
     }
 }

--- a/integration/tests/indexer/processor_quarantine.rs
+++ b/integration/tests/indexer/processor_quarantine.rs
@@ -53,6 +53,7 @@ fn make_bad_deposit(id: i64) -> DbTransaction {
         remint_signatures: None,
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
+        finality_check_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/remint_flow.rs
+++ b/integration/tests/indexer/remint_flow.rs
@@ -27,8 +27,18 @@
 //!       incremented; no status update.
 //!
 //!   (d) **Finality-check RPC error, attempts == MAX-1** — next failure
-//!       trips the cap and emits `ManualReview` with a "finality check
-//!       failed" error message.
+//!       trips the cap and emits `ManualReview` whose error message
+//!       names the underlying RPC failure.
+//!
+//!   (d.1) **Liveness gate, sig dropped + lvbh valid**: gate defers
+//!         rather than reminting because the broadcast could still land.
+//!
+//!   (d.2) **Liveness gate, sig confirmed-not-finalized + lvbh expired**:
+//!         regression guard. A confirmed tx will finalize regardless of
+//!         lvbh, so the gate must defer (not remint).
+//!
+//!   (d.3) **Liveness gate at cap**: `ManualReview` whose error message
+//!         names the liveness cause (distinct from RPC failure).
 
 #[path = "sender_fixtures.rs"]
 mod sender_fixtures;
@@ -39,7 +49,7 @@ use {
         operator::{
             sender::{
                 test_hooks,
-                types::{PendingRemint, SenderState, TransactionStatusUpdate},
+                types::{PendingRemint, PendingSig, SenderState, TransactionStatusUpdate},
             },
             utils::instruction_util::{remint_idempotency_memo, WithdrawalRemintInfo},
             SignerUtil,
@@ -90,13 +100,43 @@ fn make_pending_remint(
     finality_check_attempts: u32,
     info: WithdrawalRemintInfo,
 ) -> PendingRemint {
+    let pending_sigs = signatures
+        .into_iter()
+        .map(|signature| PendingSig {
+            signature,
+            last_valid_block_height: 0,
+        })
+        .collect();
     PendingRemint {
         ctx: withdrawal_ctx(transaction_id, nonce),
         remint_info: info,
-        signatures,
+        signatures: pending_sigs,
         original_error: "release_funds failed".to_string(),
         // Past deadline so `process_pending_remints` treats the entry
         // as matured and processes it on the first tick.
+        deadline: chrono::Utc::now() - chrono::Duration::seconds(1),
+        finality_check_attempts,
+    }
+}
+
+/// Build a PendingRemint with one signature whose `last_valid_block_height`
+/// the caller controls. Use when the test needs to exercise the gate's
+/// liveness comparison (`current_height > lvbh`).
+fn make_pending_remint_with_lvbh(
+    transaction_id: i64,
+    nonce: u64,
+    signature: Signature,
+    last_valid_block_height: u64,
+    finality_check_attempts: u32,
+) -> PendingRemint {
+    PendingRemint {
+        ctx: withdrawal_ctx(transaction_id, nonce),
+        remint_info: make_remint_info(transaction_id),
+        signatures: vec![PendingSig {
+            signature,
+            last_valid_block_height,
+        }],
+        original_error: "release_funds failed".to_string(),
         deadline: chrono::Utc::now() - chrono::Duration::seconds(1),
         finality_check_attempts,
     }
@@ -363,8 +403,12 @@ async fn process_pending_remints_routes_to_manual_review_at_max_attempts() {
     assert_eq!(update.status, TransactionStatus::ManualReview);
     let msg = update.error_message.unwrap_or_default();
     assert!(
-        msg.contains("finality check failed"),
-        "ManualReview at MAX must surface the 'finality check failed' label; got {msg:?}"
+        msg.contains("escalated to ManualReview"),
+        "ManualReview at MAX must surface the escalation label; got {msg:?}"
+    );
+    assert!(
+        msg.contains("signature status RPC failed"),
+        "ManualReview must surface the underlying RPC failure; got {msg:?}"
     );
     assert!(
         msg.contains("release_funds failed"),
@@ -374,6 +418,138 @@ async fn process_pending_remints_routes_to_manual_review_at_max_attempts() {
         state.pending_remints.is_empty(),
         "entry must NOT be re-queued past the cap"
     );
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// (d.1) Liveness gate, sig dropped but lvbh still valid → defer.
+// ─────────────────────────────────────────────────────────────────────
+//
+// Cluster has no record of the broadcast (null status). The blockhash
+// is still within its validity window, so a re-broadcast could land.
+// The gate must defer rather than remint.
+#[tokio::test]
+async fn process_pending_remints_defers_when_sig_within_blockhash_validity() {
+    let mock = MockRpcServer::start().await;
+    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+
+    let sig = Signature::new_unique();
+    state
+        .pending_remints
+        .push(make_pending_remint_with_lvbh(94, 6, sig, 1_000, 0));
+
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": { "slot": 200 },
+            "value": [null]
+        })),
+    );
+    // current_height (50) <= lvbh (1_000): sig still within validity.
+    mock.enqueue("getBlockHeight", Reply::result(json!(50)));
+
+    test_hooks::process_pending_remints(&mut state, &storage_tx).await;
+
+    assert!(
+        storage_rx.try_recv().is_err(),
+        "row must stay PendingRemint while the broadcast could still land"
+    );
+    assert_eq!(state.pending_remints.len(), 1, "entry must be re-queued");
+    assert_eq!(
+        state.pending_remints[0].finality_check_attempts, 1,
+        "deferral counter must increment by 1"
+    );
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// (d.2) Liveness gate, sig confirmed-not-finalized past lvbh → defer.
+// ─────────────────────────────────────────────────────────────────────
+//
+// Regression guard for the case where a low-fee broadcast lands late in
+// its validity window: status is `confirmed` (already in a block) and
+// the cluster has moved past lvbh, but finalization is still pending.
+// The tx will finalize regardless of lvbh, so the gate must defer.
+// Reminting here would double-pay when the tx finalizes a few slots later.
+#[tokio::test]
+async fn process_pending_remints_defers_when_sig_confirmed_not_finalized() {
+    let mock = MockRpcServer::start().await;
+    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+
+    let sig = Signature::new_unique();
+    state
+        .pending_remints
+        .push(make_pending_remint_with_lvbh(95, 7, sig, 100, 0));
+
+    // Status: confirmed (in a block) but not yet finalized, no error.
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": { "slot": 200 },
+            "value": [{
+                "slot": 100,
+                "confirmations": 1,
+                "err": null,
+                "status": { "Ok": null },
+                "confirmationStatus": "confirmed"
+            }]
+        })),
+    );
+    // current_height (1_000) > lvbh (100). The old buggy gate would
+    // treat the sig as expired here and remint.
+    mock.enqueue("getBlockHeight", Reply::result(json!(1_000)));
+
+    test_hooks::process_pending_remints(&mut state, &storage_tx).await;
+
+    assert!(
+        storage_rx.try_recv().is_err(),
+        "a confirmed-but-not-finalized sig must defer the remint"
+    );
+    assert_eq!(state.pending_remints.len(), 1);
+    assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// (d.3) Liveness gate at cap → ManualReview with liveness reason.
+// ─────────────────────────────────────────────────────────────────────
+//
+// Entry already at MAX-1 attempts. On this tick the sig is still live,
+// so the cap fires. The escalation message must identify the cause as
+// liveness, not an RPC failure, so operators can triage correctly.
+#[tokio::test]
+async fn process_pending_remints_liveness_cap_escalates_with_liveness_reason() {
+    let mock = MockRpcServer::start().await;
+    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+
+    let sig = Signature::new_unique();
+    state
+        .pending_remints
+        .push(make_pending_remint_with_lvbh(96, 8, sig, 1_000, 2));
+
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": { "slot": 200 },
+            "value": [null]
+        })),
+    );
+    mock.enqueue("getBlockHeight", Reply::result(json!(50)));
+
+    test_hooks::process_pending_remints(&mut state, &storage_tx).await;
+
+    let update = storage_rx
+        .recv()
+        .await
+        .expect("cap must emit a ManualReview update");
+    assert_eq!(update.transaction_id, 96);
+    assert_eq!(update.status, TransactionStatus::ManualReview);
+    let msg = update.error_message.unwrap_or_default();
+    assert!(
+        msg.contains("signatures still within blockhash validity"),
+        "escalation must name the liveness cause; got {msg:?}"
+    );
+    assert!(state.pending_remints.is_empty(), "entry must not re-queue");
     mock.shutdown().await;
 }
 

--- a/integration/tests/indexer/remint_flow.rs
+++ b/integration/tests/indexer/remint_flow.rs
@@ -62,7 +62,7 @@ use {
     },
     serde_json::json,
     solana_keychain::SolanaSigner,
-    solana_sdk::{commitment_config::CommitmentLevel, signature::Signature},
+    solana_sdk::{commitment_config::CommitmentLevel, pubkey::Pubkey, signature::Signature},
     std::{str::FromStr, sync::Arc},
     test_utils::mock_rpc::{MockRpcServer, Reply},
     tokio::sync::mpsc,
@@ -74,9 +74,11 @@ async fn build_state(
     SenderState,
     mpsc::Receiver<TransactionStatusUpdate>,
     mpsc::Sender<TransactionStatusUpdate>,
+    MockStorage,
 ) {
     ensure_admin_signer_env();
-    let storage = Arc::new(Storage::Mock(MockStorage::new()));
+    let mock = MockStorage::new();
+    let storage = Arc::new(Storage::Mock(mock.clone()));
     let state = test_hooks::new_sender_state(
         &make_config(rpc_url, ProgramType::Withdraw),
         CommitmentLevel::Confirmed,
@@ -90,7 +92,43 @@ async fn build_state(
     )
     .expect("SenderState construction must succeed under Mock storage");
     let (storage_tx, storage_rx) = mpsc::channel(8);
-    (state, storage_rx, storage_tx)
+    (state, storage_rx, storage_tx, mock)
+}
+
+/// Push a stub PendingRemint row into the mock so
+/// `bump_pending_remint_finality_attempt(id, ...)` finds a row to update.
+/// Defer-path tests need this; without a row the bump returns RowNotFound
+/// and the fail-closed handler escalates to ManualReview.
+fn seed_pending_remint_row(mock: &MockStorage, id: i64, attempts: i32) {
+    use private_channel_indexer::storage::common::models::{
+        DbTransaction, TransactionStatus, TransactionType,
+    };
+    let now = chrono::Utc::now();
+    mock.pending_remint_transactions
+        .lock()
+        .unwrap()
+        .push(DbTransaction {
+            id,
+            signature: Signature::new_unique().to_string(),
+            trace_id: format!("trace-{id}"),
+            slot: 0,
+            initiator: Pubkey::new_unique().to_string(),
+            recipient: Pubkey::new_unique().to_string(),
+            mint: Pubkey::new_unique().to_string(),
+            amount: 0,
+            memo: None,
+            transaction_type: TransactionType::Withdrawal,
+            withdrawal_nonce: Some(id),
+            status: TransactionStatus::PendingRemint,
+            created_at: now,
+            updated_at: now,
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            remint_last_valid_block_heights: None,
+            pending_remint_deadline_at: Some(now),
+            finality_check_attempts: attempts,
+        });
 }
 
 fn make_pending_remint(
@@ -155,7 +193,7 @@ fn make_pending_remint_with_lvbh(
 #[tokio::test]
 async fn execute_deferred_remint_short_circuits_on_prior_confirmed_remint() {
     let mock = MockRpcServer::start().await;
-    let (state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (state, mut storage_rx, storage_tx, _mock) = build_state(mock.url()).await;
 
     let txn_id: i64 = 7_777;
     let info = make_remint_info(txn_id);
@@ -270,7 +308,7 @@ async fn execute_deferred_remint_short_circuits_on_prior_confirmed_remint() {
 #[tokio::test]
 async fn process_pending_remints_skips_remint_when_withdrawal_finalized() {
     let mock = MockRpcServer::start().await;
-    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (mut state, mut storage_rx, storage_tx, _mock) = build_state(mock.url()).await;
 
     let withdrawal_sig = Signature::new_unique();
     state.pending_remints.push(make_pending_remint(
@@ -320,7 +358,9 @@ async fn process_pending_remints_skips_remint_when_withdrawal_finalized() {
 #[tokio::test]
 async fn process_pending_remints_requeues_on_finality_check_rpc_error() {
     let mock = MockRpcServer::start().await;
-    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (mut state, mut storage_rx, storage_tx, storage_mock) = build_state(mock.url()).await;
+
+    seed_pending_remint_row(&storage_mock, 92, 0);
 
     state.pending_remints.push(make_pending_remint(
         92,
@@ -372,7 +412,7 @@ async fn process_pending_remints_requeues_on_finality_check_rpc_error() {
 #[tokio::test]
 async fn process_pending_remints_routes_to_manual_review_at_max_attempts() {
     let mock = MockRpcServer::start().await;
-    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (mut state, mut storage_rx, storage_tx, _mock) = build_state(mock.url()).await;
 
     state.pending_remints.push(make_pending_remint(
         93,
@@ -431,7 +471,9 @@ async fn process_pending_remints_routes_to_manual_review_at_max_attempts() {
 #[tokio::test]
 async fn process_pending_remints_defers_when_sig_within_blockhash_validity() {
     let mock = MockRpcServer::start().await;
-    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (mut state, mut storage_rx, storage_tx, storage_mock) = build_state(mock.url()).await;
+
+    seed_pending_remint_row(&storage_mock, 94, 0);
 
     let sig = Signature::new_unique();
     state
@@ -474,7 +516,9 @@ async fn process_pending_remints_defers_when_sig_within_blockhash_validity() {
 #[tokio::test]
 async fn process_pending_remints_defers_when_sig_confirmed_not_finalized() {
     let mock = MockRpcServer::start().await;
-    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (mut state, mut storage_rx, storage_tx, storage_mock) = build_state(mock.url()).await;
+
+    seed_pending_remint_row(&storage_mock, 95, 0);
 
     let sig = Signature::new_unique();
     state
@@ -520,7 +564,7 @@ async fn process_pending_remints_defers_when_sig_confirmed_not_finalized() {
 #[tokio::test]
 async fn process_pending_remints_liveness_cap_escalates_with_liveness_reason() {
     let mock = MockRpcServer::start().await;
-    let (mut state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (mut state, mut storage_rx, storage_tx, _mock) = build_state(mock.url()).await;
 
     let sig = Signature::new_unique();
     state
@@ -566,7 +610,7 @@ async fn process_pending_remints_liveness_cap_escalates_with_liveness_reason() {
 #[tokio::test]
 async fn execute_deferred_remint_emits_failed_reminted_after_successful_send() {
     let mock = MockRpcServer::start().await;
-    let (state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (state, mut storage_rx, storage_tx, _mock) = build_state(mock.url()).await;
 
     let txn_id: i64 = 7_001;
     let info = make_remint_info(txn_id);
@@ -613,7 +657,7 @@ async fn execute_deferred_remint_emits_failed_reminted_after_successful_send() {
 #[tokio::test]
 async fn execute_deferred_remint_emits_manual_review_when_send_fails() {
     let mock = MockRpcServer::start().await;
-    let (state, mut storage_rx, storage_tx) = build_state(mock.url()).await;
+    let (state, mut storage_rx, storage_tx, _mock) = build_state(mock.url()).await;
 
     let txn_id: i64 = 7_002;
     let info = make_remint_info(txn_id);

--- a/integration/tests/indexer/remint_recovery.rs
+++ b/integration/tests/indexer/remint_recovery.rs
@@ -67,6 +67,7 @@ fn make_row(
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: Some(vec![sig.to_string()]),
+        remint_last_valid_block_heights: Some(vec![0]),
         pending_remint_deadline_at: Some(deadline),
     }
 }
@@ -129,7 +130,8 @@ async fn recover_rehydrates_valid_pending_remint_row() {
     assert_eq!(entry.remint_info.mint, mint);
     assert_eq!(entry.remint_info.user, recipient);
     assert_eq!(entry.remint_info.amount, 5_000u64);
-    assert_eq!(entry.signatures, vec![sig]);
+    assert_eq!(entry.signatures.len(), 1);
+    assert_eq!(entry.signatures[0].signature, sig);
     assert_eq!(entry.finality_check_attempts, 0);
     assert_eq!(entry.original_error, "recovered from persistent storage");
 

--- a/integration/tests/indexer/remint_recovery.rs
+++ b/integration/tests/indexer/remint_recovery.rs
@@ -69,6 +69,7 @@ fn make_row(
         remint_signatures: Some(vec![sig.to_string()]),
         remint_last_valid_block_heights: Some(vec![0]),
         pending_remint_deadline_at: Some(deadline),
+        finality_check_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/sender_max_retries.rs
+++ b/integration/tests/indexer/sender_max_retries.rs
@@ -27,7 +27,7 @@ use {
         operator::{
             sender::{
                 test_hooks,
-                types::{SenderState, TransactionStatusUpdate},
+                types::{PendingSig, SenderState, TransactionStatusUpdate},
             },
             utils::instruction_util::{ExtraErrorCheckPolicy, RetryPolicy},
         },
@@ -298,9 +298,13 @@ async fn deferral_with_stashed_signatures_pushes_pending_remint() {
     let (mut state, mut storage_rx, storage_tx, mock, _mock_storage) = build_fixture(3).await;
     let ctx = withdrawal_ctx(602, 22);
     seed_remint_cache(&mut state, 602, 22);
-    state
-        .pending_signatures
-        .insert(22, vec![Signature::new_unique()]);
+    state.pending_signatures.insert(
+        22,
+        vec![PendingSig {
+            signature: Signature::new_unique(),
+            last_valid_block_height: 0,
+        }],
+    );
 
     enqueue_failing_send(&mock, "permanent send error");
 
@@ -350,9 +354,13 @@ async fn deferral_set_pending_remint_storage_failure_routes_to_manual_review() {
     let (mut state, mut storage_rx, storage_tx, mock, mock_storage) = build_fixture(3).await;
     let ctx = withdrawal_ctx(603, 23);
     seed_remint_cache(&mut state, 603, 23);
-    state
-        .pending_signatures
-        .insert(23, vec![Signature::new_unique()]);
+    state.pending_signatures.insert(
+        23,
+        vec![PendingSig {
+            signature: Signature::new_unique(),
+            last_valid_block_height: 0,
+        }],
+    );
     mock_storage.set_should_fail("set_pending_remint", true);
 
     enqueue_failing_send(&mock, "permanent send error");

--- a/integration/tests/indexer/state_recovery_malformed.rs
+++ b/integration/tests/indexer/state_recovery_malformed.rs
@@ -65,6 +65,7 @@ fn make_row(
         remint_signatures: Some(sig_strings),
         remint_last_valid_block_heights: Some(lvbhs),
         pending_remint_deadline_at: Some(deadline),
+        finality_check_attempts: 0,
     }
 }
 

--- a/integration/tests/indexer/state_recovery_malformed.rs
+++ b/integration/tests/indexer/state_recovery_malformed.rs
@@ -44,6 +44,7 @@ fn make_row(
     deadline: DateTime<Utc>,
 ) -> DbTransaction {
     let now = Utc::now();
+    let lvbhs = vec![0; sig_strings.len()];
     DbTransaction {
         id,
         signature: Signature::new_unique().to_string(),
@@ -62,6 +63,7 @@ fn make_row(
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: Some(sig_strings),
+        remint_last_valid_block_heights: Some(lvbhs),
         pending_remint_deadline_at: Some(deadline),
     }
 }
@@ -180,7 +182,8 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
     assert_eq!(entry.ctx.transaction_id, Some(14));
     assert_eq!(entry.remint_info.mint, good_mint);
     assert_eq!(entry.remint_info.user, good_recipient);
-    assert_eq!(entry.signatures, vec![good_sig]);
+    assert_eq!(entry.signatures.len(), 1);
+    assert_eq!(entry.signatures[0].signature, good_sig);
 
     // All four bad rows must have emitted ManualReview updates.
     let mut escalated_ids: Vec<i64> = Vec::new();

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -202,6 +202,7 @@ async fn null_withdrawal_nonce_is_quarantined_to_manual_review(
         remint_signatures: None,
         remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
+        finality_check_attempts: 0,
     };
     storage.insert_db_transaction(&withdrawal).await?;
 

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -200,6 +200,7 @@ async fn null_withdrawal_nonce_is_quarantined_to_manual_review(
         processed_at: None,
         counterpart_signature: None,
         remint_signatures: None,
+        remint_last_valid_block_heights: None,
         pending_remint_deadline_at: None,
     };
     storage.insert_db_transaction(&withdrawal).await?;


### PR DESCRIPTION
Closes SOLA3-19. The pending-remint gate was reminting private-channel tokens while a prior low-fee `ReleaseFunds` broadcast could still finalize on Solana, producing a double payout. The 32s deadline ran shorter than blockhash validity (~60-90s) and the previous gate only suppressed reminting when a signature was already finalized.

The gate now classifies each stored signature by both its on-chain status and the blockhash's `last_valid_block_height`:
  - `finalized + success` → Completed
  - `finalized + error` → dead
  - `confirmed` / `processed` → still live (will finalize regardless of lvbh)
  - `null` + lvbh expired → dead
  - `null` + lvbh valid → still live

If any signature is still live, defer with a fresh deadline. Cap at `MAX_FINALITY_CHECK_ATTEMPTS`, then escalate to ManualReview.

 To support this, `last_valid_block_height` is now captured at broadcast time and persisted alongside `remint_signatures` in a new `BIGINT[]` column, plumbed through send → in-memory → DB → recovery.

Also closes SOLA3-1. `finality_check_attempts` was in-memory only, so a restart reset the safety budget to zero and let ambiguous PendingRemint rows survive indefinitely instead of escalating to ManualReview after the intended cap.

The counter is now persisted alongside `pending_remint_deadline_at` on every defer via a new `bump_pending_remint_finality_attempt` storage method, and restored on startup so the cap survives across restarts. Recovery defensively escalates corrupt (negative) counters to ManualReview, matching the existing pattern for the amount field.

Defer-time persistence is fail-closed: if the DB write fails, the entry escalates to ManualReview via `send_guaranteed` rather than continuing to defer with a counter we can't trust.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,620 | 11,100 | 86.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26546659288) |
| Indexer | 16,163 | 18,903 | 85.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26546659288) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26546659288) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26546659288) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 10,226 | 12,669 | 80.7% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26546659288) |
| **Total** | **37,720** | **44,667** | **84.4%** | |

> Last updated: 2026-05-28 00:45:36 UTC by E2E Integration