### PR TITLE
SOLA3-8: durably record confirmed remint and fail closed on idempotency lookup

### DIFF
--- a/indexer/src/operator/fetcher.rs
+++ b/indexer/src/operator/fetcher.rs
@@ -153,6 +153,7 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         }
     }
 

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -882,6 +882,7 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         }
     }
 
@@ -2205,6 +2206,7 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         };
 
         fetcher_tx.send(txn).await.unwrap();
@@ -2309,6 +2311,7 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         };
 
         fetcher_tx.send(txn).await.unwrap();

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -1676,6 +1676,7 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         });
         id
     }

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -490,6 +490,7 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         }
     }
 

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -70,11 +70,13 @@ async fn attempt_remint(
             return Ok(existing_signature);
         }
         Ok(None) => {}
+        // Fail closed: an unverifiable lookup escalates to ManualReview (via the
+        // Err arm of execute_deferred_remint) instead of risking a duplicate remint.
         Err(e) => {
-            warn!(
-                "Remint idempotency lookup failed for transaction {}: {}; proceeding with send",
+            return Err(format!(
+                "idempotency lookup unavailable for transaction {}: {}; refusing to remint",
                 info.transaction_id, e
-            );
+            ));
         }
     }
 
@@ -125,33 +127,63 @@ pub async fn execute_deferred_remint(
                 "Withdrawal failed but tokens reminted successfully: {}",
                 signature
             );
-            if let Some(transaction_id) = entry.ctx.transaction_id {
-                if let Err(e) = send_guaranteed(
-                    storage_tx,
-                    TransactionStatusUpdate {
-                        transaction_id,
-                        trace_id: entry.ctx.trace_id.clone(),
-                        status: TransactionStatus::FailedReminted,
-                        counterpart_signature: None,
-                        processed_at: Some(Utc::now()),
-                        error_message: Some(entry.original_error.clone()),
-                        remint_signature: Some(signature.to_string()),
-                        remint_attempted: true,
-                    },
-                    "transaction status update",
-                )
-                .await
-                {
-                    error!(
-                        "Failed to send FailedReminted status for txn {}: {}. \
-                         Remint sig {} confirmed on-chain but not recorded.",
-                        transaction_id, e, signature
-                    );
-                }
-            } else {
+
+            // Always Some for remint entries: they are only queued for a failed
+            // withdrawal, which has a DB row. With no id there is no row to record
+            // the landed remint against and no status message to key, so the only
+            // action is a loud log. The remint already confirmed on-chain.
+            let Some(transaction_id) = entry.ctx.transaction_id else {
                 error!(
-                    "Remint succeeded (sig: {}) but no transaction_id to record status",
+                    "Remint confirmed (sig: {}) but entry has no transaction_id; \
+                     cannot record FailedReminted",
                     signature
+                );
+                return;
+            };
+
+            // Durably record the landed remint before the async channel send.
+            // This flips status to FailedReminted now, so a crash in the window
+            // before the writer runs can no longer leave the row PendingRemint
+            // for restart recovery to pick up and remint a second time.
+            //
+            // If this write fails we do not abort: the channel send below still
+            // drives the row to FailedReminted (its UPDATE accepts pending_remint),
+            // which is enough to stop replay. Only landed_remint_signature is lost.
+            if let Err(persist_err) = state
+                .storage
+                .record_remint_result(transaction_id, signature.to_string())
+                .await
+            {
+                error!(
+                    "Remint sig {} confirmed but durable persist failed for txn {}: {}; \
+                     falling back to async status writer",
+                    signature, transaction_id, persist_err
+                );
+            }
+
+            // Drives the webhook alert, and is the fallback status write when the
+            // durable persist above errored. A no-op if the row is already
+            // FailedReminted (the UPDATE guard rejects non-pending_remint rows).
+            if let Err(e) = send_guaranteed(
+                storage_tx,
+                TransactionStatusUpdate {
+                    transaction_id,
+                    trace_id: entry.ctx.trace_id.clone(),
+                    status: TransactionStatus::FailedReminted,
+                    counterpart_signature: None,
+                    processed_at: Some(Utc::now()),
+                    error_message: Some(entry.original_error.clone()),
+                    remint_signature: Some(signature.to_string()),
+                    remint_attempted: true,
+                },
+                "transaction status update",
+            )
+            .await
+            {
+                error!(
+                    "Failed to send FailedReminted status for txn {}: {}. \
+                     Remint sig {} confirmed on-chain.",
+                    transaction_id, e, signature
                 );
             }
         }
