### PR TITLE
Fix/sola2 20 block orphan deposits v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16228,6 +16228,7 @@ name = "test_utils"
 version = "0.1.0"
 dependencies = [
  "bs58",
+ "chrono",
  "futures 0.3.31",
  "http-body-util",
  "hyper 1.7.0",

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ ci-integration-test-prebuilt:
 	@cd integration && cargo test --test checkpoint_partial_flush -- --nocapture
 	@cd integration && cargo test --test remint_recovery -- --nocapture
 	@cd integration && cargo test --test bootstrap_validation -- --nocapture
+	@cd integration && cargo test --test deposit_allowlist_e2e -- --nocapture
 	@cd integration && cargo test --test yellowstone_wiring -- --nocapture
 	@cd integration && cargo test --test malformed_yellowstone_update -- --nocapture
 	@cd integration && cargo test --test yellowstone_reconnect_gap -- --nocapture
@@ -239,6 +240,7 @@ ci-integration-test-indexer:
 	@cd integration && cargo test --test checkpoint_partial_flush -- --nocapture
 	@cd integration && cargo test --test remint_recovery -- --nocapture
 	@cd integration && cargo test --test bootstrap_validation -- --nocapture
+	@cd integration && cargo test --test deposit_allowlist_e2e -- --nocapture
 	@cd integration && cargo test --test yellowstone_wiring -- --nocapture
 	@cd integration && cargo test --test malformed_yellowstone_update -- --nocapture
 	@cd integration && cargo test --test yellowstone_reconnect_gap -- --nocapture

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -18,7 +18,7 @@ no retries). All dispatch below is keyed on the webhook payload.
 | Alert (webhook payload) | `transaction_type` | Symptom | Runbook |
 |---|---|---|---|
 | `status=manual_review` | `withdrawal` | Single row stopped; pipeline may also be halted. | [`withdrawal_manual_review.md`](withdrawal_manual_review.md) |
-| `status=manual_review` | `deposit` | Single row stopped — either deterministic build error (processor) or sender-side post-JIT mint failure (mint authority mismatch / corrupt state). No halt, no collateral. | [`deposit_manual_review.md`](deposit_manual_review.md) |
+| `status=manual_review` | `deposit` | Single row stopped — deterministic build error (processor), sender-side post-JIT mint failure (mint authority mismatch / corrupt state), or mint not in the `AllowMint` allowlist (processor-side gate). No halt, no collateral. | [`deposit_manual_review.md`](deposit_manual_review.md) |
 | `status=failed` | `withdrawal` | Single row terminated without on-chain proof. Rare for withdrawals. | [`withdrawal_failed.md`](withdrawal_failed.md) |
 | `status=failed` | `deposit` | **Primary deposit alert.** Sender-side terminal failure (RPC, build, confirmation, on-chain rejection). | [`deposit_failed.md`](deposit_failed.md) |
 | `status=failed_reminted` | `withdrawal` | Withdrawal failed; remint succeeded. Reconcile only. | [`withdrawal_failed_reminted.md`](withdrawal_failed_reminted.md) |
@@ -100,6 +100,7 @@ pins the relevant contract.
 | `drill_12_withdrawal_failed_recovery_flows` | withdrawal | `withdrawal_failed.md` LANDED → completed-with-sig; cross-row signature fence still applies on `failed`; NOT_LANDED is terminal (markdown + operator code grep); AMBIGUOUS escalates without SQL. |
 | `drill_13_withdrawal_failed_reminted_reconcile` | withdrawal | `failed_reminted` transition writes `remint_signatures`; runbook contains zero mutating SQL; LANDED verdict cannot be silently absorbed via `SET status='completed'`; webhook `remint_signature` (singular) ↔ DB `remint_signatures` (plural) asymmetry pinned. |
 | `drill_14_deposit_manual_review_post_jit_recovery_flows` | deposit | `deposit_manual_review.md` § Path D: post-JIT trigger strings present in `mint.rs`; re-arm SQL flips `manual_review` → `pending` and is targeted by id (not error_message); idempotency memo prefix anchored. |
+| `drill_15_deposit_manual_review_allowlist_gate_recovery_flows` | deposit | Allowlist-gate recovery flow in `deposit_manual_review.md` is in sync with source: triage strings still exist and recovery SQL is row-scoped. |
 
 Trigger (`make` shorthand, runs from repo root):
 

--- a/docs/runbooks/_glossary.md
+++ b/docs/runbooks/_glossary.md
@@ -18,7 +18,7 @@ DB type `transaction_status`.
 | `completed` | yes | no | Withdrawal release or deposit mint confirmed on-chain. |
 | `failed` | yes | yes | Terminal failure with no on-chain proof. **Primary alert for deposits** (sender-side failures terminate here since there is no remint path). Rare for withdrawals - those go through `pending_remint`. |
 | `failed_reminted` | yes | yes | **Withdrawal-only.** Original withdrawal failed, remint of burned private channel tokens succeeded. Deposits do not have a remint path. |
-| `manual_review` | yes | yes | Operator stopped acting on this row. Requires human triage. Withdrawals: six triggers (build error → halt, pre-flight bail → no halt, four sender-side ambiguities). Deposits: build error only (no halt, no sweep). |
+| `manual_review` | yes | yes | Operator stopped acting on this row. Requires human triage. Withdrawals: six triggers (build error → halt, pre-flight bail → no halt, four sender-side ambiguities). Deposits: build error, sender-side post-JIT mint failure, or processor-side allowlist-gate rejection (no halt, no sweep). |
 
 Webhook receivers should treat `failed`, `failed_reminted`, `manual_review` as
 the alertable set. Source: `indexer/src/operator/db_transaction_writer.rs`,

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -58,7 +58,7 @@ to the right Path below.
 
 | `error_message` contains | Cause |
 |---|---|
-| `is not in the allow-listed mints table` | The deposit's `mint` has no row in `mints`. The operator refused to issue private channel tokens because no indexed `AllowMint` event authorizes this mint. Row data is fine; no on-chain mint attempted. See **Path E**. |
+| `has no allowed status in mint_status_history` | The deposit's `mint` has no `allowed` entry in `mint_status_history` at the deposit's slot. The `mints` row may exist — the gate reads `mint_status_history`, not `mints`. The operator refused to issue private channel tokens because no indexed `AllowMint` event authorizes this mint at that slot. Row data is fine; no on-chain mint attempted. See **Path E**. |
 
 Pull the row:
 
@@ -213,9 +213,9 @@ UPDATE transactions SET status = 'pending', updated_at = NOW()
 
 ### Path E - mint not in `AllowMint` allowlist
 
-`error_message`: `is not in the allow-listed mints table`. The deposit's
-mint has no row in `mints`; the operator refused to mint on the private
-channel. **No `MintTo` was built** therefore `_verify_onchain_mint.md` does not
+`error_message`: `has no allowed status in mint_status_history`. The deposit's
+mint has no `allowed` entry in `mint_status_history` at the deposit's slot (the
+`mints` row may exist); the operator refused to mint on the private channel. **No `MintTo` was built** therefore `_verify_onchain_mint.md` does not
 apply. Steps 1–2 diagnose *why* the allowlist row is missing; Steps 3a–3c
 are the recovery branches.
 

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -257,16 +257,24 @@ which recovery branch to take:
 #### Step 3a - backfill the missing `mints` row, then re-arm
 
 The mint *is* authorized on-chain; the indexer simply missed the event.
-Re-create the `mints` row so the operator's next attempt clears the gate.
-Either replay the indexer over the `AllowMint`'s slot (preferred — it's
-the same code path that runs in production), or insert directly. Values
-must match the on-chain mint and `AllowMint` flags:
+Replay the indexer over the `AllowMint`'s slot (preferred — same code path
+as production), or insert directly. The gate (`assert_mint_allowed_at_slot`)
+reads **`mint_status_history`**, so backfilling only `mints` loops
+`pending` → `manual_review` forever — both rows are required. Values must
+match the on-chain mint and `AllowMint` flags:
 
 ```sql
 INSERT INTO mints
   (mint_address, decimals, token_program, is_pausable, has_permanent_delegate, created_at)
 VALUES
   (:mint, :decimals, :token_program, :is_pausable, :has_permanent_delegate, NOW());
+
+-- Clears the slot-aware gate. effective_slot/signature come from the AllowMint.
+INSERT INTO mint_status_history
+  (mint_address, status, effective_slot, signature, created_at)
+VALUES
+  (:mint, 'allowed', :allow_mint_slot, :allow_mint_signature, NOW())
+ON CONFLICT (mint_address, effective_slot) DO NOTHING;
 
 UPDATE transactions SET status = 'pending', updated_at = NOW()
  WHERE id = :transaction_id;

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -16,7 +16,7 @@ Practically: a single deposit `manual_review` is a single row in trouble.
 Other deposits keep flowing. There is no collateral, no sweep, no halt to
 recover from.
 
-There are **two trigger surfaces** that can land a deposit in
+There are **three trigger surfaces** that can land a deposit in
 `manual_review`:
 
 1. **Processor-side row-data validation** — deterministic per-row error
@@ -25,6 +25,9 @@ There are **two trigger surfaces** that can land a deposit in
    mint-init helper found the on-chain mint in a state it cannot fix by
    re-issuing `mint_to` (wrong authority on the private channel mint, or
    corrupt mint data). See **Path D** for recovery.
+3. **Processor-side allowlist gate** — the deposit's `mint` has no row
+   in the `mints` allowlist (`MintCache::assert_mint_allowlisted`). Row
+   data is fine; no `MintTo` was attempted. See **Path E**.
 
 ## Symptom
 
@@ -33,8 +36,8 @@ There are **two trigger surfaces** that can land a deposit in
 
 ## Triage
 
-`error_message` distinguishes the two trigger surfaces and dispatches to
-the right Path below.
+`error_message` distinguishes the three trigger surfaces and dispatches
+to the right Path below.
 
 ### Processor-side surface (`processor.rs::process_deposit_funds`)
 
@@ -50,6 +53,12 @@ the right Path below.
 |---|---|
 | `Mint instruction failed after JIT: mint_authority mismatch` | The on-chain mint's `mint_authority` is not the operator's admin pubkey. Two known triggers: (a) an existing mint on the private channel is owned by a different authority and `mint_to` produced one of the three classified `InstructionError` variants (rare — the most common rotated-admin case produces `OwnerMismatch` → `Custom(3)`, which routes to `Failed` instead of here); (b) post-`InitializeMint` race where another party initialized the same mint with a different authority during our send window. |
 | `Mint instruction failed after JIT: corrupt mint state` | The mint's account data does not decode as a valid SPL Mint (`COption` discriminant invalid, length mismatched). Defensive — should not occur in normal operation; investigate before any recovery. |
+
+### Processor-side allowlist surface (`processor.rs::process_deposit_funds`)
+
+| `error_message` contains | Cause |
+|---|---|
+| `is not in the allow-listed mints table` | The deposit's `mint` has no row in `mints`. The operator refused to issue private channel tokens because no indexed `AllowMint` event authorizes this mint. Row data is fine; no on-chain mint attempted. See **Path E**. |
 
 Pull the row:
 
@@ -202,6 +211,109 @@ UPDATE transactions SET status = 'pending', updated_at = NOW()
  WHERE id = :transaction_id;
 ```
 
