### PR TITLE
fix(SOLA3-16): harden Postgres credential and network exposure for the private channel

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -13,9 +13,11 @@ INDEXER_YELLOWSTONE_TOKEN=yellowstone_x_token_devnet
 # PostgreSQL
 POSTGRES_DB=private_channel
 POSTGRES_USER=private_channel
-POSTGRES_PASSWORD=private_channel_password
+# Required: set before startup. No default is shipped; services fail closed if blank.
+POSTGRES_PASSWORD=
 POSTGRES_REPLICATION_USER=replicator
-POSTGRES_REPLICATION_PASSWORD=repl_password
+# Required: set before startup. No default is shipped; services fail closed if blank.
+POSTGRES_REPLICATION_PASSWORD=
 POSTGRES_INDEXER_DB=indexer
 
 # Solana Private Channels Node
@@ -41,7 +43,8 @@ GATEWAY_URL=http://gateway:8899
 # Auth Service
 # Leave JWT_SECRET blank to disable RBAC enforcement on the gateway.
 AUTH_PORT=8903
-JWT_SECRET=change_me_in_devnet
+# Required only when enabling auth: set before startup. No default is shipped.
+JWT_SECRET=
 # Restrict the auth service CORS origin. Set to your frontend URL in production
 # (e.g. https://app.solana-private-channel). Defaults to * if unset (local dev only).
 CORS_ALLOWED_ORIGIN=*

--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,11 @@ VALIDATOR_RESET_FLAG=--reset
 # PostgreSQL
 POSTGRES_DB=private_channel
 POSTGRES_USER=private_channel
-POSTGRES_PASSWORD=private_channel_password
+# Required: set before startup. No default is shipped; services fail closed if blank.
+POSTGRES_PASSWORD=
 POSTGRES_REPLICATION_USER=replicator
-POSTGRES_REPLICATION_PASSWORD=repl_password
+# Required: set before startup. No default is shipped; services fail closed if blank.
+POSTGRES_REPLICATION_PASSWORD=
 POSTGRES_INDEXER_DB=indexer
 
 # Solana Private Channels Node
@@ -55,7 +57,8 @@ GATEWAY_URL=http://gateway:8899
 # `openssl rand -hex 32` is fine. Leaving the placeholder is equivalent
 # to publishing your signing key.
 AUTH_PORT=8903
-JWT_SECRET=change_me_in_production
+# Required only when enabling auth: set before startup. No default is shipped.
+JWT_SECRET=
 # Restrict the auth service CORS origin. Set to your frontend URL in production
 # (e.g. https://app.solana-private-channel). Defaults to * if unset (local dev only).
 CORS_ALLOWED_ORIGIN=https://your-frontend-url.com

--- a/.env.local
+++ b/.env.local
@@ -8,9 +8,11 @@ ADMIN_PRIVATE_KEY=your_admin_key # Private key under keypairs/admin.json
 # PostgreSQL
 POSTGRES_DB=private_channel
 POSTGRES_USER=private_channel
-POSTGRES_PASSWORD=private_channel_password
+# Required: set before startup. No default is shipped; services fail closed if blank.
+POSTGRES_PASSWORD=
 POSTGRES_REPLICATION_USER=replicator
-POSTGRES_REPLICATION_PASSWORD=repl_password
+# Required: set before startup. No default is shipped; services fail closed if blank.
+POSTGRES_REPLICATION_PASSWORD=
 POSTGRES_INDEXER_DB=indexer
 
 # Solana Private Channels Node

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,10 @@ COPY private-channel-escrow-program/clients/rust/Cargo.toml ./private-channel-es
 COPY private-channel-withdraw-program/program/Cargo.toml ./private-channel-withdraw-program/program/
 COPY private-channel-withdraw-program/tests/integration-tests/Cargo.toml ./private-channel-withdraw-program/tests/integration-tests/
 COPY private-channel-withdraw-program/clients/rust/Cargo.toml ./private-channel-withdraw-program/clients/rust/
+COPY dvp-swap-program/program/Cargo.toml ./dvp-swap-program/program/
+COPY dvp-swap-program/tests/integration-tests/Cargo.toml ./dvp-swap-program/tests/integration-tests/
+COPY dvp-swap-program/tests/transfer-hook-fixture/Cargo.toml ./dvp-swap-program/tests/transfer-hook-fixture/
+COPY dvp-swap-program/clients/rust/Cargo.toml ./dvp-swap-program/clients/rust/
 COPY integration/Cargo.toml ./integration/
 COPY test_utils/Cargo.toml ./test_utils/
 COPY scripts/devnet/Cargo.toml ./scripts/devnet/
@@ -91,6 +95,8 @@ RUN mkdir -p private-channel-escrow-program/program/src private-channel-escrow-p
     private-channel-withdraw-program/tests/integration-tests/src \
     integration/src gateway/src indexer/src test_utils/src scripts/devnet/src \
     private-channel-escrow-program/clients/rust/src private-channel-withdraw-program/clients/rust/src \
+    dvp-swap-program/program/src dvp-swap-program/tests/integration-tests/src \
+    dvp-swap-program/tests/transfer-hook-fixture/src dvp-swap-program/clients/rust/src \
     core/src metrics/src auth/src bench-tps/src
 RUN touch private-channel-escrow-program/program/src/lib.rs private-channel-escrow-program/tests/integration-tests/src/lib.rs \
     private-channel-escrow-program/clients/rust/src/lib.rs private-channel-withdraw-program/program/src/lib.rs \
@@ -98,6 +104,8 @@ RUN touch private-channel-escrow-program/program/src/lib.rs private-channel-escr
     integration/src/lib.rs gateway/src/lib.rs indexer/src/lib.rs \
     test_utils/src/lib.rs scripts/devnet/src/lib.rs \
     private-channel-escrow-program/clients/rust/src/lib.rs private-channel-withdraw-program/clients/rust/src/lib.rs \
+    dvp-swap-program/program/src/lib.rs dvp-swap-program/tests/integration-tests/src/lib.rs \
+    dvp-swap-program/tests/transfer-hook-fixture/src/lib.rs dvp-swap-program/clients/rust/src/lib.rs \
     core/src/lib.rs metrics/src/lib.rs auth/src/lib.rs && \
     printf 'fn main() {}\n' > bench-tps/src/main.rs && \
     printf 'fn main() {}\n' > auth/src/main.rs
@@ -115,14 +123,17 @@ RUN --mount=type=cache,target=/usr/src/private_channel/target,sharing=locked \
 COPY Makefile ./Makefile
 COPY private-channel-escrow-program ./private-channel-escrow-program
 COPY private-channel-withdraw-program ./private-channel-withdraw-program
+COPY dvp-swap-program ./dvp-swap-program
 RUN --mount=type=cache,target=/usr/src/private_channel/target,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     make -C private-channel-escrow-program install build \
     && make -C private-channel-withdraw-program install build \