@@ -559,6 +591,7 @@ mod tests {
                 pending_remint_deadline_at: Some(now),
                 finality_check_attempts: attempts,
                 recovery_requeue_attempts: 0,
+                landed_remint_signature: None,
             });
     }
 
@@ -951,6 +984,59 @@ mod tests {
     }
 
     // ── execute_deferred_remint paths ───────────────────────────────
+
+    /// Fail-closed: when the idempotency lookup cannot run (here the backend
+    /// rejects getSignaturesForAddress), attempt_remint must refuse to mint and
+    /// escalate to ManualReview rather than risk a duplicate remint.
+    #[tokio::test]
+    async fn execute_deferred_remint_fails_closed_when_idempotency_lookup_unavailable() {
+        ensure_test_signer();
+        let mut rpc_server = mockito::Server::new_async().await;
+        let (state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // getSignaturesForAddress unavailable on this backend.
+        let _sigs = mock_rpc(
+            &mut rpc_server,
+            "getSignaturesForAddress",
+            r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":0}"#,
+        )
+        .await;
+
+        let entry = PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(700),
+                withdrawal_nonce: Some(70),
+                trace_id: Some("trace-700".to_string()),
+            },
+            remint_info: make_remint_info(700),
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        };
+
+        execute_deferred_remint(&state, &entry, &storage_tx).await;
+
+        let update = storage_rx
+            .try_recv()
+            .expect("unavailable lookup must emit a status update");
+        assert_eq!(update.transaction_id, 700);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let err = update.error_message.as_deref().unwrap_or("");
+        // This string only comes from the fail-closed arm, before any send.
+        assert!(
+            err.contains("refusing to remint"),
+            "must escalate with the fail-closed reason: {err}"
+        );
+        assert!(
+            err.contains("release_funds failed"),
+            "must preserve the original withdrawal error: {err}"
+        );
+    }
 
     /// When the finality check returns null for a withdrawal signature
     /// (transaction was dropped), `execute_deferred_remint` is called.

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -162,8 +162,9 @@ pub async fn execute_deferred_remint(
             }
 
             // Drives the webhook alert, and is the fallback status write when the
-            // durable persist above errored. A no-op if the row is already
-            // FailedReminted (the UPDATE guard rejects non-pending_remint rows).
+            // durable persist above errored. Its UPDATE only touches
+            // processing/pending_remint rows, so once the row is FailedReminted
+            // this is a no-op.
             if let Err(e) = send_guaranteed(
                 storage_tx,
                 TransactionStatusUpdate {

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -442,6 +442,7 @@ mod tests {
             pending_remint_deadline_at: Some(deadline),
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         }
     }
 

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -82,6 +82,10 @@ pub struct DbTransaction {
     /// `processing` -> `pending`) bumps this; the cap quarantines a row that
     /// can never progress instead of looping forever.
     pub recovery_requeue_attempts: i32,
+    /// Confirmed remint signature, written in the same UPDATE that flips status
+    /// to FailedReminted. A crash before the async writer runs can no longer
+    /// leave a landed remint recorded only as PendingRemint (which would replay).
+    pub landed_remint_signature: Option<String>,
 }
 
 /// Per-mint balance aggregate used during startup reconciliation.
@@ -222,6 +226,7 @@ impl DbTransactionBuilder {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         }
     }
 }

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -25,6 +25,7 @@ pub mod insert_db_transactions_batch;
 pub mod insert_mint_statuses_batch;
 pub mod insert_release_signature;
 pub mod quarantine_all_active_withdrawals;
+pub mod record_remint_result;
 pub mod set_mint_extension_flags;
 pub mod set_pending_remint;
 pub mod try_complete_processing;
@@ -280,6 +281,17 @@ impl Storage {
         .await
     }
 
+    /// Durably record a confirmed remint (status -> FailedReminted plus the
+    /// signature) in one write, before the async status writer runs. Closes the
+    /// crash window that would otherwise leave a landed remint as PendingRemint.
+    pub async fn record_remint_result(
+        &self,
+        transaction_id: i64,
+        remint_signature: String,
+    ) -> Result<(), StorageError> {
+        record_remint_result::record_remint_result(self, transaction_id, remint_signature).await
+    }
+
     /// Returns all withdrawal transactions in PendingRemint status.
     /// Called on startup to re-hydrate the remint queue after a crash.
     pub async fn get_pending_remint_transactions(
@@ -430,6 +442,7 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         }
     }
 