+### Path E - mint not in `AllowMint` allowlist
+
+`error_message`: `is not in the allow-listed mints table`. The deposit's
+mint has no row in `mints`; the operator refused to mint on the private
+channel. **No `MintTo` was built** therefore `_verify_onchain_mint.md` does not
+apply. Steps 1–2 diagnose *why* the allowlist row is missing; Steps 3a–3c
+are the recovery branches.
+
+#### Step 1 - check whether the gap closed on its own
+
+A race is possible: the gate fired because `mints` was empty at process
+time, but the indexer may have caught up since. Confirm the current state:
+
+```sql
+SELECT id, signature, mint, slot FROM transactions WHERE id = :transaction_id;
+SELECT * FROM mints WHERE mint_address = :mint;
+```
+
+If the second query now returns a row, the gap closed on its own. Skip to
+**Step 3a** re-arm — no backfill needed.
+
+#### Step 2 - was this mint ever authorized on-chain?
+
+If the gap is real, find out whether an `AllowMint` instruction was ever
+emitted. `mints` is populated by the indexer from `AllowMint` on the
+escrow program, scoped to the configured `escrow_instance_id`. Search
+the operator-admin's mainnet signature history:
+
+```bash
+solana transaction-history <operator-admin-pubkey> \
+  --url <solana-mainnet-rpc-url> --limit 1000
+```
+
+Decode candidates against the escrow program IDL. The verdict tells you
+which recovery branch to take:
+
+| Finding | Branch |
+|---|---|
+| Found, slot < deposit slot. | **3a — indexer gap.** |
+| Found, slot ≥ deposit slot. | **Escalate (Tier 1).** Retroactive allowlist; treasury policy call. |
+| Not found after a full pass. | **3b — terminal.** |
+| Found but bound to a different `instance`. | **3c — Tier 3 defect.** |
+
+#### Step 3a - backfill the missing `mints` row, then re-arm
+
+The mint *is* authorized on-chain; the indexer simply missed the event.
+Re-create the `mints` row so the operator's next attempt clears the gate.
+Either replay the indexer over the `AllowMint`'s slot (preferred — it's
+the same code path that runs in production), or insert directly. Values
+must match the on-chain mint and `AllowMint` flags:
+
+```sql
+INSERT INTO mints
+  (mint_address, decimals, token_program, is_pausable, has_permanent_delegate, created_at)
+VALUES
+  (:mint, :decimals, :token_program, :is_pausable, :has_permanent_delegate, NOW());
+
+UPDATE transactions SET status = 'pending', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+#### Step 3b - investigate why this happened, refund if needed, then delete
+
+The indexer wrote a deposit row for a mint that has no `AllowMint` —
+**this should not happen**. The deposit-side gate caught the symptom, but
+something upstream wrote the row in the first place. Identify the cause
+before clearing it:
+
+```bash
+solana confirm -v <signature> --url <solana-mainnet-rpc-url>
+```
+
+Decode the instruction against the escrow program IDL. Classify:
+
+- **Indexer / instance-filtering defect** (row written from a
+  foreign-instance instruction or a non-`Deposit` instruction).
+  [Escalate](_escalation.md) (Tier 3) **first**; do not delete until
+  engineering confirms root cause and can reproduce against the live row.
+- **Manual DB insert.** [Escalate](_escalation.md) (Tier 3), capture
+  the offender, then delete.
+
+Once root cause is known, capture the row's full content in the
+incident record and delete it. The
+reconciliation orphan check has no status filter and runs with in-memory
+per-id dedup, so a `failed` row stays silent in steady state but
+re-appears in the orphan log — and re-posts a webhook alert via
+`reconciliation_webhook_url` (payload: `orphan_ids`, `row_count`,
+`timestamp`) — on every operator restart. Deleting the row is the only
+way to remove that recurring boot-time noise:
+
+```sql
+DELETE FROM transactions WHERE id = :transaction_id;
+```
+
+**Do not re-arm** — the next tick fails the gate identically.
+
+#### Step 3c - foreign-instance `AllowMint`, stop and escalate
+
+The `AllowMint` exists but binds to a different escrow instance than
+ours. The operator should never see foreign-instance rows — this is the
+SOLA2-27 attack surface, not an operations recovery.
+[Escalate](_escalation.md) (Tier 3). No SQL.
+
 ## Post-incident artifacts
 
 - Transaction id, originating Solana `signature`, `recipient`, `mint`.
@@ -211,4 +323,7 @@ UPDATE transactions SET status = 'pending', updated_at = NOW()
 - For Path D: on-chain `mint_authority` before/after, the
   `spl-token authorize` signature (if applicable), and the engineering
   ticket for any mint-replacement coordination.
-
+- For Path E: which branch (3a/3b/3c), the `AllowMint` signature if
+  found, any backfill SQL, refund ticket, and — for 3b — the full
+  deleted row contents and the classified root cause (user error /
+  indexer defect / manual insert).

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -265,7 +265,8 @@ pub struct OperatorConfig {
     /// Tolerance threshold in basis points (100 bps = 1%)
     #[serde(default = "default_reconciliation_tolerance")]
     pub reconciliation_tolerance_bps: u16,
-    /// Webhook URL for reconciliation alerts (optional)
+    /// Webhook URL for reconciliation alerts (optional). Carries both balance
+    /// mismatch alerts and orphan deposit alerts.
     pub reconciliation_webhook_url: Option<String>,
     /// How often to check the feepayer SOL balance (escrow operators only)
     #[serde(default = "default_feepayer_monitor_interval")]

--- a/indexer/src/error/operator.rs
+++ b/indexer/src/error/operator.rs
@@ -38,4 +38,9 @@ pub enum OperatorError {
 
     #[error("Webhook error: {0}")]
     WebhookError(String),
+
+    #[error(
+        "Mint {mint} is not in the allow-listed mints table (transaction {transaction_id}); refusing to mint"
+    )]
+    MintNotAllowed { transaction_id: i64, mint: String },
 }

--- a/indexer/src/error/operator.rs
+++ b/indexer/src/error/operator.rs
@@ -40,7 +40,7 @@ pub enum OperatorError {
     WebhookError(String),
 
     #[error(
-        "Mint {mint} is not in the allow-listed mints table (transaction {transaction_id}); refusing to mint"
+        "Mint {mint} has no allowed status in mint_status_history at the deposit's slot (transaction {transaction_id}); refusing to mint"
     )]
     MintNotAllowed { transaction_id: i64, mint: String },
 }

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -82,6 +82,11 @@ pub async fn run_startup_reconciliation(
         "Running startup reconciliation"
     );
 
+    // Snapshot of any deposit rows whose mint never had an `AllowMint` row.
+    // The log here gives a complete boot-time snapshot before runtime
+    // dedup hides anything they haven't already seen.
+    log_orphan_deposit_rows_at_startup(storage).await;
+
     let rpc_client = RpcClientWithRetry::with_retry_config(
         rpc_url.to_string(),
         RetryConfig::default(),
@@ -139,6 +144,31 @@ pub async fn run_startup_reconciliation(
     }
 
     classify_and_report(config, &results)
+}
+
+/// Log deposit rows whose mint was not allowed at the deposit's slot.
+/// Diagnostic only, surfaced at boot, never fails startup, and a query
+/// failure is logged at `warn` and swallowed rather than propagated.
+async fn log_orphan_deposit_rows_at_startup(storage: &Storage) {
+    match storage.get_orphan_deposit_ids().await {
+        Ok(orphans) if !orphans.is_empty() => {
+            error!(
+                row_count = orphans.len(),
+                orphan_ids = ?orphans,
+                "Startup reconciliation: orphan deposit row(s) present (deposit rows with \
+                 no allowed mint status at the deposit's slot) — surfaced for visibility, does not fail startup"
+            );
+        }
+        Ok(_) => {
+            info!("Startup reconciliation: no orphan deposit rows");
+        }
+        Err(e) => {
+            warn!(
+                "Startup reconciliation: failed to query orphan deposit ids: {}",
+                e
+            );
+        }
+    }
 }
 
 /// Fetch the raw token balance for an ATA.

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -21,7 +21,7 @@ use private_channel_metrics::{HealthState, MetricLabel};
 use solana_sdk::pubkey::Pubkey;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Transaction processor that converts instructions to transactions and saves to DB
 /// Tracks slot-level success/failure and emits committed checkpoints
@@ -182,7 +182,20 @@ impl TransactionProcessor {
             }
         }
 
-        if !transactions.is_empty() {
+        if transactions.is_empty() {
+            // Empty slot, just checkpoint it
+            debug!("Finalizing empty slot {}", slot);
+        } else if !send_checkpoint {
+            // A prerequisite write (mints/statuses) failed; skip the deposit
+            // rows so we don't commit a deposit with no backing row. The slot
+            // isn't checkpointed, so it replays atomically.
+            warn!(
+                "Skipping transaction insert for slot {} ({} row(s)) because an earlier \
+                 write failed; slot will be reprocessed",
+                slot,
+                transactions.len()
+            );
+        } else {
             info!(
                 "Finalizing slot {} with {} transactions",
                 slot,
@@ -212,9 +225,6 @@ impl TransactionProcessor {
                     send_checkpoint = false;
                 }
             }
-        } else {
-            // Empty slot, just checkpoint it
-            debug!("Finalizing empty slot {}", slot);
         }
 
         if send_checkpoint {
@@ -387,6 +397,17 @@ mod tests {
         sig: Option<String>,
         recipient: Option<Pubkey>,
     ) -> InstructionWithMetadata {
+        make_deposit_instruction_on_instance(slot, sig, recipient, deposit_instance())
+    }
+
+    /// Like `make_deposit_instruction` but on a caller-chosen instance, so a
+    /// deposit can share a slot with an AllowMint on the same instance.
+    fn make_deposit_instruction_on_instance(
+        slot: u64,
+        sig: Option<String>,
+        recipient: Option<Pubkey>,
+        instance: Pubkey,
+    ) -> InstructionWithMetadata {
         let user = make_pubkey(1);
         let mint = make_pubkey(2);
         InstructionWithMetadata {
@@ -394,7 +415,7 @@ mod tests {
                 accounts: DepositAccounts {
                     payer: make_pubkey(10),
                     user,
-                    instance: deposit_instance(),
+                    instance,
                     mint,
                     allowed_mint: make_pubkey(12),
                     user_ata: make_pubkey(13),
@@ -715,7 +736,8 @@ mod tests {
 
     #[tokio::test]
     async fn finalize_writes_mint_status_history_on_allow_mint() {
-        let (mut processor, mut checkpoint_rx, mock) = make_processor_with_mock();
+        let (mut processor, mut checkpoint_rx, mock) =
+            make_processor_with_mock(allow_mint_instance());
         processor
             .current_slot_instructions
             .push(make_allow_mint_instruction(
@@ -741,7 +763,8 @@ mod tests {
 
     #[tokio::test]
     async fn finalize_insert_mint_statuses_failure_skips_checkpoint() {
-        let (mut processor, mut checkpoint_rx, mock) = make_processor_with_mock();
+        let (mut processor, mut checkpoint_rx, mock) =
+            make_processor_with_mock(allow_mint_instance());
         mock.set_should_fail("insert_mint_statuses_batch", true);
         processor
             .current_slot_instructions
@@ -754,6 +777,43 @@ mod tests {
             .await;
 
         assert!(checkpoint_rx.try_recv().is_err());
+    }
+
+    /// AllowMint + Deposit for the same mint in one slot: if the mint-status
+    /// write fails, the deposit row must be withheld (else the gate would
+    /// quarantine it) and the slot replays.
+    #[tokio::test]
+    async fn finalize_mint_status_failure_withholds_deposit_in_same_slot() {
+        // Both instructions must target the configured instance, or the
+        // instance filter would drop one and defeat the test's intent.
+        let (mut processor, mut checkpoint_rx, mock) =
+            make_processor_with_mock(allow_mint_instance());
+        mock.set_should_fail("insert_mint_statuses_batch", true);
+        processor
+            .current_slot_instructions
+            .push(make_allow_mint_instruction(
+                202,
+                Some("sig-allow-3".to_string()),
+            ));
+        processor
+            .current_slot_instructions
+            .push(make_deposit_instruction_on_instance(
+                202,
+                Some("sig-deposit-3".to_string()),
+                None,
+                allow_mint_instance(),
+            ));
+        processor
+            .finalize_and_checkpoint(202, ProgramType::Escrow)
+            .await;
+
+        // Checkpoint withheld so the slot replays.
+        assert!(checkpoint_rx.try_recv().is_err());
+        // Deposit row must not be committed without its backing status row.
+        assert!(
+            mock.inserted_transactions.lock().unwrap().is_empty(),
+            "deposit must be withheld when the mint-status write failed"
+        );
     }
 
     #[tokio::test]

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -11,7 +11,9 @@ use crate::{
         },
     },
     storage::{
-        common::models::{DbMint, DbTransaction, DbTransactionBuilder, TransactionType},
+        common::models::{
+            DbMint, DbMintStatus, DbTransaction, DbTransactionBuilder, TransactionType,
+        },
         Storage,
     },
 };
@@ -100,6 +102,7 @@ impl TransactionProcessor {
     /// Saves any buffered transactions and always sends checkpoint (even if empty)
     async fn finalize_and_checkpoint(&mut self, slot: u64, program_type: ProgramType) {
         let mut mints = Vec::new();
+        let mut mint_statuses: Vec<DbMintStatus> = Vec::new();
         let mut transactions = Vec::new();
 
         for instruction_meta in &self.current_slot_instructions {
@@ -109,6 +112,15 @@ impl TransactionProcessor {
             );
 
             if let Some(mint) = mint_opt {
+                if let Some(sig) = instruction_meta.signature.clone() {
+                    mint_statuses.push(DbMintStatus {
+                        mint_address: mint.mint_address.clone(),
+                        status: "allowed".to_string(),
+                        effective_slot: slot as i64,
+                        signature: sig,
+                        created_at: chrono::Utc::now(),
+                    });
+                }
                 mints.push(mint);
             }
 
@@ -136,6 +148,32 @@ impl TransactionProcessor {
                 }
                 Err(e) => {
                     error!("Failed to save mints from slot {}: {}", slot, e);
+                    metrics::INDEXER_SLOT_SAVE_ERRORS
+                        .with_label_values(&[program_type.as_label()])
+                        .inc();
+                    send_checkpoint = false;
+                }
+            }
+        }
+
+        if !mint_statuses.is_empty() {
+            match self
+                .storage
+                .insert_mint_statuses_batch(&mint_statuses)
+                .await
+            {
+                Ok(_) => {
+                    info!(
+                        "Successfully saved {} mint status row(s) from slot {}",
+                        mint_statuses.len(),
+                        slot,
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to save mint status history from slot {}: {}",
+                        slot, e
+                    );
                     metrics::INDEXER_SLOT_SAVE_ERRORS
                         .with_label_values(&[program_type.as_label()])
                         .inc();
@@ -673,6 +711,49 @@ mod tests {
 
         let cp = checkpoint_rx.recv().await.unwrap();
         assert_eq!(cp.slot, 200);
+    }
+
+    #[tokio::test]
+    async fn finalize_writes_mint_status_history_on_allow_mint() {
+        let (mut processor, mut checkpoint_rx, mock) = make_processor_with_mock();
+        processor
+            .current_slot_instructions
+            .push(make_allow_mint_instruction(
+                200,
+                Some("sig-allow-1".to_string()),
+            ));
+        processor
+            .finalize_and_checkpoint(200, ProgramType::Escrow)
+            .await;
+
+        {
+            let rows = mock.mint_status_history.lock().unwrap();
+            assert_eq!(rows.len(), 1, "exactly one status row should be written");
+            assert_eq!(rows[0].mint_address, make_pubkey(2).to_string());
+            assert_eq!(rows[0].status, "allowed");
+            assert_eq!(rows[0].effective_slot, 200);
+            assert_eq!(rows[0].signature, "sig-allow-1");
+        }
+
+        let cp = checkpoint_rx.recv().await.unwrap();
+        assert_eq!(cp.slot, 200);
+    }
+
+    #[tokio::test]
+    async fn finalize_insert_mint_statuses_failure_skips_checkpoint() {
+        let (mut processor, mut checkpoint_rx, mock) = make_processor_with_mock();
+        mock.set_should_fail("insert_mint_statuses_batch", true);
+        processor
+            .current_slot_instructions
+            .push(make_allow_mint_instruction(
+                201,
+                Some("sig-allow-2".to_string()),
+            ));
+        processor
+            .finalize_and_checkpoint(201, ProgramType::Escrow)
+            .await;
+
+        assert!(checkpoint_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -127,6 +127,7 @@ enum ErrorDisposition {
 fn classify_processor_error(err: &OperatorError) -> ErrorDisposition {
     match err {
         OperatorError::InvalidPubkey { .. } => ErrorDisposition::Quarantine("invalid_pubkey"),
+        OperatorError::MintNotAllowed { .. } => ErrorDisposition::Quarantine("mint_not_allowed"),
         OperatorError::Program(ProgramError::InvalidBuilder { .. }) => {
             ErrorDisposition::Quarantine("invalid_builder")
         }
@@ -659,6 +660,19 @@ pub async fn process_deposit_funds(
                 }
             })?;
 
+            // Refuse to mint when the mint was not in `allowed` status at
+            // the deposit's slot, per `mint_status_history`. If we minted
+            // anyway, two things would break:
+            //   1. We'd issue PrivateChannel tokens with no Mainnet escrow
+            //      backing them.
+            //   2. Reconciliation wouldn't catch it: the balance check
+            //      only scans mints listed in `mints`, so the mismatch
+            //      never fires.
+            processor_state
+                .mint_cache
+                .assert_mint_allowed_at_slot(&mint, transaction.slot, transaction.id)
+                .await?;
+
             let token_program = processor_state
                 .mint_cache
                 .get_private_channel_token_program();
@@ -739,6 +753,7 @@ mod tests {
     use super::*;
     use crate::error::{AccountError, StorageError, TransactionError};
     use crate::operator::find_allowed_mint_pda;
+    use crate::storage::common::models::DbMint;
     use crate::storage::common::models::TransactionType;
     use crate::storage::common::storage::mock::MockStorage;
 
@@ -807,6 +822,35 @@ mod tests {
             state.get_instance_ata(&mint_b, &tp)
         );
         assert_eq!(state.instance_atas.len(), 2);
+    }
+
+    /// Insert a minimal `mints` row AND a slot-0 `allowed` status history
+    /// entry so `assert_mint_allowed_at_slot` accepts the mint at any slot.
+    fn insert_mint_row(storage: &Arc<Storage>, mint: &Pubkey) {
+        let mock_storage = match storage.as_ref() {
+            Storage::Mock(m) => m,
+            _ => unreachable!("test helper expects Storage::Mock"),
+        };
+        mock_storage.mints.lock().unwrap().insert(
+            mint.to_string(),
+            DbMint {
+                mint_address: mint.to_string(),
+                decimals: 6,
+                token_program: spl_token::id().to_string(),
+                created_at: chrono::Utc::now(),
+                is_pausable: Some(false),
+                has_permanent_delegate: Some(false),
+            },
+        );
+        mock_storage.mint_status_history.lock().unwrap().push(
+            crate::storage::common::models::DbMintStatus {
+                mint_address: mint.to_string(),
+                status: "allowed".to_string(),
+                effective_slot: 0,
+                signature: format!("test-seed-{mint}"),
+                created_at: chrono::Utc::now(),
+            },
+        );
     }
 
     fn make_db_transaction(
@@ -1085,6 +1129,7 @@ mod tests {
 
         let mint_pubkey = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
+        insert_mint_row(&storage, &mint_pubkey);
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
         let (sender_tx, mut sender_rx) = mpsc::channel(10);
@@ -1384,6 +1429,15 @@ mod tests {
         assert!(matches!(
             classify_processor_error(&other_program),
             ErrorDisposition::Quarantine("program_error")
+        ));
+
+        let mint_not_allowed = OperatorError::MintNotAllowed {
+            transaction_id: 1,
+            mint: "mint_a".into(),
+        };
+        assert!(matches!(
+            classify_processor_error(&mint_not_allowed),
+            ErrorDisposition::Quarantine("mint_not_allowed")
         ));
 
         // Fatal variants — processor is misconfigured or downstream is dead.
@@ -1800,7 +1854,7 @@ mod tests {
         let mut ps = ProcessorState {
             admin_pubkey: Pubkey::new_unique(),
             release_funds_state: None,
-            mint_cache: crate::operator::MintCache::new(storage),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
@@ -1808,10 +1862,12 @@ mod tests {
         let (storage_tx, _storage_rx) = mpsc::channel(16);
 
         for id in 1..=3 {
+            let mint = Pubkey::new_unique();
+            insert_mint_row(&storage, &mint);
             fetcher_tx
                 .send(make_db_transaction(
                     id,
-                    &Pubkey::new_unique().to_string(),
+                    &mint.to_string(),
                     &Pubkey::new_unique().to_string(),
                     None,
                     crate::storage::common::models::TransactionType::Deposit,
@@ -1852,12 +1908,17 @@ mod tests {
         let mut ps = ProcessorState {
             admin_pubkey: Pubkey::new_unique(),
             release_funds_state: None,
-            mint_cache: crate::operator::MintCache::new(storage),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
         };
 
         let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
         let (sender_tx, mut sender_rx) = mpsc::channel(16);
         let (storage_tx, mut storage_rx) = mpsc::channel(16);
+
+        let valid_mint_2 = Pubkey::new_unique();
+        let valid_mint_4 = Pubkey::new_unique();
+        insert_mint_row(&storage, &valid_mint_2);
+        insert_mint_row(&storage, &valid_mint_4);
 
         // poison, valid, poison, valid
         fetcher_tx
@@ -1873,7 +1934,7 @@ mod tests {
         fetcher_tx
             .send(make_db_transaction(
                 2,
-                &Pubkey::new_unique().to_string(),
+                &valid_mint_2.to_string(),
                 &Pubkey::new_unique().to_string(),
                 None,
                 crate::storage::common::models::TransactionType::Deposit,
@@ -1893,7 +1954,7 @@ mod tests {
         fetcher_tx
             .send(make_db_transaction(
                 4,
-                &Pubkey::new_unique().to_string(),
+                &valid_mint_4.to_string(),
                 &Pubkey::new_unique().to_string(),
                 None,
                 crate::storage::common::models::TransactionType::Deposit,
@@ -2269,6 +2330,72 @@ mod tests {
         assert!(
             storage_rx.try_recv().is_err(),
             "no ManualReview update should have been sent",
+        );
+    }
+
+    /// A deposit whose mint has no `mints` row is quarantined for manual
+    /// review, the quarantine reason mentions the allow-list, and no
+    /// `Mint` builder is forwarded to the sender.
+    #[tokio::test]
+    async fn process_deposit_funds_quarantines_when_mint_not_in_db() {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        // Mint pubkey is valid base58 but is NOT inserted into `mints`.
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let txn = make_db_transaction(
+            99,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            None,
+            crate::storage::common::models::TransactionType::Deposit,
+        );
+
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            ProgramType::Escrow,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "quarantine must not propagate as an error, got: {:?}",
+            result
+        );
+
+        let update = storage_rx
+            .try_recv()
+            .expect("a quarantine update must be sent");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert_eq!(update.transaction_id, 99);
+        let reason = update
+            .error_message
+            .as_deref()
+            .expect("quarantine update must include a reason");
+        assert!(
+            reason.contains("allow-listed") || reason.contains("not in the allow"),
+            "expected reason to mention the mint allow-list, got: {reason}",
+        );
+
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "no Mint builder should be forwarded for an unknown mint",
         );
     }
 }

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -2389,8 +2389,8 @@ mod tests {
             .as_deref()
             .expect("quarantine update must include a reason");
         assert!(
-            reason.contains("allow-listed") || reason.contains("not in the allow"),
-            "expected reason to mention the mint allow-list, got: {reason}",
+            reason.contains("mint_status_history"),
+            "expected reason to mention the mint status history gate, got: {reason}",
         );
 
         assert!(

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -20,7 +20,7 @@ use solana_client::rpc_request::TokenAccountsFilter;
 use solana_sdk::pubkey::Pubkey;
 use spl_token::solana_program::program_pack::Pack;
 use spl_token::state::Account as TokenAccount;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -63,6 +63,9 @@ pub async fn run_reconciliation(
     )
     .map_err(|e| OperatorError::WebhookError(format!("Failed to create HTTP client: {}", e)))?;
 
+    // Orphan-mint dedup state
+    let mut previously_alerted_orphans: Option<HashSet<i64>> = None;
+
     loop {
         // Check for cancellation
         if cancellation_token.is_cancelled() {
@@ -77,6 +80,7 @@ pub async fn run_reconciliation(
             &rpc_client,
             escrow_instance_id,
             &webhook_client,
+            &mut previously_alerted_orphans,
         )
         .await
         {
@@ -105,21 +109,31 @@ pub async fn run_reconciliation(
 /// Performs a single reconciliation check
 ///
 /// This function orchestrates the complete reconciliation flow:
-/// 1. Fetch on-chain balances for all mints held by the escrow
-/// 2. Query database for sum of completed deposits minus withdrawals per mint
-/// 3. Compare balances with tolerance threshold
-/// 4. Send webhook alert if mismatch exceeds tolerance
+/// 1. Surface orphan deposit rows
+/// 2. Fetch on-chain balances for all mints held by the escrow
+/// 3. Query database for sum of completed deposits minus withdrawals per mint
+/// 4. Compare balances with tolerance threshold
+/// 5. Send webhook alert if mismatch exceeds tolerance
 async fn perform_reconciliation_check(
     storage: &Arc<Storage>,
     config: &OperatorConfig,
     rpc_client: &Arc<RpcClientWithRetry>,
     escrow_instance_id: Pubkey,
     webhook_client: &WebhookClient,
+    previously_alerted_orphans: &mut Option<HashSet<i64>>,
 ) -> Result<(), OperatorError> {
-    // Step 1: Fetch on-chain balances from Solana RPC
+    check_orphan_deposit_rows(
+        storage,
+        previously_alerted_orphans,
+        webhook_client,
+        &config.reconciliation_webhook_url,
+    )
+    .await;
+
+    // Step 2: Fetch on-chain balances from Solana RPC
     let on_chain_balances = fetch_on_chain_balances(rpc_client, escrow_instance_id).await?;
 
-    // Step 2: Query database for completed transaction balances per mint
+    // Step 3: Query database for completed transaction balances per mint
     let db_balance_results = storage
         .get_escrow_balances_by_mint()
         .await
@@ -153,14 +167,14 @@ async fn perform_reconciliation_check(
         db_balances.insert(mint, net_balance);
     }
 
-    // Step 3: Compare balances with tolerance threshold
+    // Step 4: Compare balances with tolerance threshold
     let mismatches = compare_balances(
         &on_chain_balances,
         &db_balances,
         config.reconciliation_tolerance_bps,
     );
 
-    // Step 4: Send webhook alert if mismatches found
+    // Step 5: Send webhook alert if mismatches found
     if !mismatches.is_empty() {
         error!(
             "Balance reconciliation failed: found {} mismatch(es) exceeding tolerance of {} bps",
@@ -186,6 +200,84 @@ async fn perform_reconciliation_check(
     }
 
     Ok(())
+}
+
+/// Surface orphan deposit rows (deposits whose mint was not `allowed` at the
+/// deposit's slot) via `error!` log and a webhook alert. Dedup is per
+/// `transactions.id` (in `previously_alerted_orphans`): each id alerts once
+/// then stays silent.
+///
+/// - `None` (baseline tick): empty set logs `info!`; non-empty logs `error!`
+///   and posts the full set.
+/// - `Some(seen)`: only ids not in `seen` are new, they log `error!` and post.
+/// - Storage-query failure logs `warn!` and leaves dedup state untouched.
+async fn check_orphan_deposit_rows(
+    storage: &Arc<Storage>,
+    previously_alerted_orphans: &mut Option<HashSet<i64>>,
+    webhook_client: &WebhookClient,
+    webhook_url: &Option<String>,
+) {
+    let orphans = match storage.get_orphan_deposit_ids().await {
+        Ok(orphans) => orphans,
+        Err(e) => {
+            warn!("Failed to query orphan deposit ids: {}", e);
+            return;
+        }
+    };
+
+    match previously_alerted_orphans {
+        None => {
+            // Baseline pass
+            if orphans.is_empty() {
+                info!("Reconciliation baseline: no orphan deposit rows detected");
+            } else {
+                error!(
+                    row_count = orphans.len(),
+                    orphan_ids = ?orphans,
+                    "Reconciliation baseline: {} orphan deposit row(s) currently present \
+                     (no allowed mint status at the deposit's slot); subsequent ticks will only log on new entries",
+                    orphans.len()
+                );
+
+                // Post the full current orphan set so restarts re-surface unresolved orphans.
+                if let Err(e) =
+                    send_orphan_deposit_alert(webhook_url, &orphans, webhook_client).await
+                {
+                    error!("Failed to send orphan deposit webhook alert: {}", e);
+                }
+            }
+            *previously_alerted_orphans = Some(orphans.into_iter().collect());
+        }
+        Some(seen) => {
+            // Delta pass, only NEW orphan rows (not in `seen`) get logged.
+            let new_orphans: Vec<i64> = orphans
+                .into_iter()
+                .filter(|id| !seen.contains(id))
+                .collect();
+
+            if new_orphans.is_empty() {
+                // Steady state, silent to avoid log spam on every tick.
+                return;
+            }
+
+            error!(
+                new_row_count = new_orphans.len(),
+                new_orphan_ids = ?new_orphans,
+                "Reconciliation found {} new orphan deposit row(s) (no allowed mint status at the deposit's slot)",
+                new_orphans.len()
+            );
+
+            // Alert on the newly-arrived orphans only. Webhook failures are
+            // logged inside the helper but must not abort the tick.
+            if let Err(e) =
+                send_orphan_deposit_alert(webhook_url, &new_orphans, webhook_client).await
+            {
+                error!("Failed to send orphan deposit webhook alert: {}", e);
+            }
+
+            seen.extend(new_orphans);
+        }
+    }
 }
 
 /// Represents a balance mismatch between on-chain and database balances for a specific mint
@@ -458,9 +550,68 @@ pub async fn send_webhook_alert(
     Ok(())
 }
 
+/// Posts orphan deposit transaction ids to `webhook_url` as a single JSON
+/// payload `{ orphan_ids, row_count, timestamp }` (ids only — operators resolve
+/// mint/amount/signature via `docs/runbooks/deposit_manual_review.md`).
+///
+/// Retries up to 3 times with exponential backoff on transient HTTP errors.
+/// `None` URL with ids present logs a `warn!` and returns `Ok`. Returns
+/// `Err(OperatorError::WebhookError)` if delivery fails after retries.
+pub async fn send_orphan_deposit_alert(
+    webhook_url: &Option<String>,
+    orphan_ids: &[i64],
+    webhook_client: &WebhookClient,
+) -> Result<(), OperatorError> {
+    // If no webhook URL configured, log and return early
+    let url = match webhook_url {
+        Some(url) => url,
+        None => {
+            if !orphan_ids.is_empty() {
+                warn!(
+                    "Orphan deposit rows detected but no webhook URL configured (found {} row(s))",
+                    orphan_ids.len()
+                );
+            }
+            return Ok(());
+        }
+    };
+
+    let payload = serde_json::json!({
+        "row_count": orphan_ids.len(),
+        "orphan_ids": orphan_ids,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    });
+
+    let context = format!("orphan deposits: {} row(s)", orphan_ids.len());
+
+    webhook_client
+        .post_json(url, &payload, &context)
+        .await
+        .map_err(|error| {
+            error!(
+                "Failed to send orphan deposit webhook alert after {} attempts: {}",
+                error.attempts(),
+                error.message()
+            );
+            OperatorError::WebhookError(format!(
+                "Failed to send orphan deposit webhook alert after {} attempts: {}",
+                error.attempts(),
+                error.message()
+            ))
+        })?;
+
+    info!(
+        "Orphan deposit webhook alert sent for {} row(s)",
+        orphan_ids.len()
+    );
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::common::storage::{mock::MockStorage, Storage};
     use solana_sdk::pubkey::Pubkey;
 
     #[test]
@@ -947,6 +1098,163 @@ mod tests {
         mock.assert_async().await;
     }
 
+    // ── orphan-deposit webhook alert tests ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_send_orphan_deposit_alert_no_url() {
+        // No webhook URL configured with orphan ids present -> no-op Ok(())
+        let orphan_ids = vec![123_i64, 456];
+
+        let client = test_webhook_client();
+        let result = send_orphan_deposit_alert(&None, &orphan_ids, &client).await;
+        assert!(
+            result.is_ok(),
+            "Should succeed when no webhook URL configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_orphan_deposit_alert_success() {
+        // Successful single POST of the orphan id payload
+        let mut server = mockito::Server::new_async().await;
+        // Assert the received alert carries the expected payload. The
+        // timestamp is dynamic, so match only the stable fields via partial
+        // JSON.
+        let mock = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "row_count": 2,
+                "orphan_ids": [123, 456],
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let webhook_url = Some(server.url());
+        let orphan_ids = vec![123_i64, 456];
+
+        let client = test_webhook_client();
+        let result = send_orphan_deposit_alert(&webhook_url, &orphan_ids, &client).await;
+        assert!(result.is_ok(), "Should successfully send orphan webhook");
+
+        // Verifies the request was received AND its body matched the payload.
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_send_orphan_deposit_alert_max_retries_exceeded() {
+        // All requests fail -> returns WebhookError after exhausting retries
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .with_status(500)
+            .expect(3) // Should retry 3 times
+            .create_async()
+            .await;
+
+        let webhook_url = Some(server.url());
+        let orphan_ids = vec![123_i64];
+
+        let client = test_webhook_client();
+        let result = send_orphan_deposit_alert(&webhook_url, &orphan_ids, &client).await;
+        assert!(result.is_err(), "Should fail after max retries");
+        assert!(
+            matches!(result.unwrap_err(), OperatorError::WebhookError(_)),
+            "Should return WebhookError"
+        );
+
+        mock.assert_async().await;
+    }
+
+    /// Baseline tick posts the full orphan set once; a steady-state tick with the same orphans posts nothing more.
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_webhook_posts_baseline_once_then_silent() {
+        let mut server = mockito::Server::new_async().await;
+        // Exactly one POST is expected across both ticks: the baseline.
+        let mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let webhook_url = Some(server.url());
+        let client = test_webhook_client();
+
+        let mock_storage = MockStorage::new();
+        seed_orphan_deposit(&mock_storage, "mint_a");
+        seed_orphan_deposit(&mock_storage, "mint_b");
+        let storage = Arc::new(Storage::Mock(mock_storage));
+
+        let mut state: Option<HashSet<i64>> = None;
+
+        // Baseline tick: posts the full current orphan set.
+        check_orphan_deposit_rows(&storage, &mut state, &client, &webhook_url).await;
+        assert_eq!(
+            state.as_ref().map(|s| s.len()),
+            Some(2),
+            "baseline should capture every current orphan"
+        );
+
+        // Steady-state tick: same orphans, no new ids -> no additional POST.
+        check_orphan_deposit_rows(&storage, &mut state, &client, &webhook_url).await;
+        assert_eq!(
+            state.as_ref().map(|s| s.len()),
+            Some(2),
+            "steady-state tick must leave the dedup set unchanged"
+        );
+
+        mock.assert_async().await;
+    }
+
+    /// A newly-arrived orphan in a delta tick posts exactly once for the new
+    /// id (not the already-seen ones).
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_webhook_posts_new_orphan_once() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let webhook_url = Some(server.url());
+        let client = test_webhook_client();
+
+        let mock_storage = MockStorage::new();
+        let id_a = seed_orphan_deposit(&mock_storage, "mint_a");
+        let id_b = seed_orphan_deposit(&mock_storage, "mint_b");
+        let storage = Arc::new(Storage::Mock(mock_storage));
+
+        // Pre-seed dedup state as if `id_a` had already been alerted; only
+        // `id_b` is new and should drive a single webhook POST.
+        let mut state: Option<HashSet<i64>> = Some([id_a].into_iter().collect());
+
+        check_orphan_deposit_rows(&storage, &mut state, &client, &webhook_url).await;
+
+        let seen = state.expect("state should remain Some after delta tick");
+        assert_eq!(
+            seen.len(),
+            2,
+            "dedup set should now hold both the pre-seen and the new orphan"
+        );
+        assert!(
+            seen.contains(&id_a),
+            "already-seen orphan must stay in the dedup set"
+        );
+        assert!(
+            seen.contains(&id_b),
+            "newly-arrived orphan must be added to the dedup set"
+        );
+
+        // Exactly one POST: only the new id (`id_b`) is alerted; the
+        // already-seen `id_a` does not re-post.
+        mock.assert_async().await;
+    }
+
     // Additional edge case tests for basis points calculation
 
     #[test]
@@ -1257,5 +1565,144 @@ mod tests {
         assert_eq!(deltas[&mint1], 50, "0.5% should be 50 bps");
         assert_eq!(deltas[&mint2], 25, "0.25% should be 25 bps");
         assert_eq!(deltas[&mint3], 12, "0.125% should be 12 bps (rounded down)");
+    }
+
+    // The dedup tests below cover the orphan-detection wiring at the
+    // boundary we *can* exercise without a test validator: the
+    // `check_orphan_deposit_rows` helper, driven through its three state
+    // transitions (baseline / stable / new-orphan) plus the
+    // storage-error path.
+
+    /// Insert a deposit row whose mint has no `mints` entry. Used by the
+    /// dedup tests below, the actual orphan-detection SQL is exercised by
+    /// the storage-layer tests; here we only need MockStorage to return the
+    /// mint as orphaned so `check_orphan_deposit_rows` is driven through
+    /// its state transitions.
+    fn seed_orphan_deposit(
+        mock: &crate::storage::common::storage::mock::MockStorage,
+        mint: &str,
+    ) -> i64 {
+        use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
+        use chrono::Utc;
+        let mut txs = mock.pending_transactions.lock().unwrap();
+        let id = txs.len() as i64 + 1;
+        txs.push(DbTransaction {
+            id,
+            signature: format!("sig_orphan_{}", mint),
+            trace_id: format!("trace_orphan_{}", mint),
+            slot: 1,
+            initiator: "init".to_string(),
+            recipient: "recip".to_string(),
+            mint: mint.to_string(),
+            amount: 1,
+            memo: None,
+            transaction_type: TransactionType::Deposit,
+            withdrawal_nonce: None,
+            status: TransactionStatus::Pending,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            pending_remint_deadline_at: None,
+        });
+        id
+    }
+
+    /// Baseline tick (`None` in → `Some` out): full current orphan set is
+    /// captured into the dedup cache, info-log only.
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_baseline_seeds_state() {
+        let mock = MockStorage::new();
+        let id_a = seed_orphan_deposit(&mock, "mint_a");
+        let id_b = seed_orphan_deposit(&mock, "mint_b");
+
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut state: Option<HashSet<i64>> = None;
+
+        check_orphan_deposit_rows(&storage, &mut state, &test_webhook_client(), &None).await;
+
+        let seen = state.expect("baseline tick must populate dedup cache");
+        assert_eq!(
+            seen.len(),
+            2,
+            "baseline should capture every current orphan"
+        );
+        assert!(seen.contains(&id_a));
+        assert!(seen.contains(&id_b));
+    }
+
+    /// Baseline with no orphans still flips state to `Some(empty)` so the
+    /// next tick is in delta mode.
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_baseline_with_no_orphans_still_flips_state() {
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut state: Option<HashSet<i64>> = None;
+
+        check_orphan_deposit_rows(&storage, &mut state, &test_webhook_client(), &None).await;
+
+        let seen = state.expect("baseline must seed state even when empty");
+        assert!(seen.is_empty());
+    }
+
+    /// Delta tick where the orphan set hasn't changed: dedup cache must not
+    /// grow and nothing should be logged (cache contents unchanged).
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_stable_orphans_dont_realert() {
+        let mock = MockStorage::new();
+        let id_a = seed_orphan_deposit(&mock, "mint_a");
+
+        let storage = Arc::new(Storage::Mock(mock));
+        // Pre-seed dedup state as if a prior baseline tick had already
+        // captured `id_a`. A second tick with the same row must be a no-op
+        // as far as state is concerned.
+        let mut state: Option<HashSet<i64>> = Some([id_a].into_iter().collect());
+
+        check_orphan_deposit_rows(&storage, &mut state, &test_webhook_client(), &None).await;
+
+        let seen = state.expect("state should remain Some after delta tick");
+        assert_eq!(seen.len(), 1, "stable orphan must not grow the cache");
+        assert!(seen.contains(&id_a));
+    }
+
+    /// Delta tick where a NEW orphan row has appeared, even sharing the same
+    /// mint as a previously-seen orphan: the new id must extend the cache.
+    /// This is the regression guard for the old mint-level dedup, which
+    /// would have silently suppressed subsequent deposits on a known mint.
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_new_orphan_extends_cache() {
+        let mock = MockStorage::new();
+        let id_a = seed_orphan_deposit(&mock, "shared_mint");
+        let id_b = seed_orphan_deposit(&mock, "shared_mint");
+
+        let storage = Arc::new(Storage::Mock(mock));
+        // Cache already contains `id_a` from a prior tick. `id_b` is a
+        // brand-new orphan row (same mint, different deposit) that must
+        // trigger the error log even though the mint is already "known".
+        let mut state: Option<HashSet<i64>> = Some([id_a].into_iter().collect());
+
+        check_orphan_deposit_rows(&storage, &mut state, &test_webhook_client(), &None).await;
+
+        let seen = state.expect("state should remain Some after delta tick");
+        assert_eq!(seen.len(), 2, "cache should grow by exactly the new row");
+        assert!(seen.contains(&id_a));
+        assert!(seen.contains(&id_b));
+    }
+
+    /// Storage failure must leave the dedup state untouched so the next
+    /// tick can retry the baseline (or delta) cleanly.
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_storage_error_preserves_state() {
+        let mock = MockStorage::new();
+        mock.set_should_fail("get_orphan_deposit_ids", true);
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut state: Option<HashSet<i64>> = None;
+
+        check_orphan_deposit_rows(&storage, &mut state, &test_webhook_client(), &None).await;
+
+        assert!(
+            state.is_none(),
+            "baseline must not be marked done if the storage query failed"
+        );
     }
 }

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -230,23 +230,29 @@ async fn check_orphan_deposit_rows(
             // Baseline pass
             if orphans.is_empty() {
                 info!("Reconciliation baseline: no orphan deposit rows detected");
-            } else {
-                error!(
-                    row_count = orphans.len(),
-                    orphan_ids = ?orphans,
-                    "Reconciliation baseline: {} orphan deposit row(s) currently present \
-                     (no allowed mint status at the deposit's slot); subsequent ticks will only log on new entries",
-                    orphans.len()
-                );
+                // No alert needed; establish an empty baseline.
+                *previously_alerted_orphans = Some(HashSet::new());
+                return;
+            }
 
-                // Post the full current orphan set so restarts re-surface unresolved orphans.
-                if let Err(e) =
-                    send_orphan_deposit_alert(webhook_url, &orphans, webhook_client).await
-                {
+            error!(
+                row_count = orphans.len(),
+                orphan_ids = ?orphans,
+                "Reconciliation baseline: {} orphan deposit row(s) currently present \
+                 (no allowed mint status at the deposit's slot); subsequent ticks will only log on new entries",
+                orphans.len()
+            );
+
+            // Advance dedup state only after the alert is delivered; on failure
+            // leave it `None` so the next tick re-runs the baseline and retries.
+            match send_orphan_deposit_alert(webhook_url, &orphans, webhook_client).await {
+                Ok(()) => {
+                    *previously_alerted_orphans = Some(orphans.into_iter().collect());
+                }
+                Err(e) => {
                     error!("Failed to send orphan deposit webhook alert: {}", e);
                 }
             }
-            *previously_alerted_orphans = Some(orphans.into_iter().collect());
         }
         Some(seen) => {
             // Delta pass, only NEW orphan rows (not in `seen`) get logged.
@@ -267,15 +273,16 @@ async fn check_orphan_deposit_rows(
                 new_orphans.len()
             );
 
-            // Alert on the newly-arrived orphans only. Webhook failures are
-            // logged inside the helper but must not abort the tick.
-            if let Err(e) =
-                send_orphan_deposit_alert(webhook_url, &new_orphans, webhook_client).await
-            {
-                error!("Failed to send orphan deposit webhook alert: {}", e);
+            // Mark seen only after a successful alert; a failed send leaves
+            // them unseen so the next tick re-alerts.
+            match send_orphan_deposit_alert(webhook_url, &new_orphans, webhook_client).await {
+                Ok(()) => {
+                    seen.extend(new_orphans);
+                }
+                Err(e) => {
+                    error!("Failed to send orphan deposit webhook alert: {}", e);
+                }
             }
-
-            seen.extend(new_orphans);
         }
     }
 }
@@ -1255,6 +1262,67 @@ mod tests {
         mock.assert_async().await;
     }
 
+    /// A failed baseline alert must leave state `None` so the next tick retries
+    /// instead of suppressing the orphan forever.
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_failed_webhook_does_not_seed_baseline_state() {
+        let mut server = mockito::Server::new_async().await;
+        // Endpoint is down: every attempt 500s, so the alert exhausts retries.
+        let mock = server
+            .mock("POST", "/")
+            .with_status(500)
+            .expect(3) // alert exhausts its 3 retries
+            .create_async()
+            .await;
+
+        let webhook_url = Some(server.url());
+        let client = test_webhook_client();
+
+        let mock_storage = MockStorage::new();
+        seed_orphan_deposit(&mock_storage, "mint_a");
+        let storage = Arc::new(Storage::Mock(mock_storage));
+
+        let mut state: Option<HashSet<i64>> = None;
+        check_orphan_deposit_rows(&storage, &mut state, &client, &webhook_url).await;
+
+        assert!(
+            state.is_none(),
+            "failed baseline alert must leave dedup state unset so the next tick retries"
+        );
+        mock.assert_async().await;
+    }
+
+    /// A failed delta alert must not mark the new orphan seen, so a later tick
+    /// re-alerts.
+    #[tokio::test]
+    async fn check_orphan_deposit_rows_failed_webhook_does_not_mark_new_orphan_seen() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .with_status(500)
+            .expect(3) // alert exhausts its 3 retries
+            .create_async()
+            .await;
+
+        let webhook_url = Some(server.url());
+        let client = test_webhook_client();
+
+        let mock_storage = MockStorage::new();
+        let id_a = seed_orphan_deposit(&mock_storage, "mint_a");
+        let storage = Arc::new(Storage::Mock(mock_storage));
+
+        // Already in delta mode (baseline established as empty); id_a is new.
+        let mut state: Option<HashSet<i64>> = Some(HashSet::new());
+        check_orphan_deposit_rows(&storage, &mut state, &client, &webhook_url).await;
+
+        let seen = state.expect("state must remain Some after a delta tick");
+        assert!(
+            !seen.contains(&id_a),
+            "a new orphan whose alert failed must not be marked seen (so it re-alerts)"
+        );
+        mock.assert_async().await;
+    }
+
     // Additional edge case tests for basis points calculation
 
     #[test]
@@ -1605,6 +1673,8 @@ mod tests {
             counterpart_signature: None,
             remint_signatures: None,
             pending_remint_deadline_at: None,
+            remint_last_valid_block_heights: None,
+            finality_check_attempts: 0,
         });
         id
     }

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -189,7 +189,21 @@ pub(super) async fn try_jit_mint_initialization(
         }
     }
 
-    // 3. Look up mint decimals from mint cache.
+    // Look up the mint's decimals. This is a pure metadata read,
+    // only `decimals` is used.
+    //
+    // `get_mint_metadata` checks the in-memory cache first, then the
+    // DB, and finally falls back to a source-chain RPC fetch if
+    // neither has the mint. That last fallback would be dangerous on
+    // its own: it would let any source-chain mint be resolved
+    // here, initialized on the private channel, and minted into a
+    // user's account.
+    //
+    // It's safe in this position because the deposit processor
+    // already refuses to forward a deposit whose mint was not in
+    // allowed status at the deposit's slot (see
+    // `assert_mint_allowed_at_slot` in `process_deposit_funds`). By the
+    // time execution reaches this point, the mint is known-allowed.
     let Ok(mint_metadata) = state.mint_cache.get_mint_metadata(&mint).await else {
         error!("Mint {} not found in mint cache", mint);
         return JitOutcome::PermanentFailure(format!("mint not in mint cache: {}", mint));

--- a/indexer/src/operator/utils/mint_util.rs
+++ b/indexer/src/operator/utils/mint_util.rs
@@ -1,5 +1,6 @@
 use crate::error::{AccountError, OperatorError};
 use crate::operator::RpcClientWithRetry;
+use crate::storage::common::models::MintStatusAtSlot;
 use crate::storage::Storage;
 use solana_rpc_client_api::client_error;
 use solana_rpc_client_api::client_error::ErrorKind;
@@ -313,14 +314,38 @@ impl MintCache {
     pub fn get_private_channel_token_program(&self) -> Pubkey {
         TOKEN_PROGRAM_ID
     }
+
+    /// Operator gate: refuses deposits whose mint was not in `allowed`
+    /// status at the deposit's slot, per `mint_status_history`.
+    pub async fn assert_mint_allowed_at_slot(
+        &self,
+        mint: &Pubkey,
+        deposit_slot: i64,
+        transaction_id: i64,
+    ) -> Result<(), OperatorError> {
+        let mint_str = mint.to_string();
+        let status = self
+            .storage
+            .get_mint_status_at_slot(&mint_str, deposit_slot)
+            .await?;
+        match status {
+            MintStatusAtSlot::Allowed => Ok(()),
+            _ => Err(OperatorError::MintNotAllowed {
+                transaction_id,
+                mint: mint_str,
+            }),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::OperatorError;
     use crate::operator::rpc_util::RpcClientWithRetry;
     use crate::operator::RetryConfig;
     use crate::storage::common::models::DbMint;
+    use crate::storage::common::models::DbMintStatus;
     use crate::storage::common::storage::mock::MockStorage;
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine;
@@ -395,6 +420,13 @@ mod tests {
             created_at: chrono::Utc::now(),
             is_pausable: Some(false),
             has_permanent_delegate: Some(false),
+        });
+        mock.mint_status_history.lock().unwrap().push(DbMintStatus {
+            mint_address: mint.to_string(),
+            status: "allowed".to_string(),
+            effective_slot: 0,
+            signature: format!("test-seed-{mint}"),
+            created_at: chrono::Utc::now(),
         });
 
         Arc::new(Storage::Mock(mock))
@@ -710,6 +742,100 @@ mod tests {
             matches!(err, crate::error::OperatorError::RpcError(_)),
             "expected RpcError, got {err:?}",
         );
+    }
+
+    fn seed_status(mock: &MockStorage, mint: &Pubkey, status: &str, slot: i64) {
+        mock.mint_status_history.lock().unwrap().push(DbMintStatus {
+            mint_address: mint.to_string(),
+            status: status.to_string(),
+            effective_slot: slot,
+            signature: format!("test-seed-{mint}-{slot}"),
+            created_at: chrono::Utc::now(),
+        });
+    }
+
+    #[tokio::test]
+    async fn assert_mint_allowed_at_slot_passes_when_allowed_before_deposit() {
+        let mint = create_test_mint();
+        let mock = MockStorage::new();
+        seed_status(&mock, &mint, "allowed", 10);
+        let storage = Arc::new(Storage::Mock(mock));
+
+        let cache = MintCache::new(storage);
+
+        cache
+            .assert_mint_allowed_at_slot(&mint, 50, 1)
+            .await
+            .expect("status allowed at slot 10 must apply at deposit slot 50");
+    }
+
+    #[tokio::test]
+    async fn assert_mint_allowed_at_slot_rejects_deposit_before_allow() {
+        let mint = create_test_mint();
+        let mock = MockStorage::new();
+        seed_status(&mock, &mint, "allowed", 50);
+        let storage = Arc::new(Storage::Mock(mock));
+
+        let cache = MintCache::new(storage);
+
+        let err = cache
+            .assert_mint_allowed_at_slot(&mint, 10, 7)
+            .await
+            .expect_err("deposit before allow must be rejected");
+        match err {
+            OperatorError::MintNotAllowed {
+                transaction_id,
+                mint: m,
+            } => {
+                assert_eq!(transaction_id, 7);
+                assert_eq!(m, mint.to_string());
+            }
+            other => panic!("expected MintNotAllowed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn assert_mint_allowed_at_slot_rejects_during_blocked_window() {
+        let mint = create_test_mint();
+        let mock = MockStorage::new();
+        seed_status(&mock, &mint, "allowed", 10);
+        seed_status(&mock, &mint, "blocked", 20);
+        let storage = Arc::new(Storage::Mock(mock));
+
+        let cache = MintCache::new(storage);
+
+        let err = cache
+            .assert_mint_allowed_at_slot(&mint, 25, 9)
+            .await
+            .expect_err("deposit during blocked window must be rejected");
+        assert!(
+            matches!(err, OperatorError::MintNotAllowed { .. }),
+            "expected MintNotAllowed, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn assert_mint_allowed_at_slot_rejects_when_no_history() {
+        let mint = create_test_mint();
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+
+        let cache = MintCache::new(storage);
+
+        let err = cache
+            .assert_mint_allowed_at_slot(&mint, 100, 42)
+            .await
+            .expect_err("mint with no history must be rejected");
+
+        match err {
+            OperatorError::MintNotAllowed {
+                transaction_id,
+                mint: m,
+            } => {
+                assert_eq!(transaction_id, 42);
+                assert_eq!(m, mint.to_string());
+            }
+            other => panic!("expected MintNotAllowed, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -123,6 +123,24 @@ impl DbMint {
     }
 }
 
+/// Status transition row recording an Allow/Block decision for a mint at a slot.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DbMintStatus {
+    pub mint_address: String,
+    pub status: String,
+    pub effective_slot: i64,
+    pub signature: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Resolved mint status at a particular slot, derived from `mint_status_history`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MintStatusAtSlot {
+    Allowed,
+    Blocked,
+    NeverAllowed,
+}
+
 /// Builder for DbTransaction
 pub struct DbTransactionBuilder {
     signature: String,

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -11,11 +11,14 @@ pub mod get_completed_withdrawal_nonces;
 pub mod get_escrow_balances_by_mint;
 pub mod get_mint;
 pub mod get_mint_balances_for_reconciliation;
+pub mod get_mint_status_at_slot;
+pub mod get_orphan_deposit_ids;
 pub mod get_pending_db_transactions;
 pub mod get_pending_remint_transactions;
 pub mod init_schema;
 pub mod insert_db_transaction;
 pub mod insert_db_transactions_batch;
+pub mod insert_mint_statuses_batch;
 pub mod quarantine_all_active_withdrawals;
 pub mod set_mint_extension_flags;
 pub mod set_pending_remint;
@@ -140,6 +143,24 @@ impl Storage {
         upsert_mints_batch::upsert_mints_batch(self, mints).await
     }
 
+    /// Append Allow/Block transition rows to `mint_status_history`.
+    /// Idempotent on (mint_address, effective_slot)
+    pub async fn insert_mint_statuses_batch(
+        &self,
+        statuses: &[DbMintStatus],
+    ) -> Result<(), StorageError> {
+        insert_mint_statuses_batch::insert_mint_statuses_batch(self, statuses).await
+    }
+
+    /// Resolve a mint's status (Allowed / Blocked / NeverAllowed) as of `slot`.
+    pub async fn get_mint_status_at_slot(
+        &self,
+        mint_address: &str,
+        slot: i64,
+    ) -> Result<MintStatusAtSlot, StorageError> {
+        get_mint_status_at_slot::get_mint_status_at_slot(self, mint_address, slot).await
+    }
+
     /// Get mint metadata by address
     pub async fn get_mint(&self, mint_address: &str) -> Result<Option<DbMint>, StorageError> {
         get_mint::get_mint(self, mint_address).await
@@ -175,6 +196,19 @@ impl Storage {
     /// Returns per-mint aggregate balances where net_balance = total_deposits - total_withdrawals.
     pub async fn get_escrow_balances_by_mint(&self) -> Result<Vec<MintDbBalance>, StorageError> {
         get_escrow_balances_by_mint::get_escrow_balances_by_mint(self).await
+    }
+
+    /// `transactions.id` for every `deposit` row whose mint was not in
+    /// `allowed` status at the deposit's slot, per `mint_status_history`.
+    ///
+    /// A non-empty result means the indexer recorded a deposit for a mint
+    /// that was either never allowlisted or was blocked at the time of the
+    /// deposit — a trust-boundary leak. Reconciliation queries this to
+    /// alert on any such rows; they describe the same condition the
+    /// deposit-side gate (`assert_mint_allowed_at_slot`) refuses at process
+    /// time. So, this is a second line of defense.
+    pub async fn get_orphan_deposit_ids(&self) -> Result<Vec<i64>, StorageError> {
+        get_orphan_deposit_ids::get_orphan_deposit_ids(self).await
     }
 
     /// Close the storage connection pool gracefully
@@ -816,6 +850,278 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(affected, 0);
+    }
+
+    // ── insert_mint_statuses_batch ────────────────────────────────────
+
+    #[tokio::test]
+    async fn insert_mint_statuses_batch_persists_rows() {
+        use std::sync::Arc;
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mint = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+        storage
+            .insert_mint_statuses_batch(&[DbMintStatus {
+                mint_address: mint.clone(),
+                status: "allowed".to_string(),
+                effective_slot: 100,
+                signature: "sig-1".to_string(),
+                created_at: Utc::now(),
+            }])
+            .await
+            .unwrap();
+        let rows = match storage.as_ref() {
+            Storage::Mock(m) => m.mint_status_history.lock().unwrap().clone(),
+            _ => panic!("expected mock"),
+        };
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].mint_address, mint);
+    }
+
+    #[tokio::test]
+    async fn insert_mint_statuses_batch_idempotent_on_pk_conflict() {
+        use std::sync::Arc;
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mint = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+        let row = DbMintStatus {
+            mint_address: mint.clone(),
+            status: "allowed".to_string(),
+            effective_slot: 100,
+            signature: "sig-1".to_string(),
+            created_at: Utc::now(),
+        };
+        storage
+            .insert_mint_statuses_batch(std::slice::from_ref(&row))
+            .await
+            .unwrap();
+        storage.insert_mint_statuses_batch(&[row]).await.unwrap();
+        let rows = match storage.as_ref() {
+            Storage::Mock(m) => m.mint_status_history.lock().unwrap().clone(),
+            _ => panic!("expected mock"),
+        };
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn insert_mint_statuses_batch_empty_input_is_noop() {
+        let (storage, mock) = make_mock_storage();
+
+        let result = storage.insert_mint_statuses_batch(&[]).await;
+
+        assert!(result.is_ok(), "empty batch should succeed");
+        assert_eq!(
+            mock.mint_status_history.lock().unwrap().len(),
+            0,
+            "empty batch must not write any mint status rows"
+        );
+    }
+
+    // ── get_mint_status_at_slot ──────────────────────────────────────
+
+    fn status_row(mint: &str, status: &str, slot: i64) -> DbMintStatus {
+        DbMintStatus {
+            mint_address: mint.to_string(),
+            status: status.to_string(),
+            effective_slot: slot,
+            signature: format!("sig-{mint}-{slot}"),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_returns_never_allowed_when_no_history() {
+        let (storage, _mock) = make_mock_storage();
+        let res = storage
+            .get_mint_status_at_slot("mint_a", 100)
+            .await
+            .unwrap();
+        assert_eq!(res, MintStatusAtSlot::NeverAllowed);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_returns_never_allowed_when_only_future_entry_exists() {
+        let (storage, _mock) = make_mock_storage();
+        storage
+            .insert_mint_statuses_batch(&[status_row("mint_a", "allowed", 10)])
+            .await
+            .unwrap();
+        let res = storage.get_mint_status_at_slot("mint_a", 5).await.unwrap();
+        assert_eq!(res, MintStatusAtSlot::NeverAllowed);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_returns_allowed_at_exact_effective_slot() {
+        let (storage, _mock) = make_mock_storage();
+        storage
+            .insert_mint_statuses_batch(&[status_row("mint_a", "allowed", 10)])
+            .await
+            .unwrap();
+        let res = storage.get_mint_status_at_slot("mint_a", 10).await.unwrap();
+        assert_eq!(res, MintStatusAtSlot::Allowed);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_returns_allowed_after_allow_entry() {
+        let (storage, _mock) = make_mock_storage();
+        storage
+            .insert_mint_statuses_batch(&[status_row("mint_a", "allowed", 10)])
+            .await
+            .unwrap();
+        let res = storage
+            .get_mint_status_at_slot("mint_a", 100)
+            .await
+            .unwrap();
+        assert_eq!(res, MintStatusAtSlot::Allowed);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_returns_allowed_in_window_between_allow_and_block() {
+        let (storage, _mock) = make_mock_storage();
+        storage
+            .insert_mint_statuses_batch(&[
+                status_row("mint_a", "allowed", 10),
+                status_row("mint_a", "blocked", 20),
+            ])
+            .await
+            .unwrap();
+        let res = storage.get_mint_status_at_slot("mint_a", 15).await.unwrap();
+        assert_eq!(res, MintStatusAtSlot::Allowed);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_returns_blocked_after_block_entry() {
+        let (storage, _mock) = make_mock_storage();
+        storage
+            .insert_mint_statuses_batch(&[
+                status_row("mint_a", "allowed", 10),
+                status_row("mint_a", "blocked", 20),
+            ])
+            .await
+            .unwrap();
+        let res = storage.get_mint_status_at_slot("mint_a", 25).await.unwrap();
+        assert_eq!(res, MintStatusAtSlot::Blocked);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_returns_blocked_in_window_between_block_and_reallow() {
+        let (storage, _mock) = make_mock_storage();
+        storage
+            .insert_mint_statuses_batch(&[
+                status_row("mint_a", "allowed", 10),
+                status_row("mint_a", "blocked", 20),
+                status_row("mint_a", "allowed", 30),
+            ])
+            .await
+            .unwrap();
+        let res = storage.get_mint_status_at_slot("mint_a", 25).await.unwrap();
+        assert_eq!(res, MintStatusAtSlot::Blocked);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_returns_allowed_after_reallow_in_cycle() {
+        let (storage, _mock) = make_mock_storage();
+        storage
+            .insert_mint_statuses_batch(&[
+                status_row("mint_a", "allowed", 10),
+                status_row("mint_a", "blocked", 20),
+                status_row("mint_a", "allowed", 30),
+            ])
+            .await
+            .unwrap();
+        let res = storage.get_mint_status_at_slot("mint_a", 35).await.unwrap();
+        assert_eq!(res, MintStatusAtSlot::Allowed);
+    }
+
+    // ── orphan query against status history ──────────────────────────
+
+    fn seed_deposit(mock: &MockStorage, id: i64, mint: &str, slot: i64) {
+        let mut pending = mock.pending_transactions.lock().unwrap();
+        pending.push(DbTransaction {
+            id,
+            signature: format!("sig-orphan-{id}"),
+            trace_id: format!("trace-orphan-{id}"),
+            slot,
+            initiator: "init".to_string(),
+            recipient: "recip".to_string(),
+            mint: mint.to_string(),
+            amount: 1,
+            memo: None,
+            transaction_type: TransactionType::Deposit,
+            withdrawal_nonce: None,
+            status: TransactionStatus::Pending,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            pending_remint_deadline_at: None,
+        });
+    }
+
+    #[tokio::test]
+    async fn orphan_query_flags_deposit_before_mint_allowed() {
+        let (storage, mock) = make_mock_storage();
+        seed_deposit(&mock, 1, "mint_a", 5);
+        storage
+            .insert_mint_statuses_batch(&[status_row("mint_a", "allowed", 10)])
+            .await
+            .unwrap();
+        let ids = storage.get_orphan_deposit_ids().await.unwrap();
+        assert_eq!(ids, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn orphan_query_passes_deposit_at_or_after_allow() {
+        let (storage, mock) = make_mock_storage();
+        seed_deposit(&mock, 1, "mint_a", 10);
+        seed_deposit(&mock, 2, "mint_a", 15);
+        storage
+            .insert_mint_statuses_batch(&[status_row("mint_a", "allowed", 10)])
+            .await
+            .unwrap();
+        let ids = storage.get_orphan_deposit_ids().await.unwrap();
+        assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn orphan_query_flags_deposit_during_blocked_window() {
+        let (storage, mock) = make_mock_storage();
+        seed_deposit(&mock, 7, "mint_a", 25);
+        storage
+            .insert_mint_statuses_batch(&[
+                status_row("mint_a", "allowed", 10),
+                status_row("mint_a", "blocked", 20),
+            ])
+            .await
+            .unwrap();
+        let ids = storage.get_orphan_deposit_ids().await.unwrap();
+        assert_eq!(ids, vec![7]);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_unrecognized_status_fails_closed_to_blocked() {
+        let (storage, _mock) = make_mock_storage();
+        // A status value that is neither "allowed" nor "blocked" is data
+        // corruption — it must resolve to a not-allowed variant, never Allowed.
+        storage
+            .insert_mint_statuses_batch(&[status_row("mint_a", "bogus", 10)])
+            .await
+            .unwrap();
+        let res = storage.get_mint_status_at_slot("mint_a", 15).await.unwrap();
+        assert_eq!(res, MintStatusAtSlot::Blocked);
+    }
+
+    #[tokio::test]
+    async fn get_mint_status_at_slot_distinguishes_status_across_two_mints() {
+        let (storage, _mock) = make_mock_storage();
+        storage
+            .insert_mint_statuses_batch(&[status_row("mint_a", "allowed", 10)])
+            .await
+            .unwrap();
+        let res = storage
+            .get_mint_status_at_slot("mint_b", 100)
+            .await
+            .unwrap();
+        assert_eq!(res, MintStatusAtSlot::NeverAllowed);
     }
 
     /// `exclude_id` must skip the poison row so it is not flipped twice —

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -1054,6 +1054,8 @@ mod tests {
             counterpart_signature: None,
             remint_signatures: None,
             pending_remint_deadline_at: None,
+            remint_last_valid_block_heights: None,
+            finality_check_attempts: 0,
         });
     }
 

--- a/indexer/src/storage/common/storage/get_mint_status_at_slot.rs
+++ b/indexer/src/storage/common/storage/get_mint_status_at_slot.rs
@@ -1,0 +1,22 @@
+use crate::{
+    error::StorageError,
+    storage::common::{models::MintStatusAtSlot, storage::Storage},
+};
+
+/// Resolve a mint's status as of `slot` by reading the latest history row
+/// with `effective_slot <= slot`. Returns `NeverAllowed` when no such row
+/// exists (the mint has never been allowlisted at or before that slot).
+pub async fn get_mint_status_at_slot(
+    storage: &Storage,
+    mint_address: &str,
+    slot: i64,
+) -> Result<MintStatusAtSlot, StorageError> {
+    match storage {
+        Storage::Postgres(db) => {
+            db.get_mint_status_at_slot_internal(mint_address, slot)
+                .await
+        }
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.get_mint_status_at_slot(mint_address, slot).await,
+    }
+}

--- a/indexer/src/storage/common/storage/get_orphan_deposit_ids.rs
+++ b/indexer/src/storage/common/storage/get_orphan_deposit_ids.rs
@@ -1,0 +1,18 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// `transactions.id` for every `deposit` row whose mint was not in `allowed`
+/// status at the deposit's slot (per `mint_status_history`). A non-empty
+/// result means the indexer recorded a deposit for a mint that was either
+/// never allowlisted or was blocked at the time of the deposit — a
+/// trust-boundary leak. Reconciliation queries this to alert on any such
+/// rows.
+///
+/// IDs (not mints) are returned so reconciliation detects
+/// *each new* orphan deposit.
+pub async fn get_orphan_deposit_ids(storage: &Storage) -> Result<Vec<i64>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db.get_orphan_deposit_ids_internal().await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.get_orphan_deposit_ids().await,
+    }
+}

--- a/indexer/src/storage/common/storage/insert_mint_statuses_batch.rs
+++ b/indexer/src/storage/common/storage/insert_mint_statuses_batch.rs
@@ -1,0 +1,18 @@
+use crate::{
+    error::StorageError,
+    storage::common::{models::DbMintStatus, storage::Storage},
+};
+
+pub async fn insert_mint_statuses_batch(
+    storage: &Storage,
+    statuses: &[DbMintStatus],
+) -> Result<(), StorageError> {
+    match storage {
+        Storage::Postgres(db) => {
+            db.insert_mint_statuses_batch_internal(statuses).await?;
+            Ok(())
+        }
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.insert_mint_statuses_batch(statuses).await,
+    }
+}

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -1,10 +1,11 @@
 use crate::error::StorageError;
 use crate::storage::common::models::{
-    DbMint, DbTransaction, MintDbBalance, TransactionStatus, TransactionType,
+    DbMint, DbMintStatus, DbTransaction, MintDbBalance, MintStatusAtSlot, TransactionStatus,
+    TransactionType,
 };
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// Recorded status update from `update_transaction_status`.
 pub type StatusUpdateRecord = (i64, TransactionStatus, Option<String>, DateTime<Utc>);
@@ -27,6 +28,7 @@ pub struct MockStorage {
     pub pending_remint_signatures: std::sync::Arc<Mutex<Vec<PendingRemintRecord>>>,
     /// Transactions currently in PendingRemint status, used in tests to simulate startup recovery.
     pub pending_remint_transactions: std::sync::Arc<Mutex<Vec<DbTransaction>>>,
+    pub mint_status_history: Arc<Mutex<Vec<DbMintStatus>>>,
 }
 
 impl MockStorage {
@@ -231,6 +233,42 @@ impl MockStorage {
         Ok(self.mints.lock().unwrap().get(mint_address).cloned())
     }
 
+    pub async fn insert_mint_statuses_batch(
+        &self,
+        statuses: &[DbMintStatus],
+    ) -> Result<(), StorageError> {
+        self.check_should_fail("insert_mint_statuses_batch")?;
+        let mut store = self.mint_status_history.lock().unwrap();
+        for s in statuses {
+            let exists = store
+                .iter()
+                .any(|r| r.mint_address == s.mint_address && r.effective_slot == s.effective_slot);
+            if !exists {
+                store.push(s.clone());
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn get_mint_status_at_slot(
+        &self,
+        mint_address: &str,
+        slot: i64,
+    ) -> Result<MintStatusAtSlot, StorageError> {
+        let store = self.mint_status_history.lock().unwrap();
+        let latest = store
+            .iter()
+            .filter(|r| r.mint_address == mint_address && r.effective_slot <= slot)
+            .max_by_key(|r| r.effective_slot);
+        match latest {
+            Some(r) if r.status == "allowed" => Ok(MintStatusAtSlot::Allowed),
+            Some(r) if r.status == "blocked" => Ok(MintStatusAtSlot::Blocked),
+            // Mirror the postgres path: an unrecognized status fails closed to Blocked.
+            Some(_) => Ok(MintStatusAtSlot::Blocked),
+            None => Ok(MintStatusAtSlot::NeverAllowed),
+        }
+    }
+
     pub async fn set_mint_extension_flags(
         &self,
         mint_address: &str,
@@ -263,6 +301,26 @@ impl MockStorage {
 
     pub async fn get_escrow_balances_by_mint(&self) -> Result<Vec<MintDbBalance>, StorageError> {
         Ok(self.mint_balances.lock().unwrap().clone())
+    }
+
+    pub async fn get_orphan_deposit_ids(&self) -> Result<Vec<i64>, StorageError> {
+        self.check_should_fail("get_orphan_deposit_ids")?;
+        let deposits: Vec<DbTransaction> = {
+            let txs = self.pending_transactions.lock().unwrap();
+            txs.iter()
+                .filter(|t| t.transaction_type == TransactionType::Deposit)
+                .cloned()
+                .collect()
+        };
+        let mut ids = Vec::new();
+        for t in deposits {
+            let status = self.get_mint_status_at_slot(&t.mint, t.slot).await?;
+            if !matches!(status, MintStatusAtSlot::Allowed) {
+                ids.push(t.id);
+            }
+        }
+        ids.sort();
+        Ok(ids)
     }
 
     pub async fn close(&self) -> Result<(), StorageError> {

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -305,10 +305,19 @@ impl MockStorage {
 
     pub async fn get_orphan_deposit_ids(&self) -> Result<Vec<i64>, StorageError> {
         self.check_should_fail("get_orphan_deposit_ids")?;
+        // Mirror Postgres, which scans the whole `transactions` table regardless
+        // of status: union every transaction store the mock holds, deduped by id.
         let deposits: Vec<DbTransaction> = {
-            let txs = self.pending_transactions.lock().unwrap();
-            txs.iter()
+            let pending = self.pending_transactions.lock().unwrap();
+            let singles = self.inserted_single_transactions.lock().unwrap();
+            let batches = self.inserted_transactions.lock().unwrap();
+            let mut seen_ids = std::collections::HashSet::new();
+            pending
+                .iter()
+                .chain(singles.iter())
+                .chain(batches.iter().flatten())
                 .filter(|t| t.transaction_type == TransactionType::Deposit)
+                .filter(|t| seen_ids.insert(t.id))
                 .cloned()
                 .collect()
         };

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1,10 +1,11 @@
 use sqlx::{postgres::PgPoolOptions, PgPool};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     error::StorageError,
     storage::common::models::{
-        DbMint, DbTransaction, MintDbBalance, TransactionStatus, TransactionType,
+        DbMint, DbMintStatus, DbTransaction, MintDbBalance, MintStatusAtSlot, TransactionStatus,
+        TransactionType,
     },
     PostgresConfig,
 };
@@ -396,6 +397,28 @@ impl PostgresDb {
             r#"
             ALTER TYPE transaction_status ADD VALUE IF NOT EXISTS 'pending_remint';
             "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS mint_status_history (
+                mint_address    TEXT       NOT NULL,
+                status          TEXT       NOT NULL CHECK (status IN ('allowed','blocked')),
+                effective_slot  BIGINT     NOT NULL,
+                signature       TEXT       NOT NULL,
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (mint_address, effective_slot)
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_mint_status_history_lookup
+             ON mint_status_history (mint_address, effective_slot DESC)",
         )
         .execute(&self.pool)
         .await?;
@@ -1011,6 +1034,72 @@ impl PostgresDb {
         Ok(())
     }
 
+    pub async fn insert_mint_statuses_batch_internal(
+        &self,
+        statuses: &[DbMintStatus],
+    ) -> Result<(), StorageError> {
+        if statuses.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+
+        for status in statuses {
+            sqlx::query(
+                r#"
+                INSERT INTO mint_status_history
+                    (mint_address, status, effective_slot, signature)
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT (mint_address, effective_slot) DO NOTHING
+                "#,
+            )
+            .bind(&status.mint_address)
+            .bind(&status.status)
+            .bind(status.effective_slot)
+            .bind(&status.signature)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn get_mint_status_at_slot_internal(
+        &self,
+        mint_address: &str,
+        slot: i64,
+    ) -> Result<MintStatusAtSlot, StorageError> {
+        let row: Option<(String,)> = sqlx::query_as(
+            r#"
+            SELECT status FROM mint_status_history
+            WHERE mint_address = $1 AND effective_slot <= $2
+            ORDER BY effective_slot DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(mint_address)
+        .bind(slot)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some((s,)) if s == "allowed" => Ok(MintStatusAtSlot::Allowed),
+            Some((s,)) if s == "blocked" => Ok(MintStatusAtSlot::Blocked),
+            // Unrecognized status is data corruption; fail closed to `Blocked` and log loudly.
+            Some((other,)) => {
+                warn!(
+                    mint_address,
+                    slot,
+                    status = %other,
+                    "Unrecognized mint status in mint_status_history; treating as Blocked"
+                );
+                Ok(MintStatusAtSlot::Blocked)
+            }
+            None => Ok(MintStatusAtSlot::NeverAllowed),
+        }
+    }
+
     /// Write-back from the operator's MintCache after it resolves whether
     /// the on-chain mint carries the Token-2022 PausableConfig and
     /// PermanentDelegate extensions. Both flags are always resolved in the
@@ -1122,6 +1211,31 @@ impl PostgresDb {
         )
         .fetch_all(&self.pool)
         .await
+    }
+
+    /// `transactions.id` for every `deposit` row whose mint was not in
+    /// `allowed` status at the deposit's slot, per `mint_status_history`.
+    pub async fn get_orphan_deposit_ids_internal(&self) -> Result<Vec<i64>, sqlx::Error> {
+        let rows: Vec<(i64,)> = sqlx::query_as(
+            r#"
+            SELECT t.id
+            FROM transactions t
+            LEFT JOIN LATERAL (
+                SELECT status
+                FROM mint_status_history h
+                WHERE h.mint_address = t.mint
+                  AND h.effective_slot <= t.slot
+                ORDER BY h.effective_slot DESC
+                LIMIT 1
+            ) latest ON true
+            WHERE t.transaction_type = 'deposit'
+              AND (latest.status IS NULL OR latest.status = 'blocked')
+            ORDER BY t.id ASC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
     pub async fn close(&self) -> Result<(), sqlx::Error> {

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -8,8 +8,8 @@
 use chrono::Utc;
 use private_channel_indexer::{
     storage::{
-        common::models::DbMint, DbTransaction, PostgresDb, Storage, TransactionStatus,
-        TransactionType,
+        common::models::{DbMint, DbMintStatus, MintStatusAtSlot},
+        DbTransaction, PostgresDb, Storage, TransactionStatus, TransactionType,
     },
     PostgresConfig,
 };
@@ -620,5 +620,116 @@ async fn set_mint_extension_flags_fails_when_no_row() -> Result<(), Box<dyn std:
         .await;
 
     assert!(result.is_err(), "should fail when mints row doesn't exist");
+    Ok(())
+}
+
+// ── mint_status_history ──────────────────────────────────────────────────────
+
+fn mk_status(mint: &str, status: &str, slot: i64, sig: &str) -> DbMintStatus {
+    DbMintStatus {
+        mint_address: mint.to_string(),
+        status: status.to_string(),
+        effective_slot: slot,
+        signature: sig.to_string(),
+        created_at: Utc::now(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_mint_statuses_batch_persists_rows_pg() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    storage
+        .insert_mint_statuses_batch(&[mk_status("mint_pg1", "allowed", 100, "sig-1")])
+        .await?;
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*)::BIGINT FROM mint_status_history WHERE mint_address = $1")
+            .bind("mint_pg1")
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(count, 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_mint_statuses_batch_idempotent_on_pk_conflict_pg(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let row = mk_status("mint_pg2", "allowed", 100, "sig-1");
+    storage
+        .insert_mint_statuses_batch(std::slice::from_ref(&row))
+        .await?;
+    storage.insert_mint_statuses_batch(&[row]).await?;
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*)::BIGINT FROM mint_status_history WHERE mint_address = $1")
+            .bind("mint_pg2")
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(count, 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_mint_statuses_batch_empty_input_is_noop_pg(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    storage.insert_mint_statuses_batch(&[]).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mint_status_at_slot_returns_blocked_in_window_between_block_and_reallow(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    storage
+        .insert_mint_statuses_batch(&[
+            mk_status("mint_cycle1", "allowed", 10, "sig-a"),
+            mk_status("mint_cycle1", "blocked", 20, "sig-b"),
+            mk_status("mint_cycle1", "allowed", 30, "sig-c"),
+        ])
+        .await?;
+
+    let res = storage.get_mint_status_at_slot("mint_cycle1", 25).await?;
+    assert_eq!(res, MintStatusAtSlot::Blocked);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mint_status_at_slot_returns_allowed_after_reallow_in_cycle(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    storage
+        .insert_mint_statuses_batch(&[
+            mk_status("mint_cycle2", "allowed", 10, "sig-a"),
+            mk_status("mint_cycle2", "blocked", 20, "sig-b"),
+            mk_status("mint_cycle2", "allowed", 30, "sig-c"),
+        ])
+        .await?;
+
+    let res = storage.get_mint_status_at_slot("mint_cycle2", 35).await?;
+    assert_eq!(res, MintStatusAtSlot::Allowed);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mint_status_at_slot_returns_never_allowed_when_no_history(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    let res = storage.get_mint_status_at_slot("mint_absent", 100).await?;
+    assert_eq!(res, MintStatusAtSlot::NeverAllowed);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mint_status_at_slot_returns_blocked_after_block_entry(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_pool, storage, _pg) = start_postgres().await?;
+    storage
+        .insert_mint_statuses_batch(&[
+            mk_status("mint_blk", "allowed", 10, "sig-a"),
+            mk_status("mint_blk", "blocked", 20, "sig-b"),
+        ])
+        .await?;
+    let res = storage.get_mint_status_at_slot("mint_blk", 25).await?;
+    assert_eq!(res, MintStatusAtSlot::Blocked);
     Ok(())
 }

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -1166,9 +1166,10 @@ async fn drill_15_deposit_manual_review_allowlist_gate_recovery_flows(
     let branch_3b_id = seed_deposit(&pool, "manual_review").await?;
     let control_id = seed_deposit(&pool, "completed").await?;
 
-    // 3a — indexer-gap branch: after the operator backfills `mints`,
-    // re-arm the row to `pending`. SQL must be id-targeted and not
-    // reference `error_message` (drill_14's fungibility contract).
+    // 3a — indexer-gap branch: after the operator backfills `mints` AND
+    // `mint_status_history` (the slot-aware gate reads the latter), re-arm
+    // the row to `pending`. SQL must be id-targeted and not reference
+    // `error_message` (drill_14's fungibility contract).
     sqlx::query("UPDATE transactions SET status='pending', updated_at=NOW() WHERE id=$1")
         .bind(branch_3a_id)
         .execute(&pool)

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -287,7 +287,7 @@ fn drill_1_error_message_contracts_present_in_source() {
         // `OperatorError::MintNotAllowed`'s `#[error(...)]` template; if
         // that string is refactored, the triage table desyncs silently.
         (
-            "is not in the allow-listed mints table",
+            "has no allowed status in mint_status_history",
             "indexer/src/error/operator.rs",
         ),
     ];
