### PR TITLE
Fix/dvp ottersec review

### DIFF
--- a/dvp-swap-program/README.md
+++ b/dvp-swap-program/README.md
@@ -93,6 +93,8 @@ PDA seeds: `[b"dvp", settlement_authority, user_a, user_b, mint_a, mint_b, nonce
 | 8    | `SameMint`                    | Create with `mint_a == mint_b`                                                                                                       |
 | 9    | `ZeroAmount`                  | Create with `amount_a == 0` or `amount_b == 0`                                                                                       |
 | 10   | `BlockedMintExtension`        | Create with a Token-2022 mint carrying an unsupported extension (TransferFee, InterestBearing, ScaledUiAmount, ConfidentialTransfer) |
+| 11   | `SettlementAuthorityIsParty`  | Create with `settlement_authority` equal to `user_a` or `user_b`                                                                    |
+| 12   | `SettlementAuthorityExecutable` | Create with an executable `settlement_authority` (can't be credited closed-account rent)                                          |
 
 ## Build & test
 

--- a/dvp-swap-program/idl/dvp_swap_program.json
+++ b/dvp-swap-program/idl/dvp_swap_program.json
@@ -177,6 +177,12 @@
         "kind": "errorNode",
         "message": "Mint carries an unsupported Token-2022 extension",
         "name": "blockedMintExtension"
+      },
+      {
+        "code": 11,
+        "kind": "errorNode",
+        "message": "settlement_authority must not be user_a or user_b",
+        "name": "settlementAuthorityIsParty"
       }
     ],
     "instructions": [

--- a/dvp-swap-program/idl/dvp_swap_program.json
+++ b/dvp-swap-program/idl/dvp_swap_program.json
@@ -183,6 +183,12 @@
         "kind": "errorNode",
         "message": "settlement_authority must not be user_a or user_b",
         "name": "settlementAuthorityIsParty"
+      },
+      {
+        "code": 12,
+        "kind": "errorNode",
+        "message": "settlement_authority must not be executable",
+        "name": "settlementAuthorityExecutable"
       }
     ],
     "instructions": [
@@ -205,6 +211,15 @@
             "isWritable": true,
             "kind": "instructionAccountNode",
             "name": "swapDvp"
+          },
+          {
+            "docs": [
+              "Third-party authority allowed to settle/cancel; must not be executable so it can receive closed-account rent"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "settlementAuthority"
           },
           {
             "docs": [
@@ -304,13 +319,6 @@
           {
             "kind": "instructionArgumentNode",
             "name": "userB",
-            "type": {
-              "kind": "publicKeyTypeNode"
-            }
-          },
-          {
-            "kind": "instructionArgumentNode",
-            "name": "settlementAuthority",
             "type": {
               "kind": "publicKeyTypeNode"
             }

--- a/dvp-swap-program/program/src/error.rs
+++ b/dvp-swap-program/program/src/error.rs
@@ -51,6 +51,11 @@ pub enum DvpSwapProgramError {
     /// scaled UI amount). Checked only at CreateDvp.
     #[error("Mint carries an unsupported Token-2022 extension")]
     BlockedMintExtension,
+
+    /// (11) `settlement_authority` equals `user_a` or `user_b`: it must be
+    /// a third party, per the documented role.
+    #[error("settlement_authority must not be user_a or user_b")]
+    SettlementAuthorityIsParty,
 }
 
 impl From<DvpSwapProgramError> for ProgramError {

--- a/dvp-swap-program/program/src/error.rs
+++ b/dvp-swap-program/program/src/error.rs
@@ -56,6 +56,11 @@ pub enum DvpSwapProgramError {
     /// a third party, per the documented role.
     #[error("settlement_authority must not be user_a or user_b")]
     SettlementAuthorityIsParty,
+
+    /// (12) `settlement_authority` is an executable account, which can't be
+    /// credited the closed-account rent at Settle/Cancel.
+    #[error("settlement_authority must not be executable")]
+    SettlementAuthorityExecutable,
 }
 
 impl From<DvpSwapProgramError> for ProgramError {

--- a/dvp-swap-program/program/src/instructions.rs
+++ b/dvp-swap-program/program/src/instructions.rs
@@ -42,6 +42,10 @@ pub enum DvpSwapProgramInstruction {
         writable
     ))]
     #[codama(account(name = "swap_dvp", docs = "SwapDvp PDA to be created", writable))]
+    #[codama(account(
+        name = "settlement_authority",
+        docs = "Third-party authority allowed to settle/cancel; must not be executable so it can receive closed-account rent"
+    ))]
     #[codama(account(name = "mint_a", docs = "Mint of the asset leg (seller delivers)"))]
     #[codama(account(name = "mint_b", docs = "Mint of the cash leg (buyer delivers)"))]
     #[codama(account(
@@ -72,8 +76,6 @@ pub enum DvpSwapProgramInstruction {
         user_a: Pubkey,
         /// Buyer; delivers `amount_b` of `mint_b`.
         user_b: Pubkey,
-        /// Only party allowed to settle. Also signs Cancel.
-        settlement_authority: Pubkey,
         /// Asset leg size.
         amount_a: u64,
         /// Cash leg size.

--- a/dvp-swap-program/program/src/processor/cancel_dvp.rs
+++ b/dvp-swap-program/program/src/processor/cancel_dvp.rs
@@ -1,17 +1,12 @@
 use crate::{
     error::DvpSwapProgramError,
     processor::shared::account_check::{verify_account_owner, verify_signer, verify_token_program},
-    processor::shared::token_utils::{
-        get_mint_decimals, get_token_account_balance, transfer_checked_cpi, verify_canonical_ata,
-    },
+    processor::shared::refund::refund_and_close_dvp,
     processor::shared::utils::split_leg_remaining_accounts,
     require,
     state::swap_dvp::SwapDvp,
 };
-use pinocchio::{
-    account::AccountView, address::Address, cpi::Signer, error::ProgramError, ProgramResult,
-};
-use pinocchio_token_2022::instructions::CloseAccount;
+use pinocchio::{account::AccountView, address::Address, error::ProgramError, ProgramResult};
 
 /// Length of the fixed account prefix; anything beyond this is treated
 /// as transfer-hook remaining accounts split between the two legs.
@@ -60,7 +55,7 @@ pub fn process_cancel_dvp(
 ) -> ProgramResult {
     let (fixed, leg_a_extras, leg_b_extras) =
         split_leg_remaining_accounts(accounts, instruction_data, FIXED_ACCOUNTS_LEN)?;
-    let [settlement_authority_info, swap_dvp_info, mint_a_info, mint_b_info, dvp_ata_a_info, dvp_ata_b_info, user_a_ata_a_info, user_b_ata_b_info, token_program_a_info, token_program_b_info] =
+    let [settlement_authority_info, swap_dvp_info, .., token_program_a_info, token_program_b_info] =
         fixed
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
@@ -81,110 +76,5 @@ pub fn process_cancel_dvp(
         DvpSwapProgramError::SettlementAuthorityMismatch
     );
 
-    require!(
-        mint_a_info.address() == &dvp.mint_a && mint_b_info.address() == &dvp.mint_b,
-        ProgramError::InvalidAccountData
-    );
-    verify_account_owner(mint_a_info, token_program_a_info.address())?;
-    verify_account_owner(mint_b_info, token_program_b_info.address())?;
-
-    // Address validation only — initialization state of the user ATAs
-    // is not checked here. If a leg is unfunded the ATA can be
-    // uninitialized (caller still passes the canonical pubkey).
-    // If the leg is funded the Transfer below will fail naturally on
-    // an uninitialized destination. Note: refund pairing — each user
-    // gets their *own* mint back (not the cross used at Settle).
-    // dvp_ata_a: DvP PDA's escrow for mint_a (asset escrow).
-    verify_canonical_ata(
-        dvp_ata_a_info,
-        swap_dvp_info.address(),
-        &dvp.mint_a,
-        token_program_a_info,
-    )?;
-    // dvp_ata_b: DvP PDA's escrow for mint_b (cash escrow).
-    verify_canonical_ata(
-        dvp_ata_b_info,
-        swap_dvp_info.address(),
-        &dvp.mint_b,
-        token_program_b_info,
-    )?;
-    // user_a_ata_a: seller's ATA for mint_a — refund destination if asset leg was funded.
-    verify_canonical_ata(
-        user_a_ata_a_info,
-        &dvp.user_a,
-        &dvp.mint_a,
-        token_program_a_info,
-    )?;
-    // user_b_ata_b: buyer's ATA for mint_b — refund destination if cash leg was funded.
-    verify_canonical_ata(
-        user_b_ata_b_info,
-        &dvp.user_b,
-        &dvp.mint_b,
-        token_program_b_info,
-    )?;
-
-    let (nonce_bytes, bump_bytes) = dvp.seed_buffers();
-    let swap_dvp_seeds = dvp.signing_seeds(&nonce_bytes, &bump_bytes);
-    let signer_seeds = [Signer::from(&swap_dvp_seeds)];
-
-    // Snapshot both balances before any CPI runs, so a hook drain of
-    // one leg during the other leg's refund forces InsufficientFunds
-    // on the second transfer instead of being silently skipped.
-    let leg_a_amount = get_token_account_balance(dvp_ata_a_info)?;
-    let leg_b_amount = get_token_account_balance(dvp_ata_b_info)?;
-
-    if leg_a_amount > 0 {
-        transfer_checked_cpi(
-            dvp_ata_a_info,
-            mint_a_info,
-            user_a_ata_a_info,
-            swap_dvp_info,
-            leg_a_amount,
-            get_mint_decimals(mint_a_info)?,
-            token_program_a_info.address(),
-            leg_a_extras,
-            &signer_seeds,
-        )?;
-    }
-
-    if leg_b_amount > 0 {
-        transfer_checked_cpi(
-            dvp_ata_b_info,
-            mint_b_info,
-            user_b_ata_b_info,
-            swap_dvp_info,
-            leg_b_amount,
-            get_mint_decimals(mint_b_info)?,
-            token_program_b_info.address(),
-            leg_b_extras,
-            &signer_seeds,
-        )?;
-    }
-
-    CloseAccount {
-        account: dvp_ata_a_info,
-        destination: settlement_authority_info,
-        authority: swap_dvp_info,
-        token_program: token_program_a_info.address(),
-    }
-    .invoke_signed(&signer_seeds)?;
-
-    CloseAccount {
-        account: dvp_ata_b_info,
-        destination: settlement_authority_info,
-        authority: swap_dvp_info,
-        token_program: token_program_b_info.address(),
-    }
-    .invoke_signed(&signer_seeds)?;
-
-    let authority_lamports = settlement_authority_info.lamports();
-    settlement_authority_info.set_lamports(
-        authority_lamports
-            .checked_add(swap_dvp_info.lamports())
-            .ok_or(ProgramError::ArithmeticOverflow)?,
-    );
-    swap_dvp_info.set_lamports(0);
-    swap_dvp_info.close()?;
-
-    Ok(())
+    refund_and_close_dvp(fixed, &dvp, leg_a_extras, leg_b_extras)
 }

--- a/dvp-swap-program/program/src/processor/cancel_dvp.rs
+++ b/dvp-swap-program/program/src/processor/cancel_dvp.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::DvpSwapProgramError,
-    processor::shared::account_check::{verify_account_owner, verify_signer, verify_token_program},
+    processor::shared::account_check::{verify_account_owner, verify_signer},
     processor::shared::refund::refund_and_close_dvp,
     processor::shared::utils::split_leg_remaining_accounts,
     require,
@@ -55,15 +55,11 @@ pub fn process_cancel_dvp(
 ) -> ProgramResult {
     let (fixed, leg_a_extras, leg_b_extras) =
         split_leg_remaining_accounts(accounts, instruction_data, FIXED_ACCOUNTS_LEN)?;
-    let [settlement_authority_info, swap_dvp_info, .., token_program_a_info, token_program_b_info] =
-        fixed
-    else {
+    let [settlement_authority_info, swap_dvp_info, ..] = fixed else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
     verify_signer(settlement_authority_info, true)?;
-    verify_token_program(token_program_a_info)?;
-    verify_token_program(token_program_b_info)?;
     verify_account_owner(swap_dvp_info, program_id)?;
 
     let dvp = {

--- a/dvp-swap-program/program/src/processor/create_dvp.rs
+++ b/dvp-swap-program/program/src/processor/create_dvp.rs
@@ -30,19 +30,19 @@ use pinocchio_associated_token_account::instructions::CreateIdempotent as Create
 /// # Account Layout
 /// 0. `[signer, writable]` payer - Funds account/ATA creation rent
 /// 1. `[writable]` swap_dvp - SwapDvp PDA to be created
-/// 2. `[]` mint_a - Mint of the asset leg (seller delivers)
-/// 3. `[]` mint_b - Mint of the cash leg (buyer delivers)
-/// 4. `[writable]` dvp_ata_a - swap_dvp's ATA for mint_a (created here)
-/// 5. `[writable]` dvp_ata_b - swap_dvp's ATA for mint_b (created here)
-/// 6. `[]` system_program
-/// 7. `[]` token_program_a - SPL Token or Token-2022; must own mint_a
-/// 8. `[]` token_program_b - SPL Token or Token-2022; must own mint_b
-/// 9. `[]` associated_token_program
+/// 2. `[]` settlement_authority - Third party allowed to settle/cancel; must not be executable
+/// 3. `[]` mint_a - Mint of the asset leg (seller delivers)
+/// 4. `[]` mint_b - Mint of the cash leg (buyer delivers)
+/// 5. `[writable]` dvp_ata_a - swap_dvp's ATA for mint_a (created here)
+/// 6. `[writable]` dvp_ata_b - swap_dvp's ATA for mint_b (created here)
+/// 7. `[]` system_program
+/// 8. `[]` token_program_a - SPL Token or Token-2022; must own mint_a
+/// 9. `[]` token_program_b - SPL Token or Token-2022; must own mint_b
+/// 10. `[]` associated_token_program
 ///
 /// # Instruction Data
 /// * `user_a` (Pubkey) - Seller
 /// * `user_b` (Pubkey) - Buyer
-/// * `settlement_authority` (Pubkey) - Only party allowed to settle
 /// * `amount_a` (u64) - Asset leg size
 /// * `amount_b` (u64) - Cash leg size
 /// * `expiry_timestamp` (i64) - After this, settlement is rejected
@@ -56,7 +56,7 @@ pub fn process_create_dvp(
 ) -> ProgramResult {
     let args = parse_instruction_data(instruction_data)?;
 
-    let [payer_info, swap_dvp_info, mint_a_info, mint_b_info, dvp_ata_a_info, dvp_ata_b_info, system_program_info, token_program_a_info, token_program_b_info, associated_token_program_info] =
+    let [payer_info, swap_dvp_info, settlement_authority_info, mint_a_info, mint_b_info, dvp_ata_a_info, dvp_ata_b_info, system_program_info, token_program_a_info, token_program_b_info, associated_token_program_info] =
         accounts
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
@@ -68,19 +68,32 @@ pub fn process_create_dvp(
     verify_token_program(token_program_a_info)?;
     verify_token_program(token_program_b_info)?;
     verify_ata_program(associated_token_program_info)?;
+    // settlement_authority receives the closed-account rent at Settle/Cancel.
+    // An executable account can't be credited lamports (ExecutableLamportChange),
+    // so reject it at creation rather than stranding funds until Reject/Reclaim.
+    require!(
+        !settlement_authority_info.executable(),
+        DvpSwapProgramError::SettlementAuthorityExecutable
+    );
     verify_account_owner(mint_a_info, token_program_a_info.address())?;
     verify_account_owner(mint_b_info, token_program_b_info.address())?;
     validate_mint_extensions(mint_a_info)?;
     validate_mint_extensions(mint_b_info)?;
 
     let now = Clock::get()?.unix_timestamp;
-    validate_args(&args, mint_a_info.address(), mint_b_info.address(), now)?;
+    validate_args(
+        &args,
+        settlement_authority_info.address(),
+        mint_a_info.address(),
+        mint_b_info.address(),
+        now,
+    )?;
 
     let nonce_bytes = args.nonce.to_le_bytes();
     let (expected_swap_dvp, bump) = Address::find_program_address(
         &[
             SWAP_DVP_SEED,
-            args.settlement_authority.as_ref(),
+            settlement_authority_info.address().as_ref(),
             args.user_a.as_ref(),
             args.user_b.as_ref(),
             mint_a_info.address().as_ref(),
@@ -115,7 +128,7 @@ pub fn process_create_dvp(
         user_b: args.user_b,
         mint_a: *mint_a_info.address(),
         mint_b: *mint_b_info.address(),
-        settlement_authority: args.settlement_authority,
+        settlement_authority: *settlement_authority_info.address(),
         amount_a: args.amount_a,
         amount_b: args.amount_b,
         expiry_timestamp: args.expiry_timestamp,
@@ -166,7 +179,6 @@ pub fn process_create_dvp(
 struct CreateDvpArgs {
     user_a: Address,
     user_b: Address,
-    settlement_authority: Address,
     amount_a: u64,
     amount_b: u64,
     expiry_timestamp: i64,
@@ -174,15 +186,15 @@ struct CreateDvpArgs {
     earliest_settlement_timestamp: Option<i64>,
 }
 
-/// Wire layout (variable, 129–137 bytes):
-///   user_a(32) | user_b(32) | settlement_authority(32) |
+/// Wire layout (variable, 97–105 bytes):
+///   user_a(32) | user_b(32) |
 ///   amount_a(8) | amount_b(8) | expiry_timestamp(8) | nonce(8) |
 ///   earliest_tag(1) [ | earliest_payload(8) if tag == 1 ]
 ///
 /// Codama-style Option encoding: payload is omitted when tag == 0.
 fn parse_instruction_data(data: &[u8]) -> Result<CreateDvpArgs, ProgramError> {
-    // Required prefix: three pubkeys + four u64/i64 fields + option tag.
-    require_len!(data, 32 * 3 + 8 * 4 + 1);
+    // Required prefix: two pubkeys + four u64/i64 fields + option tag.
+    require_len!(data, 32 * 2 + 8 * 4 + 1);
 
     let mut offset = 0;
 
@@ -192,10 +204,6 @@ fn parse_instruction_data(data: &[u8]) -> Result<CreateDvpArgs, ProgramError> {
 
     let mut user_b = [0u8; 32];
     user_b.copy_from_slice(&data[offset..offset + 32]);
-    offset += 32;
-
-    let mut settlement_authority = [0u8; 32];
-    settlement_authority.copy_from_slice(&data[offset..offset + 32]);
     offset += 32;
 
     let amount_a = u64::from_le_bytes(
@@ -242,7 +250,6 @@ fn parse_instruction_data(data: &[u8]) -> Result<CreateDvpArgs, ProgramError> {
     Ok(CreateDvpArgs {
         user_a: Address::new_from_array(user_a),
         user_b: Address::new_from_array(user_b),
-        settlement_authority: Address::new_from_array(settlement_authority),
         amount_a,
         amount_b,
         expiry_timestamp,
@@ -255,6 +262,7 @@ fn parse_instruction_data(data: &[u8]) -> Result<CreateDvpArgs, ProgramError> {
 /// configurations the rest of the processor would mishandle later.
 fn validate_args(
     args: &CreateDvpArgs,
+    settlement_authority: &Address,
     mint_a: &Address,
     mint_b: &Address,
     now: i64,
@@ -271,7 +279,7 @@ fn validate_args(
     }
     require!(args.user_a != args.user_b, DvpSwapProgramError::SelfDvp);
     require!(
-        args.settlement_authority != args.user_a && args.settlement_authority != args.user_b,
+        settlement_authority != &args.user_a && settlement_authority != &args.user_b,
         DvpSwapProgramError::SettlementAuthorityIsParty
     );
     require!(mint_a != mint_b, DvpSwapProgramError::SameMint);
@@ -292,13 +300,16 @@ mod tests {
         CreateDvpArgs {
             user_a: Address::new_from_array([1u8; 32]),
             user_b: Address::new_from_array([2u8; 32]),
-            settlement_authority: Address::new_from_array([3u8; 32]),
             amount_a: 1_000,
             amount_b: 2_000,
             expiry_timestamp: NOW + 3_600,
             nonce: 0,
             earliest_settlement_timestamp: None,
         }
+    }
+
+    fn settlement_authority() -> Address {
+        Address::new_from_array([3u8; 32])
     }
 
     fn mint_a() -> Address {
@@ -314,28 +325,32 @@ mod tests {
 
     #[test]
     fn validate_args_accepts_well_formed_input() {
-        validate_args(&args(), &mint_a(), &mint_b(), NOW).expect("baseline must pass");
+        validate_args(&args(), &settlement_authority(), &mint_a(), &mint_b(), NOW)
+            .expect("baseline must pass");
     }
 
     #[test]
     fn validate_args_accepts_earliest_equal_to_expiry() {
         let mut a = args();
         a.earliest_settlement_timestamp = Some(a.expiry_timestamp);
-        validate_args(&a, &mint_a(), &mint_b(), NOW).expect("earliest == expiry is allowed");
+        validate_args(&a, &settlement_authority(), &mint_a(), &mint_b(), NOW)
+            .expect("earliest == expiry is allowed");
     }
 
     #[test]
     fn validate_args_accepts_earliest_in_the_past() {
         let mut a = args();
         a.earliest_settlement_timestamp = Some(NOW - 100);
-        validate_args(&a, &mint_a(), &mint_b(), NOW).expect("past earliest means 'any time'");
+        validate_args(&a, &settlement_authority(), &mint_a(), &mint_b(), NOW)
+            .expect("past earliest means 'any time'");
     }
 
     #[test]
     fn validate_args_rejects_expiry_at_now() {
         let mut a = args();
         a.expiry_timestamp = NOW;
-        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        let err =
+            validate_args(&a, &settlement_authority(), &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::ExpiryNotInFuture);
     }
 
@@ -343,7 +358,8 @@ mod tests {
     fn validate_args_rejects_expiry_in_past() {
         let mut a = args();
         a.expiry_timestamp = NOW - 1;
-        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        let err =
+            validate_args(&a, &settlement_authority(), &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::ExpiryNotInFuture);
     }
 
@@ -351,7 +367,8 @@ mod tests {
     fn validate_args_rejects_earliest_after_expiry() {
         let mut a = args();
         a.earliest_settlement_timestamp = Some(a.expiry_timestamp + 1);
-        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        let err =
+            validate_args(&a, &settlement_authority(), &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::EarliestAfterExpiry);
     }
 
@@ -359,29 +376,29 @@ mod tests {
     fn validate_args_rejects_self_dvp() {
         let mut a = args();
         a.user_b = a.user_a;
-        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        let err =
+            validate_args(&a, &settlement_authority(), &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::SelfDvp);
     }
 
     #[test]
     fn validate_args_rejects_settlement_authority_equal_to_user_a() {
-        let mut a = args();
-        a.settlement_authority = a.user_a;
-        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        let a = args();
+        let err = validate_args(&a, &a.user_a, &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::SettlementAuthorityIsParty);
     }
 
     #[test]
     fn validate_args_rejects_settlement_authority_equal_to_user_b() {
-        let mut a = args();
-        a.settlement_authority = a.user_b;
-        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        let a = args();
+        let err = validate_args(&a, &a.user_b, &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::SettlementAuthorityIsParty);
     }
 
     #[test]
     fn validate_args_rejects_same_mint() {
-        let err = validate_args(&args(), &mint_a(), &mint_a(), NOW).unwrap_err();
+        let err =
+            validate_args(&args(), &settlement_authority(), &mint_a(), &mint_a(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::SameMint);
     }
 
@@ -389,7 +406,8 @@ mod tests {
     fn validate_args_rejects_zero_amount_a() {
         let mut a = args();
         a.amount_a = 0;
-        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        let err =
+            validate_args(&a, &settlement_authority(), &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::ZeroAmount);
     }
 
@@ -397,7 +415,8 @@ mod tests {
     fn validate_args_rejects_zero_amount_b() {
         let mut a = args();
         a.amount_b = 0;
-        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        let err =
+            validate_args(&a, &settlement_authority(), &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::ZeroAmount);
     }
 }

--- a/dvp-swap-program/program/src/processor/create_dvp.rs
+++ b/dvp-swap-program/program/src/processor/create_dvp.rs
@@ -133,7 +133,6 @@ pub fn process_create_dvp(
         program_id,
         swap_dvp_info,
         swap_dvp_seeds,
-        None,
     )?;
 
     CreateAtaIdempotent {

--- a/dvp-swap-program/program/src/processor/create_dvp.rs
+++ b/dvp-swap-program/program/src/processor/create_dvp.rs
@@ -270,6 +270,10 @@ fn validate_args(
         );
     }
     require!(args.user_a != args.user_b, DvpSwapProgramError::SelfDvp);
+    require!(
+        args.settlement_authority != args.user_a && args.settlement_authority != args.user_b,
+        DvpSwapProgramError::SettlementAuthorityIsParty
+    );
     require!(mint_a != mint_b, DvpSwapProgramError::SameMint);
     require!(
         args.amount_a != 0 && args.amount_b != 0,
@@ -357,6 +361,22 @@ mod tests {
         a.user_b = a.user_a;
         let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
         assert_custom(err, DvpSwapProgramError::SelfDvp);
+    }
+
+    #[test]
+    fn validate_args_rejects_settlement_authority_equal_to_user_a() {
+        let mut a = args();
+        a.settlement_authority = a.user_a;
+        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        assert_custom(err, DvpSwapProgramError::SettlementAuthorityIsParty);
+    }
+
+    #[test]
+    fn validate_args_rejects_settlement_authority_equal_to_user_b() {
+        let mut a = args();
+        a.settlement_authority = a.user_b;
+        let err = validate_args(&a, &mint_a(), &mint_b(), NOW).unwrap_err();
+        assert_custom(err, DvpSwapProgramError::SettlementAuthorityIsParty);
     }
 
     #[test]

--- a/dvp-swap-program/program/src/processor/reject_dvp.rs
+++ b/dvp-swap-program/program/src/processor/reject_dvp.rs
@@ -1,17 +1,12 @@
 use crate::{
     error::DvpSwapProgramError,
     processor::shared::account_check::{verify_account_owner, verify_signer, verify_token_program},
-    processor::shared::token_utils::{
-        get_mint_decimals, get_token_account_balance, transfer_checked_cpi, verify_canonical_ata,
-    },
+    processor::shared::refund::refund_and_close_dvp,
     processor::shared::utils::split_leg_remaining_accounts,
     require,
     state::swap_dvp::SwapDvp,
 };
-use pinocchio::{
-    account::AccountView, address::Address, cpi::Signer, error::ProgramError, ProgramResult,
-};
-use pinocchio_token_2022::instructions::CloseAccount;
+use pinocchio::{account::AccountView, address::Address, error::ProgramError, ProgramResult};
 
 /// Length of the fixed account prefix; anything beyond this is treated
 /// as transfer-hook remaining accounts split between the two legs.
@@ -63,9 +58,7 @@ pub fn process_reject_dvp(
 ) -> ProgramResult {
     let (fixed, leg_a_extras, leg_b_extras) =
         split_leg_remaining_accounts(accounts, instruction_data, FIXED_ACCOUNTS_LEN)?;
-    let [signer_info, swap_dvp_info, mint_a_info, mint_b_info, dvp_ata_a_info, dvp_ata_b_info, user_a_ata_a_info, user_b_ata_b_info, token_program_a_info, token_program_b_info] =
-        fixed
-    else {
+    let [signer_info, swap_dvp_info, .., token_program_a_info, token_program_b_info] = fixed else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
@@ -84,112 +77,7 @@ pub fn process_reject_dvp(
         DvpSwapProgramError::SignerNotParty
     );
 
-    require!(
-        mint_a_info.address() == &dvp.mint_a && mint_b_info.address() == &dvp.mint_b,
-        ProgramError::InvalidAccountData
-    );
-    verify_account_owner(mint_a_info, token_program_a_info.address())?;
-    verify_account_owner(mint_b_info, token_program_b_info.address())?;
-
-    // Address-only validation: an unfunded leg's user ATA can be
-    // uninitialized; the canonical pubkey is well-defined regardless.
-    // Note: refund pairing — each user gets their *own* mint back (not
-    // the cross used at Settle).
-    // dvp_ata_a: DvP PDA's escrow for mint_a (asset escrow).
-    verify_canonical_ata(
-        dvp_ata_a_info,
-        swap_dvp_info.address(),
-        &dvp.mint_a,
-        token_program_a_info,
-    )?;
-    // dvp_ata_b: DvP PDA's escrow for mint_b (cash escrow).
-    verify_canonical_ata(
-        dvp_ata_b_info,
-        swap_dvp_info.address(),
-        &dvp.mint_b,
-        token_program_b_info,
-    )?;
-    // user_a_ata_a: seller's ATA for mint_a — refund destination if asset leg was funded.
-    verify_canonical_ata(
-        user_a_ata_a_info,
-        &dvp.user_a,
-        &dvp.mint_a,
-        token_program_a_info,
-    )?;
-    // user_b_ata_b: buyer's ATA for mint_b — refund destination if cash leg was funded.
-    verify_canonical_ata(
-        user_b_ata_b_info,
-        &dvp.user_b,
-        &dvp.mint_b,
-        token_program_b_info,
-    )?;
-
-    let (nonce_bytes, bump_bytes) = dvp.seed_buffers();
-    let swap_dvp_seeds = dvp.signing_seeds(&nonce_bytes, &bump_bytes);
-    let signer_seeds = [Signer::from(&swap_dvp_seeds)];
-
-    // Snapshot both balances before any CPI runs, so a hook drain of
-    // one leg during the other leg's refund forces InsufficientFunds
-    // on the second transfer instead of being silently skipped.
-    let leg_a_amount = get_token_account_balance(dvp_ata_a_info)?;
-    let leg_b_amount = get_token_account_balance(dvp_ata_b_info)?;
-
-    if leg_a_amount > 0 {
-        transfer_checked_cpi(
-            dvp_ata_a_info,
-            mint_a_info,
-            user_a_ata_a_info,
-            swap_dvp_info,
-            leg_a_amount,
-            get_mint_decimals(mint_a_info)?,
-            token_program_a_info.address(),
-            leg_a_extras,
-            &signer_seeds,
-        )?;
-    }
-
-    if leg_b_amount > 0 {
-        transfer_checked_cpi(
-            dvp_ata_b_info,
-            mint_b_info,
-            user_b_ata_b_info,
-            swap_dvp_info,
-            leg_b_amount,
-            get_mint_decimals(mint_b_info)?,
-            token_program_b_info.address(),
-            leg_b_extras,
-            &signer_seeds,
-        )?;
-    }
-
-    // Rent recipient is the signer, not `dvp.settlement_authority`.
-    // Reject must remain callable even if the settlement authority is
-    // unreachable (e.g. sysvar/executable address that the runtime
-    // refuses to pass as writable); see the doc comment above.
-    CloseAccount {
-        account: dvp_ata_a_info,
-        destination: signer_info,
-        authority: swap_dvp_info,
-        token_program: token_program_a_info.address(),
-    }
-    .invoke_signed(&signer_seeds)?;
-
-    CloseAccount {
-        account: dvp_ata_b_info,
-        destination: signer_info,
-        authority: swap_dvp_info,
-        token_program: token_program_b_info.address(),
-    }
-    .invoke_signed(&signer_seeds)?;
-
-    let signer_lamports = signer_info.lamports();
-    signer_info.set_lamports(
-        signer_lamports
-            .checked_add(swap_dvp_info.lamports())
-            .ok_or(ProgramError::ArithmeticOverflow)?,
-    );
-    swap_dvp_info.set_lamports(0);
-    swap_dvp_info.close()?;
-
-    Ok(())
+    // Rent is swept to `fixed[0]` (the signer here), not the settlement
+    // authority — see the doc comment above for why.
+    refund_and_close_dvp(fixed, &dvp, leg_a_extras, leg_b_extras)
 }

--- a/dvp-swap-program/program/src/processor/reject_dvp.rs
+++ b/dvp-swap-program/program/src/processor/reject_dvp.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::DvpSwapProgramError,
-    processor::shared::account_check::{verify_account_owner, verify_signer, verify_token_program},
+    processor::shared::account_check::{verify_account_owner, verify_signer},
     processor::shared::refund::refund_and_close_dvp,
     processor::shared::utils::split_leg_remaining_accounts,
     require,
@@ -58,13 +58,11 @@ pub fn process_reject_dvp(
 ) -> ProgramResult {
     let (fixed, leg_a_extras, leg_b_extras) =
         split_leg_remaining_accounts(accounts, instruction_data, FIXED_ACCOUNTS_LEN)?;
-    let [signer_info, swap_dvp_info, .., token_program_a_info, token_program_b_info] = fixed else {
+    let [signer_info, swap_dvp_info, ..] = fixed else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
     verify_signer(signer_info, true)?;
-    verify_token_program(token_program_a_info)?;
-    verify_token_program(token_program_b_info)?;
     verify_account_owner(swap_dvp_info, program_id)?;
 
     let dvp = {

--- a/dvp-swap-program/program/src/processor/reject_dvp.rs
+++ b/dvp-swap-program/program/src/processor/reject_dvp.rs
@@ -21,8 +21,8 @@ const FIXED_ACCOUNTS_LEN: usize = 10;
 ///
 /// Closed-account rent goes to `signer`, not `dvp.settlement_authority`.
 /// Reject is the safety valve and must work even if the configured
-/// settlement authority is unreachable (e.g. a sysvar or executable
-/// the runtime refuses to pass as writable). Settle and Cancel still
+/// settlement authority is unreachable (e.g. a sysvar the runtime
+/// refuses to pass as writable). Settle and Cancel still
 /// pay rent to the settlement authority — it's their signer there, so
 /// it's already required to be usable.
 ///

--- a/dvp-swap-program/program/src/processor/shared/mod.rs
+++ b/dvp-swap-program/program/src/processor/shared/mod.rs
@@ -1,9 +1,11 @@
 pub mod account_check;
 pub mod pda_utils;
+pub mod refund;
 pub mod token_utils;
 pub mod utils;
 
 pub use account_check::*;
 pub use pda_utils::*;
+pub use refund::*;
 pub use token_utils::*;
 pub use utils::*;

--- a/dvp-swap-program/program/src/processor/shared/pda_utils.rs
+++ b/dvp-swap-program/program/src/processor/shared/pda_utils.rs
@@ -14,11 +14,9 @@ pub fn create_pda_account<const N: usize>(
     owner: &Address,
     new_pda_account: &AccountView,
     new_pda_signer_seeds: [Seed; N],
-    min_rent_space: Option<usize>,
 ) -> ProgramResult {
     let signers = [Signer::from(&new_pda_signer_seeds)];
-    let rent_space = min_rent_space.map_or(space, |min| min.max(space));
-    let required_lamports = rent.try_minimum_balance(rent_space)?.max(1);
+    let required_lamports = rent.try_minimum_balance(space)?.max(1);
 
     if new_pda_account.lamports() > 0 {
         let required_lamports = required_lamports.saturating_sub(new_pda_account.lamports());

--- a/dvp-swap-program/program/src/processor/shared/refund.rs
+++ b/dvp-swap-program/program/src/processor/shared/refund.rs
@@ -2,7 +2,7 @@ use pinocchio::{account::AccountView, cpi::Signer, error::ProgramError, ProgramR
 use pinocchio_token_2022::instructions::CloseAccount;
 
 use crate::{
-    processor::shared::account_check::verify_account_owner,
+    processor::shared::account_check::{verify_account_owner, verify_token_program},
     processor::shared::token_utils::{
         get_mint_decimals, get_token_account_balance, transfer_checked_cpi, verify_canonical_ata,
     },
@@ -40,6 +40,8 @@ pub fn refund_and_close_dvp(
         mint_a_info.address() == &dvp.mint_a && mint_b_info.address() == &dvp.mint_b,
         ProgramError::InvalidAccountData
     );
+    verify_token_program(token_program_a_info)?;
+    verify_token_program(token_program_b_info)?;
     verify_account_owner(mint_a_info, token_program_a_info.address())?;
     verify_account_owner(mint_b_info, token_program_b_info.address())?;
 

--- a/dvp-swap-program/program/src/processor/shared/refund.rs
+++ b/dvp-swap-program/program/src/processor/shared/refund.rs
@@ -1,0 +1,144 @@
+use pinocchio::{account::AccountView, cpi::Signer, error::ProgramError, ProgramResult};
+use pinocchio_token_2022::instructions::CloseAccount;
+
+use crate::{
+    processor::shared::account_check::verify_account_owner,
+    processor::shared::token_utils::{
+        get_mint_decimals, get_token_account_balance, transfer_checked_cpi, verify_canonical_ata,
+    },
+    require,
+    state::swap_dvp::SwapDvp,
+};
+
+/// Shared refund-and-close path for CancelDvp and RejectDvp. Validates
+/// the mints and escrow ATAs, refunds each funded leg to its depositor,
+/// closes both escrow ATAs and the SwapDvp PDA, and sweeps reclaimed
+/// rent to `rent_destination` (`fixed[0]`, the instruction signer).
+///
+/// The two instructions are otherwise identical; their only behavioural
+/// difference — who is authorized to sign — is checked by the caller
+/// before this runs. No extension validation here: Create is the consent
+/// point, and the refund path must stay available even if a mint's
+/// extension parameters change post-Create so funds are never stranded.
+///
+/// `fixed` is the 10-account prefix from `split_leg_remaining_accounts`;
+/// `leg_a_extras`/`leg_b_extras` are the per-leg transfer-hook accounts.
+#[inline(always)]
+pub fn refund_and_close_dvp(
+    fixed: &[AccountView],
+    dvp: &SwapDvp,
+    leg_a_extras: &[AccountView],
+    leg_b_extras: &[AccountView],
+) -> ProgramResult {
+    let [rent_destination_info, swap_dvp_info, mint_a_info, mint_b_info, dvp_ata_a_info, dvp_ata_b_info, user_a_ata_a_info, user_b_ata_b_info, token_program_a_info, token_program_b_info] =
+        fixed
+    else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    require!(
+        mint_a_info.address() == &dvp.mint_a && mint_b_info.address() == &dvp.mint_b,
+        ProgramError::InvalidAccountData
+    );
+    verify_account_owner(mint_a_info, token_program_a_info.address())?;
+    verify_account_owner(mint_b_info, token_program_b_info.address())?;
+
+    // Address-only validation: an unfunded leg's user ATA can be
+    // uninitialized; the canonical pubkey is well-defined regardless.
+    // If a leg is funded the Transfer below fails naturally on an
+    // uninitialized destination. Note: refund pairing — each user gets
+    // their *own* mint back (not the cross used at Settle).
+    // dvp_ata_a: DvP PDA's escrow for mint_a (asset escrow).
+    verify_canonical_ata(
+        dvp_ata_a_info,
+        swap_dvp_info.address(),
+        &dvp.mint_a,
+        token_program_a_info,
+    )?;
+    // dvp_ata_b: DvP PDA's escrow for mint_b (cash escrow).
+    verify_canonical_ata(
+        dvp_ata_b_info,
+        swap_dvp_info.address(),
+        &dvp.mint_b,
+        token_program_b_info,
+    )?;
+    // user_a_ata_a: seller's ATA for mint_a — refund destination if asset leg was funded.
+    verify_canonical_ata(
+        user_a_ata_a_info,
+        &dvp.user_a,
+        &dvp.mint_a,
+        token_program_a_info,
+    )?;
+    // user_b_ata_b: buyer's ATA for mint_b — refund destination if cash leg was funded.
+    verify_canonical_ata(
+        user_b_ata_b_info,
+        &dvp.user_b,
+        &dvp.mint_b,
+        token_program_b_info,
+    )?;
+
+    let (nonce_bytes, bump_bytes) = dvp.seed_buffers();
+    let swap_dvp_seeds = dvp.signing_seeds(&nonce_bytes, &bump_bytes);
+    let signer_seeds = [Signer::from(&swap_dvp_seeds)];
+
+    // Snapshot both balances before any CPI runs, so a hook drain of
+    // one leg during the other leg's refund forces InsufficientFunds
+    // on the second transfer instead of being silently skipped.
+    let leg_a_amount = get_token_account_balance(dvp_ata_a_info)?;
+    let leg_b_amount = get_token_account_balance(dvp_ata_b_info)?;
+
+    if leg_a_amount > 0 {
+        transfer_checked_cpi(
+            dvp_ata_a_info,
+            mint_a_info,
+            user_a_ata_a_info,
+            swap_dvp_info,
+            leg_a_amount,
+            get_mint_decimals(mint_a_info)?,
+            token_program_a_info.address(),
+            leg_a_extras,
+            &signer_seeds,
+        )?;
+    }
+
+    if leg_b_amount > 0 {
+        transfer_checked_cpi(
+            dvp_ata_b_info,
+            mint_b_info,
+            user_b_ata_b_info,
+            swap_dvp_info,
+            leg_b_amount,
+            get_mint_decimals(mint_b_info)?,
+            token_program_b_info.address(),
+            leg_b_extras,
+            &signer_seeds,
+        )?;
+    }
+
+    CloseAccount {
+        account: dvp_ata_a_info,
+        destination: rent_destination_info,
+        authority: swap_dvp_info,
+        token_program: token_program_a_info.address(),
+    }
+    .invoke_signed(&signer_seeds)?;
+
+    CloseAccount {
+        account: dvp_ata_b_info,
+        destination: rent_destination_info,
+        authority: swap_dvp_info,
+        token_program: token_program_b_info.address(),
+    }
+    .invoke_signed(&signer_seeds)?;
+
+    let rent_destination_lamports = rent_destination_info.lamports();
+    rent_destination_info.set_lamports(
+        rent_destination_lamports
+            .checked_add(swap_dvp_info.lamports())
+            .ok_or(ProgramError::ArithmeticOverflow)?,
+    );
+    swap_dvp_info.set_lamports(0);
+    swap_dvp_info.close()?;
+
+    Ok(())
+}

--- a/dvp-swap-program/program/src/processor/shared/token_utils.rs
+++ b/dvp-swap-program/program/src/processor/shared/token_utils.rs
@@ -112,10 +112,17 @@ pub fn get_mint_decimals(mint_info: &AccountView) -> Result<u8, ProgramError> {
 ///
 /// Called only at CreateDvp. Unwind paths skip this check so funds
 /// remain recoverable if extension parameters change post-Create.
-/// No-op for legacy SPL Token mints.
+/// Legacy SPL Token mints only get a mint-size check.
 #[inline(always)]
 pub fn validate_mint_extensions(mint_info: &AccountView) -> ProgramResult {
     if !mint_info.owned_by(&TOKEN_2022_PROGRAM_ID) {
+        // Legacy SPL Token mint: no extensions, but confirm it's a real
+        // mint (exact size) rather than trusting the owner check alone.
+        let data = mint_info.try_borrow()?;
+        require!(
+            data.len() == TokenMint::LEN,
+            ProgramError::InvalidAccountData
+        );
         return Ok(());
     }
 

--- a/dvp-swap-program/tests/integration-tests/src/test_create_dvp/mod.rs
+++ b/dvp-swap-program/tests/integration-tests/src/test_create_dvp/mod.rs
@@ -6,7 +6,8 @@ use crate::{
     state_utils::{assert_create_dvp, setup_dvp, AMOUNT_A, AMOUNT_B},
     utils::{
         assert_program_error, get_token_balance, TestContext, EARLIEST_AFTER_EXPIRY,
-        EXPIRY_NOT_IN_FUTURE, SAME_MINT, SELF_DVP, ZERO_AMOUNT,
+        EXPIRY_NOT_IN_FUTURE, SAME_MINT, SELF_DVP, SETTLEMENT_AUTHORITY_EXECUTABLE,
+        SWAP_PROGRAM_ID, ZERO_AMOUNT,
     },
 };
 
@@ -194,6 +195,35 @@ fn test_create_dvp_rejects_zero_amount_b() {
         .instruction();
 
     assert_program_error(context.send(ix, &[]), ZERO_AMOUNT);
+}
+
+#[test]
+fn test_create_dvp_rejects_executable_settlement_authority() {
+    let mut context = TestContext::new();
+    let fixture = setup_dvp(&mut context, 0);
+
+    // Point settlement_authority at an executable account (the program
+    // under test). An executable can't be credited the closed-account rent
+    // at Settle/Cancel, so CreateDvp must reject it up front.
+    let ix = CreateDvpBuilder::new()
+        .payer(context.payer.pubkey())
+        .swap_dvp(fixture.swap_dvp)
+        .mint_a(fixture.mint_a)
+        .mint_b(fixture.mint_b)
+        .dvp_ata_a(fixture.dvp_ata_a)
+        .dvp_ata_b(fixture.dvp_ata_b)
+        .token_program_a(fixture.token_program_a)
+        .token_program_b(fixture.token_program_b)
+        .user_a(fixture.user_a.pubkey())
+        .user_b(fixture.user_b.pubkey())
+        .settlement_authority(SWAP_PROGRAM_ID)
+        .amount_a(AMOUNT_A)
+        .amount_b(AMOUNT_B)
+        .expiry_timestamp(fixture.expiry)
+        .nonce(fixture.nonce)
+        .instruction();
+
+    assert_program_error(context.send(ix, &[]), SETTLEMENT_AUTHORITY_EXECUTABLE);
 }
 
 /// A front-runner pre-creates the canonical asset escrow ATA before

--- a/dvp-swap-program/tests/integration-tests/src/test_create_dvp/mod.rs
+++ b/dvp-swap-program/tests/integration-tests/src/test_create_dvp/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::{
         assert_program_error, get_token_balance, TestContext, EARLIEST_AFTER_EXPIRY,
         EXPIRY_NOT_IN_FUTURE, SAME_MINT, SELF_DVP, SETTLEMENT_AUTHORITY_EXECUTABLE,
-        SWAP_PROGRAM_ID, ZERO_AMOUNT,
+        SETTLEMENT_AUTHORITY_IS_PARTY, SWAP_PROGRAM_ID, ZERO_AMOUNT,
     },
 };
 
@@ -224,6 +224,37 @@ fn test_create_dvp_rejects_executable_settlement_authority() {
         .instruction();
 
     assert_program_error(context.send(ix, &[]), SETTLEMENT_AUTHORITY_EXECUTABLE);
+}
+
+#[test]
+fn test_create_dvp_rejects_settlement_authority_as_party() {
+    let mut context = TestContext::new();
+    let fixture = setup_dvp(&mut context, 0);
+
+    // settlement_authority must be a neutral third party. Pointing it at
+    // either swap counterparty would let a party settle its own trade, so
+    // CreateDvp must reject both user_a and user_b up front.
+    for party in [fixture.user_a.pubkey(), fixture.user_b.pubkey()] {
+        let ix = CreateDvpBuilder::new()
+            .payer(context.payer.pubkey())
+            .swap_dvp(fixture.swap_dvp)
+            .mint_a(fixture.mint_a)
+            .mint_b(fixture.mint_b)
+            .dvp_ata_a(fixture.dvp_ata_a)
+            .dvp_ata_b(fixture.dvp_ata_b)
+            .token_program_a(fixture.token_program_a)
+            .token_program_b(fixture.token_program_b)
+            .user_a(fixture.user_a.pubkey())
+            .user_b(fixture.user_b.pubkey())
+            .settlement_authority(party)
+            .amount_a(AMOUNT_A)
+            .amount_b(AMOUNT_B)
+            .expiry_timestamp(fixture.expiry)
+            .nonce(fixture.nonce)
+            .instruction();
+
+        assert_program_error(context.send(ix, &[]), SETTLEMENT_AUTHORITY_IS_PARTY);
+    }
 }
 
 /// A front-runner pre-creates the canonical asset escrow ATA before

--- a/dvp-swap-program/tests/integration-tests/src/utils.rs
+++ b/dvp-swap-program/tests/integration-tests/src/utils.rs
@@ -56,6 +56,8 @@ pub const SELF_DVP: u32 = DvpSwapProgramError::SelfDvp as u32;
 pub const SAME_MINT: u32 = DvpSwapProgramError::SameMint as u32;
 pub const ZERO_AMOUNT: u32 = DvpSwapProgramError::ZeroAmount as u32;
 pub const BLOCKED_MINT_EXTENSION: u32 = DvpSwapProgramError::BlockedMintExtension as u32;
+pub const SETTLEMENT_AUTHORITY_EXECUTABLE: u32 =
+    DvpSwapProgramError::SettlementAuthorityExecutable as u32;
 
 const MIN_LAMPORTS: u64 = 500_000_000;
 

--- a/dvp-swap-program/tests/integration-tests/src/utils.rs
+++ b/dvp-swap-program/tests/integration-tests/src/utils.rs
@@ -58,6 +58,8 @@ pub const ZERO_AMOUNT: u32 = DvpSwapProgramError::ZeroAmount as u32;
 pub const BLOCKED_MINT_EXTENSION: u32 = DvpSwapProgramError::BlockedMintExtension as u32;
 pub const SETTLEMENT_AUTHORITY_EXECUTABLE: u32 =
     DvpSwapProgramError::SettlementAuthorityExecutable as u32;
+pub const SETTLEMENT_AUTHORITY_IS_PARTY: u32 =
+    DvpSwapProgramError::SettlementAuthorityIsParty as u32;
 
 const MIN_LAMPORTS: u64 = 500_000_000;
 


### PR DESCRIPTION
Addresses the OtterSec DvP review findings:

  1. `validate_mint_extensions` now length-checks legacy mints (`data.len() == Mint::LEN`) instead of returning `Ok` for any non-Token-2022 account.
  2. Extracted the identical `cancel_dvp`/`reject_dvp` bodies into a shared `refund_and_close_dvp` helper.
  3. Removed the dead `min_rent_space` param from `create_pda_account` (eliminates the `space`/`rent_space` asymmetry).
  4. `create_dvp` rejects `settlement_authority == user_a || user_b` (`SettlementAuthorityIsParty`).
  5. `settlement_authority` is now passed as an account and rejected if executable (`SettlementAuthorityExecutable`), so it can actually receive lamports at Settle/Cancel.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | 120 | 232 | 51.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26533736758) |
| Escrow Program | 1,185 | 1,963 | 60.4% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26533736758) |
| DvP Swap Program | 217 | 1,001 | 21.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26533736758) |
| E2E Integration | 10,028 | 12,397 | 80.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26533736990) |
| **Total** | **11,333** | **14,592** | **77.7%** | |

> Last updated: 2026-05-27 20:01:20 UTC by DvP Swap Program