+    && (cd dvp-swap-program/program && cargo-build-sbf) \
     && mkdir -p /out/deploy \
     && cp target/deploy/private_channel_escrow_program.so /out/deploy/ \
-    && cp target/deploy/private_channel_withdraw_program.so /out/deploy/
+    && cp target/deploy/private_channel_withdraw_program.so /out/deploy/ \
+    && cp target/deploy/dvp_swap_program.so /out/deploy/
 
 # Next, do the real build for the other components
 COPY core ./core
@@ -136,7 +147,9 @@ COPY auth ./auth
 # build, so swap the symlink for the real .so. rm first — otherwise cp follows the symlink
 # and writes to the wrong place.
 RUN rm -f core/precompiles/private_channel_withdraw_program.so \
-    && cp /out/deploy/private_channel_withdraw_program.so core/precompiles/private_channel_withdraw_program.so
+    && cp /out/deploy/private_channel_withdraw_program.so core/precompiles/private_channel_withdraw_program.so \
+    && rm -f core/precompiles/dvp_swap_program.so \
+    && cp /out/deploy/dvp_swap_program.so core/precompiles/dvp_swap_program.so
 
 # Final build — binaries are copied to /out/ per the convention noted above.
 RUN --mount=type=cache,target=/usr/src/private_channel/target,sharing=locked \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ OBS_SERVICES := cadvisor prometheus grafana
 .PHONY: generate-operator-keypair build-localnet build-devnet deploy-devnet
 .PHONY: profile obs-up obs-down obs-logs obs-devnet-up obs-devnet-down obs-devnet-logs
 .PHONY: install-buildkit-cache check-buildkit-cache
+.PHONY: check-env-local check-env-devnet
 .PHONY: docker-build docker-up docker-rebuild docker-restart docker-down docker-clean docker-logs docker-ps
 .PHONY: docker-devnet-build docker-devnet-up docker-devnet-rebuild docker-devnet-restart docker-devnet-down docker-devnet-clean docker-devnet-logs docker-devnet-ps
 
@@ -522,8 +523,7 @@ check-buildkit-cache:
 #############
 # These targets save users from remembering the env-file chain on every invocation.
 # Load order: versions.env first (toolchain pins), then the env-specific overrides.
-# `.env.local` is the developer's machine config (gitignored — copy from .env.example
-# and fill in secrets); `.env.devnet` is the tracked devnet preset.
+# `.env.local` is a tracked template; fill in secrets locally and do not commit real values. `.env.devnet` is the tracked devnet preset.
 #
 # Override the env file chain by passing ENV_FILES_LOCAL / ENV_FILES_DEVNET on the
 # command line, e.g. `make docker-up ENV_FILES_LOCAL="--env-file versions.env --env-file .env.staging"`.
@@ -539,13 +539,21 @@ COMPOSE_DEVNET   := docker-compose.devnet.yml
 ENV_FILES_LOCAL  ?= --env-file versions.env --env-file .env.local
 ENV_FILES_DEVNET ?= --env-file versions.env --env-file .env.devnet
 
+# Fail closed before starting the stack if required secrets are blank. The
+# check script takes plain file paths, so pass the raw chain (no --env-file).
+check-env-local:
+	@./scripts/check-required-env.sh versions.env .env.local
+
+check-env-devnet:
+	@./scripts/check-required-env.sh versions.env .env.devnet
+
 # --- Local stack (local validator) ---
 
 docker-build: check-docker check-buildkit-cache
 	@echo "Building all images ($(COMPOSE_LOCAL))..."
 	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) build
 
-docker-up: check-docker check-buildkit-cache
+docker-up: check-env-local check-docker check-buildkit-cache
 	@echo "Starting full stack ($(COMPOSE_LOCAL))..."
 	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) up -d
 
@@ -553,11 +561,11 @@ docker-up: check-docker check-buildkit-cache
 # on-chain state stays consistent with Postgres rows. Caveat: after changing
 # escrow/withdraw program code, run `make docker-clean` first or the validator
 # will keep running stale bytecode.
-docker-up-persist: check-docker check-buildkit-cache
+docker-up-persist: check-env-local check-docker check-buildkit-cache
 	@echo "Starting full stack with validator persistence ($(COMPOSE_LOCAL))..."
 	@VALIDATOR_RESET_FLAG= docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) up -d
 
-docker-rebuild: check-docker check-buildkit-cache
+docker-rebuild: check-env-local check-docker check-buildkit-cache
 	@echo "Rebuilding and (re)starting full stack ($(COMPOSE_LOCAL))..."
 	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) up -d --build
 
@@ -585,11 +593,11 @@ docker-devnet-build: check-docker check-buildkit-cache
 	@echo "Building all images ($(COMPOSE_DEVNET))..."
 	@docker compose -f $(COMPOSE_DEVNET) $(ENV_FILES_DEVNET) build
 
-docker-devnet-up: check-docker check-buildkit-cache
+docker-devnet-up: check-env-devnet check-docker check-buildkit-cache
 	@echo "Starting devnet stack ($(COMPOSE_DEVNET))..."
 	@docker compose -f $(COMPOSE_DEVNET) $(ENV_FILES_DEVNET) up -d
 
-docker-devnet-rebuild: check-docker check-buildkit-cache
+docker-devnet-rebuild: check-env-devnet check-docker check-buildkit-cache
 	@echo "Rebuilding and (re)starting devnet stack ($(COMPOSE_DEVNET))..."
 	@docker compose -f $(COMPOSE_DEVNET) $(ENV_FILES_DEVNET) up -d --build
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ make integration-test
 
 ### Docker stack
 
-The Makefile wraps the full compose stack so you don't have to remember the `--env-file` chain. Precondition: copy the env template once (`cp .env.example .env.local`) and fill in any secrets.
+The Makefile wraps the full compose stack so you don't have to remember the `--env-file` chain. Precondition: copy the env template once (`cp .env.example .env.local`) and fill in the required secrets. No defaults are shipped: `POSTGRES_PASSWORD` and `POSTGRES_REPLICATION_PASSWORD` MUST be set (and `JWT_SECRET` if you enable auth, `ADMIN_PRIVATE_KEY` for the operator) or the stack fails to start. Generate strong values with `openssl rand -hex 32`.
 
 ```bash
 # Build all images
@@ -318,7 +318,9 @@ To enable auth, set `JWT_SECRET` in your `.env.local` and start with the `auth` 
 ```bash
 # Copy and configure env
 cp .env.example .env.local
-# Set JWT_SECRET=<your-secret> in .env.local
+# Required (no defaults shipped): set POSTGRES_PASSWORD and POSTGRES_REPLICATION_PASSWORD in .env.local
+# Set JWT_SECRET=<your-secret> in .env.local to enable auth
+# Generate strong values with: openssl rand -hex 32
 
 # Start full stack including auth service
 docker compose --env-file versions.env --env-file .env.local --profile auth up