@@ -1109,7 +1109,7 @@ async fn drill_15_deposit_manual_review_allowlist_gate_recovery_flows(
         "Path E depends on OperatorError::MintNotAllowed — variant missing from operator.rs",
     );
     assert!(
-        operator_err.contains("is not in the allow-listed mints table"),
+        operator_err.contains("has no allowed status in mint_status_history"),
         "Path E triage dispatches on this substring — missing from operator.rs",
     );
     eprintln!("OK   error/operator.rs: MintNotAllowed + dispatch substring");

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -282,6 +282,14 @@ fn drill_1_error_message_contracts_present_in_source() {
             "private_channel:mint-idempotency:",
             "indexer/src/operator/constants.rs",
         ),
+        // Deposit — processor-side allowlist gate (Path E). The runbook
+        // dispatches on the user-visible portion of
+        // `OperatorError::MintNotAllowed`'s `#[error(...)]` template; if
+        // that string is refactored, the triage table desyncs silently.
+        (
+            "is not in the allow-listed mints table",
+            "indexer/src/error/operator.rs",
+        ),
     ];
 
     // The integration test runs from the indexer crate root.
@@ -1053,6 +1061,175 @@ async fn drill_14_deposit_manual_review_post_jit_recovery_flows(
     );
 
     eprintln!("Path D recovery flows verified end-to-end.");