@@ -1152,6 +1165,7 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         });
     }
 

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -451,11 +451,41 @@ impl MockStorage {
         Ok(())
     }
 
+    /// Mirror `record_remint_result_internal`: flip a PendingRemint row to
+    /// FailedReminted and store the signature. The status guard means a row
+    /// that already moved on is RowNotFound, matching Postgres semantics.
+    /// Honors `should_fail("record_remint_result")`.
+    pub async fn record_remint_result(
+        &self,
+        transaction_id: i64,
+        remint_signature: String,
+    ) -> Result<(), StorageError> {
+        self.check_should_fail("record_remint_result")?;
+        let mut rows = self.pending_remint_transactions.lock().unwrap();
+        let row = rows
+            .iter_mut()
+            .find(|t| t.id == transaction_id && t.status == TransactionStatus::PendingRemint)
+            .ok_or_else(|| StorageError::DatabaseError {
+                message: format!("no PendingRemint row for id {transaction_id}"),
+            })?;
+        row.status = TransactionStatus::FailedReminted;
+        row.landed_remint_signature = Some(remint_signature);
+        row.processed_at = Some(Utc::now());
+        Ok(())
+    }
+
     pub async fn get_pending_remint_transactions(
         &self,
     ) -> Result<Vec<DbTransaction>, StorageError> {
+        // Match the Postgres query's status filter: a row that already moved to
+        // FailedReminted (via record_remint_result) is not re-hydrated, so a
+        // landed remint cannot be replayed on restart.
         let pending = self.pending_remint_transactions.lock().unwrap();
-        Ok(pending.clone())
+        Ok(pending
+            .iter()
+            .filter(|t| t.status == TransactionStatus::PendingRemint)
+            .cloned()
+            .collect())
     }
 
     pub async fn quarantine_all_active_withdrawals(

--- a/indexer/src/storage/common/storage/record_remint_result.rs
+++ b/indexer/src/storage/common/storage/record_remint_result.rs
@@ -1,0 +1,21 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+pub async fn record_remint_result(
+    storage: &Storage,
+    transaction_id: i64,
+    remint_signature: String,
+) -> Result<(), StorageError> {
+    match storage {
+        Storage::Postgres(db) => {
+            db.record_remint_result_internal(transaction_id, remint_signature)
+                .await?;
+            Ok(())
+        }
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .record_remint_result(transaction_id, remint_signature)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -33,6 +33,7 @@ mod transaction_cols {
     pub const PENDING_REMINT_DEADLINE_AT: &str = "pending_remint_deadline_at";
     pub const FINALITY_CHECK_ATTEMPTS: &str = "finality_check_attempts";
     pub const RECOVERY_REQUEUE_ATTEMPTS: &str = "recovery_requeue_attempts";
+    pub const LANDED_REMINT_SIGNATURE: &str = "landed_remint_signature";
 }
 
 #[derive(Clone)]
@@ -234,6 +235,22 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
         info!("recovery_requeue_attempts migration complete");
+
+        // Confirmed remint signature, recorded synchronously after the remint
+        // confirms so a crash before the async writer cannot leave the row at
+        // pending_remint with a landed remint (which restart recovery replays).
+        info!("Running landed_remint_signature migration if needed...");
+        sqlx::query(
+            r#"
+            DO $$ BEGIN
+                ALTER TABLE transactions
+                ADD COLUMN IF NOT EXISTS landed_remint_signature TEXT;
+            END $$;
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        info!("landed_remint_signature migration complete");
 
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_trace_id ON transactions (trace_id)",
@@ -671,7 +688,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -698,6 +715,7 @@ impl PostgresDb {
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
+            transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -720,7 +738,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -746,6 +764,7 @@ impl PostgresDb {
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
+            transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -768,7 +787,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1
             ORDER BY {} DESC
@@ -795,6 +814,7 @@ impl PostgresDb {
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
+            transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filter
             transaction_cols::TRANSACTION_TYPE,
             // Ordering
@@ -857,7 +877,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -885,6 +905,7 @@ impl PostgresDb {
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
+            transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
@@ -958,7 +979,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = 'processing'
               AND {} < NOW() - make_interval(secs => $1)
@@ -986,6 +1007,7 @@ impl PostgresDb {
             transaction_cols::PENDING_REMINT_DEADLINE_AT,
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
+            transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filters
             transaction_cols::STATUS,
             transaction_cols::UPDATED_AT,
@@ -1133,6 +1155,40 @@ impl PostgresDb {
         .bind(transaction_id)
         .bind(attempts)
         .bind(new_deadline)
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(sqlx::Error::RowNotFound);
+        }
+
+        Ok(())
+    }
+
+    /// Durably record a confirmed remint: flip status to FailedReminted and
+    /// store the signature in one UPDATE, before the async writer runs. The
+    /// `pending_remint` guard makes it a no-op on an already-terminal row, so
+    /// a replayed call can never resurrect or double-record.
+    pub async fn record_remint_result_internal(
+        &self,
+        transaction_id: i64,
+        remint_signature: String,
+    ) -> Result<(), sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET
+                status = $2,
+                landed_remint_signature = $3,
+                processed_at = NOW(),
+                updated_at = NOW()
+            WHERE id = $1
+                AND status = 'pending_remint'
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(TransactionStatus::FailedReminted)
+        .bind(remint_signature)
         .execute(&self.pool)
         .await?;
 

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1193,6 +1193,23 @@ impl PostgresDb {
         .await?;
 
         if result.rows_affected() == 0 {
+            // The guarded UPDATE matched nothing. Distinguish the two cases for
+            // on-call: a missing row is a bug (the id came from a live
+            // PendingRemint row), a non-pending_remint status is expected on an
+            // idempotent replay. Both still signal RowNotFound so the caller
+            // falls back to the async writer.
+            let current: Option<String> =
+                sqlx::query_scalar("SELECT status::text FROM transactions WHERE id = $1")
+                    .bind(transaction_id)
+                    .fetch_optional(&self.pool)
+                    .await?;
+            match current.as_deref() {
+                None => warn!("record_remint_result: transaction {transaction_id} not found"),
+                Some(status) => info!(
+                    "record_remint_result: transaction {transaction_id} not pending_remint \
+                     (status {status}); skipping"
+                ),
+            }
             return Err(sqlx::Error::RowNotFound);
         }
 

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -69,6 +69,7 @@ fn make_db_transaction(sig: &str, txn_type: TransactionType) -> DbTransaction {
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     }
 }
 

--- a/integration/tests/indexer/harness_sanity.rs
+++ b/integration/tests/indexer/harness_sanity.rs
@@ -69,6 +69,7 @@ fn pending_deposit_row(id: i64, mint: Pubkey, recipient: Pubkey) -> DbTransactio
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     }
 }
 

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -229,6 +229,7 @@ fn make_withdrawal_transaction(
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     }
 }
 

--- a/integration/tests/indexer/pausable_mint.rs
+++ b/integration/tests/indexer/pausable_mint.rs
@@ -242,6 +242,7 @@ fn make_withdrawal_transaction(
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     }
 }
 

--- a/integration/tests/indexer/permanent_delegate_mint.rs
+++ b/integration/tests/indexer/permanent_delegate_mint.rs
@@ -273,6 +273,7 @@ fn make_withdrawal_transaction(
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     }
 }
 

--- a/integration/tests/indexer/processor_quarantine.rs
+++ b/integration/tests/indexer/processor_quarantine.rs
@@ -55,6 +55,7 @@ fn make_bad_deposit(id: i64) -> DbTransaction {
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     }
 }
 

--- a/integration/tests/indexer/remint_flow.rs
+++ b/integration/tests/indexer/remint_flow.rs
@@ -129,6 +129,7 @@ fn seed_pending_remint_row(mock: &MockStorage, id: i64, attempts: i32) {
             pending_remint_deadline_at: Some(now),
             finality_check_attempts: attempts,
             recovery_requeue_attempts: 0,
+            landed_remint_signature: None,
         });
 }
 