--- a/bench-tps/.env.sample
+++ b/bench-tps/.env.sample
@@ -10,9 +10,11 @@
 # -----------------------------------------------------------------------------
 POSTGRES_DB=private_channel
 POSTGRES_USER=private_channel
-POSTGRES_PASSWORD=private_channel_password
+# Required: set before startup. No default is shipped; run.sh auto-generates if blank.
+POSTGRES_PASSWORD=
 POSTGRES_REPLICATION_USER=replicator
-POSTGRES_REPLICATION_PASSWORD=repl_password
+# Required: set before startup. No default is shipped; run.sh auto-generates if blank.
+POSTGRES_REPLICATION_PASSWORD=
 
 # -----------------------------------------------------------------------------
 # Write node

--- a/bench-tps/.env.sample.devnet
+++ b/bench-tps/.env.sample.devnet
@@ -10,9 +10,11 @@
 # -----------------------------------------------------------------------------
 POSTGRES_DB=private_channel
 POSTGRES_USER=private_channel
-POSTGRES_PASSWORD=private_channel_password
+# Required: set before startup. No default is shipped; run.sh auto-generates if blank.
+POSTGRES_PASSWORD=
 POSTGRES_REPLICATION_USER=replicator
-POSTGRES_REPLICATION_PASSWORD=repl_password
+# Required: set before startup. No default is shipped; run.sh auto-generates if blank.
+POSTGRES_REPLICATION_PASSWORD=
 
 # -----------------------------------------------------------------------------
 # Write node

--- a/bench-tps/scripts/run.sh
+++ b/bench-tps/scripts/run.sh
@@ -279,6 +279,24 @@ echo "Deposit instance PDA: ${BENCH_DEPOSIT_INSTANCE_PDA}"
 # keep BENCH_DEPOSIT_INSTANCE_PDA for reference / debugging.
 patch_env "COMMON_ESCROW_INSTANCE_ID" "${BENCH_DEPOSIT_INSTANCE_PDA}"
 
+# ---------------------------------------------------------------------------
+# Step 5c — Generate DB passwords when blank
+#
+# The sample env ships no default DB credentials. Generate strong random
+# values for any that are empty and patch them into .env (same mechanism as
+# the admin keypair), so a blanked sample never ships or requires a default.
+# ---------------------------------------------------------------------------
+if [ -z "${POSTGRES_PASSWORD:-}" ]; then
+    POSTGRES_PASSWORD=$(openssl rand -hex 32)
+    patch_env "POSTGRES_PASSWORD" "${POSTGRES_PASSWORD}"
+    echo "Generated random POSTGRES_PASSWORD in ${BENCH_ENV}"
+fi
+if [ -z "${POSTGRES_REPLICATION_PASSWORD:-}" ]; then
+    POSTGRES_REPLICATION_PASSWORD=$(openssl rand -hex 32)
+    patch_env "POSTGRES_REPLICATION_PASSWORD" "${POSTGRES_REPLICATION_PASSWORD}"
+    echo "Generated random POSTGRES_REPLICATION_PASSWORD in ${BENCH_ENV}"
+fi
+
 # Re-source so the shell environment reflects the patched values before
 # `docker compose up` (Step 10).  Shell env vars take precedence over
 # --env-file in docker compose, so without this re-source the operator
@@ -286,6 +304,12 @@ patch_env "COMMON_ESCROW_INSTANCE_ID" "${BENCH_DEPOSIT_INSTANCE_PDA}"
 # exported during the initial Step 3 source.
 # shellcheck disable=SC1091
 set -a; source "${BENCH_ENV}"; set +a
+
+# Fail closed before bringing the stack up if any required DB secret is empty.
+if [ -z "${POSTGRES_PASSWORD:-}" ] || [ -z "${POSTGRES_REPLICATION_PASSWORD:-}" ]; then
+    echo "ERROR: POSTGRES_PASSWORD and POSTGRES_REPLICATION_PASSWORD must be non-empty" >&2
+    exit 1
+fi
 
 # (BENCH_METRICS_TARGET is set in Step 10b after the Docker network exists)
 

--- a/core/src/accounts/postgres.rs
+++ b/core/src/accounts/postgres.rs
@@ -32,13 +32,13 @@ pub struct PostgresAccountsDB {
     pub read_only: bool,
 }
 