+    Ok(())
+}
+
+// ── Drill 15: deposit_manual_review.md § Path E recovery flows ─────────────
+//
+// `deposit_manual_review.md` § Path E documents recovery for the
+// processor-side allowlist gate (`assert_mint_allowed_at_slot` rejects a
+// deposit whose mint was not in `allowed` status at the deposit's slot).
+// This drill pins:
+//
+//   1. The dispatch substring exists in source — `OperatorError::MintNotAllowed`'s
+//      `#[error(...)]` template lives in `error/operator.rs`, and is also
+//      anchored globally by drill_1.
+//   2. The classifier routes `MintNotAllowed` to a quarantine reason of
+//      `mint_not_allowed`, and the call to `assert_mint_allowed_at_slot`
+//      is still wired into `process_deposit_funds`. A future refactor
+//      that drops either of these breaks Path E silently.
+//   3. Path E recovery SQL: 3a re-arms to `pending`; 3b `DELETE`s the
+//      row (the orphan reconciliation query has no status filter, so
+//      DELETE is the only way to silence it). Both are id-targeted and
+//      leave unrelated rows alone.
+//   4. The reconciliation cross-signal contract — the runbook references
+//      the orphan alert and reconciliation actually runs the
+//      orphan-mint check.
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drill_15_deposit_manual_review_allowlist_gate_recovery_flows(
+) -> Result<(), Box<dyn std::error::Error>> {
+    drill_header(
+        "deposit_manual_review.md",
+        "Path E — processor-side allowlist gate",
+    );
+
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+
+    // ── Step 1: dispatch substring + variant present in operator.rs ──
+    let operator_err_path = workspace_root.join("indexer/src/error/operator.rs");
+    let operator_err = std::fs::read_to_string(&operator_err_path)
+        .unwrap_or_else(|e| panic!("read {operator_err_path:?}: {e}"));
+    assert!(
+        operator_err.contains("MintNotAllowed"),
+        "Path E depends on OperatorError::MintNotAllowed — variant missing from operator.rs",
+    );
+    assert!(
+        operator_err.contains("is not in the allow-listed mints table"),
+        "Path E triage dispatches on this substring — missing from operator.rs",
+    );
+    eprintln!("OK   error/operator.rs: MintNotAllowed + dispatch substring");
+
+    // ── Step 2: classifier label + processor wiring ──────────────────
+    let processor_path = workspace_root.join("indexer/src/operator/processor.rs");
+    let processor = std::fs::read_to_string(&processor_path)
+        .unwrap_or_else(|e| panic!("read {processor_path:?}: {e}"));
+    assert!(
+        processor.contains("mint_not_allowed"),
+        "Classifier must label MintNotAllowed quarantines as \"mint_not_allowed\" — \
+         drives the OPERATOR_TRANSACTION_QUARANTINED metric the runbook references",
+    );
+    assert!(
+        processor.contains("assert_mint_allowed_at_slot"),
+        "process_deposit_funds must call assert_mint_allowed_at_slot — Path E's \
+         entire trigger surface depends on this gate firing before the sender path",
+    );
+    eprintln!("OK   processor.rs: \"mint_not_allowed\" label + assert_mint_allowed_at_slot call");
+
+    // ── Step 3: cross-signal contract with reconciliation ────────────
+    // Path E's recovery for the terminal branch tells the on-call that
+    // the reconciliation orphan check is the same incident — so the
+    // runbook must reference that check, and reconciliation must
+    // actually run the orphan-row check. Anchor each side concretely.
+    let reconciliation_path = workspace_root.join("indexer/src/operator/reconciliation.rs");
+    let reconciliation = std::fs::read_to_string(&reconciliation_path)
+        .unwrap_or_else(|e| panic!("read {reconciliation_path:?}: {e}"));
+    assert!(
+        reconciliation.contains("check_orphan_deposit_rows"),
+        "Reconciliation must run `check_orphan_deposit_rows` — the orphan \
+         alert Path E's recovery refers to",
+    );
+    let runbook_path = workspace_root.join("docs/runbooks/deposit_manual_review.md");
+    let runbook = std::fs::read_to_string(&runbook_path)
+        .unwrap_or_else(|e| panic!("read {runbook_path:?}: {e}"));
+    // Match the common stem so the assertion survives minor wording
+    // tweaks ("orphan alert" / "orphan check" / "orphan log") — what we
+    // anchor is the existence of the cross-link, not its exact phrasing.
+    assert!(
+        runbook.contains("reconciliation orphan"),
+        "deposit_manual_review.md Path E must reference the reconciliation \
+         orphan check — without it, on-call triages the same incident twice",
+    );
+    eprintln!("OK   reconciliation.rs + runbook: orphan-alert cross-link");
+
+    // ── Step 4: recovery SQL fungibility (3a re-arm, 3b mark-failed) ─
+    let (pool, _storage, _pg) = start_postgres().await?;
+
+    // Three deposits: one for each sub-branch we exercise, plus a
+    // terminal control to confirm the recovery SQL is targeted by id
+    // and never sweeps unrelated rows.
+    let branch_3a_id = seed_deposit(&pool, "manual_review").await?;
+    let branch_3b_id = seed_deposit(&pool, "manual_review").await?;
+    let control_id = seed_deposit(&pool, "completed").await?;
+
+    // 3a — indexer-gap branch: after the operator backfills `mints`,
+    // re-arm the row to `pending`. SQL must be id-targeted and not
+    // reference `error_message` (drill_14's fungibility contract).
+    sqlx::query("UPDATE transactions SET status='pending', updated_at=NOW() WHERE id=$1")
+        .bind(branch_3a_id)
+        .execute(&pool)
+        .await?;
+    assert_eq!(
+        status_of(&pool, branch_3a_id).await?,
+        "pending",
+        "Path E branch 3a re-arm must flip manual_review → pending",
+    );
+
+    // 3b — not-allowlisted branch: DELETE the row (the orphan
+    // reconciliation query has no status filter, so leaving a `failed`
+    // row in place would keep firing the orphan alert forever — the
+    // runbook prescribes DELETE for noise reduction after refund is
+    // coordinated out-of-band).
+    let rows_deleted = sqlx::query("DELETE FROM transactions WHERE id=$1")
+        .bind(branch_3b_id)
+        .execute(&pool)
+        .await?
+        .rows_affected();
+    assert_eq!(
+        rows_deleted, 1,
+        "Path E branch 3b must DELETE exactly the trigger row"
+    );
+    let exists: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE id=$1")
+        .bind(branch_3b_id)
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(exists, 0, "Path E branch 3b row must be gone after DELETE");
+
+    // Control: a completed row must be untouched by either recovery —
+    // and specifically not swept by the 3b DELETE.
+    assert_eq!(
+        status_of(&pool, control_id).await?,
+        "completed",
+        "unrelated terminal rows must be untouched by Path E recovery",
+    );
+
+    // 3c — foreign-instance branch: documented as escalate-only, no
+    // recovery SQL. The contract here is the absence of any mutating
+    // SQL after the Step 3c heading; mirror drill_13's "no mutating
+    // SQL" check rather than execute anything against the pool.
+    let step_3c_idx = runbook
+        .find("Step 3c")
+        .expect("Path E Step 3c heading must exist");
+    let step_3c_section = &runbook[step_3c_idx..];
+    let next_section_idx = step_3c_section[1..]
+        .find("\n## ")
+        .map(|i| i + 1)
+        .unwrap_or(step_3c_section.len());
+    let step_3c_body = &step_3c_section[..next_section_idx];
+    assert!(
+        !step_3c_body.contains("UPDATE transactions")
+            && !step_3c_body.contains("INSERT INTO")
+            && !step_3c_body.contains("DELETE FROM"),
+        "Path E Step 3c (foreign-instance) must contain no mutating SQL — \
+         escalate-only per the runbook",
+    );
+    eprintln!("OK   Step 3c body contains no mutating SQL");
+
+    eprintln!("Path E recovery flows verified end-to-end.");
     Ok(())
 }
 

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -76,6 +76,10 @@ name = "bootstrap_validation"
 path = "tests/indexer/bootstrap_validation.rs"
 
 [[test]]