@@ -647,7 +648,67 @@ async fn execute_deferred_remint_emits_failed_reminted_after_successful_send() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// (f) attempt_remint send fails — ManualReview combined error.
+// (e2) Durable persist on a confirmed remint.
+// ─────────────────────────────────────────────────────────────────────
+// A confirmed remint must record its result on the transaction row itself.
+// record_remint_result is the only writer of landed_remint_signature (the
+// async status path never sets that column), so finding it on the row proves
+// the synchronous write ran. The row is then terminal, so the restart sweep
+// no longer returns it to be reminted again.
+#[tokio::test]
+async fn execute_deferred_remint_durably_records_landed_signature() {
+    let mock = MockRpcServer::start().await;
+    let (state, mut storage_rx, storage_tx, storage_mock) = build_state(mock.url()).await;
+
+    let txn_id: i64 = 7_003;
+    let info = make_remint_info(txn_id);
+    // The PendingRemint row this remint resolves.
+    seed_pending_remint_row(&storage_mock, txn_id, 0);
+
+    // Idempotency lookup empty, then a clean send and confirm.
+    mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("sendTransaction", send_transaction_echo_reply());
+    mock.enqueue("getSignatureStatuses", confirmed_status_reply());
+
+    let entry = make_pending_remint(txn_id, 33, vec![Signature::new_unique()], 0, info);
+    test_hooks::execute_deferred_remint(&state, &entry, &storage_tx).await;
+
+    let update = storage_rx
+        .recv()
+        .await
+        .expect("successful remint must emit a FailedReminted update");
+    assert_eq!(update.status, TransactionStatus::FailedReminted);
+    let landed = update
+        .remint_signature
+        .clone()
+        .expect("update carries the remint signature");
+
+    // landed_remint_signature is only ever written by record_remint_result.
+    {
+        let rows = storage_mock.pending_remint_transactions.lock().unwrap();
+        let row = rows.iter().find(|t| t.id == txn_id).expect("row present");
+        assert_eq!(row.status, TransactionStatus::FailedReminted);
+        assert_eq!(
+            row.landed_remint_signature.as_deref(),
+            Some(landed.as_str())
+        );
+    }
+
+    // Terminal row is not handed back to the restart sweep.
+    let still_pending = storage_mock
+        .get_pending_remint_transactions()
+        .await
+        .unwrap();
+    assert!(
+        still_pending.is_empty(),
+        "a reminted row must not re-hydrate as PendingRemint"
+    );
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// (f) attempt_remint send fails: ManualReview combined error.
 // ─────────────────────────────────────────────────────────────────────
 //
 // Idempotency lookup returns empty; `sendTransaction` returns a

--- a/integration/tests/indexer/remint_recovery.rs
+++ b/integration/tests/indexer/remint_recovery.rs
@@ -71,6 +71,7 @@ fn make_row(
         pending_remint_deadline_at: Some(deadline),
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     }
 }
 