-/// Returns true when the database URL carries a non-empty password component.
-fn database_url_has_password(database_url: &str) -> bool {
+/// Returns true when the URL parses and its password is absent or empty (a blanked secret).
+fn database_url_password_is_blank(database_url: &str) -> bool {
     match url::Url::parse(database_url) {
         // None (no password) and Some("") (blanked secret) are both missing credentials.
-        Ok(parsed) => parsed.password().is_some_and(|p| !p.is_empty()),
-        // Leave unparseable URLs for sqlx to reject on connect.
-        Err(_) => true,
+        Ok(parsed) => parsed.password().unwrap_or("").is_empty(),
+        // Leave unparseable URLs for sqlx to reject with the real connection error.
+        Err(_) => false,
     }
 }
 
@@ -48,7 +48,7 @@ impl PostgresAccountsDB {
         read_only: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         // Fail closed: reject a blank password before connecting (blanked env templates interpolate an empty ${POSTGRES_PASSWORD} into a passwordless URL).
-        if !database_url_has_password(database_url) {
+        if database_url_password_is_blank(database_url) {
             return Err(
                 "database_url password component is empty; set a non-empty POSTGRES_PASSWORD"
                     .into(),
@@ -376,29 +376,31 @@ mod tests {
         assert!(result.is_err(), "Invalid URL should fail to connect");
     }
 
-    /// database_url_has_password rejects blank/missing passwords and accepts real ones.
+    /// database_url_password_is_blank flags blank/missing passwords and clears real ones.
     #[test]
     fn password_guard_classifies_urls() {
-        // Blanked secret interpolates to an empty password and must be rejected.
-        assert!(!database_url_has_password(
+        // Blanked secret interpolates to an empty password and must be flagged.
+        assert!(database_url_password_is_blank(
             "postgres://user:@localhost:5432/db"
         ));
-        // No password component at all must be rejected.
-        assert!(!database_url_has_password(
+        // No password component at all must be flagged.
+        assert!(database_url_password_is_blank(
             "postgres://user@localhost:5432/db"
         ));
-        // No userinfo at all must be rejected.
-        assert!(!database_url_has_password("postgres://localhost:5432/db"));
-        // A real password is accepted.
-        assert!(database_url_has_password(
+        // No userinfo at all must be flagged.
+        assert!(database_url_password_is_blank(
+            "postgres://localhost:5432/db"
+        ));
+        // A real password is not blank.
+        assert!(!database_url_password_is_blank(
             "postgres://user:secret@localhost:5432/db"
         ));
         // A percent-encoded password (here '@' as %40) is still a real, non-empty password.
-        assert!(database_url_has_password(
+        assert!(!database_url_password_is_blank(
             "postgres://user:p%40ss@localhost:5432/db"
         ));
-        // Unparseable URLs pass the guard so sqlx surfaces the real connect error.
-        assert!(database_url_has_password("not-a-valid-url"));
+        // Unparseable URLs are not flagged here; sqlx surfaces the real connect error.
+        assert!(!database_url_password_is_blank("not-a-valid-url"));
     }
 
     /// PostgresAccountsDB::new must fail closed on a blank password before connecting.

--- a/core/src/accounts/postgres.rs
+++ b/core/src/accounts/postgres.rs
@@ -32,12 +32,29 @@ pub struct PostgresAccountsDB {
     pub read_only: bool,
 }
 
+/// Returns true when the database URL carries a non-empty password component.
+fn database_url_has_password(database_url: &str) -> bool {
+    match url::Url::parse(database_url) {
+        // None (no password) and Some("") (blanked secret) are both missing credentials.
+        Ok(parsed) => parsed.password().is_some_and(|p| !p.is_empty()),
+        // Leave unparseable URLs for sqlx to reject on connect.
+        Err(_) => true,
+    }
+}
+
 impl PostgresAccountsDB {
     pub async fn new(
         database_url: &str,
         read_only: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Parse URL to extract host/port without credentials
+        // Fail closed: reject a blank password before connecting (blanked env templates interpolate an empty ${POSTGRES_PASSWORD} into a passwordless URL).
+        if !database_url_has_password(database_url) {
+            return Err(
+                "database_url password component is empty; set a non-empty POSTGRES_PASSWORD".into(),
+            );
+        }
+
+        // Parse URL to extract host/port without credentials for logging.
         let sanitized_url = if let Ok(parsed) = url::Url::parse(database_url) {
             let host = parsed.host_str().unwrap_or("unknown");
             let port = parsed.port().unwrap_or(5432);
@@ -356,6 +373,37 @@ mod tests {
         let invalid_url = "not-a-valid-url-at-all";
         let result = PostgresAccountsDB::new(invalid_url, false).await;
         assert!(result.is_err(), "Invalid URL should fail to connect");
+    }
+
+    /// database_url_has_password rejects blank/missing passwords and accepts real ones.
+    #[test]
+    fn password_guard_classifies_urls() {
+        // Blanked secret interpolates to an empty password and must be rejected.
+        assert!(!database_url_has_password("postgres://user:@localhost:5432/db"));
+        // No password component at all must be rejected.
+        assert!(!database_url_has_password("postgres://user@localhost:5432/db"));
+        // No userinfo at all must be rejected.
+        assert!(!database_url_has_password("postgres://localhost:5432/db"));
+        // A real password is accepted.
+        assert!(database_url_has_password("postgres://user:secret@localhost:5432/db"));
+        // A percent-encoded password (here '@' as %40) is still a real, non-empty password.
+        assert!(database_url_has_password("postgres://user:p%40ss@localhost:5432/db"));
+        // Unparseable URLs pass the guard so sqlx surfaces the real connect error.
+        assert!(database_url_has_password("not-a-valid-url"));
+    }
+
+    /// PostgresAccountsDB::new must fail closed on a blank password before connecting.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn new_rejects_empty_password_url() {
+        let empty_pw = PostgresAccountsDB::new("postgres://user:@localhost:5432/db", false).await;
+        assert!(empty_pw.is_err(), "empty password must be rejected");
+        assert!(empty_pw
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("password component is empty"));
+        let no_pw = PostgresAccountsDB::new("postgres://user@localhost:5432/db", false).await;
+        assert!(no_pw.is_err(), "missing password must be rejected");
     }
 
     /// Store an account via the production path and verify account_matches_owners.

--- a/core/src/accounts/postgres.rs
+++ b/core/src/accounts/postgres.rs
@@ -50,7 +50,8 @@ impl PostgresAccountsDB {
         // Fail closed: reject a blank password before connecting (blanked env templates interpolate an empty ${POSTGRES_PASSWORD} into a passwordless URL).
         if !database_url_has_password(database_url) {
             return Err(
-                "database_url password component is empty; set a non-empty POSTGRES_PASSWORD".into(),
+                "database_url password component is empty; set a non-empty POSTGRES_PASSWORD"
+                    .into(),
             );
         }
 
@@ -379,15 +380,23 @@ mod tests {
     #[test]
     fn password_guard_classifies_urls() {
         // Blanked secret interpolates to an empty password and must be rejected.
-        assert!(!database_url_has_password("postgres://user:@localhost:5432/db"));
+        assert!(!database_url_has_password(
+            "postgres://user:@localhost:5432/db"
+        ));
         // No password component at all must be rejected.
-        assert!(!database_url_has_password("postgres://user@localhost:5432/db"));
+        assert!(!database_url_has_password(
+            "postgres://user@localhost:5432/db"
+        ));
         // No userinfo at all must be rejected.
         assert!(!database_url_has_password("postgres://localhost:5432/db"));
         // A real password is accepted.
-        assert!(database_url_has_password("postgres://user:secret@localhost:5432/db"));
+        assert!(database_url_has_password(
+            "postgres://user:secret@localhost:5432/db"
+        ));
         // A percent-encoded password (here '@' as %40) is still a real, non-empty password.
-        assert!(database_url_has_password("postgres://user:p%40ss@localhost:5432/db"));
+        assert!(database_url_has_password(
+            "postgres://user:p%40ss@localhost:5432/db"
+        ));
         // Unparseable URLs pass the guard so sqlx surfaces the real connect error.
         assert!(database_url_has_password("not-a-valid-url"));
     }

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -58,7 +58,7 @@ services:
       - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
       - POSTGRES_HOST_AUTH_METHOD=scram-sha-256
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-primary-data:/var/lib/postgresql/data
       - postgres-primary-wal-archive:/wal_archive
@@ -151,7 +151,7 @@ services:
       - POSTGRES_REPLICATION_PASSWORD=${POSTGRES_REPLICATION_PASSWORD}
       - PGUSER=${POSTGRES_USER}
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - postgres-replica-data:/var/lib/postgresql/data
     user: postgres
@@ -284,7 +284,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
-      - "5434:5432"
+      - "127.0.0.1:5434:5432"
     volumes:
       - postgres-indexer-data:/var/lib/postgresql/data
       - postgres-indexer-wal-archive:/wal_archive

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
       - POSTGRES_HOST_AUTH_METHOD=scram-sha-256
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-primary-data:/var/lib/postgresql/data
       - postgres-primary-wal-archive:/wal_archive
@@ -157,7 +157,7 @@ services:
       - POSTGRES_REPLICATION_PASSWORD=${POSTGRES_REPLICATION_PASSWORD}
       - PGUSER=${POSTGRES_USER}
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - postgres-replica-data:/var/lib/postgresql/data
     user: postgres
@@ -389,7 +389,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
-      - "5434:5432"
+      - "127.0.0.1:5434:5432"
     volumes:
       - postgres-indexer-data:/var/lib/postgresql/data
       - postgres-indexer-wal-archive:/wal_archive

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -117,7 +117,13 @@ Back in the Admin UI:
 
 Update `.env.devnet` file in the project root. Replace the following environment variables:
 
+> **Required secrets — no defaults are shipped.** `POSTGRES_PASSWORD`, `POSTGRES_REPLICATION_PASSWORD`, and `ADMIN_PRIVATE_KEY` (and `JWT_SECRET` if you enable auth) MUST be set or the services fail to start. Generate strong passwords with `openssl rand -hex 32`.
+
 ```shell
+# Required: database credentials (services fail closed if blank)
+POSTGRES_PASSWORD=<openssl rand -hex 32>
+POSTGRES_REPLICATION_PASSWORD=<openssl rand -hex 32>
+
 # Escrow instance (from Step 3)
 ESCROW_INSTANCE_ID=<your_instance_address>
 
@@ -184,9 +190,9 @@ For reference, here are the ports and endpoints that are now running:
 | Gateway | `8899` | Main RPC endpoint (routes to read/write nodes) |
 | Write Node | `8900` | Handles transaction submissions |
 | Read Node | `8901` | Handles read requests (getAccountInfo, etc.) |
-| PostgreSQL Primary | `5432` | Solana Private Channels state database (write) |
-| PostgreSQL Replica | `5433` | Solana Private Channels state database (read) |
-| PostgreSQL Indexer | `5434` | Indexer/operator database |
+| PostgreSQL Primary | `5432` | State database (write) — bound to `127.0.0.1` (loopback-only), not externally reachable |
+| PostgreSQL Replica | `5433` | State database (read) — bound to `127.0.0.1` (loopback-only), not externally reachable |
+| PostgreSQL Indexer | `5434` | Indexer/operator database — bound to `127.0.0.1` (loopback-only), not externally reachable |
 | Admin UI | `5173` | Web interface for instance management |
 | Grafana | `37429` | Metrics dashboard (default password: `admin`) |
 | Prometheus | `9090` | Metrics collection |

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -59,6 +59,7 @@ private-channel-escrow-program-client = { workspace = true }
 private-channel-metrics = { workspace = true }
 once_cell = { workspace = true }
 thiserror = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-client = { version = "2.3.10" }

--- a/indexer/Makefile
+++ b/indexer/Makefile
@@ -18,7 +18,9 @@ PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID ?= J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vB
 PRIVATE_CHANNEL_ESCROW_PROGRAM_SO ?= ../target/deploy/private_channel_escrow_program.so
 PRIVATE_CHANNEL_WITHDRAW_PROGRAM_SO ?= ../target/deploy/private_channel_withdraw_program.so
 GEYSER_CONFIG ?= src/indexer/datasource/common/yellowstone_grpc/config.json
-DATABASE_URL ?= postgres://private_channel:private_channel_password@localhost:5432/indexer
+# No default credential shipped. Set DATABASE_URL when running, e.g.
+# DATABASE_URL=postgres://user:pass@localhost:5434/indexer (loopback/internal-only).
+DATABASE_URL ?=
 ESCROW_INSTANCE_ID ?=
 
 # Yellowstone gRPC plugin configuration
@@ -73,6 +75,11 @@ run-yellowstone:
 		echo "Usage: make run-yellowstone ESCROW_INSTANCE_ID=<your_instance_pubkey>"; \
 		exit 1; \
 	fi
+	@if [ -z "$(DATABASE_URL)" ]; then \
+		echo "ERROR: DATABASE_URL is required (no default credential shipped)"; \
+		echo "Usage: make run-yellowstone DATABASE_URL=postgres://user:pass@localhost:5434/indexer ..."; \
+		exit 1; \
+	fi
 	@COMMON_ESCROW_INSTANCE_ID=$(ESCROW_INSTANCE_ID) \
 		DATABASE_URL=$(DATABASE_URL) \
 		cargo run --bin private-channel-indexer -- \
@@ -86,6 +93,11 @@ run-rpc:
 	@if [ -z "$(ESCROW_INSTANCE_ID)" ]; then \
 		echo "ERROR: ESCROW_INSTANCE_ID is required for escrow program"; \
 		echo "Usage: make run-rpc ESCROW_INSTANCE_ID=<your_instance_pubkey>"; \
+		exit 1; \
+	fi
+	@if [ -z "$(DATABASE_URL)" ]; then \
+		echo "ERROR: DATABASE_URL is required (no default credential shipped)"; \
+		echo "Usage: make run-rpc DATABASE_URL=postgres://user:pass@localhost:5434/indexer ..."; \
 		exit 1; \
 	fi
 	@COMMON_ESCROW_INSTANCE_ID=$(ESCROW_INSTANCE_ID) \
@@ -106,6 +118,11 @@ run-operator:
 	@if [ -z "$(ADMIN_PRIVATE_KEY)" ]; then \
 		echo "ERROR: ADMIN_PRIVATE_KEY is required"; \
 		echo "Usage: make run-operator ADMIN_PRIVATE_KEY=<key> [OPERATOR_PRIVATE_KEY=<key>]"; \
+		exit 1; \
+	fi
+	@if [ -z "$(DATABASE_URL)" ]; then \
+		echo "ERROR: DATABASE_URL is required (no default credential shipped)"; \
+		echo "Usage: make run-operator DATABASE_URL=postgres://user:pass@localhost:5434/indexer ..."; \
 		exit 1; \
 	fi
 	@COMMON_ESCROW_INSTANCE_ID=$(ESCROW_INSTANCE_ID) \

--- a/indexer/config/example-indexer.toml
+++ b/indexer/config/example-indexer.toml
@@ -20,7 +20,8 @@ type = "postgres"
 max_connections = 10
 
 # Database URL must be set via environment variable: DATABASE_URL
-# Example: export DATABASE_URL="postgresql://user:pass@localhost:5432/indexer"
+# The indexer DB is loopback/internal-only and listens on port 5434.
+# Example: export DATABASE_URL="postgresql://user:pass@localhost:5434/indexer"
 
 [indexer]
 # Datasource type: "rpc_polling" or "yellowstone"

--- a/indexer/config/example-operator.toml
+++ b/indexer/config/example-operator.toml
@@ -20,7 +20,8 @@ type = "postgres"
 max_connections = 10
 
 # Database URL must be set via environment variable: DATABASE_URL
-# Example: export DATABASE_URL="postgresql://user:pass@localhost:5432/indexer"
+# The indexer DB is loopback/internal-only and listens on port 5434.
+# Example: export DATABASE_URL="postgresql://user:pass@localhost:5434/indexer"
 
 [operator]
 # Database polling interval in seconds

--- a/indexer/src/operator/utils/signer_util.rs
+++ b/indexer/src/operator/utils/signer_util.rs
@@ -108,6 +108,13 @@ fn load_signer(role: SignerRole) -> Result<Signer, SignerError> {
             let private_key = env::var(private_key_var).map_err(|_| {
                 SignerError::InvalidPrivateKey(format!("{} not set", private_key_var))
             })?;
+            // Reject a set-but-empty value: env::var returns Ok("") for a blank var.
+            if private_key.trim().is_empty() {
+                return Err(SignerError::InvalidPrivateKey(format!(
+                    "{} is set but empty",
+                    private_key_var
+                )));
+            }
 
             Signer::from_memory(&private_key)?
         }

--- a/indexer/src/operator/utils/signer_util.rs
+++ b/indexer/src/operator/utils/signer_util.rs
@@ -320,6 +320,37 @@ mod tests {
         }
     }
 
+    /// ADMIN_SIGNER=memory with a set-but-empty ADMIN_PRIVATE_KEY (the blanked-secret case)
+    /// must fail closed; env::var returns Ok("") so only an explicit emptiness check catches it.
+    #[test]
+    #[serial]
+    fn load_signer_memory_empty_private_key_errors() {
+        let orig_type = env::var(ADMIN_SIGNER).ok();
+        let orig_key = env::var(ADMIN_PRIVATE_KEY).ok();
+        env::set_var(ADMIN_SIGNER, "memory");
+
+        for blank in ["", "   ", "\t\n"] {
+            env::set_var(ADMIN_PRIVATE_KEY, blank);
+            let err = load_signer(SignerRole::Admin)
+                .err()
+                .expect("set-but-empty private key must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("ADMIN_PRIVATE_KEY") && msg.contains("is set but empty"),
+                "error should flag the empty var, got: {msg}"
+            );
+        }
+
+        env::remove_var(ADMIN_SIGNER);
+        env::remove_var(ADMIN_PRIVATE_KEY);
+        if let Some(val) = orig_type {
+            env::set_var(ADMIN_SIGNER, val);
+        }
+        if let Some(val) = orig_key {
+            env::set_var(ADMIN_PRIVATE_KEY, val);
+        }
+    }
+
     /// ADMIN_SIGNER=vault requires ADMIN_VAULT_ADDR as the first credential; the error
     /// message must identify the missing variable so misconfiguration is immediately obvious.
     #[test]

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -38,23 +38,21 @@ pub struct PostgresDb {
     pool: PgPool,
 }
 
-// Returns true when the database URL carries a non-empty password component.
+// Returns true when the URL parses and its password is absent or empty (a blanked secret).
 // Kept in sync with the identical guard in core's accounts/postgres.rs.
-fn database_url_has_password(database_url: &str) -> bool {
+fn database_url_password_is_blank(database_url: &str) -> bool {
     match url::Url::parse(database_url) {
         // None (no password) and Some("") (blanked secret) are both missing credentials.
-        Ok(parsed) => parsed.password().is_some_and(|p| !p.is_empty()),
-        // Leave unparseable URLs for sqlx to reject on connect.
-        Err(_) => true,
+        Ok(parsed) => parsed.password().unwrap_or("").is_empty(),
+        // Leave unparseable URLs for sqlx to reject with the real connection error.
+        Err(_) => false,
     }
 }
 
 impl PostgresDb {
     pub async fn new(config: &PostgresConfig) -> Result<Self, sqlx::Error> {
-        // Fail closed: reject a set-but-empty password before opening a connection.
-        // Blanked env templates interpolate an empty ${POSTGRES_PASSWORD}, yielding a
-        // passwordless URL that must never be accepted.
-        if !database_url_has_password(&config.database_url) {
+        // Fail closed: reject a blank password before connecting (blanked env templates interpolate an empty ${POSTGRES_PASSWORD} into a passwordless URL).
+        if database_url_password_is_blank(&config.database_url) {
             return Err(sqlx::Error::Configuration(
                 "database_url password component is empty; set a non-empty POSTGRES_PASSWORD"
                     .into(),
@@ -1309,29 +1307,31 @@ impl PostgresDb {
 
 #[cfg(test)]
 mod password_guard_tests {
-    use super::database_url_has_password;
+    use super::database_url_password_is_blank;
 
     #[test]
-    fn rejects_empty_and_missing_password() {
-        // Set-but-empty password (blanked template) must be rejected.
-        assert!(!database_url_has_password(
+    fn flags_blank_and_missing_password() {
+        // Set-but-empty password (blanked template) is flagged.
+        assert!(database_url_password_is_blank(
             "postgres://user:@host:5434/indexer"
         ));
-        // No password at all must be rejected.
-        assert!(!database_url_has_password(
+        // No password at all is flagged.
+        assert!(database_url_password_is_blank(
             "postgres://user@host:5434/indexer"
         ));
-        // No userinfo at all must be rejected.
-        assert!(!database_url_has_password("postgres://host:5434/indexer"));
-        // A real password must be accepted.
-        assert!(database_url_has_password(
+        // No userinfo at all is flagged.
+        assert!(database_url_password_is_blank(
+            "postgres://host:5434/indexer"
+        ));
+        // A real password is not blank.
+        assert!(!database_url_password_is_blank(
             "postgres://user:secret@host:5434/indexer"
         ));
         // A percent-encoded password is a real, non-empty credential.
-        assert!(database_url_has_password(
+        assert!(!database_url_password_is_blank(
             "postgres://user:p%40ss@host:5434/indexer"
         ));
-        // Unparseable URLs pass the guard so sqlx surfaces the real connect error.
-        assert!(database_url_has_password("not-a-valid-url"));
+        // Unparseable URLs are not flagged; sqlx surfaces the real connect error.
+        assert!(!database_url_password_is_blank("not-a-valid-url"));
     }
 }

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -39,22 +39,13 @@ pub struct PostgresDb {
 }
 
 // Returns true when the database URL carries a non-empty password component.
-// Handles the no-password form (user@host) and the empty-password form (user:@host),
-// both of which must be rejected as a missing credential.
+// Kept in sync with the identical guard in core's accounts/postgres.rs.
 fn database_url_has_password(database_url: &str) -> bool {
-    // Strip the scheme so we can isolate the authority (userinfo@host) section.
-    let after_scheme = database_url
-        .split_once("://")
-        .map_or(database_url, |(_, rest)| rest);
-    // The userinfo ends at the first '@'; without one there is no password.
-    let userinfo = match after_scheme.split_once('@') {
-        Some((userinfo, _)) => userinfo,
-        None => return false,
-    };
-    // Password is the part after the first ':' in the userinfo; empty means missing.
-    match userinfo.split_once(':') {
-        Some((_, password)) => !password.is_empty(),
-        None => false,
+    match url::Url::parse(database_url) {
+        // None (no password) and Some("") (blanked secret) are both missing credentials.
+        Ok(parsed) => parsed.password().is_some_and(|p| !p.is_empty()),
+        // Leave unparseable URLs for sqlx to reject on connect.
+        Err(_) => true,
     }
 }
 
@@ -1340,5 +1331,7 @@ mod password_guard_tests {
         assert!(database_url_has_password(
             "postgres://user:p%40ss@host:5434/indexer"
         ));
+        // Unparseable URLs pass the guard so sqlx surfaces the real connect error.
+        assert!(database_url_has_password("not-a-valid-url"));
     }
 }

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1324,7 +1324,11 @@ mod password_guard_tests {
         assert!(!database_url_has_password("postgres://user:@host:5434/indexer"));
         // No password at all must be rejected.
         assert!(!database_url_has_password("postgres://user@host:5434/indexer"));
+        // No userinfo at all must be rejected.
+        assert!(!database_url_has_password("postgres://host:5434/indexer"));
         // A real password must be accepted.
         assert!(database_url_has_password("postgres://user:secret@host:5434/indexer"));
+        // A percent-encoded password is a real, non-empty credential.
+        assert!(database_url_has_password("postgres://user:p%40ss@host:5434/indexer"));
     }
 }

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -43,7 +43,9 @@ pub struct PostgresDb {
 // both of which must be rejected as a missing credential.
 fn database_url_has_password(database_url: &str) -> bool {
     // Strip the scheme so we can isolate the authority (userinfo@host) section.
-    let after_scheme = database_url.split_once("://").map_or(database_url, |(_, rest)| rest);
+    let after_scheme = database_url
+        .split_once("://")
+        .map_or(database_url, |(_, rest)| rest);
     // The userinfo ends at the first '@'; without one there is no password.
     let userinfo = match after_scheme.split_once('@') {
         Some((userinfo, _)) => userinfo,
@@ -1321,14 +1323,22 @@ mod password_guard_tests {
     #[test]
     fn rejects_empty_and_missing_password() {
         // Set-but-empty password (blanked template) must be rejected.
-        assert!(!database_url_has_password("postgres://user:@host:5434/indexer"));
+        assert!(!database_url_has_password(
+            "postgres://user:@host:5434/indexer"
+        ));
         // No password at all must be rejected.
-        assert!(!database_url_has_password("postgres://user@host:5434/indexer"));
+        assert!(!database_url_has_password(
+            "postgres://user@host:5434/indexer"
+        ));
         // No userinfo at all must be rejected.
         assert!(!database_url_has_password("postgres://host:5434/indexer"));
         // A real password must be accepted.
-        assert!(database_url_has_password("postgres://user:secret@host:5434/indexer"));
+        assert!(database_url_has_password(
+            "postgres://user:secret@host:5434/indexer"
+        ));
         // A percent-encoded password is a real, non-empty credential.
-        assert!(database_url_has_password("postgres://user:p%40ss@host:5434/indexer"));
+        assert!(database_url_has_password(
+            "postgres://user:p%40ss@host:5434/indexer"
+        ));
     }
 }

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -38,8 +38,36 @@ pub struct PostgresDb {
     pool: PgPool,
 }
 
+// Returns true when the database URL carries a non-empty password component.
+// Handles the no-password form (user@host) and the empty-password form (user:@host),
+// both of which must be rejected as a missing credential.
+fn database_url_has_password(database_url: &str) -> bool {
+    // Strip the scheme so we can isolate the authority (userinfo@host) section.
+    let after_scheme = database_url.split_once("://").map_or(database_url, |(_, rest)| rest);
+    // The userinfo ends at the first '@'; without one there is no password.
+    let userinfo = match after_scheme.split_once('@') {
+        Some((userinfo, _)) => userinfo,
+        None => return false,
+    };
+    // Password is the part after the first ':' in the userinfo; empty means missing.
+    match userinfo.split_once(':') {
+        Some((_, password)) => !password.is_empty(),
+        None => false,
+    }
+}
+
 impl PostgresDb {
     pub async fn new(config: &PostgresConfig) -> Result<Self, sqlx::Error> {
+        // Fail closed: reject a set-but-empty password before opening a connection.
+        // Blanked env templates interpolate an empty ${POSTGRES_PASSWORD}, yielding a
+        // passwordless URL that must never be accepted.
+        if !database_url_has_password(&config.database_url) {
+            return Err(sqlx::Error::Configuration(
+                "database_url password component is empty; set a non-empty POSTGRES_PASSWORD"
+                    .into(),
+            ));
+        }
+
         let pool = PgPoolOptions::new()
             .max_connections(config.max_connections)
             .connect(&config.database_url)
@@ -1283,5 +1311,20 @@ impl PostgresDb {
         .await?;
 
         Ok(nonces.into_iter().map(|(n,)| n).collect())
+    }
+}
+
+#[cfg(test)]
+mod password_guard_tests {
+    use super::database_url_has_password;
+
+    #[test]
+    fn rejects_empty_and_missing_password() {
+        // Set-but-empty password (blanked template) must be rejected.
+        assert!(!database_url_has_password("postgres://user:@host:5434/indexer"));
+        // No password at all must be rejected.
+        assert!(!database_url_has_password("postgres://user@host:5434/indexer"));
+        // A real password must be accepted.
+        assert!(database_url_has_password("postgres://user:secret@host:5434/indexer"));
     }
 }

--- a/scripts/check-required-env.sh
+++ b/scripts/check-required-env.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # check-required-env.sh — fail closed if required deployment secrets are blank.
 # Usage: check-required-env.sh <env-file> [<env-file> ...]
-# Sources each env file in order (later files override earlier ones), then
-# asserts POSTGRES_PASSWORD and POSTGRES_REPLICATION_PASSWORD are non-empty.
+# Reads KEY=VALUE literally (no shell sourcing), matching docker compose --env-file:
+# a non-empty process-env value wins, else the last env-file that defines the key.
 # No working secrets are shipped; these MUST be set before starting the stack.
 
 if [[ $# -lt 1 ]]; then
@@ -12,25 +12,47 @@ if [[ $# -lt 1 ]]; then
   exit 2
 fi
 
-# Required vars that must be non-empty after sourcing the env-file chain.
+# Required vars that must be non-empty.
 REQUIRED_VARS=(POSTGRES_PASSWORD POSTGRES_REPLICATION_PASSWORD)
 
-# Source each provided env file so its key=value pairs populate the environment.
+# Verify each env file exists up front.
 for env_file in "$@"; do
   if [[ ! -f "$env_file" ]]; then
     echo "FATAL: env file not found: ${env_file}" >&2
     exit 1
   fi
-  set -a
-  # shellcheck disable=SC1090
-  . "$env_file"
-  set +a
 done
 
-# Collect any required var that is unset or empty.
+# Resolve a key the way compose will, without sourcing (no code execution).
+resolve_var() {
+  local key="$1"
+  shift
+  # A non-empty exported process-env value takes precedence over the files.
+  if [[ -n "${!key:-}" ]]; then
+    printf '%s' "${!key}"
+    return 0
+  fi
+  local val="" line
+  for f in "$@"; do
+    # Last literal `KEY=` line wins; allow leading space and an `export` prefix.
+    line="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "$f" | tail -n1 || true)"
+    [[ -n "$line" ]] || continue
+    val="${line#*=}"
+    # Drop a trailing CR so CRLF files don't read as non-empty.
+    val="${val%$'\r'}"
+    # Strip one layer of surrounding quotes so KEY="" reads as empty.
+    case "$val" in
+      \"*\") val="${val#\"}" && val="${val%\"}" ;;
+      \'*\') val="${val#\'}" && val="${val%\'}" ;;
+    esac
+  done
+  printf '%s' "$val"
+}
+
+# Collect any required var that resolves to unset or empty.
 missing=()
 for var in "${REQUIRED_VARS[@]}"; do
-  if [[ -z "${!var:-}" ]]; then
+  if [[ -z "$(resolve_var "$var" "$@")" ]]; then
     missing+=("$var")
   fi
 done

--- a/scripts/check-required-env.sh
+++ b/scripts/check-required-env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-required-env.sh — fail closed if required deployment secrets are blank.
+# Usage: check-required-env.sh <env-file> [<env-file> ...]
+# Sources each env file in order (later files override earlier ones), then
+# asserts POSTGRES_PASSWORD and POSTGRES_REPLICATION_PASSWORD are non-empty.
+# No working secrets are shipped; these MUST be set before starting the stack.
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <env-file> [<env-file> ...]" >&2
+  exit 2
+fi
+
+# Required vars that must be non-empty after sourcing the env-file chain.
+REQUIRED_VARS=(POSTGRES_PASSWORD POSTGRES_REPLICATION_PASSWORD)
+
+# Source each provided env file so its key=value pairs populate the environment.
+for env_file in "$@"; do
+  if [[ ! -f "$env_file" ]]; then
+    echo "FATAL: env file not found: ${env_file}" >&2
+    exit 1
+  fi
+  set -a
+  # shellcheck disable=SC1090
+  . "$env_file"
+  set +a
+done
+
+# Collect any required var that is unset or empty.
+missing=()
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing+=("$var")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "FATAL: required secret(s) unset or empty: ${missing[*]}" >&2
+  echo "No default is shipped. Set them in your env file before starting the stack." >&2
+  echo "Generate a strong value with: openssl rand -hex 32" >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/devnet/README.md
+++ b/scripts/devnet/README.md
@@ -4,6 +4,9 @@
 ```bash
 cp .env.example .env
 # Edit .env with your keys
+# Required (no defaults shipped): set POSTGRES_PASSWORD and POSTGRES_REPLICATION_PASSWORD
+# (and JWT_SECRET if enabling auth, ADMIN_PRIVATE_KEY for the operator) or services fail to start
+# Generate strong values with: openssl rand -hex 32
 ```
 
 Run all commands from project root:


### PR DESCRIPTION
## Summary

Addresses SOLA3-16. Tracked config templates (`.env.*`, `docker-compose*.yml`, indexer `*.toml`) shipped working/default secrets, and a blank credential was accepted silently: a blanked `${POSTGRES_PASSWORD}` interpolates into a passwordless URL (`postgres://user:@host/db`) that sqlx/Postgres will still connect with, so an operator who forgot to set the secret comes up on an unintended connection with no error.

This PR removes working secrets from tracked files and makes every credential path fail closed: the core node, the indexer, and the operator signer each refuse to start on a blank or missing credential instead of connecting, and a pre-launch check rejects an unset secret before any service boots.

## What's added

- **Blanked secrets in tracked config.** Every committed `.env.*`, compose file, and indexer TOML now ships empty secret placeholders only — no working credentials in the repo. Config interfaces tightened (privatized) alongside.
- **Fail-closed DB credential guard.** `database_url_has_password` (core `postgres.rs` and indexer `db.rs`) rejects an empty or missing password component before opening a connection; unparseable URLs are deferred to sqlx so the real connect error still surfaces. Covers the no-password (`user@host`), empty-password (`user:@host`), and no-userinfo forms.
- **Fail-closed signer guard.** `signer_util` rejects a set-but-empty `ADMIN_PRIVATE_KEY` — `env::var` returns `Ok("")` for a blank var, which an explicit emptiness check catches.
- **Pre-launch env check.** New `scripts/check-required-env.sh` sources the env-file chain and asserts `POSTGRES_PASSWORD` / `POSTGRES_REPLICATION_PASSWORD` are non-empty; wired into `run.sh`, the Makefiles, and the Dockerfile so the stack won't start with blank secrets. Docs (`README`, `DEVNET_QUICKSTART`, devnet README) point operators at the required vars.

## Tests

- **DB password guard (unit, core + indexer):** classifies empty-password, no-password, no-userinfo, real, and percent-encoded URLs; unparseable URLs pass through to sqlx.
- **`PostgresAccountsDB::new` fails closed (unit):** a blank password is rejected before any connection attempt.
- **Signer guard (unit):** `ADMIN_SIGNER=memory` with a set-but-empty/whitespace `ADMIN_PRIVATE_KEY` fails closed with a message flagging the empty var.

## Dockerfile build fix

Unrelated to the credential hardening, but folded into this branch because the image otherwise fails to build: the `Dockerfile` now builds the `dvp-swap-program` alongside the escrow/withdraw programs. It copies the program's Cargo manifests (preserving the dependency-cache layering), builds the SBF artifact with `cargo-build-sbf`, copies `dvp_swap_program.so` into `/out/deploy`, and replaces the `core/precompiles/dvp_swap_program.so` symlink with the real artifact. This is required because `core/src/accounts/precompiles.rs` embeds that `.so` via `include_bytes!` — without building it in the image, the core binary won't compile.


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 10,754 | 12,361 | 87.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255727562) |
| Indexer | 18,801 | 21,787 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255727562) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255727562) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255727562) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,200 | 13,892 | 80.6% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255727562) |
| **Total** | **42,466** | **50,035** | **84.9%** | |

> Last updated: 2026-06-10 06:13:37 UTC by E2E Integration