+name = "deposit_allowlist_e2e"
+path = "tests/indexer/deposit_allowlist_e2e.rs"
+
+[[test]]
 name = "withdrawal_null_nonce"
 path = "tests/indexer/withdrawal_null_nonce.rs"
 

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -53,6 +53,7 @@ integration-test:
 	@cargo test --test checkpoint_partial_flush -- --nocapture
 	@cargo test --test remint_recovery -- --nocapture
 	@cargo test --test bootstrap_validation -- --nocapture
+	@cargo test --test deposit_allowlist_e2e -- --nocapture
 	@cargo test --test yellowstone_wiring -- --nocapture
 	@cargo test --test malformed_yellowstone_update -- --nocapture
 	@cargo test --test yellowstone_reconnect_gap -- --nocapture
@@ -252,6 +253,8 @@ integration-coverage-indexer:
 	@cargo llvm-cov test --no-report --workspace --test remint_recovery -- --nocapture
 	@echo "Running indexer bootstrap validation tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test bootstrap_validation -- --nocapture
+	@echo "Running deposit-allowlist e2e tests with coverage instrumentation..."
+	@cargo llvm-cov test --no-report --workspace --test deposit_allowlist_e2e -- --nocapture
 	@echo "Running Yellowstone wiring tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test yellowstone_wiring -- --nocapture
 	@echo "Running malformed Yellowstone update tests with coverage instrumentation..."

