### PR TITLE
fix(indexer): make checkpoint gap-safe under concurrent backfill (SOLA3-17)

### DIFF
--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -219,9 +219,15 @@ impl BackfillService {
         }
     }
 
-    /// Run the backfill process
-    /// Returns Ok(()) if no gap or backfill successful, Err if gap too large or backfill failed
-    pub async fn run(&self, instruction_tx: InstructionSender) -> Result<(), IndexerError> {
+    /// Work out which slots backfill needs to fill: `Some((from_slot, target))`, or
+    /// `None` if there's no gap. `from_slot` is exclusive (the last durable
+    /// checkpoint) and `target` is inclusive, so the range to fill is
+    /// `(from_slot, target]` — derived from the stored checkpoint, the configured
+    /// `start_slot`, the current chain tip, and the max gap size.
+    ///
+    /// The caller resolves the range once and uses it for two things — gating the
+    /// checkpoint writer and driving the fill — so both see the exact same bounds.
+    pub async fn resolve_range(&self) -> Result<Option<(u64, u64)>, IndexerError> {
         info!(
             "Checking for gaps in indexed data for {:?}...",
             self.program_type
@@ -270,20 +276,29 @@ impl BackfillService {
                     "No gap detected for {:?}. Current slot: {}, From slot: {}",
                     self.program_type, current_slot, from_slot
                 );
-                return Ok(());
+                Ok(None)
             }
             Some(gap) => {
                 info!(
                     "Gap detected for {:?}: {} slots (from {} to {}). Starting backfill...",
                     self.program_type, gap, from_slot, current_slot
                 );
+                Ok(Some((from_slot, current_slot)))
             }
         }
+    }
 