--- a/integration/tests/indexer/state_recovery_malformed.rs
+++ b/integration/tests/indexer/state_recovery_malformed.rs
@@ -67,6 +67,7 @@ fn make_row(
         pending_remint_deadline_at: Some(deadline),
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     }
 }
 

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -213,6 +213,7 @@ async fn null_withdrawal_nonce_is_quarantined_to_manual_review(
         pending_remint_deadline_at: None,
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
+        landed_remint_signature: None,
     };
     storage.insert_db_transaction(&withdrawal).await?;
 


### PR DESCRIPTION
## SOLA3-8: Crash after a confirmed remint can replay the remint
### Problem
After a remint confirmed on-chain, persistence was async (channel →
`DbTransactionWriter`). If the operator died between confirmation and that write, the
row stayed `PendingRemint`. On restart it was re-hydrated and reminted again. The only
guard, `attempt_remint`'s idempotency lookup, was **fail-open**: on any lookup error it
logged a warning and minted anyway, producing duplicate channel assets from one failed
withdrawal.

### Fix
1. **Durable record before ack.** New `record_remint_result` does one guarded `UPDATE`
  (`status → FailedReminted`, `landed_remint_signature`, `processed_at`), called
  synchronously in `execute_deferred_remint` before the channel send. New
  `landed_remint_signature` column (idempotent migration).
2. **Recovery keys off the durable record.** The status flip means
  `get_pending_remint_transactions` (filters `status = 'pending_remint'`) no longer
  returns the row, so restart recovery never re-queues it.
3. **Fail closed on unavailable lookup.** `attempt_remint` now escalates to
  `ManualReview` when the idempotency lookup can't run, instead of minting blind
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 10,361 | 11,940 | 86.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27178141777) |
| Indexer | 18,806 | 21,906 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27178141777) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27178141777) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27178141777) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,198 | 13,926 | 80.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27178141777) |
| **Total** | **42,076** | **49,767** | **84.5%** | |

> Last updated: 2026-06-09 01:57:02 UTC by E2E Integration