--- a/integration/tests/indexer/deposit_allowlist_e2e.rs
+++ b/integration/tests/indexer/deposit_allowlist_e2e.rs
@@ -1,0 +1,420 @@
+//! Integration tests for the deposit-allowlist enforcement, against a
+//! real Postgres
+//!
+//! Two changes are exercised here:
+//!
+//! 1. **Deposit-operator allowlist gate** — `MintCache::assert_mint_allowed_at_slot`
+//!    must reject mints with no row in `mints` and accept those that do,
+//!    using the public `Storage::Postgres` backend.
+//!
+//! 2. **Reconciliation orphan-row detection** — `Storage::get_orphan_deposit_ids`
+//!    must return exactly the deposit rows whose mint has no allowlist
+//!    entry, with realistic mixed-state inputs.
+//!
+//! Full operator-pipeline e2e (indexer → operator → on-chain submission)
+//! is covered separately by the validator-driven tests in this crate.
+//! What we get from this file is the load-bearing SQL behavior and the
+//! gate behavior verified against the same Postgres engine that runs in
+//! production, without the cost of bringing up a validator.
+
+use private_channel_indexer::{
+    operator::MintCache,
+    storage::{
+        common::models::{DbMint, DbTransactionBuilder, TransactionType},
+        PostgresDb, Storage,
+    },
+    PostgresConfig,
+};
+use solana_sdk::pubkey::Pubkey;
+use std::sync::Arc;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+/// Start a fresh Postgres container, init schema, return the public
+/// `Storage` (the SUT) and the container guard (kept alive for the
+/// test's lifetime).
+async fn start_postgres(
+) -> Result<(Arc<Storage>, testcontainers::ContainerAsync<Postgres>), Box<dyn std::error::Error>> {
+    let container = Postgres::default()
+        .with_db_name("deposit_allowlist_test")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await?;
+
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let db_url = format!(
+        "postgres://postgres:password@{}:{}/deposit_allowlist_test",
+        host, port
+    );
+
+    let storage = Arc::new(Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: db_url,
+            max_connections: 5,
+        })
+        .await?,
+    ));
+    storage.init_schema().await?;
+
+    Ok((storage, container))
+}
+
+/// Land a single allowlist entry via the same upsert path the indexer
+/// uses for `AllowMint` events. Keeping fixtures on the production API
+/// means any future schema migration breaks here in the same way it
+/// would break the real ingest path.
+async fn insert_mint_row(storage: &Storage, mint: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mint_row = DbMint::new(mint.to_string(), 6, spl_token::id().to_string());
+    storage.upsert_mints_batch(&[mint_row]).await?;
+    storage
+        .insert_mint_statuses_batch(&[
+            private_channel_indexer::storage::common::models::DbMintStatus {
+                mint_address: mint.to_string(),
+                status: "allowed".to_string(),
+                effective_slot: 0,
+                signature: format!("test-seed-{mint}"),
+                created_at: chrono::Utc::now(),
+            },
+        ])
+        .await?;
+    Ok(())
+}
+
+/// Insert a deposit transaction row via the production insert path
+/// (`Storage::insert_db_transaction` → `insert_transaction_internal`).
+/// Returns the assigned row id. Status defaults to `Pending` —
+/// orphan detection is status-agnostic, so this matches the worst-case
+/// shape where the operator has not yet processed the row.
+async fn insert_deposit_row(
+    storage: &Storage,
+    signature: &str,
+    mint: &str,
+) -> Result<i64, Box<dyn std::error::Error>> {
+    let tx = DbTransactionBuilder::new(signature.to_string(), 1, mint.to_string(), 100)
+        .initiator("init".to_string())
+        .recipient("recip".to_string())
+        .transaction_type(TransactionType::Deposit)
+        .build();
+    let id = storage.insert_db_transaction(&tx).await?;
+    Ok(id)
+}
+
+/// Insert a withdrawal transaction row via the production insert path.
+/// Used to prove the orphan query scopes to deposits — withdrawals are
+/// not part of this surface.
+async fn insert_withdrawal_row(
+    storage: &Storage,
+    signature: &str,
+    mint: &str,
+) -> Result<i64, Box<dyn std::error::Error>> {
+    let mut tx = DbTransactionBuilder::new(signature.to_string(), 1, mint.to_string(), 100)
+        .initiator("init".to_string())
+        .recipient("recip".to_string())
+        .transaction_type(TransactionType::Withdrawal)
+        .build();
+    // The builder doesn't take `withdrawal_nonce`; production code path
+    // assigns it directly on the struct (see `pending_remint_storage.rs`).
+    tx.withdrawal_nonce = Some(0);
+    let id = storage.insert_db_transaction(&tx).await?;
+    Ok(id)
+}
+
+// ── Orphan query: positive case ──────────────────────────────────────────────
+
+/// A deposit row whose mint has no `mints` entry must surface as an
+/// orphan. This is the core signal the reconciliation log is built on —
+/// without it, foreign-mint deposits accumulate invisibly.
+#[tokio::test(flavor = "multi_thread")]
+async fn orphan_query_returns_deposit_with_no_allowlist_entry(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    let orphan_mint = Pubkey::new_unique().to_string();
+    let orphan_id = insert_deposit_row(&storage, "sig_orphan", &orphan_mint).await?;
+
+    let ids = storage.get_orphan_deposit_ids().await?;
+    assert_eq!(
+        ids,
+        vec![orphan_id],
+        "deposit with no AllowMint must surface as orphan",
+    );
+
+    Ok(())
+}
+
+// ── Orphan query: false-positive bounds ──────────────────────────────────────
+
+/// Allowlisted-mint deposits must NOT appear in the orphan set. Without
+/// this bound, the dedup loop would log on every healthy deposit.
+#[tokio::test(flavor = "multi_thread")]
+async fn orphan_query_excludes_allowlisted_deposits() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    let mint = Pubkey::new_unique().to_string();
+    insert_mint_row(&storage, &mint).await?;
+    insert_deposit_row(&storage, "sig_allowed", &mint).await?;
+
+    let ids = storage.get_orphan_deposit_ids().await?;
+    assert!(
+        ids.is_empty(),
+        "allowlisted deposit must not appear as orphan, got {:?}",
+        ids,
+    );
+
+    Ok(())
+}
+
+/// Withdrawals are intentionally outside the orphan-detection scope.
+/// Burning channel tokens on-chain already bounds the withdrawal side
+/// (you can't burn what you don't have), and conflating withdrawal rows
+/// would dilute the deposit-side signal.
+#[tokio::test(flavor = "multi_thread")]
+async fn orphan_query_excludes_withdrawals() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    // No mints row; transaction_type = withdrawal.
+    let mint = Pubkey::new_unique().to_string();
+    insert_withdrawal_row(&storage, "sig_w", &mint).await?;
+
+    let ids = storage.get_orphan_deposit_ids().await?;
+    assert!(
+        ids.is_empty(),
+        "orphan query must scope to deposits, got {:?}",
+        ids,
+    );
+
+    Ok(())
+}
+
+// ── Orphan query: cardinality + mixed state ──────────────────────────────────
+
+/// Multiple deposit rows for the same orphan mint must all be returned.
+/// If the query accidentally collapsed by mint, a single foreign mint
+/// with 100 rows would report as "1" — losing the magnitude signal
+/// on-callers need to triage attack vs. ordering race.
+#[tokio::test(flavor = "multi_thread")]
+async fn orphan_query_returns_every_orphan_row() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    let mint = Pubkey::new_unique().to_string();
+    let id1 = insert_deposit_row(&storage, "sig_1", &mint).await?;
+    let id2 = insert_deposit_row(&storage, "sig_2", &mint).await?;
+    let id3 = insert_deposit_row(&storage, "sig_3", &mint).await?;
+
+    let mut ids = storage.get_orphan_deposit_ids().await?;
+    ids.sort();
+    let mut expected = vec![id1, id2, id3];
+    expected.sort();
+    assert_eq!(
+        ids, expected,
+        "every orphan row must be returned (no implicit DISTINCT mint)",
+    );
+
+    Ok(())
+}
+
+/// Realistic shape: some mints allowlisted, some not. A single query
+/// must isolate exactly the orphan rows and leave allowlisted-mint
+/// deposits alone.
+#[tokio::test(flavor = "multi_thread")]
+async fn orphan_query_isolates_orphans_in_mixed_state() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    let allowed_mint = Pubkey::new_unique().to_string();
+    let orphan_mint = Pubkey::new_unique().to_string();
+    insert_mint_row(&storage, &allowed_mint).await?;
+
+    insert_deposit_row(&storage, "sig_allowed", &allowed_mint).await?;
+    let orphan_id = insert_deposit_row(&storage, "sig_orphan", &orphan_mint).await?;
+
+    let ids = storage.get_orphan_deposit_ids().await?;
+    assert_eq!(
+        ids,
+        vec![orphan_id],
+        "only the foreign-mint row should be flagged",
+    );
+
+    Ok(())
+}
+
+// ── Orphan query: late-arriving AllowMint ─────────────────────────────────────
+
+/// A deposit arrives before its `AllowMint` is indexed (slot-ordering
+/// race). On the first reconciliation tick the row is orphaned; once
+/// `AllowMint` lands the query no longer flags it. This is the benign
+/// case that justifies the dedup helper's design over a hard
+/// halt-on-orphan.
+#[tokio::test(flavor = "multi_thread")]
+async fn orphan_query_clears_when_allowmint_arrives_late() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (storage, _pg) = start_postgres().await?;
+
+    let mint = Pubkey::new_unique().to_string();
+    let orphan_id = insert_deposit_row(&storage, "sig_late", &mint).await?;
+
+    // Tick 1: row is orphaned because mints is empty.
+    let ids_before = storage.get_orphan_deposit_ids().await?;
+    assert_eq!(
+        ids_before,
+        vec![orphan_id],
+        "row must be orphaned before AllowMint lands",
+    );
+
+    // AllowMint arrives.
+    insert_mint_row(&storage, &mint).await?;
+
+    // Tick 2: same row is no longer orphaned.
+    let ids_after = storage.get_orphan_deposit_ids().await?;
+    assert!(
+        ids_after.is_empty(),
+        "AllowMint landing must clear the orphan, got {:?}",
+        ids_after,
+    );
+
+    Ok(())
+}
+
+// ── Deposit gate against real Postgres ───────────────────────────────────────
+
+/// Deposit gate end-to-end against real Postgres:
+///   • Unknown mint → gate errors (operator quarantines the row in
+///     production).
+///   • Same mint after AllowMint lands → gate passes.
+#[tokio::test(flavor = "multi_thread")]
+async fn assert_mint_allowed_at_slot_against_real_postgres(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    let mint = Pubkey::new_unique();
+    let cache = MintCache::new(storage.clone());
+
+    // Pre-AllowMint: the gate must refuse. The error variant itself is
+    // covered by the unit tests; here we only need to confirm the call
+    // errors when the row is absent.
+    let err = cache
+        .assert_mint_allowed_at_slot(&mint, 100, 42)
+        .await
+        .expect_err("unknown mint must not pass the gate");
+    let _ = err;
+
+    // AllowMint lands.
+    insert_mint_row(&storage, &mint.to_string()).await?;
+
+    // Post-AllowMint: the gate accepts. A fresh cache is used to rule
+    // out any in-memory shortcut — every call must consult the DB.
+    let cache = MintCache::new(storage.clone());
+    cache
+        .assert_mint_allowed_at_slot(&mint, 100, 42)
+        .await
+        .expect("allowlisted mint must pass the gate");
+
+    Ok(())
+}
+
+/// The gate must NOT cache a negative result. If the first call (mint
+/// absent) cached `not allowlisted` and the second call (mint present,
+/// after AllowMint indexing) used the cache, the operator would
+/// permanently refuse a legitimate mint until restart.
+///
+/// Regression-guard for the cache-bypass property documented on
+/// `assert_mint_allowed_at_slot` — unit tests prove the in-memory layer is
+/// bypassed; this proves the property holds when the underlying store
+/// is Postgres rather than the mock.
+#[tokio::test(flavor = "multi_thread")]
+async fn assert_mint_allowed_at_slot_does_not_cache_negative_result(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    let mint = Pubkey::new_unique();
+    // Same cache instance across both calls — the second call would
+    // be served from cache if the gate ever decided to memoize.
+    let cache = MintCache::new(storage.clone());
+
+    // First call: mint absent → gate refuses.
+    cache
+        .assert_mint_allowed_at_slot(&mint, 100, 1)
+        .await
+        .expect_err("first call must refuse the unknown mint");
+
+    // AllowMint lands between the two calls.
+    insert_mint_row(&storage, &mint.to_string()).await?;
+
+    // Second call on the same cache: gate must consult the DB again
+    // and accept. A cached "not allowlisted" answer here would be a
+    // bug — the deposit operator would never recover.
+    cache
+        .assert_mint_allowed_at_slot(&mint, 100, 1)
+        .await
+        .expect("second call must consult the DB and accept the newly-allowlisted mint");
+
+    Ok(())
+}
+
+// ── Combined: gate + orphan-query agree on the same row ──────────────────────
+
+/// Cross-check of the two changes on a single shared row:
+///   • The deposit gate refuses the mint (production: row gets
+///     quarantined to ManualReview, no PrivateChannel mint issued).
+///   • The same row surfaces in the orphan query (production: row is
+///     surfaced in the reconciliation log for triage).
+///
+/// And the inverse path: once `AllowMint` lands, the gate accepts AND
+/// the orphan query clears — both signals flip together.
+///
+/// This is the integration-level proof that the two halves of the
+/// mitigation agree. If a future schema change broke the `mints`
+/// lookup for one path but not the other (e.g. gate started reading
+/// from a different column than the orphan query), the operator and
+/// the reconciliation signal would disagree about which mints are
+/// allowed — a more dangerous state than either failure alone, since
+/// it would silently degrade either detection (orphans missed) or
+/// safety (gate too permissive). This test guarantees they stay in
+/// lock-step.
+///
+/// Note: this verifies the DB-layer agreement only. The actual
+/// quarantine-to-ManualReview transition lives in the operator's
+/// `process_deposit_funds` loop and requires a running fetcher +
+/// sender, which is the validator-level concern covered separately.
+#[tokio::test(flavor = "multi_thread")]
+async fn gate_and_orphan_query_agree_on_same_row() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    let mint = Pubkey::new_unique();
+    let orphan_id = insert_deposit_row(&storage, "sig_shared", &mint.to_string()).await?;
+    let cache = MintCache::new(storage.clone());
+
+    // ── Pre-AllowMint state ──────────────────────────────────────────────
+    cache
+        .assert_mint_allowed_at_slot(&mint, 1, orphan_id)
+        .await
+        .expect_err("gate must refuse the mint before AllowMint lands");
+
+    let orphans_before = storage.get_orphan_deposit_ids().await?;
+    assert_eq!(
+        orphans_before,
+        vec![orphan_id],
+        "the same row the gate refused must also show up as orphan",
+    );
+
+    // ── AllowMint lands ──────────────────────────────────────────────────
+    insert_mint_row(&storage, &mint.to_string()).await?;
+
+    // ── Post-AllowMint state ─────────────────────────────────────────────
+    cache
+        .assert_mint_allowed_at_slot(&mint, 1, orphan_id)
+        .await
+        .expect("gate must accept the mint once AllowMint lands");
+
+    let orphans_after = storage.get_orphan_deposit_ids().await?;
+    assert!(
+        orphans_after.is_empty(),
+        "the orphan query must clear once AllowMint lands, got {:?}",
+        orphans_after,
+    );
+
+    Ok(())
+}