+    /// Fill the resolved range `(from_slot, to_slot]` over the instruction channel.
+    pub async fn run_range(
+        &self,
+        from_slot: u64,
+        to_slot: u64,
+        instruction_tx: InstructionSender,
+    ) -> Result<(), IndexerError> {
         fill_slot_range(
             &self.rpc_poller,
             from_slot,
-            current_slot,
+            to_slot,
             self.config.batch_size,
             self.program_type,
             self.escrow_instance_id,
@@ -293,6 +308,15 @@ impl BackfillService {
 
         info!("Backfill complete for {:?}", self.program_type);
         Ok(())
+    }
+
+    /// Run the backfill process
+    /// Returns Ok(()) if no gap or backfill successful, Err if gap too large or backfill failed
+    pub async fn run(&self, instruction_tx: InstructionSender) -> Result<(), IndexerError> {
+        match self.resolve_range().await? {
+            None => Ok(()),
+            Some((from_slot, to_slot)) => self.run_range(from_slot, to_slot, instruction_tx).await,
+        }
     }
 }
 

--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -262,11 +262,32 @@ impl BackfillService {
             last_checkpoint
         };
 
-        let current_slot = self
-            .rpc_poller
-            .get_latest_slot()
-            .await
-            .map_err(|e| BackfillError::SlotFetchFailed { slot: 0, source: e })?;
+        // Retry transient RPC failures with backoff (same policy as block fetches), so a
+        // single hiccup gating the checkpoint writer doesn't force an ungated fallback.
+        let mut retry_count = 0;
+        let current_slot = loop {
+            match self.rpc_poller.get_latest_slot().await {
+                Ok(slot) => break slot,
+                Err(e) => {
+                    retry_count += 1;
+                    if retry_count >= BACKFILL_MAX_RETRIES {
+                        error!(
+                            "Failed to fetch latest slot after {} retries: {}",
+                            BACKFILL_MAX_RETRIES, e
+                        );
+                        return Err(BackfillError::SlotFetchFailed { slot: 0, source: e }.into());
+                    }
+                    warn!(
+                        "Retry {}/{} fetching latest slot after error: {}",
+                        retry_count, BACKFILL_MAX_RETRIES, e
+                    );
+                    tokio::time::sleep(Duration::from_millis(
+                        BACKFILL_RETRY_DELAY_MS * retry_count as u64,
+                    ))
+                    .await;
+                }
+            }
+        };
 
         match validate_gap(current_slot, from_slot, self.config.max_gap_slots)
             .map_err(DataSourceError::from)?

--- a/indexer/src/indexer/checkpoint.rs
+++ b/indexer/src/indexer/checkpoint.rs
@@ -1,11 +1,16 @@
+use crate::metrics;
 use crate::{config::ProgramType, error::CheckpointError, storage::Storage};
-use std::collections::HashMap;
+use private_channel_metrics::MetricLabel;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::interval;
 use tracing::{error, info, warn};
+
+/// Gated ticks with no frontier advance before a stall warning fires (~15s at 5s/tick).
+const STALL_WARN_TICKS: u32 = 3;
 
 /// Checkpoint update message sent by transaction processor
 /// Indicates that a slot has been fully processed (transactions saved or confirmed empty)
@@ -15,15 +20,113 @@ pub struct CheckpointUpdate {
     pub slot: u64,
 }
 
+/// Per-program-type checkpoint progress.
+///
+/// `frontier` is the contiguous, fully-processed prefix and equals the value
+/// persisted to storage — it never advances past a slot that is not yet durably
+/// processed. While gated to a backfill range `(from_slot, target]`, out-of-range
+/// and out-of-order updates are staged in `completed` and only fold into
+/// `frontier` once they make it literally contiguous, so a missing slot cannot be
+/// leapfrogged.
+struct CheckpointState {
+    // Highest contiguous fully-processed slot; the value persisted to storage.
+    frontier: u64,
+    // Processed-but-not-yet-contiguous slots in `(frontier, target]`, awaiting the fold.
+    completed: HashSet<u64>,
+    // Backfill target `T0` while gated; `None` once handed off / ungated (plain max).
+    gate: Option<u64>,
+    // True when `frontier` advanced since the last successful flush (so flush has work).
+    dirty: bool,
+    // Consecutive gated ticks with no frontier advance, for the stall warning.
+    stalled_ticks: u32,
+}
+
+impl CheckpointState {
+    fn ungated() -> Self {
+        Self {
+            frontier: 0,
+            completed: HashSet::new(),
+            gate: None,
+            dirty: false,
+            stalled_ticks: 0,
+        }
+    }
+
+    /// Gated state seeded at backfill's effective `from_slot`. Seeding the frontier
+    /// from `from_slot` (not a bare DB read) is required because a configured
+    /// `start_slot` can push `from_slot` above the stored checkpoint; seeding lower
+    /// would stall the frontier on slots that backfill will never emit.
+    fn gated(from_slot: u64, target: u64) -> Self {
+        Self {
+            frontier: from_slot,
+            completed: HashSet::new(),
+            gate: Some(target),
+            dirty: false,
+            stalled_ticks: 0,
+        }
+    }
+
+    /// Record that `slot` is fully processed, advance `frontier` (the durable
+    /// checkpoint), and return whether it moved.
+    ///
+    /// When ungated, or after a backfill gap has been filled, `frontier` just tracks
+    /// the highest slot seen. While a gap is still open it advances only across
+    /// contiguous slots, so a slot that hasn't arrived yet can never be skipped.
+    fn apply(&mut self, slot: u64) -> bool {
+        let before = self.frontier;
+
+        match self.gate {
+            // Still filling a backfill gap — advance only across contiguous slots.
+            Some(target) if self.frontier < target => self.fill_gap(slot, target),
+            // Ungated, or the gap is filled — track the highest slot seen.
+            _ => self.frontier = self.frontier.max(slot),
+        }
+
+        let advanced = self.frontier > before;
+        // If the frontier moved, mark it so the next flush persists it.
+        self.dirty |= advanced;
+        advanced
+    }
+
+    /// While gated, pull `frontier` up across the contiguous run of processed slots,
+    /// parking out-of-order slots in `completed` until the ones before them arrive.
+    fn fill_gap(&mut self, slot: u64, target: u64) {
+        // Only slots inside the open gap `(frontier, target]` matter; a lower one is
+        // already covered, a higher one is a live tip whose row persists regardless.
+        let in_gap = self.frontier < slot && slot <= target;
+        if !in_gap {
+            return;
+        }
+
+        // Record the slot, then advance the frontier over each now-contiguous slot.
+        self.completed.insert(slot);
+        while self.completed.remove(&(self.frontier + 1)) {
+            self.frontier += 1;
+        }
+
+        // Gap fully closed — drop the staging set; later slots use the plain-max path.
+        if self.frontier >= target {
+            self.completed.clear();
+        }
+    }
+
+    /// Slots left to fill while gated (`target - frontier`), saturating to 0 post-handoff.
+    fn lag(&self) -> u64 {
+        match self.gate {
+            Some(t0) => t0.saturating_sub(self.frontier),
+            None => 0,
+        }
+    }
+}
+
 /// Checkpoint writer service that batches and persists checkpoint updates
 pub struct CheckpointWriter {
     storage: Arc<Storage>,
     batch_interval_secs: u64,
     max_batch_size: usize,
+    // Backfill range `(from_slot, target]` each new program state is gated to; `None` runs ungated.
+    gate: Option<(u64, u64)>,
 }
-
-/// Pending checkpoints waiting to be flushed to storage
-type PendingCheckpoints = HashMap<ProgramType, u64>;
 
 impl CheckpointWriter {
     pub fn new(storage: Arc<Storage>) -> Self {
@@ -31,7 +134,14 @@ impl CheckpointWriter {
             storage,
             batch_interval_secs: 5, // Write every 5 seconds
             max_batch_size: 100,    // Or every 100 updates
+            gate: None,
         }
+    }
+
+    /// Gate the frontier to the backfill range `(from_slot, target]` (from exclusive, target inclusive) so the checkpoint can't cross the unfilled gap.
+    pub fn with_gate(mut self, from_slot: u64, target: u64) -> Self {
+        self.gate = Some((from_slot, target));
+        self
     }
 
     pub fn with_batch_interval(mut self, seconds: u64) -> Self {
@@ -44,16 +154,25 @@ impl CheckpointWriter {
         self
     }
 
+    fn new_state(&self) -> CheckpointState {
+        match self.gate {
+            Some((from_slot, target)) => CheckpointState::gated(from_slot, target),
+            None => CheckpointState::ungated(),
+        }
+    }
+
     /// Start the checkpoint writer service
     /// Spawns a background task that listens for checkpoint updates and batches writes to DB
     pub fn start(self, mut rx: mpsc::Receiver<CheckpointUpdate>) -> JoinHandle<()> {
         tokio::spawn(async move {
             info!(
-                "Starting CheckpointWriter service (batch interval: {}s, max batch size: {})",
-                self.batch_interval_secs, self.max_batch_size
+                "Starting CheckpointWriter service (batch interval: {}s, max batch size: {}, gated: {})",
+                self.batch_interval_secs,
+                self.max_batch_size,
+                self.gate.is_some()
             );
 
-            let mut pending: PendingCheckpoints = HashMap::new();
+            let mut states: HashMap<ProgramType, CheckpointState> = HashMap::new();
             let mut update_count = 0;
 
             let mut ticker = interval(Duration::from_secs(self.batch_interval_secs));
@@ -64,19 +183,12 @@ impl CheckpointWriter {
                     update = rx.recv() => {
                         match update {
                             Some(update) => {
-                                pending
-                                    .entry(update.program_type)
-                                    .and_modify(|slot| {
-                                        if update.slot > *slot {
-                                            *slot = update.slot;
-                                        }
-                                    })
-                                    .or_insert(update.slot);
+                                self.record_update(&mut states, update);
 
                                 update_count += 1;
 
                                 if update_count >= self.max_batch_size {
-                                    if let Err(e) = self.flush_checkpoints(&mut pending).await {
+                                    if let Err(e) = self.flush_checkpoints(&mut states).await {
                                         error!("Failed to flush checkpoints: {}", e);
                                     }
                                     update_count = 0;
@@ -84,10 +196,8 @@ impl CheckpointWriter {
                             }
                             None => {
                                 info!("Checkpoint channel closed, flushing remaining checkpoints");
-                                if !pending.is_empty() {
-                                    if let Err(e) = self.flush_checkpoints(&mut pending).await {
-                                        error!("Failed to flush checkpoints on shutdown: {}", e);
-                                    }
+                                if let Err(e) = self.flush_checkpoints(&mut states).await {
+                                    error!("Failed to flush checkpoints on shutdown: {}", e);
                                 }
                                 break;
                             }
@@ -95,12 +205,11 @@ impl CheckpointWriter {
                     }
 
                     _ = ticker.tick() => {
-                        if !pending.is_empty() {
-                            if let Err(e) = self.flush_checkpoints(&mut pending).await {
-                                error!("Failed to flush checkpoints on timer: {}", e);
-                            }
-                            update_count = 0;
+                        Self::warn_on_stall(&mut states);
+                        if let Err(e) = self.flush_checkpoints(&mut states).await {
+                            error!("Failed to flush checkpoints on timer: {}", e);
                         }
+                        update_count = 0;
                     }
                 }
             }
@@ -109,40 +218,73 @@ impl CheckpointWriter {
         })
     }
 
-    /// Flush all pending checkpoints to storage
-    /// Only removes checkpoints from pending after successful DB write
+    fn record_update(
+        &self,
+        states: &mut HashMap<ProgramType, CheckpointState>,
+        update: CheckpointUpdate,
+    ) {
+        let state = states
+            .entry(update.program_type)
+            .or_insert_with(|| self.new_state());
+        state.apply(update.slot);
+        metrics::INDEXER_CHECKPOINT_FRONTIER_LAG
+            .with_label_values(&[update.program_type.as_label()])
+            .set(state.lag() as f64);
+    }
+
+    /// Warn once per program type whose gated frontier stays frozen `STALL_WARN_TICKS` ticks, and refresh the lag gauge so it stays live when no updates arrive.
+    fn warn_on_stall(states: &mut HashMap<ProgramType, CheckpointState>) {
+        for (&program_type, state) in states.iter_mut() {
+            metrics::INDEXER_CHECKPOINT_FRONTIER_LAG
+                .with_label_values(&[program_type.as_label()])
+                .set(state.lag() as f64);
+            if state.gate.is_none() || state.lag() == 0 || state.dirty {
+                state.stalled_ticks = 0;
+                continue;
+            }
+            state.stalled_ticks += 1;
+            if state.stalled_ticks == STALL_WARN_TICKS {
+                warn!(
+                    ?program_type,
+                    frontier = state.frontier,
+                    t0 = state.gate.unwrap_or_default(),
+                    lag = state.lag(),
+                    "checkpoint frontier stalled while gated; backfill blocked on a missing or unprocessed slot"
+                );
+            }
+        }
+    }
+
+    /// Persist each dirty program type's contiguous frontier, clearing `dirty` only on a successful write.
     async fn flush_checkpoints(
         &self,
-        pending: &mut PendingCheckpoints,
+        states: &mut HashMap<ProgramType, CheckpointState>,
     ) -> Result<(), CheckpointError> {
-        // Track which checkpoints were successfully written
-        let mut success = Vec::new();
-
-        // Flush all checkpoints
-        for (&program_type, &slot) in pending.iter() {
+        for (&program_type, state) in states.iter_mut() {
+            if !state.dirty {
+                continue;
+            }
             let program_type_str = format!("{:?}", program_type).to_lowercase();
 
             match self
                 .storage
-                .update_committed_checkpoint(&program_type_str, slot)
+                .update_committed_checkpoint(&program_type_str, state.frontier)
                 .await
             {
                 Ok(_) => {
-                    info!("Checkpoint updated: {:?} -> slot {}", program_type, slot);
-                    success.push(program_type);
+                    info!(
+                        "Checkpoint updated: {:?} -> slot {}",
+                        program_type, state.frontier
+                    );
+                    state.dirty = false;
                 }
                 Err(e) => {
                     warn!(
                         "Failed to update checkpoint for {:?} at slot {}: {}",
-                        program_type, slot, e
+                        program_type, state.frontier, e
                     );
                 }
             }
-        }
-
-        // Only remove successfully written checkpoints
-        for program_type in success {
-            pending.remove(&program_type);
         }
 
         Ok(())
@@ -168,6 +310,103 @@ pub async fn get_last_checkpoint(
 mod tests {
     use super::*;
     use crate::storage::common::storage::mock::MockStorage;
+
+    /// Backfill range boundaries shared across the gated tests: `FROM` is
+    /// exclusive (last durable checkpoint), `T0` is inclusive (last slot backfill
+    /// must fill), so the gated range is the closed interval `[FROM+1, T0]`.
+    const FROM: u64 = 100;
+    const T0: u64 = 110;
+
+    /// Apply a sequence of slot updates to a state and return the resulting frontier.
+    fn drive(state: &mut CheckpointState, slots: &[u64]) -> u64 {
+        for &slot in slots {
+            state.apply(slot);
+        }
+        state.frontier
+    }
+
+    /// Build the pending-state map a flush test expects: one dirty ungated state
+    /// per (program_type, frontier), matching how the writer stages updates.
+    fn pending_states(entries: &[(ProgramType, u64)]) -> HashMap<ProgramType, CheckpointState> {
+        let mut states = HashMap::new();
+        for &(program_type, slot) in entries {
+            let mut state = CheckpointState::ungated();
+            state.apply(slot);
+            states.insert(program_type, state);
+        }
+        states
+    }
+
+    // ============================================================================
+    // Gated-contiguous frontier Tests
+    // ============================================================================
+
+    #[test]
+    fn gated_drops_live_tip_above_t0() {
+        let mut state = CheckpointState::gated(FROM, T0);
+        // 101,102 fold contiguously; the live tip 1_000_000 is > T0 → dropped.
+        assert_eq!(drive(&mut state, &[101, 102, 1_000_000]), 102);
+        assert!(state.dirty);
+    }
+
+    /// The whole gated range folds the frontier up to exactly T0, after which it
+    /// hands off and a later live-tip slot advances via plain max.
+    #[test]
+    fn gated_fills_range_then_hands_off_to_max() {
+        let mut state = CheckpointState::gated(FROM, T0);
+        let full: Vec<u64> = (FROM + 1..=T0).collect();
+        assert_eq!(drive(&mut state, &full), T0);
+        assert_eq!(drive(&mut state, &[T0 + 50]), T0 + 50);
+    }
+
+    /// A hole at 103 must freeze the frontier at 102 even though 104..=110 and a live tip arrive after it.
+    #[test]
+    fn gated_stalls_on_hole_no_leapfrog() {
+        let mut state = CheckpointState::gated(FROM, T0);
+        let mut slots = vec![101, 102];
+        slots.extend(104..=110);
+        slots.push(1_000_000);
+        assert_eq!(drive(&mut state, &slots), 102);
+    }
+
+    #[test]
+    fn gated_out_of_order_within_range() {
+        let mut state = CheckpointState::gated(FROM, T0);
+        // 103 arrives before 101/102; frontier only reaches 103 once all three are present.
+        assert_eq!(drive(&mut state, &[103]), FROM);
+        assert_eq!(drive(&mut state, &[101]), 101);
+        assert_eq!(drive(&mut state, &[102]), 103);
+    }
+
+    /// With start_slot configured, the gate's `from` = max(start_slot-1, checkpoint);
+    /// the frontier must seed at that `from`, not the lower DB checkpoint, or it
+    /// would stall on slots backfill never emits.
+    #[test]
+    fn seed_respects_start_slot() {
+        const START_SLOT: u64 = 200;
+        const DB_CHECKPOINT: u64 = 100;
+        let from = (START_SLOT - 1).max(DB_CHECKPOINT);
+        let mut state = CheckpointState::gated(from, from + 5);
+        assert_eq!(state.frontier, START_SLOT - 1);
+        assert_eq!(drive(&mut state, &[START_SLOT]), START_SLOT);
+    }
+
+    /// Regression contract: ungated state is byte-for-byte today's max-of-seen.
+    #[test]
+    fn ungated_is_pure_max() {
+        let mut state = CheckpointState::ungated();
+        assert_eq!(drive(&mut state, &[300, 100]), 300);
+    }
+
+    #[test]
+    fn lag_gauge_saturating() {
+        let mut state = CheckpointState::gated(FROM, T0);
+        let full: Vec<u64> = (FROM + 1..=T0).collect();
+        drive(&mut state, &full);
+        drive(&mut state, &[T0 + 50]);
+        // frontier (T0+50) > target (T0): saturating_sub must report 0, not wrap.
+        assert_eq!(state.lag(), 0);
+    }
 
     // ============================================================================
     // Builder Tests
@@ -210,14 +449,14 @@ mod tests {
         let storage = Arc::new(Storage::Mock(mock.clone()));
         let writer = CheckpointWriter::new(storage.clone());
 
-        let mut pending = HashMap::new();
-        pending.insert(ProgramType::Escrow, 100);
-        pending.insert(ProgramType::Withdraw, 200);
+        let mut pending =
+            pending_states(&[(ProgramType::Escrow, 100), (ProgramType::Withdraw, 200)]);
 
         let result = writer.flush_checkpoints(&mut pending).await;
 
         assert!(result.is_ok());
-        assert!(pending.is_empty());
+        // Successful writes clear the dirty flag; nothing remains to flush.
+        assert!(pending.values().all(|s| !s.dirty));
 
         // Verify checkpoints were written
         let escrow_checkpoint = storage
@@ -242,17 +481,17 @@ mod tests {
         let storage = Arc::new(Storage::Mock(mock.clone()));
         let writer = CheckpointWriter::new(storage.clone());
 
-        let mut pending = HashMap::new();
-        pending.insert(ProgramType::Escrow, 100);
-        pending.insert(ProgramType::Withdraw, 200);
+        let mut pending =
+            pending_states(&[(ProgramType::Escrow, 100), (ProgramType::Withdraw, 200)]);
 
         let result = writer.flush_checkpoints(&mut pending).await;
 
         assert!(result.is_ok()); // flush_checkpoints itself succeeds
 
-        // Failed checkpoint should remain in pending
-        assert_eq!(pending.len(), 1);
-        assert_eq!(pending.get(&ProgramType::Escrow), Some(&100));
+        // Failed checkpoint stays dirty for retry; the successful one is cleared.
+        assert!(pending.get(&ProgramType::Escrow).unwrap().dirty);
+        assert_eq!(pending.get(&ProgramType::Escrow).unwrap().frontier, 100);
+        assert!(!pending.get(&ProgramType::Withdraw).unwrap().dirty);
 
         // Successful checkpoint should be written
         let withdraw_checkpoint = storage
@@ -272,7 +511,7 @@ mod tests {
         let storage = Arc::new(Storage::Mock(MockStorage::new()));
         let writer = CheckpointWriter::new(storage);
 
-        let mut pending = HashMap::new();
+        let mut pending: HashMap<ProgramType, CheckpointState> = HashMap::new();
 
         let result = writer.flush_checkpoints(&mut pending).await;
 

--- a/indexer/src/indexer/checkpoint.rs
+++ b/indexer/src/indexer/checkpoint.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::interval;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 /// Gated ticks with no frontier advance before a stall warning fires (~15s at 5s/tick).
 const STALL_WARN_TICKS: u32 = 3;
@@ -188,17 +188,13 @@ impl CheckpointWriter {
                                 update_count += 1;
 
                                 if update_count >= self.max_batch_size {
-                                    if let Err(e) = self.flush_checkpoints(&mut states).await {
-                                        error!("Failed to flush checkpoints: {}", e);
-                                    }
+                                    self.flush_checkpoints(&mut states).await;
                                     update_count = 0;
                                 }
                             }
                             None => {
                                 info!("Checkpoint channel closed, flushing remaining checkpoints");
-                                if let Err(e) = self.flush_checkpoints(&mut states).await {
-                                    error!("Failed to flush checkpoints on shutdown: {}", e);
-                                }
+                                self.flush_checkpoints(&mut states).await;
                                 break;
                             }
                         }
@@ -206,9 +202,7 @@ impl CheckpointWriter {
 
                     _ = ticker.tick() => {
                         Self::warn_on_stall(&mut states);
-                        if let Err(e) = self.flush_checkpoints(&mut states).await {
-                            error!("Failed to flush checkpoints on timer: {}", e);
-                        }
+                        self.flush_checkpoints(&mut states).await;
                         update_count = 0;
                     }
                 }
@@ -232,7 +226,7 @@ impl CheckpointWriter {
             .set(state.lag() as f64);
     }
 
-    /// Warn once per program type whose gated frontier stays frozen `STALL_WARN_TICKS` ticks, and refresh the lag gauge so it stays live when no updates arrive.
+    /// Re-warn every `STALL_WARN_TICKS` ticks that a gated frontier stays frozen, and refresh the lag gauge so it stays live when no updates arrive.
     fn warn_on_stall(states: &mut HashMap<ProgramType, CheckpointState>) {
         for (&program_type, state) in states.iter_mut() {
             metrics::INDEXER_CHECKPOINT_FRONTIER_LAG
@@ -243,7 +237,8 @@ impl CheckpointWriter {
                 continue;
             }
             state.stalled_ticks += 1;
-            if state.stalled_ticks == STALL_WARN_TICKS {
+            // Re-fire periodically (not just once) so a hours-long stall keeps logging.
+            if state.stalled_ticks % STALL_WARN_TICKS == 0 {
                 warn!(
                     ?program_type,
                     frontier = state.frontier,
@@ -255,11 +250,9 @@ impl CheckpointWriter {
         }
     }
 
-    /// Persist each dirty program type's contiguous frontier, clearing `dirty` only on a successful write.
-    async fn flush_checkpoints(
-        &self,
-        states: &mut HashMap<ProgramType, CheckpointState>,
-    ) -> Result<(), CheckpointError> {
+    /// Persist each dirty program type's contiguous frontier, clearing `dirty` only on a
+    /// successful write. A failed write logs and leaves `dirty` set so the next tick retries.
+    async fn flush_checkpoints(&self, states: &mut HashMap<ProgramType, CheckpointState>) {
         for (&program_type, state) in states.iter_mut() {
             if !state.dirty {
                 continue;
@@ -286,8 +279,6 @@ impl CheckpointWriter {
                 }
             }
         }
-
-        Ok(())
     }
 }
 
@@ -452,9 +443,8 @@ mod tests {
         let mut pending =
             pending_states(&[(ProgramType::Escrow, 100), (ProgramType::Withdraw, 200)]);
 
-        let result = writer.flush_checkpoints(&mut pending).await;
+        writer.flush_checkpoints(&mut pending).await;
 
-        assert!(result.is_ok());
         // Successful writes clear the dirty flag; nothing remains to flush.
         assert!(pending.values().all(|s| !s.dirty));
 
@@ -484,9 +474,7 @@ mod tests {
         let mut pending =
             pending_states(&[(ProgramType::Escrow, 100), (ProgramType::Withdraw, 200)]);
 
-        let result = writer.flush_checkpoints(&mut pending).await;
-
-        assert!(result.is_ok()); // flush_checkpoints itself succeeds
+        writer.flush_checkpoints(&mut pending).await;
 
         // Failed checkpoint stays dirty for retry; the successful one is cleared.
         assert!(pending.get(&ProgramType::Escrow).unwrap().dirty);
@@ -513,9 +501,8 @@ mod tests {
 
         let mut pending: HashMap<ProgramType, CheckpointState> = HashMap::new();
 
-        let result = writer.flush_checkpoints(&mut pending).await;
+        writer.flush_checkpoints(&mut pending).await;
 
-        assert!(result.is_ok());
         assert!(pending.is_empty());
     }
 

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -91,12 +91,12 @@ pub async fn run(
     let (instruction_tx, instruction_rx) = mpsc::channel(1000);
     let (checkpoint_tx, checkpoint_rx) = mpsc::channel(1000);
 
-    // 4. Start checkpoint writer service
-    let checkpoint_writer = CheckpointWriter::new(storage.clone());
-    let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
-    info!("CheckpointWriter service started");
+    // 4. Resolve the backfill range, gate the checkpoint writer to it, then start
+    //    the writer. Checkpoint updates only begin once the processor starts further
+    //    below (step 8), so the gate is always in place before the first update —
+    //    no live-tip slot can slip past it and push the checkpoint over the gap.
+    let mut checkpoint_writer = CheckpointWriter::new(storage.clone());
 
-    // 5. Run backfill if enabled
     if indexer_config.backfill.enabled {
         #[cfg(not(feature = "datasource-rpc"))]
         return Err(DataSourceError::InvalidConfig {
@@ -127,8 +127,21 @@ pub async fn run(
             );
 
             if indexer_config.backfill.exit_after_backfill {
-                // Run backfill synchronously if exiting after
-                backfill_service.run(instruction_tx.clone()).await?;
+                // Backfill-only: gate the writer to the fill range so a withheld
+                // (failed-write) slot stalls the checkpoint instead of being
+                // leapfrogged by a later one. No live stream, so a resolve failure
+                // fails closed rather than falling back to ungated.
+                let range = backfill_service.resolve_range().await?;
+                if let Some((from_slot, target)) = range {
+                    checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
+                }
+                let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
+                info!("CheckpointWriter service started");
+                if let Some((from_slot, target)) = range {
+                    backfill_service
+                        .run_range(from_slot, target, instruction_tx.clone())
+                        .await?;
+                }
                 info!("Backfill completed, performing graceful cleanup...");
                 if let Err(e) =
                     cleanup_after_backfill(checkpoint_handle, checkpoint_tx, storage).await
@@ -138,18 +151,40 @@ pub async fn run(
                 }
                 return Ok(());
             } else {
-                // Run backfill concurrently with live indexing
-                let instruction_tx_clone = instruction_tx.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = backfill_service.run(instruction_tx_clone).await {
-                        error!("Backfill failed: {}", e);
-                    } else {
-                        info!("Backfill completed successfully");
+                // Gate the writer to the exact range backfill will fill; on resolve
+                // failure fall back to an ungated writer (today's behavior) rather
+                // than aborting startup, since the live datasource still runs.
+                match backfill_service.resolve_range().await {
+                    Ok(Some((from_slot, target))) => {
+                        checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
+                        let instruction_tx_clone = instruction_tx.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = backfill_service
+                                .run_range(from_slot, target, instruction_tx_clone)
+                                .await
+                            {
+                                error!("Backfill failed: {}", e);
+                            } else {
+                                info!("Backfill completed successfully");
+                            }
+                        });
                     }
-                });
+                    Ok(None) => {
+                        info!("No backfill gap; checkpoint writer left ungated");
+                    }
+                    Err(e) => {
+                        error!(
+                            "Backfill range resolution failed; running ungated without backfill: {}",
+                            e
+                        );
+                    }
+                }
             }
         }
     }
+
+    let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
+    info!("CheckpointWriter service started");
 
     // 6. Start datasource
     let mut datasource: Box<dyn DataSource> = match indexer_config.datasource_type {

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -151,9 +151,8 @@ pub async fn run(
                 }
                 return Ok(());
             } else {
-                // Gate the writer to the exact range backfill will fill; on resolve
-                // failure fall back to an ungated writer (today's behavior) rather
-                // than aborting startup, since the live datasource still runs.
+                // Gate the writer to the range backfill will fill. resolve_range retries
+                // transient RPC failures; a persistent failure fails closed (see below).
                 match backfill_service.resolve_range().await {
                     Ok(Some((from_slot, target))) => {
                         checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
@@ -174,9 +173,11 @@ pub async fn run(
                     }
                     Err(e) => {
                         error!(
-                            "Backfill range resolution failed; running ungated without backfill: {}",
+                            "Backfill range resolution failed after retries; refusing to start \
+                             rather than running ungated past the unfilled gap: {}",
                             e
                         );
+                        return Err(e);
                     }
                 }
             }

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use private_channel_metrics::{HealthState, MetricLabel};
 use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
@@ -30,11 +31,9 @@ use tracing::{debug, error, info, warn};
 pub struct TransactionProcessor {
     storage: Arc<Storage>,
     checkpoint_tx: mpsc::Sender<CheckpointUpdate>,
-    current_slot: Option<u64>,
-    current_program_type: Option<ProgramType>,
 
-    // Buffer all instructions from current slot for batch processing
-    current_slot_instructions: Vec<InstructionWithMetadata>,
+    // Per-slot instruction buffers, so a foreign SlotComplete finalizes only its own slot's rows.
+    slot_buffers: HashMap<u64, Vec<InstructionWithMetadata>>,
 
     // Optional health state — bumped on each SlotComplete so /health knows the
     // indexer pipeline is making progress. None in tests / standalone uses.
@@ -48,9 +47,7 @@ impl TransactionProcessor {
         Self {
             storage,
             checkpoint_tx,
-            current_slot: None,
-            current_program_type: None,
-            current_slot_instructions: Vec::new(),
+            slot_buffers: HashMap::new(),
             health: None,
             configured_escrow_instance_id: None,
         }
@@ -76,10 +73,10 @@ impl TransactionProcessor {
         while let Some(message) = instruction_rx.recv().await {
             match message {
                 ProcessorMessage::Instruction(instruction_meta) => {
-                    // Buffer instruction for current slot
-                    self.current_slot = Some(instruction_meta.slot);
-                    self.current_program_type = Some(instruction_meta.program_type);
-                    self.current_slot_instructions.push(instruction_meta);
+                    self.slot_buffers
+                        .entry(instruction_meta.slot)
+                        .or_default()
+                        .push(instruction_meta);
                 }
                 ProcessorMessage::SlotComplete { slot, program_type } => {
                     let start = std::time::Instant::now();
@@ -105,7 +102,8 @@ impl TransactionProcessor {
         let mut mint_statuses: Vec<DbMintStatus> = Vec::new();
         let mut transactions = Vec::new();
 
-        for instruction_meta in &self.current_slot_instructions {
+        let slot_instructions = self.slot_buffers.remove(&slot).unwrap_or_default();
+        for instruction_meta in &slot_instructions {
             let (mint_opt, transaction_opt) = convert_to_db_models(
                 instruction_meta,
                 self.configured_escrow_instance_id.as_ref(),
@@ -262,10 +260,11 @@ impl TransactionProcessor {
                 }
             }
         }
+    }
 
-        self.current_slot_instructions.clear();
-        self.current_slot = None;
-        self.current_program_type = None;
+    #[cfg(test)]
+    fn buffer(&mut self, ix: InstructionWithMetadata) {
+        self.slot_buffers.entry(ix.slot).or_default().push(ix);
     }
 }
 
@@ -364,6 +363,7 @@ fn convert_to_db_models(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::indexer::checkpoint::CheckpointWriter;
     use crate::indexer::datasource::common::parser::{
         AllowMintAccounts, AllowMintData, AllowMintEvent, DepositAccounts, DepositData,
         DepositEvent, ResetSmtRootAccounts, WithdrawFundsAccounts, WithdrawFundsData,
@@ -690,15 +690,13 @@ mod tests {
         let cp = checkpoint_rx.recv().await.unwrap();
         assert_eq!(cp.slot, 42);
         assert_eq!(cp.program_type, ProgramType::Escrow);
-        assert!(processor.current_slot_instructions.is_empty());
+        assert!(processor.slot_buffers.is_empty());
     }
 
     #[tokio::test]
     async fn finalize_with_deposits_inserts_batch() {
         let (mut processor, mut checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
-        processor
-            .current_slot_instructions
-            .push(make_deposit_instruction(100, Some("s1".to_string()), None));
+        processor.buffer(make_deposit_instruction(100, Some("s1".to_string()), None));
         processor
             .finalize_and_checkpoint(100, ProgramType::Escrow)
             .await;
@@ -717,9 +715,7 @@ mod tests {
     async fn finalize_with_mints_upserts_first() {
         let (mut processor, mut checkpoint_rx, mock) =
             make_processor_with_mock(allow_mint_instance());
-        processor
-            .current_slot_instructions
-            .push(make_allow_mint_instruction(200, Some("s2".to_string())));
+        processor.buffer(make_allow_mint_instruction(200, Some("s2".to_string())));
         processor
             .finalize_and_checkpoint(200, ProgramType::Escrow)
             .await;
@@ -738,12 +734,10 @@ mod tests {
     async fn finalize_writes_mint_status_history_on_allow_mint() {
         let (mut processor, mut checkpoint_rx, mock) =
             make_processor_with_mock(allow_mint_instance());
-        processor
-            .current_slot_instructions
-            .push(make_allow_mint_instruction(
-                200,
-                Some("sig-allow-1".to_string()),
-            ));
+        processor.buffer(make_allow_mint_instruction(
+            200,
+            Some("sig-allow-1".to_string()),
+        ));
         processor
             .finalize_and_checkpoint(200, ProgramType::Escrow)
             .await;
@@ -766,12 +760,10 @@ mod tests {
         let (mut processor, mut checkpoint_rx, mock) =
             make_processor_with_mock(allow_mint_instance());
         mock.set_should_fail("insert_mint_statuses_batch", true);
-        processor
-            .current_slot_instructions
-            .push(make_allow_mint_instruction(
-                201,
-                Some("sig-allow-2".to_string()),
-            ));
+        processor.buffer(make_allow_mint_instruction(
+            201,
+            Some("sig-allow-2".to_string()),
+        ));
         processor
             .finalize_and_checkpoint(201, ProgramType::Escrow)
             .await;
@@ -789,20 +781,16 @@ mod tests {
         let (mut processor, mut checkpoint_rx, mock) =
             make_processor_with_mock(allow_mint_instance());
         mock.set_should_fail("insert_mint_statuses_batch", true);
-        processor
-            .current_slot_instructions
-            .push(make_allow_mint_instruction(
-                202,
-                Some("sig-allow-3".to_string()),
-            ));
-        processor
-            .current_slot_instructions
-            .push(make_deposit_instruction_on_instance(
-                202,
-                Some("sig-deposit-3".to_string()),
-                None,
-                allow_mint_instance(),
-            ));
+        processor.buffer(make_allow_mint_instruction(
+            202,
+            Some("sig-allow-3".to_string()),
+        ));
+        processor.buffer(make_deposit_instruction_on_instance(
+            202,
+            Some("sig-deposit-3".to_string()),
+            None,
+            allow_mint_instance(),
+        ));
         processor
             .finalize_and_checkpoint(202, ProgramType::Escrow)
             .await;
@@ -821,9 +809,7 @@ mod tests {
         let (mut processor, mut checkpoint_rx, mock) =
             make_processor_with_mock(allow_mint_instance());
         mock.set_should_fail("upsert_mints_batch", true);
-        processor
-            .current_slot_instructions
-            .push(make_allow_mint_instruction(300, Some("s3".to_string())));
+        processor.buffer(make_allow_mint_instruction(300, Some("s3".to_string())));
         processor
             .finalize_and_checkpoint(300, ProgramType::Escrow)
             .await;
@@ -836,9 +822,7 @@ mod tests {
     async fn finalize_insert_batch_failure_skips_checkpoint() {
         let (mut processor, mut checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
         mock.set_should_fail("insert_db_transactions_batch", true);
-        processor
-            .current_slot_instructions
-            .push(make_deposit_instruction(400, Some("s4".to_string()), None));
+        processor.buffer(make_deposit_instruction(400, Some("s4".to_string()), None));
         processor
             .finalize_and_checkpoint(400, ProgramType::Escrow)
             .await;
@@ -873,6 +857,115 @@ mod tests {
         assert_eq!(cp.slot, 500);
     }
 
+    /// Finalizing slot A inserts only A's rows and leaves B buffered until B's own SlotComplete.
+    #[tokio::test]
+    async fn interleaved_slots_finalize_independently() {
+        const SLOT_A: u64 = 600;
+        const SLOT_B: u64 = 601;
+        let (processor, mut checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
+
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            SLOT_A,
+            Some("a".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            SLOT_B,
+            Some("b".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: SLOT_A,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: SLOT_B,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+
+        processor.start(rx).await.unwrap();
+
+        let batches = mock.inserted_transactions.lock().unwrap();
+        assert_eq!(batches.len(), 2, "each slot finalizes its own batch");
+        assert_eq!(batches[0][0].signature, "a");
+        assert_eq!(batches[0][0].slot, SLOT_A as i64);
+        assert_eq!(batches[1][0].signature, "b");
+        assert_eq!(batches[1][0].slot, SLOT_B as i64);
+        drop(batches);
+
+        let first = checkpoint_rx.recv().await.unwrap();
+        let second = checkpoint_rx.recv().await.unwrap();
+        assert_eq!(first.slot, SLOT_A);
+        assert_eq!(second.slot, SLOT_B);
+    }
+
+    /// A foreign SlotComplete between a same-slot AllowMint and Deposit must not split the
+    /// finalize: the later mint-status failure still withholds the deposit and the checkpoint.
+    #[tokio::test]
+    async fn same_slot_atomicity_survives_foreign_slotcomplete() {
+        const SLOT_S: u64 = 700;
+        const LIVE_TIP: u64 = 9_000_000;
+        let (processor, mut checkpoint_rx, mock) = make_processor_with_mock(allow_mint_instance());
+        mock.set_should_fail("insert_mint_statuses_batch", true);
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
+
+        tx.send(ProcessorMessage::Instruction(make_allow_mint_instruction(
+            SLOT_S,
+            Some("allow".to_string()),
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: LIVE_TIP,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::Instruction(
+            make_deposit_instruction_on_instance(
+                SLOT_S,
+                Some("deposit".to_string()),
+                None,
+                allow_mint_instance(),
+            ),
+        ))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: SLOT_S,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+
+        processor.start(rx).await.unwrap();
+
+        let mut checkpointed = Vec::new();
+        while let Ok(cp) = checkpoint_rx.try_recv() {
+            checkpointed.push(cp.slot);
+        }
+        assert_eq!(
+            checkpointed,
+            vec![LIVE_TIP],
+            "only the empty live tip checkpoints; SLOT_S is withheld"
+        );
+        assert!(
+            mock.inserted_transactions.lock().unwrap().is_empty(),
+            "deposit must be withheld when its same-slot mint-status write failed"
+        );
+    }
+
     #[tokio::test]
     async fn start_channel_close_exits_ok() {
         let (processor, _checkpoint_rx) = make_processor_and_rx(deposit_instance());
@@ -881,5 +974,138 @@ mod tests {
 
         let result = processor.start(rx).await;
         assert!(result.is_ok());
+    }
+
+    // ========================================================================
+    // Channel-level integration: processor + checkpoint writer over real mpsc
+    // ========================================================================
+
+    /// Wire a real processor + checkpoint writer over real channels on one `MockStorage`, optionally gated, as the indexer does.
+    fn spawn_pipeline(
+        escrow_instance_id: Pubkey,
+        gate: Option<(u64, u64)>,
+    ) -> (
+        mpsc::Sender<ProcessorMessage>,
+        tokio::task::JoinHandle<()>,
+        tokio::task::JoinHandle<()>,
+        MockStorage,
+    ) {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let (instruction_tx, instruction_rx) = mpsc::channel(64);
+        let (checkpoint_tx, checkpoint_rx) = mpsc::channel(64);
+
+        let mut writer = CheckpointWriter::new(storage.clone())
+            .with_batch_interval(1)
+            .with_max_batch_size(1);
+        if let Some((from_slot, target)) = gate {
+            writer = writer.with_gate(from_slot, target);
+        }
+        let checkpoint_handle = writer.start(checkpoint_rx);
+
+        let processor = TransactionProcessor::new(storage, checkpoint_tx)
+            .with_escrow_instance_id(escrow_instance_id);
+        let processor_handle = tokio::spawn(async move {
+            processor.start(instruction_rx).await.unwrap();
+        });
+
+        (instruction_tx, processor_handle, checkpoint_handle, mock)
+    }
+
+    /// A live-tip SlotComplete during backfill must not advance the checkpoint past the unfilled gap (gate `(100, 105]`, fill 101..=105).
+    #[tokio::test]
+    async fn concurrent_backfill_live_interleave_never_skips() {
+        const FROM: u64 = 100;
+        const T0: u64 = 105;
+        const DEPOSIT_SLOT: u64 = 103;
+        const LIVE_TIP: u64 = 1_000_000;
+        let (tx, processor_handle, checkpoint_handle, mock) =
+            spawn_pipeline(deposit_instance(), Some((FROM, T0)));
+
+        // A historical deposit, then the attack: a live-tip SlotComplete arrives
+        // before backfill has filled the gap.
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            DEPOSIT_SLOT,
+            Some("dep-103".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: LIVE_TIP,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+
+        // Backfill now closes the gap contiguously.
+        for slot in (FROM + 1)..=T0 {
+            tx.send(ProcessorMessage::SlotComplete {
+                slot,
+                program_type: ProgramType::Escrow,
+            })
+            .await
+            .unwrap();
+        }
+
+        drop(tx);
+        processor_handle.await.unwrap();
+        checkpoint_handle.await.unwrap();
+
+        // The persisted checkpoint ends at T0 and never reached the live tip.
+        let committed = mock
+            .get_committed_checkpoint("escrow")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            committed, T0,
+            "checkpoint hands off at T0, never the live tip"
+        );
+        assert!(
+            committed < LIVE_TIP,
+            "checkpoint must never cross the unfilled gap to the live tip"
+        );
+
+        // The historical deposit row exists, and a restart would re-backfill from
+        // a checkpoint at/above DEPOSIT_SLOT — the slot is not skipped.
+        let inserted = mock.inserted_transactions.lock().unwrap();
+        assert_eq!(inserted.len(), 1);
+        assert_eq!(inserted[0][0].slot, DEPOSIT_SLOT as i64);
+        assert!(committed >= DEPOSIT_SLOT);
+    }
+
+    /// A crash mid-backfill persists the contiguous frontier, not the tip, so resume re-backfills with no tail skipped.
+    #[tokio::test]
+    async fn interrupt_mid_backfill_resumes_from_frontier() {
+        const FROM: u64 = 100;
+        const T0: u64 = 110;
+        let (tx, processor_handle, checkpoint_handle, mock) =
+            spawn_pipeline(deposit_instance(), Some((FROM, T0)));
+
+        for slot in [101u64, 102] {
+            tx.send(ProcessorMessage::SlotComplete {
+                slot,
+                program_type: ProgramType::Escrow,
+            })
+            .await
+            .unwrap();
+        }
+
+        // Simulated crash: drop the channel before the gap is filled.
+        drop(tx);
+        processor_handle.await.unwrap();
+        checkpoint_handle.await.unwrap();
+
+        let committed = mock
+            .get_committed_checkpoint("escrow")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(committed, 102, "frontier persisted, not T0");
+        assert!(
+            committed < T0,
+            "the unfilled tail (103..=110) is not skipped"
+        );
     }
 }

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -60,6 +60,13 @@ gauge_vec!(
     &["program_type"]
 );
 
+gauge_vec!(
+    INDEXER_CHECKPOINT_FRONTIER_LAG,
+    "private_channel_indexer_checkpoint_frontier_lag",
+    "Slots between the backfill target tip and the contiguous checkpoint frontier while gated (0 when ungated or after handoff)",
+    &["program_type"]
+);
+
 counter_vec!(
     INDEXER_DATASOURCE_RECONNECTS,
     "private_channel_indexer_datasource_reconnects_total",
@@ -177,6 +184,7 @@ pub fn init_labels(program_type: &str) {
     INDEXER_CURRENT_SLOT.with_label_values(&[program_type]);
     INDEXER_CHAIN_TIP_SLOT.with_label_values(&[program_type]);
     INDEXER_BACKFILL_SLOTS_REMAINING.with_label_values(&[program_type]);
+    INDEXER_CHECKPOINT_FRONTIER_LAG.with_label_values(&[program_type]);
     INDEXER_SLOT_PROCESSING_DURATION.with_label_values(&[program_type]);
 
     for error_type in &["stream", "get_slots", "get_block"] {
@@ -255,6 +263,7 @@ pub fn init() {
         INDEXER_RPC_ERRORS,
         INDEXER_CHAIN_TIP_SLOT,
         INDEXER_BACKFILL_SLOTS_REMAINING,
+        INDEXER_CHECKPOINT_FRONTIER_LAG,
         INDEXER_DATASOURCE_RECONNECTS,
         INDEXER_SLOT_PROCESSING_DURATION,
         OPERATOR_TRANSACTIONS_FETCHED,
@@ -310,6 +319,7 @@ mod tests {
             "private_channel_indexer_current_slot",
             "private_channel_indexer_chain_tip_slot",
             "private_channel_indexer_backfill_slots_remaining",
+            "private_channel_indexer_checkpoint_frontier_lag",
             "private_channel_indexer_slot_processing_duration_seconds",
             "private_channel_operator_transactions_fetched_total",
             "private_channel_operator_db_update_errors_total",
@@ -342,6 +352,7 @@ mod tests {
             "private_channel_indexer_rpc_errors_total",
             "private_channel_indexer_chain_tip_slot",
             "private_channel_indexer_backfill_slots_remaining",
+            "private_channel_indexer_checkpoint_frontier_lag",
             "private_channel_indexer_datasource_reconnects_total",
             "private_channel_indexer_slot_processing_duration_seconds",
             "private_channel_operator_transactions_fetched_total",


### PR DESCRIPTION
## Summary

Addresses SOLA3-17. With the shipped indexer config (`backfill.enabled = true`, `exit_after_backfill = false`), backfill and the live datasource feed one channel into a slot-agnostic processor, and the checkpoint writer persisted the **max** slot it saw. A live-tip `SlotComplete` arriving while backfill was still draining could advance `indexer_state` past the unfilled historical range; a second interruption then made startup backfill resume from the advanced checkpoint, **permanently skipping** the remaining slots, silently dropping deposits/withdrawals that landed during the outage.

This PR makes the persisted checkpoint **monotonic and gap-safe** under concurrent backfill, and makes slot finalization **per-slot atomic**. Concurrent live-during-backfill ingestion is preserved.

## What's changed

- **Per-slot finalize (`transaction_processor.rs`).** Instructions are buffered in a per-slot map instead of one shared `Vec`, so each `SlotComplete` finalizes only its own slot. A foreign (live-tip) marker can no longer flush another slot's in-flight rows, restoring slot-atomic finalize.
- **Gated-contiguous checkpoint (`checkpoint.rs`).** The writer persists a per-program-type `frontier` and advances it only across contiguous slots. While gated to the backfill range `(from_slot, target]`, live-tip slots above `target` are still written but can't move the checkpoint; once the frontier reaches `target` it hands off to plain max-logic. Ungated (no backfill / no gap) keeps the prior max behavior.
- **Single resolved range, armed before live (`backfill.rs`, `indexer.rs`).** `BackfillService` gains `resolve_range()` and `run_range(from, to)` (`run()` is now a thin wrapper). `run()` resolves the range once and gates the writer to the **same** bounds backfill fills, arming it before the processor starts so no live slot can move the checkpoint first. `exit_after_backfill` is gated too, so a withheld slot stalls rather than being leapfrogged.
- **Stall observability (`metrics.rs`, `checkpoint.rs`).** New `INDEXER_CHECKPOINT_FRONTIER_LAG` gauge (saturating) plus a single `warn!` after ~15s of a gated frontier not advancing, signalling a hole or blocked backfill. (`INDEXER_BACKFILL_SLOTS_REMAINING` tracks the fill cursor, not the durable frontier, so it misses a frontier frozen on a hole.)

## Design decisions

- **Contiguity is scoped to the backfill range, not all slot numbers.** Yellowstone emits `SlotComplete` only for slots that produced a block, so Solana-skipped slot numbers never arrive, and a global contiguous watermark would freeze at the first skip. Backfill's own stream *is* contiguous over its range, so the gate enforces contiguity there and hands off to max-logic above `target`, where skipped slots are vacuously covered as today.
- **Data is never gated, only the checkpoint.** Live rows are written immediately (idempotent); only checkpoint advancement waits for the gap to close, so memory stays bounded (≈`max_gap_slots` u64s) and live deposits are visible to the operator at once. On restart, backfill idempotently re-touches them.
- **Fail-closed.** A withheld slot (DB write failed, so no checkpoint update) stalls the frontier below the hole rather than letting a later slot leapfrog it; the next restart re-backfills it. Handoff keys on `frontier == target`, never on "backfill task returned Ok," so a partial/failed backfill cannot release the gate.

## Tests

- **Gated checkpoint (unit):** drops live-tip slots above `target`; folds the full range to `target` and then hands off to max; **stalls on a hole without leapfrogging**; folds out-of-order arrivals; seeds the frontier from `from_slot` (respects `start_slot`); ungated path is byte-for-byte the prior max behavior; lag gauge saturates post-handoff.
- **Per-slot atomicity (unit):** two interleaved slots finalize independently; a foreign `SlotComplete` between a same-slot AllowMint and Deposit does not split the finalize (the deposit is still withheld on mint-status failure).
- **Channel-level integration:** the auditor's exact scenario (`deposit@103` + live `SlotComplete{1_000_000}` interleaved with backfill `101..=105`) asserts the checkpoint ends at `105`, never the tip, and the deposit row survives; a mid-backfill "crash" persists the frontier (`102`), not the tip, so resume skips nothing.



### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 10,965 | 12,563 | 87.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27351062579) |
| Indexer | 19,697 | 22,644 | 87.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27351062579) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27351062579) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27351062579) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,421 | 14,180 | 80.5% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27351062579) |
| **Total** | **43,794** | **51,382** | **85.2%** | |

> Last updated: 2026-06-11 14:16:31 UTC by E2E Integration