--- a/integration/tests/indexer/deposit_allowlist_e2e.rs
+++ b/integration/tests/indexer/deposit_allowlist_e2e.rs
@@ -68,6 +68,16 @@ async fn start_postgres(
 /// means any future schema migration breaks here in the same way it
 /// would break the real ingest path.
 async fn insert_mint_row(storage: &Storage, mint: &str) -> Result<(), Box<dyn std::error::Error>> {
+    insert_mint_row_at_slot(storage, mint, 0).await
+}
+
+/// Like [`insert_mint_row`] but records the `allowed` status at an explicit
+/// `effective_slot` (the slot the AllowMint took effect on-chain).
+async fn insert_mint_row_at_slot(
+    storage: &Storage,
+    mint: &str,
+    effective_slot: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mint_row = DbMint::new(mint.to_string(), 6, spl_token::id().to_string());
     storage.upsert_mints_batch(&[mint_row]).await?;
     storage
@@ -75,8 +85,8 @@ async fn insert_mint_row(storage: &Storage, mint: &str) -> Result<(), Box<dyn st
             private_channel_indexer::storage::common::models::DbMintStatus {
                 mint_address: mint.to_string(),
                 status: "allowed".to_string(),
-                effective_slot: 0,
-                signature: format!("test-seed-{mint}"),
+                effective_slot,
+                signature: format!("test-seed-{mint}-{effective_slot}"),
                 created_at: chrono::Utc::now(),
             },
         ])
@@ -94,7 +104,18 @@ async fn insert_deposit_row(
     signature: &str,
     mint: &str,
 ) -> Result<i64, Box<dyn std::error::Error>> {
-    let tx = DbTransactionBuilder::new(signature.to_string(), 1, mint.to_string(), 100)
+    insert_deposit_row_at_slot(storage, signature, mint, 1).await
+}
+
+/// Like [`insert_deposit_row`] but at an explicit slot (the orphan query
+/// compares deposit slot against each mint-status `effective_slot`).
+async fn insert_deposit_row_at_slot(
+    storage: &Storage,
+    signature: &str,
+    mint: &str,
+    slot: u64,
+) -> Result<i64, Box<dyn std::error::Error>> {
+    let tx = DbTransactionBuilder::new(signature.to_string(), slot, mint.to_string(), 100)
         .initiator("init".to_string())
         .recipient("recip".to_string())
         .transaction_type(TransactionType::Deposit)
@@ -241,22 +262,21 @@ async fn orphan_query_isolates_orphans_in_mixed_state() -> Result<(), Box<dyn st
     Ok(())
 }
 
-// ── Orphan query: late-arriving AllowMint ─────────────────────────────────────
+// ── Orphan query: late-INGESTED AllowMint (effective at/before deposit) ───────
 
-/// A deposit arrives before its `AllowMint` is indexed (slot-ordering
-/// race). On the first reconciliation tick the row is orphaned; once
-/// `AllowMint` lands the query no longer flags it. This is the benign
-/// case that justifies the dedup helper's design over a hard
-/// halt-on-orphan.
+/// Benign slot-ordering race: an `AllowMint` effective at/before the deposit's
+/// slot (3 <= 5) but ingested after it. The deposit is orphaned on the first
+/// tick, then clears once the AllowMint lands. ("Late" = ingested late, not
+/// effective late; the opposite case is the `_effective_after_deposit` test.)
 #[tokio::test(flavor = "multi_thread")]
-async fn orphan_query_clears_when_allowmint_arrives_late() -> Result<(), Box<dyn std::error::Error>>
+async fn orphan_query_clears_when_allowmint_ingested_late() -> Result<(), Box<dyn std::error::Error>>
 {
     let (storage, _pg) = start_postgres().await?;
 
     let mint = Pubkey::new_unique().to_string();
-    let orphan_id = insert_deposit_row(&storage, "sig_late", &mint).await?;
+    let orphan_id = insert_deposit_row_at_slot(&storage, "sig_late", &mint, 5).await?;
 
-    // Tick 1: row is orphaned because mints is empty.
+    // Tick 1: row is orphaned because no status row exists yet.
     let ids_before = storage.get_orphan_deposit_ids().await?;
     assert_eq!(
         ids_before,
@@ -264,15 +284,40 @@ async fn orphan_query_clears_when_allowmint_arrives_late() -> Result<(), Box<dyn
         "row must be orphaned before AllowMint lands",
     );
 
-    // AllowMint arrives.
-    insert_mint_row(&storage, &mint).await?;
+    // AllowMint lands, effective at slot 3 (<= the deposit slot 5).
+    insert_mint_row_at_slot(&storage, &mint, 3).await?;
 
     // Tick 2: same row is no longer orphaned.
     let ids_after = storage.get_orphan_deposit_ids().await?;
     assert!(
         ids_after.is_empty(),
-        "AllowMint landing must clear the orphan, got {:?}",
+        "AllowMint effective before the deposit must clear the orphan, got {:?}",
         ids_after,
+    );
+
+    Ok(())
+}
+
+/// An `AllowMint` effective *after* the deposit (5 > 3) must NOT clear the
+/// orphan — the deposit landed before the mint was allowed. Pins the
+/// `effective_slot <= deposit.slot` gating against retroactive legitimization.
+#[tokio::test(flavor = "multi_thread")]
+async fn orphan_query_persists_when_allowmint_effective_after_deposit(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, _pg) = start_postgres().await?;
+
+    let mint = Pubkey::new_unique().to_string();
+    let orphan_id = insert_deposit_row_at_slot(&storage, "sig_pre_allow", &mint, 3).await?;
+
+    // AllowMint becomes effective at slot 5 — strictly after the deposit.
+    insert_mint_row_at_slot(&storage, &mint, 5).await?;
+
+    let ids = storage.get_orphan_deposit_ids().await?;
+    assert_eq!(
+        ids,
+        vec![orphan_id],
+        "deposit before the mint's allowed slot must remain an orphan, got {:?}",
+        ids,
     );
 
     Ok(())

--- a/integration/tests/indexer/harness_sanity.rs
+++ b/integration/tests/indexer/harness_sanity.rs
@@ -31,7 +31,7 @@
 
 use {
     private_channel_indexer::storage::common::models::{
-        DbTransaction, TransactionStatus, TransactionType,
+        DbMint, DbMintStatus, DbTransaction, TransactionStatus, TransactionType,
     },
     serde_json::json,
     solana_sdk::{pubkey::Pubkey, signature::Keypair},
@@ -160,6 +160,28 @@ async fn operator_mock_harness_drives_deposit_through_to_send_transaction() {
     //    dequeued within a few ticks.
     let mint_pk = Pubkey::new_unique();
     let recipient_pk = Pubkey::new_unique();
+    // operator gate: a `mint_status_history` row with status=allowed at
+    // or before the deposit's slot must exist or
+    // `assert_mint_allowed_at_slot` quarantines the row before the
+    // sender ever runs. We seed the `mints` row in parallel to mirror the
+    // production AllowMint dual-write.
+    harness.storage.mints.lock().unwrap().insert(
+        mint_pk.to_string(),
+        DbMint::new(mint_pk.to_string(), 6, spl_token::id().to_string()),
+    );
+    harness
+        .storage
+        .mint_status_history
+        .lock()
+        .unwrap()
+        .push(DbMintStatus {
+            mint_address: mint_pk.to_string(),
+            status: "allowed".to_string(),
+            effective_slot: 0,
+            signature: format!("test-seed-{mint_pk}"),
+            created_at: chrono::Utc::now(),
+        });
+
     harness
         .storage
         .pending_transactions

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -34,7 +34,7 @@ use private_channel_indexer::operator;
 use private_channel_indexer::operator::reconciliation::run_reconciliation;
 use private_channel_indexer::operator::{RetryConfig, RpcClientWithRetry};
 use private_channel_indexer::storage::common::models::{
-    DbMint, DbTransaction, DbTransactionBuilder, TransactionStatus,
+    DbMint, DbMintStatus, DbTransaction, DbTransactionBuilder, TransactionStatus,
 };
 use private_channel_indexer::storage::{PostgresDb, Storage, TransactionType};
 use private_channel_indexer::PostgresConfig;
@@ -53,6 +53,22 @@ use testcontainers_modules::postgres::Postgres;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
+
+async fn seed_mint_status_allowed(
+    storage: &Storage,
+    mint_address: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    storage
+        .insert_mint_statuses_batch(&[DbMintStatus {
+            mint_address: mint_address.to_string(),
+            status: "allowed".to_string(),
+            effective_slot: 0,
+            signature: format!("test-seed-{mint_address}"),
+            created_at: Utc::now(),
+        }])
+        .await?;
+    Ok(())
+}
 
 fn default_operator_config(alert_url: Option<String>) -> OperatorConfig {
     OperatorConfig {
@@ -255,6 +271,20 @@ async fn test_deposit_operator_processes_single_mint() -> Result<(), Box<dyn std
 
     let env = TestEnvironment::setup(&client, &faucet_keypair, 1, 1_000_000, None).await?;
 
+    // deposit gate refuses to mint unless the mint was in `allowed`
+    // status at the deposit's slot. This test bypasses the indexer, so no
+    // `AllowMint` event is ingested, seed both rows manually to mirror
+    // what `convert_to_db_models` + `finalize_and_checkpoint` would have
+    // produced in production.
+    storage
+        .upsert_mints_batch(&[DbMint::new(
+            env.mint.to_string(),
+            6,
+            spl_token::id().to_string(),
+        )])
+        .await?;
+    seed_mint_status_allowed(&storage, &env.mint.to_string()).await?;
+
     // 2. Insert 1 pending deposit directly via storage.insert_db_transaction()
     let signature = Signature::new_unique().to_string();
     let recipient = env.users[0].pubkey().to_string();
@@ -332,6 +362,18 @@ async fn test_issuance_operator_idempotent_no_double_mint() -> Result<(), Box<dy
 
     let env = TestEnvironment::setup(&client, &faucet_keypair, 1, 1_000_000, None).await?;
     let user_pubkey = env.users[0].pubkey();
+
+    // deposit gate requires an allowed status row for any mint we issue
+    // private channel tokens for; the test bypasses the indexer so seed
+    // the rows directly. See `test_deposit_operator_processes_single_mint`.
+    storage
+        .upsert_mints_batch(&[DbMint::new(
+            env.mint.to_string(),
+            6,
+            spl_token::id().to_string(),
+        )])
+        .await?;
+    seed_mint_status_allowed(&storage, &env.mint.to_string()).await?;
 
     let signature = Signature::new_unique().to_string();
     let recipient = user_pubkey.to_string();
@@ -413,6 +455,7 @@ async fn test_withdrawal_operator_prevents_double_withdrawal(
     // Seed mint metadata so the withdrawal operator can build the instruction.
     let mint_meta = DbMint::new(env.mint.to_string(), 6, spl_token::id().to_string());
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    seed_mint_status_allowed(&storage, &env.mint.to_string()).await?;
 
     // Ensure escrow ATA has funds to withdraw.
     let admin = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..])?;
@@ -548,6 +591,7 @@ async fn test_failed_withdrawals_and_mints_fire_alerts() -> Result<(), Box<dyn s
         spl_token::id().to_string(),
     );
     storage.upsert_mints_batch(&[bad_mint_meta]).await?;
+    seed_mint_status_allowed(&storage, &bad_mint.pubkey().to_string()).await?;
 
     let mint_fail_sig = Signature::new_unique().to_string();
     let recipient = env.users[0].pubkey().to_string();
@@ -570,6 +614,7 @@ async fn test_failed_withdrawals_and_mints_fire_alerts() -> Result<(), Box<dyn s
     let bad_mint_pubkey = generate_mint(&client, &admin, &admin, &bad_withdraw_mint).await?;
     let mint_meta = DbMint::new(bad_mint_pubkey.to_string(), 6, spl_token::id().to_string());
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    seed_mint_status_allowed(&storage, &bad_mint_pubkey.to_string()).await?;
     mint_to_owner(
         &client,
         &admin,
@@ -664,6 +709,18 @@ async fn test_batch_deposits_multiple_recipients() -> Result<(), Box<dyn std::er
 
     // Create 5 users with 0 initial balance so we can verify the exact deposit amount.
     let env = TestEnvironment::setup(&client, &faucet_keypair, NUM_USERS, 0, None).await?;
+
+    // deposit gate requires an allowed status row for any mint we issue
+    // private channel tokens for; the test bypasses the indexer so seed
+    // the rows directly. See `test_deposit_operator_processes_single_mint`.
+    storage
+        .upsert_mints_batch(&[DbMint::new(
+            env.mint.to_string(),
+            6,
+            spl_token::id().to_string(),
+        )])
+        .await?;
+    seed_mint_status_allowed(&storage, &env.mint.to_string()).await?;
 
     // Insert one pending deposit per user, each with a unique on-chain signature.
     let mut signatures = Vec::with_capacity(NUM_USERS);
@@ -828,6 +885,7 @@ async fn test_periodic_reconciliation_fires_webhook_on_mismatch(
     // Register the mint in the indexer DB so the reconciliation query includes it.
     let mint_meta = DbMint::new(env.mint.to_string(), 6, spl_token::id().to_string());
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    seed_mint_status_allowed(&storage, &env.mint.to_string()).await?;
 
     // Insert a deposit and mark it completed: DB now shows SEEDED_AMOUNT deposited,
     // while on-chain remains 0 — a guaranteed mismatch with tolerance_bps = 0.
@@ -965,6 +1023,7 @@ async fn test_sequential_withdrawals_multiple_nonces() -> Result<(), Box<dyn std
     // Register the mint so the withdrawal processor can build the instruction.
     let mint_meta = DbMint::new(env.mint.to_string(), 6, spl_token::id().to_string());
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    seed_mint_status_allowed(&storage, &env.mint.to_string()).await?;
 
     // Fund the escrow ATA with enough tokens to cover both withdrawals.
     let admin = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..])?;
@@ -1101,6 +1160,7 @@ async fn test_operator_aborts_on_smt_root_mismatch_at_startup(
     TestEnvironment::setup_operator(&client, &faucet_keypair, env.instance).await?;
     let mint_meta = DbMint::new(env.mint.to_string(), 6, spl_token::id().to_string());
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    seed_mint_status_allowed(&storage, &env.mint.to_string()).await?;
 
     // Step 1: seed the DB with a COMPLETED withdrawal at nonce 0 — this
     // poisons the SMT state: when the operator rebuilds the SMT locally

--- a/integration/tests/indexer/pausable_mint.rs
+++ b/integration/tests/indexer/pausable_mint.rs
@@ -30,7 +30,7 @@ use private_channel_escrow_program_client::{
     instructions::AllowMintBuilder, PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
 };
 use private_channel_indexer::storage::common::models::{
-    DbMint, DbTransaction, TransactionStatus, TransactionType,
+    DbMint, DbMintStatus, DbTransaction, TransactionStatus, TransactionType,
 };
 use private_channel_indexer::storage::{PostgresDb, Storage};
 use private_channel_indexer::PostgresConfig;
@@ -348,6 +348,15 @@ async fn test_withdrawal_routed_to_manual_review_when_pausable_mint_is_paused(
         TOKEN_2022_PROGRAM_ID.to_string(),
     );
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    storage
+        .insert_mint_statuses_batch(&[DbMintStatus {
+            mint_address: mint_pubkey.to_string(),
+            status: "allowed".to_string(),
+            effective_slot: 0,
+            signature: format!("test-seed-{mint_pubkey}"),
+            created_at: Utc::now(),
+        }])
+        .await?;
     assert!(
         storage
             .get_mint(&mint_pubkey.to_string())

--- a/integration/tests/indexer/permanent_delegate_mint.rs
+++ b/integration/tests/indexer/permanent_delegate_mint.rs
@@ -34,7 +34,7 @@ use private_channel_escrow_program_client::{
     instructions::AllowMintBuilder, PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
 };
 use private_channel_indexer::storage::common::models::{
-    DbMint, DbTransaction, TransactionStatus, TransactionType,
+    DbMint, DbMintStatus, DbTransaction, TransactionStatus, TransactionType,
 };
 use private_channel_indexer::storage::{PostgresDb, Storage};
 use private_channel_indexer::PostgresConfig;
@@ -419,6 +419,15 @@ async fn test_withdrawal_routed_to_manual_review_when_permanent_delegate_drained
         TOKEN_2022_PROGRAM_ID.to_string(),
     );
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    storage
+        .insert_mint_statuses_batch(&[DbMintStatus {
+            mint_address: mint_pubkey.to_string(),
+            status: "allowed".to_string(),
+            effective_slot: 0,
+            signature: format!("test-seed-{mint_pubkey}"),
+            created_at: Utc::now(),
+        }])
+        .await?;
     let pre = storage
         .get_mint(&mint_pubkey.to_string())
         .await?
@@ -582,6 +591,15 @@ async fn test_withdrawal_routed_to_manual_review_when_escrow_ata_does_not_exist(
         TOKEN_2022_PROGRAM_ID.to_string(),
     );
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    storage
+        .insert_mint_statuses_batch(&[DbMintStatus {
+            mint_address: mint_pubkey.to_string(),
+            status: "allowed".to_string(),
+            effective_slot: 0,
+            signature: format!("test-seed-{mint_pubkey}"),
+            created_at: Utc::now(),
+        }])
+        .await?;
 
     let withdraw_amount: u64 = 50_000;
     let withdrawal_sig = Signature::new_unique().to_string();

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -31,7 +31,7 @@ use {
     private_channel_indexer::{
         config::{OperatorConfig, PrivateChannelIndexerConfig, ProgramType, StorageType},
         operator,
-        storage::common::models::{DbMint, DbTransaction, TransactionStatus},
+        storage::common::models::{DbMint, DbMintStatus, DbTransaction, TransactionStatus},
         storage::{PostgresDb, Storage, TransactionType},
         PostgresConfig,
     },
@@ -172,6 +172,15 @@ async fn null_withdrawal_nonce_is_quarantined_to_manual_review(
     TestEnvironment::setup_operator(&client, &faucet_keypair, env.instance).await?;
     let mint_meta = DbMint::new(env.mint.to_string(), 6, spl_token::id().to_string());
     storage.upsert_mints_batch(&[mint_meta]).await?;
+    storage
+        .insert_mint_statuses_batch(&[DbMintStatus {
+            mint_address: env.mint.to_string(),
+            status: "allowed".to_string(),
+            effective_slot: 0,
+            signature: format!("test-seed-{}", env.mint),
+            created_at: Utc::now(),
+        }])
+        .await?;
 
     // Escrow ATA needs funds (not that a successful withdrawal is expected — we
     // just want the non-NULL-nonce path to not kick in first).

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 bs58.workspace = true
+chrono.workspace = true
 private-channel-escrow-program-client.workspace = true
 private-channel-withdraw-program-client.workspace = true
 private-channel-indexer = { path = "../indexer" }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod indexer_helper;
+pub mod mint_helper;
 pub mod mock_rpc;
 #[cfg(feature = "test-mock-yellowstone")]
 pub mod mock_yellowstone;

--- a/test_utils/src/mint_helper.rs
+++ b/test_utils/src/mint_helper.rs
@@ -1,0 +1,36 @@
+use private_channel_indexer::{
+    error::StorageError,
+    storage::{
+        common::models::{DbMint, DbMintStatus},
+        Storage,
+    },
+};
+
+/// Test helper: seed a mint AND a slot-0 `allowed` history entry so the
+/// operator gate (`assert_mint_allowed_at_slot`) and the reconciliation
+/// orphan query both treat the mint as allowed for any deposit slot.
+pub async fn seed_allowed_mint(
+    storage: &Storage,
+    mint_address: &str,
+    decimals: i16,
+    token_program: &str,
+    effective_slot: i64,
+) -> Result<(), StorageError> {
+    storage
+        .upsert_mints_batch(&[DbMint::new(
+            mint_address.to_string(),
+            decimals,
+            token_program.to_string(),
+        )])
+        .await?;
+    storage
+        .insert_mint_statuses_batch(&[DbMintStatus {
+            mint_address: mint_address.to_string(),
+            status: "allowed".to_string(),
+            effective_slot,
+            signature: format!("test-seed-{mint_address}"),
+            created_at: chrono::Utc::now(),
+        }])
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Addresses SOLA2-20 finding. The deposit operator would issue private-channel tokens for any mint present on a `transactions` row, without checking whether the mint had ever been authorized on-chain via `AllowMint`. A foreign mint slipping past the indexer's checks (or inserted manually) would get mirrored on the private channel with no Mainnet escrow backing, and balance reconciliation wouldn't catch it (the balance check only iterates `mints`).

This PR adds the in-line allowlist gate, plus a reconciliation orphan check that flags any deposit row that should never have been written. Both compose: the gate prevents the next bad mint, the orphan check detects anything that already slipped past or arrives via a future indexer bug.

## What's added

- **Deposit-side gate.** New `MintCache::assert_mint_allowlisted` is called from `process_deposit_funds` before any builder construction. Non-allowlisted rows quarantine to `ManualReview`; the deposit loop continues.
- **Reconciliation orphan check.** Each tick queries deposit row IDs whose mint has no `mints` entry and logs them with per-row dedup (baseline once, error on each new id, silent in steady state). Startup logs a full snapshot.
- **Runbook + drill.** `deposit_manual_review.md` adds Path E (indexer-gap backfill / investigate-then-delete / foreign-instance Tier 3). `drill_15` pins the runbook against source.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 9,620 | 11,100 | 86.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26851349846) |
| Indexer | 17,232 | 20,061 | 85.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26851349846) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26851349846) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26851349846) |
| Withdraw Program | 120 | 232 | 51.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26851349707) |
| Escrow Program | 1,185 | 1,963 | 60.4% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26851349707) |
| DvP Swap Program | 217 | 1,001 | 21.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26851349707) |
| E2E Integration | 10,427 | 12,953 | 80.5% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/26851349846) |
| **Total** | **40,295** | **48,304** | **83.4%** | |

> Last updated: 2026-06-02 22:47:33 UTC by E2E Integration