### PR TITLE
fix(core): bound the write-pipeline hot-path queues and shed at public ingress (SOLA2-8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6570,6 +6570,7 @@ dependencies = [
  "private-channel-core",
  "private-channel-escrow-program-client",
  "private-channel-indexer",
+ "private-channel-metrics",
  "private-channel-withdraw-program-client",
  "redis",
  "serde_json",

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,8 @@ ci-integration-test-prebuilt:
 	@cd integration && cargo test --test test_sequencer_zero_deadline -- --nocapture
 	@cd integration && cargo test --test test_signatures_corruption_guard -- --nocapture
 	@cd integration && cargo test --test test_node_config_validation -- --nocapture
+	@# Backpressure CI guards (health + no-deadlock); the RSS load test stays #[ignore] for staging.
+	@cd integration && cargo test --test ingress_backpressure -- --nocapture
 	@cd integration && cargo test --test test_redis_cache_path -- --nocapture --test-threads=1
 	@echo "=== prod-feature indexer group ==="
 	@cd integration && cargo test --test reconciliation_integration -- --nocapture

--- a/core/src/bin/node.rs
+++ b/core/src/bin/node.rs
@@ -1,7 +1,10 @@
 use {
     clap::Parser,
     private_channel_core::{
-        nodes::node::{run_node, NodeConfig, NodeMode},
+        nodes::node::{
+            run_node, NodeConfig, NodeMode, DEFAULT_EXECUTION_RESULTS_CAPACITY,
+            DEFAULT_INGRESS_QUEUE_CAPACITY, DEFAULT_SEQUENCER_QUEUE_CAPACITY,
+        },
         stage_metrics::{init_prometheus_metrics, NoopMetrics, PrometheusMetrics},
     },
     private_channel_metrics::start_metrics_server,
@@ -57,6 +60,30 @@ struct Args {
         env = "PRIVATE_CHANNEL_BATCH_CHANNEL_CAPACITY"
     )]
     batch_channel_capacity: usize,
+
+    /// RPC→dedup ingress queue capacity; a full queue sheds load at admission.
+    #[arg(
+        long,
+        default_value_t = DEFAULT_INGRESS_QUEUE_CAPACITY,
+        env = "PRIVATE_CHANNEL_INGRESS_QUEUE_CAPACITY"
+    )]
+    ingress_queue_capacity: usize,
+
+    /// sigverify→sequencer queue capacity; full applies upstream backpressure.
+    #[arg(
+        long,
+        default_value_t = DEFAULT_SEQUENCER_QUEUE_CAPACITY,
+        env = "PRIVATE_CHANNEL_SEQUENCER_QUEUE_CAPACITY"
+    )]
+    sequencer_queue_capacity: usize,
+
+    /// executor→settler results queue capacity; full applies upstream backpressure.
+    #[arg(
+        long,
+        default_value_t = DEFAULT_EXECUTION_RESULTS_CAPACITY,
+        env = "PRIVATE_CHANNEL_EXECUTION_RESULTS_CAPACITY"
+    )]
+    execution_results_capacity: usize,
 
     /// Maximum parallel SVM worker threads per batch (including the calling thread).
     /// Set to 1 to disable intra-batch parallelism. Effective only for batches
@@ -161,6 +188,9 @@ async fn run_node_with_args(args: Args) -> Result<(), Box<dyn std::error::Error>
         max_tx_per_batch: args.max_tx_per_batch,
         batch_deadline_ms: args.batch_deadline_ms,
         batch_channel_capacity: args.batch_channel_capacity,
+        ingress_queue_capacity: args.ingress_queue_capacity,
+        sequencer_queue_capacity: args.sequencer_queue_capacity,
+        execution_results_capacity: args.execution_results_capacity,
         max_svm_workers: args.max_svm_workers,
         accountsdb_connection_url: args.accountsdb_connection_url,
         admin_keys,

--- a/core/src/health.rs
+++ b/core/src/health.rs
@@ -196,6 +196,43 @@ mod tests {
         assert_eq!(r.first_unhealthy(), None);
     }
 
+    // Backpressure-with-progress must read healthy: every stage keeps recording
+    // input and progress in lockstep at the pipeline's drain rate, so none looks
+    // wedged. Guards against a false /health 503 (and a needless restart) when the
+    // pipeline is merely backpressured rather than stalled.
+    #[test]
+    fn health_ok_under_sustained_backpressure() {
+        let mut r = HeartbeatRegistry::new();
+        r.dedup = Some(StageHeartbeat::new());
+        r.sigverify = Some(StageHeartbeat::new());
+        r.sequencer = Some(StageHeartbeat::new());
+        r.executor = Some(StageHeartbeat::new());
+        r.settler = Some(StageHeartbeat::new());
+
+        // Simulate several drain cycles: each stage records input then progress,
+        // mirroring a backpressured-but-advancing pipeline.
+        for _ in 0..5 {
+            for hb in [
+                &r.dedup,
+                &r.sigverify,
+                &r.sequencer,
+                &r.executor,
+                &r.settler,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                hb.record_input();
+                hb.record_progress();
+            }
+            assert_eq!(
+                r.first_unhealthy(),
+                None,
+                "backpressure with progress must never report a stage unhealthy"
+            );
+        }
+    }
+
     #[test]
     fn registry_attributes_to_correct_stage() {
         // Only the executor is unhealthy — the registry must name "executor".

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -27,6 +27,13 @@ use {
     tracing::{error, info, warn},
 };
 
+/// RPC→dedup ingress queue capacity. Sized so steady state never sheds.
+pub const DEFAULT_INGRESS_QUEUE_CAPACITY: usize = 10_000;
+/// sigverify→sequencer queue capacity (mirrors the sigverify queue size).
+pub const DEFAULT_SEQUENCER_QUEUE_CAPACITY: usize = 1000;
+/// executor→settler results queue capacity.
+pub const DEFAULT_EXECUTION_RESULTS_CAPACITY: usize = 1000;
+
 #[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
 pub enum NodeMode {
     /// Read-only node - serves read RPCs only
@@ -47,6 +54,12 @@ pub struct NodeConfig {
     pub max_tx_per_batch: usize,
     pub batch_deadline_ms: u64,
     pub batch_channel_capacity: usize,
+    /// RPC→dedup ingress queue capacity; a full queue sheds load at admission.
+    pub ingress_queue_capacity: usize,
+    /// sigverify→sequencer queue capacity; full applies upstream backpressure.
+    pub sequencer_queue_capacity: usize,
+    /// executor→settler results queue capacity; full applies upstream backpressure.
+    pub execution_results_capacity: usize,
     /// Max parallel SVM worker threads per batch (including the calling thread).
     /// Set to 1 to disable intra-batch parallelism entirely. Effective only for
     /// batches ≥ `MIN_PARALLEL_BATCH_SIZE`; smaller batches always run sequentially.
@@ -78,6 +91,9 @@ impl Default for NodeConfig {
             max_tx_per_batch: 64,
             batch_deadline_ms: 10,
             batch_channel_capacity: 16,
+            ingress_queue_capacity: DEFAULT_INGRESS_QUEUE_CAPACITY,
+            sequencer_queue_capacity: DEFAULT_SEQUENCER_QUEUE_CAPACITY,
+            execution_results_capacity: DEFAULT_EXECUTION_RESULTS_CAPACITY,
             max_svm_workers: 8,
             accountsdb_connection_url: "postgresql://user:password@localhost:5432/private_channel"
                 .to_string(),
@@ -120,6 +136,21 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
             "transaction_expiration_ms must be >= blocktime_ms (max_blockhashes would be 0)".into(),
         );
     }
+    // Zero capacity would panic the bounded-channel constructors below; fail closed instead.
+    if matches!(config.mode, NodeMode::Write | NodeMode::Aio) {
+        for (name, cap) in [
+            ("ingress_queue_capacity", config.ingress_queue_capacity),
+            ("sequencer_queue_capacity", config.sequencer_queue_capacity),
+            (
+                "execution_results_capacity",
+                config.execution_results_capacity,
+            ),
+        ] {
+            if cap == 0 {
+                return Err(format!("{name} must be greater than 0").into());
+            }
+        }
+    }
 
     // Create a single shutdown token for all services
     let shutdown_token = CancellationToken::new();
@@ -131,25 +162,29 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
     let mut write_workers: Vec<WorkerHandle> = Vec::new();
     let (write_deps, live_blockhashes_arc) =
         if matches!(config.mode, NodeMode::Write | NodeMode::Aio) {
-            // Create the dedup channel (receives from RPC, sends to sigverify) - unbounded
-            let (dedup_tx, dedup_rx) = crate::stages::create_dedup_channel();
+            // Create the bounded dedup channel (receives from RPC, sends to sigverify);
+            // a full queue sheds load at RPC ingress.
+            let (dedup_tx, dedup_rx) =
+                crate::stages::create_dedup_channel(config.ingress_queue_capacity);
 
             // Create the sigverify channel (needed for NodeHandles in all modes)
             let (sigverify_tx, sigverify_rx) =
                 async_channel::bounded::<SanitizedTransaction>(config.sigverify_queue_size);
 
-            // Create sequencer channel (unbounded mpsc for single consumer)
-            let (sequencer_tx, sequencer_rx) = mpsc::unbounded_channel::<SanitizedTransaction>();
+            // Create sequencer channel (bounded so backpressure chains upstream)
+            let (sequencer_tx, sequencer_rx) =
+                mpsc::channel::<SanitizedTransaction>(config.sequencer_queue_capacity);
 
             // Create batch channel between sequencer and executor (bounded for back-pressure)
             let (batch_tx, batch_rx) =
                 mpsc::channel::<ConflictFreeBatch>(config.batch_channel_capacity);
 
-            // Create execution results channel between executor and settler (unbounded for pipelining)
-            let (execution_results_tx, execution_results_rx) = mpsc::unbounded_channel::<(
-                LoadAndExecuteSanitizedTransactionsOutput,
-                Vec<SanitizedTransaction>,
-            )>();
+            // Create execution results channel between executor and settler (bounded for back-pressure)
+            let (execution_results_tx, execution_results_rx) =
+                mpsc::channel::<(
+                    LoadAndExecuteSanitizedTransactionsOutput,
+                    Vec<SanitizedTransaction>,
+                )>(config.execution_results_capacity);
 
             // Create settled accounts channel between settler and executor
             let (settled_accounts_tx, settled_accounts_rx) =
@@ -276,6 +311,7 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
             (
                 Some(WriteDeps {
                     dedup_tx: dedup_tx.clone(),
+                    metrics: Arc::clone(&config.metrics),
                 }),
                 live_blockhashes,
             )
@@ -405,6 +441,21 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "transaction_expiration_ms must be >= blocktime_ms (max_blockhashes would be 0)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_node_rejects_zero_queue_capacity() {
+        let config = NodeConfig {
+            sequencer_queue_capacity: 0,
+            ..Default::default()
+        };
+
+        let result = run_node(config).await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "sequencer_queue_capacity must be greater than 0"
         );
     }
 }

--- a/core/src/rpc/error.rs
+++ b/core/src/rpc/error.rs
@@ -7,6 +7,9 @@ pub use jsonrpsee::types::error::{
 /// Generic JSON-RPC server error (base of the -32000..-32099 reserved range).
 pub const JSON_RPC_SERVER_ERROR: i32 = -32000;
 
+/// Retryable: the write pipeline ingress queue is full; the tx was not accepted.
+pub const NODE_AT_CAPACITY_CODE: i32 = -32003;
+
 pub fn custom_error(code: i32, message: impl ToString) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(code, message.to_string(), None::<()>)
 }
@@ -17,4 +20,8 @@ pub fn read_not_enabled() -> ErrorObjectOwned {
 
 pub fn write_not_enabled() -> ErrorObjectOwned {
     custom_error(-32001, "Write operations not enabled")
+}
+
+pub fn node_at_capacity() -> ErrorObjectOwned {
+    custom_error(NODE_AT_CAPACITY_CODE, "Node at capacity, retry shortly")
 }

--- a/core/src/rpc/rpc_impl.rs
+++ b/core/src/rpc/rpc_impl.rs
@@ -27,6 +27,7 @@ use {
             send_transaction_impl::send_transaction_impl,
             simulate_transaction_impl::simulate_transaction,
         },
+        stage_metrics::SharedMetrics,
     },
     jsonrpsee::core::{async_trait, RpcResult},
     serde_json::Value,
@@ -63,7 +64,8 @@ pub struct ReadDeps {
 }
 
 pub struct WriteDeps {
-    pub dedup_tx: mpsc::UnboundedSender<SanitizedTransaction>,
+    pub dedup_tx: mpsc::Sender<SanitizedTransaction>,
+    pub metrics: SharedMetrics,
 }
 
 /// RPC implementation for PrivateChannel

--- a/core/src/rpc/send_transaction_impl.rs
+++ b/core/src/rpc/send_transaction_impl.rs
@@ -1,6 +1,6 @@
 use crate::rpc::{
     constants::PACKET_DATA_SIZE,
-    error::{custom_error, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
+    error::{custom_error, node_at_capacity, INVALID_PARAMS_CODE, JSON_RPC_SERVER_ERROR},
     WriteDeps,
 };
 use base64::{engine::general_purpose::STANDARD, Engine};
@@ -13,6 +13,7 @@ use solana_sdk::{
     transaction::{MessageHash, VersionedTransaction},
 };
 use std::collections::HashSet;
+use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 pub async fn send_transaction_impl(
@@ -104,23 +105,32 @@ pub async fn send_transaction_impl(
     // Get the signature before sending to channel
     let signature = sanitized_tx.signature().to_string();
 
-    // Send to dedup channel (which forwards to sigverify after deduplication)
+    // Fail fast on a full ingress queue: shedding frees the RPC connection slot
+    // immediately rather than parking it, so a memory-DoS can't become a
+    // connection-exhaustion DoS. The shed surfaces a distinct retryable code.
     info!("Sending transaction {} to dedup stage", signature);
-    write_deps.dedup_tx.send(sanitized_tx).map_err(|_| {
-        custom_error(
+    match write_deps.dedup_tx.try_send(sanitized_tx) {
+        Ok(()) => {
+            debug!("Transaction {} sent to dedup stage", signature);
+            Ok(signature)
+        }
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            write_deps.metrics.rpc_ingress_shed();
+            warn!("Shed transaction {}: ingress queue full", signature);
+            Err(node_at_capacity())
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => Err(custom_error(
             JSON_RPC_SERVER_ERROR,
             "Internal error: dedup channel closed",
-        )
-    })?;
-
-    debug!("Transaction {} sent to dedup stage", signature);
-    Ok(signature)
+        )),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rpc::WriteDeps;
+    use crate::rpc::{error::NODE_AT_CAPACITY_CODE, WriteDeps};
+    use crate::stage_metrics::{NoopMetrics, PrometheusMetrics, SharedMetrics};
     use solana_sdk::{
         hash::Hash,
         instruction::Instruction,
@@ -128,7 +138,9 @@ mod tests {
         signature::{Keypair, Signer},
         transaction::{SanitizedTransaction, Transaction},
     };
-    use tokio::sync::mpsc;
+    use std::sync::Arc;
+
+    const TEST_INGRESS_CAP: usize = 4;
 
     fn encode_tx(tx: &Transaction) -> String {
         let bytes = bincode::serialize(tx).unwrap();
@@ -136,9 +148,106 @@ mod tests {
     }
 
     /// Returns WriteDeps and the receiver (must be held alive for happy-path tests).
-    fn make_write_deps() -> (WriteDeps, mpsc::UnboundedReceiver<SanitizedTransaction>) {
-        let (dedup_tx, rx) = mpsc::unbounded_channel();
-        (WriteDeps { dedup_tx }, rx)
+    fn make_write_deps() -> (WriteDeps, mpsc::Receiver<SanitizedTransaction>) {
+        make_write_deps_with(Arc::new(NoopMetrics))
+    }
+
+    fn make_write_deps_with(
+        metrics: SharedMetrics,
+    ) -> (WriteDeps, mpsc::Receiver<SanitizedTransaction>) {
+        let (dedup_tx, rx) = mpsc::channel(TEST_INGRESS_CAP);
+        (WriteDeps { dedup_tx, metrics }, rx)
+    }
+
+    fn spl_tx() -> Transaction {
+        let payer = Keypair::new();
+        let from_ata = Pubkey::new_unique();
+        let to_ata = Pubkey::new_unique();
+        let ix = spl_token::instruction::transfer(
+            &spl_token::id(),
+            &from_ata,
+            &to_ata,
+            &payer.pubkey(),
+            &[],
+            1_000,
+        )
+        .unwrap();
+        Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], Hash::default())
+    }
+
+    #[tokio::test]
+    async fn ingress_sheds_when_full() {
+        let (deps, rx) = make_write_deps();
+        // Fill to capacity without draining.
+        for _ in 0..TEST_INGRESS_CAP {
+            send_transaction_impl(&deps, encode_tx(&spl_tx()), None)
+                .await
+                .expect("accept until full");
+        }
+
+        let err = send_transaction_impl(&deps, encode_tx(&spl_tx()), None)
+            .await
+            .expect_err("a full ingress queue must shed");
+        assert_eq!(err.code(), NODE_AT_CAPACITY_CODE);
+        assert_eq!(
+            rx.max_capacity(),
+            TEST_INGRESS_CAP,
+            "receiver must never exceed the bounded capacity"
+        );
+    }
+
+    #[tokio::test]
+    async fn ingress_shed_increments_metric() {
+        let metrics: SharedMetrics = Arc::new(PrometheusMetrics);
+        let (deps, _rx) = make_write_deps_with(Arc::clone(&metrics));
+        for _ in 0..TEST_INGRESS_CAP {
+            send_transaction_impl(&deps, encode_tx(&spl_tx()), None)
+                .await
+                .unwrap();
+        }
+
+        let before = shed_counter_value();
+        let _ = send_transaction_impl(&deps, encode_tx(&spl_tx()), None).await;
+        assert_eq!(
+            shed_counter_value(),
+            before + 1.0,
+            "shed path must increment rpc_ingress_shed_total"
+        );
+    }
+
+    // A shed happens at ingress, before the dedup cache insert, so the identical
+    // tx can be resubmitted once capacity frees and is accepted (not rejected as
+    // a duplicate). Proves the shed-before-dedup client-retry contract.
+    #[tokio::test]
+    async fn shed_tx_can_be_resubmitted() {
+        let (deps, mut rx) = make_write_deps();
+        for _ in 0..TEST_INGRESS_CAP {
+            send_transaction_impl(&deps, encode_tx(&spl_tx()), None)
+                .await
+                .unwrap();
+        }
+
+        let tx = spl_tx();
+        let encoded = encode_tx(&tx);
+        let shed = send_transaction_impl(&deps, encoded.clone(), None).await;
+        assert_eq!(shed.unwrap_err().code(), NODE_AT_CAPACITY_CODE);
+
+        // Free capacity, then resubmit the identical tx — must be accepted.
+        rx.recv().await.expect("drain one to free capacity");
+        let resubmit = send_transaction_impl(&deps, encoded, None).await;
+        assert!(
+            resubmit.is_ok(),
+            "a shed tx must be resubmittable: {resubmit:?}"
+        );
+    }
+
+    fn shed_counter_value() -> f64 {
+        private_channel_metrics::prometheus::gather()
+            .into_iter()
+            .filter(|mf| mf.name() == "private_channel_rpc_ingress_shed_total")
+            .flat_map(|mf| mf.get_metric().to_vec())
+            .map(|m| m.get_counter().value())
+            .sum()
     }
 
     #[tokio::test]

--- a/core/src/rpc/send_transaction_impl.rs
+++ b/core/src/rpc/send_transaction_impl.rs
@@ -190,9 +190,9 @@ mod tests {
             .expect_err("a full ingress queue must shed");
         assert_eq!(err.code(), NODE_AT_CAPACITY_CODE);
         assert_eq!(
-            rx.max_capacity(),
+            rx.len(),
             TEST_INGRESS_CAP,
-            "receiver must never exceed the bounded capacity"
+            "every accepted tx stays buffered, so the queue is saturated at the shed point"
         );
     }
 

--- a/core/src/stage_metrics.rs
+++ b/core/src/stage_metrics.rs
@@ -3,6 +3,9 @@ use tracing::debug;
 
 /// Instrumentation trait — each stage calls into this; no pipeline logic changes.
 pub trait StageMetrics: Send + Sync {
+    // RPC ingress
+    fn rpc_ingress_shed(&self);
+
     // Dedup
     fn dedup_received(&self);
     fn dedup_forwarded(&self);
@@ -52,6 +55,9 @@ pub type SharedMetrics = Arc<dyn StageMetrics>;
 pub struct NoopMetrics;
 
 impl StageMetrics for NoopMetrics {
+    fn rpc_ingress_shed(&self) {
+        debug!("rpc: ingress shed");
+    }
     fn dedup_received(&self) {
         debug!("dedup: received");
     }
@@ -136,6 +142,12 @@ impl StageMetrics for NoopMetrics {
 use private_channel_metrics::{counter_vec, gauge_vec, init_metrics};
 
 // Counters
+counter_vec!(
+    RPC_INGRESS_SHED,
+    "private_channel_rpc_ingress_shed_total",
+    "Transactions shed at RPC ingress because the dedup queue was full",
+    &[]
+);
 counter_vec!(
     DEDUP_RECEIVED,
     "private_channel_dedup_received_total",
@@ -298,6 +310,9 @@ histogram_vec!(
 pub struct PrometheusMetrics;
 
 impl StageMetrics for PrometheusMetrics {
+    fn rpc_ingress_shed(&self) {
+        RPC_INGRESS_SHED.with_label_values(&[] as &[&str]).inc();
+    }
     fn dedup_received(&self) {
         DEDUP_RECEIVED.with_label_values(&[] as &[&str]).inc();
     }
@@ -412,6 +427,7 @@ impl StageMetrics for PrometheusMetrics {
 /// Force-initialise all metric statics so they appear in /metrics from startup.
 pub fn init_prometheus_metrics() {
     init_metrics!(
+        RPC_INGRESS_SHED,
         DEDUP_RECEIVED,
         DEDUP_FORWARDED,
         DEDUP_DROPPED_DUP,

--- a/core/src/stages/dedup.rs
+++ b/core/src/stages/dedup.rs
@@ -16,7 +16,7 @@ use {
 
 pub struct DedupArgs {
     pub max_blockhashes: usize,
-    pub input_rx: mpsc::UnboundedReceiver<SanitizedTransaction>,
+    pub input_rx: mpsc::Receiver<SanitizedTransaction>,
     pub settled_blockhashes_rx: mpsc::UnboundedReceiver<Hash>,
     pub output_tx: async_channel::Sender<SanitizedTransaction>,
     pub shutdown_token: CancellationToken,
@@ -28,12 +28,14 @@ pub struct DedupArgs {
     pub heartbeat: Arc<StageHeartbeat>,
 }
 
-/// Create the dedup channel pair (unbounded)
-pub fn create_dedup_channel() -> (
-    mpsc::UnboundedSender<SanitizedTransaction>,
-    mpsc::UnboundedReceiver<SanitizedTransaction>,
+/// Create the bounded dedup channel pair; a full queue sheds load at RPC ingress.
+pub fn create_dedup_channel(
+    capacity: usize,
+) -> (
+    mpsc::Sender<SanitizedTransaction>,
+    mpsc::Receiver<SanitizedTransaction>,
 ) {
-    mpsc::unbounded_channel()
+    mpsc::channel(capacity)
 }
 
 /// Load dedup state from the DB to seed the cache on restart.
@@ -373,14 +375,16 @@ mod tests {
         }
     }
 
+    const TEST_INGRESS_CAP: usize = 64;
+
     /// Spin up the dedup stage and return the handles needed for driving it.
     fn start_test_dedup() -> (
-        mpsc::UnboundedSender<SanitizedTransaction>,
+        mpsc::Sender<SanitizedTransaction>,
         mpsc::UnboundedSender<Hash>,
         async_channel::Receiver<SanitizedTransaction>,
         CancellationToken,
     ) {
-        let (input_tx, input_rx) = mpsc::unbounded_channel();
+        let (input_tx, input_rx) = mpsc::channel(TEST_INGRESS_CAP);
         let (bh_tx, bh_rx) = mpsc::unbounded_channel();
         let (output_tx, output_rx) = async_channel::bounded(64);
         let shutdown = CancellationToken::new();
@@ -416,7 +420,7 @@ mod tests {
         let payer = Keypair::new();
         let unknown_bh = Hash::new_unique();
         let tx = make_tx(&payer, unknown_bh);
-        input_tx.send(tx).unwrap();
+        input_tx.send(tx).await.unwrap();
 
         let result = tokio::time::timeout(Duration::from_millis(100), output_rx.recv()).await;
         assert!(
@@ -438,11 +442,11 @@ mod tests {
         let payer = Keypair::new();
         let tx = make_tx(&payer, bh);
 
-        input_tx.send(tx.clone()).unwrap();
+        input_tx.send(tx.clone()).await.unwrap();
         let first = tokio::time::timeout(Duration::from_millis(200), output_rx.recv()).await;
         assert!(first.is_ok(), "first tx should be forwarded");
 
-        input_tx.send(tx).unwrap();
+        input_tx.send(tx).await.unwrap();
         let second = tokio::time::timeout(Duration::from_millis(100), output_rx.recv()).await;
         assert!(second.is_err(), "duplicate tx should not be forwarded");
 
@@ -461,7 +465,7 @@ mod tests {
         let tx = make_tx(&payer, bh);
         let expected_sig = *tx.signature();
 
-        input_tx.send(tx).unwrap();
+        input_tx.send(tx).await.unwrap();
 
         let result = tokio::time::timeout(Duration::from_millis(200), output_rx.recv()).await;
         match result {
@@ -488,7 +492,7 @@ mod tests {
 
         let payer = Keypair::new();
         let tx = make_tx(&payer, hashes[0]);
-        input_tx.send(tx).unwrap();
+        input_tx.send(tx).await.unwrap();
         let result = tokio::time::timeout(Duration::from_millis(100), output_rx.recv()).await;
         assert!(
             result.is_err(),
@@ -496,7 +500,7 @@ mod tests {
         );
 
         let tx2 = make_tx(&payer, hashes[8]);
-        input_tx.send(tx2).unwrap();
+        input_tx.send(tx2).await.unwrap();
         let result2 = tokio::time::timeout(Duration::from_millis(200), output_rx.recv()).await;
         assert!(
             result2.is_ok(),

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -55,7 +55,7 @@ const MIN_PARALLEL_BATCH_FACTOR: usize = 4;
 pub struct ExecutionArgs {
     pub batch_rx: mpsc::Receiver<ConflictFreeBatch>,
     pub settled_accounts_rx: mpsc::UnboundedReceiver<Vec<(Pubkey, AccountSettlement)>>,
-    pub execution_results_tx: mpsc::UnboundedSender<(
+    pub execution_results_tx: mpsc::Sender<(
         LoadAndExecuteSanitizedTransactionsOutput,
         Vec<SanitizedTransaction>,
     )>,
@@ -146,10 +146,21 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                             if !execution_result.admin_transactions.is_empty() {
                                 if let Some(admin_results) = execution_result.admin_results {
                                     let len = execution_result.admin_transactions.len();
-                                    if let Err(e) = execution_results_tx.send((admin_results, execution_result.admin_transactions)) {
-                                        metrics.executor_results_send_failed("admin");
-                                        error!("Failed to send admin results: {:?}", e);
-                                        break;
+                                    // Bounded send applies backpressure; race shutdown so a full
+                                    // settler queue never wedges executor exit. Owned values only,
+                                    // no lock guard is held across this await.
+                                    tokio::select! {
+                                        send_result = execution_results_tx.send((admin_results, execution_result.admin_transactions)) => {
+                                            if let Err(e) = send_result {
+                                                metrics.executor_results_send_failed("admin");
+                                                error!("Failed to send admin results: {:?}", e);
+                                                break;
+                                            }
+                                        }
+                                        _ = shutdown_token.cancelled() => {
+                                            info!("Executor shutdown while sending admin results");
+                                            return;
+                                        }
                                     }
                                     metrics.executor_results_sent(len);
                                 } else {
@@ -161,10 +172,18 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                             if !execution_result.regular_transactions.is_empty() {
                                 if let Some(regular_results) = execution_result.regular_results {
                                     let len = execution_result.regular_transactions.len();
-                                    if let Err(e) = execution_results_tx.send((regular_results, execution_result.regular_transactions)) {
-                                        metrics.executor_results_send_failed("regular");
-                                        error!("Failed to send regular results: {:?}", e);
-                                        break;
+                                    tokio::select! {
+                                        send_result = execution_results_tx.send((regular_results, execution_result.regular_transactions)) => {
+                                            if let Err(e) = send_result {
+                                                metrics.executor_results_send_failed("regular");
+                                                error!("Failed to send regular results: {:?}", e);
+                                                break;
+                                            }
+                                        }
+                                        _ = shutdown_token.cancelled() => {
+                                            info!("Executor shutdown while sending regular results");
+                                            return;
+                                        }
                                     }
                                     metrics.executor_results_sent(len);
                                 } else {
@@ -711,6 +730,8 @@ mod tests {
     use std::sync::{Arc, RwLock};
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
+
+    use crate::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY as RESULTS_CAP;
 
     /// Helper: live-blockhash window containing only `Hash::default()` so the
     /// canned test transactions (built with `Hash::default()` as their recent
@@ -1448,10 +1469,10 @@ mod tests {
 
         let (_batch_tx, batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
         let (_settled_tx, settled_rx) = mpsc::unbounded_channel();
-        let (execution_results_tx, _execution_results_rx) = mpsc::unbounded_channel::<(
+        let (execution_results_tx, _execution_results_rx) = mpsc::channel::<(
             LoadAndExecuteSanitizedTransactionsOutput,
             Vec<SanitizedTransaction>,
-        )>();
+        )>(RESULTS_CAP);
         let shutdown = CancellationToken::new();
 
         let handle = start_execution_worker(ExecutionArgs {
@@ -1776,10 +1797,10 @@ mod tests {
 
         let (batch_tx, batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
         let (_settled_tx, settled_rx) = mpsc::unbounded_channel();
-        let (execution_results_tx, _execution_results_rx) = mpsc::unbounded_channel::<(
+        let (execution_results_tx, _execution_results_rx) = mpsc::channel::<(
             LoadAndExecuteSanitizedTransactionsOutput,
             Vec<SanitizedTransaction>,
-        )>();
+        )>(RESULTS_CAP);
         let shutdown = CancellationToken::new();
 
         let handle = start_execution_worker(ExecutionArgs {
@@ -1888,5 +1909,108 @@ mod tests {
         assert_eq!(result.regular_transactions.len(), 1);
         assert!(result.admin_results.is_some());
         assert!(result.regular_results.is_some());
+    }
+
+    // A full results channel blocks the executor's send (backpressure) without
+    // panic or lock poison — proving no guard is held across the await — and the
+    // blocked result is delivered once the receiver drains.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn executor_blocks_then_completes_on_full_results() {
+        let (_accounts_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+
+        let (batch_tx, batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
+        let (_settled_tx, settled_rx) = mpsc::unbounded_channel();
+        let (execution_results_tx, mut execution_results_rx) = mpsc::channel::<(
+            LoadAndExecuteSanitizedTransactionsOutput,
+            Vec<SanitizedTransaction>,
+        )>(1);
+        let shutdown = CancellationToken::new();
+
+        let _handle = start_execution_worker(ExecutionArgs {
+            batch_rx,
+            settled_accounts_rx: settled_rx,
+            execution_results_tx,
+            accountsdb_connection_url: url,
+            shutdown_token: shutdown.clone(),
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: crate::health::StageHeartbeat::new(),
+            max_svm_workers: 1,
+            live_blockhashes: default_live_blockhashes(),
+        })
+        .await;
+
+        let one_batch = || ConflictFreeBatch {
+            transactions: vec![crate::scheduler::TransactionWithIndex {
+                transaction: Arc::new(create_test_transaction()),
+                index: 0,
+            }],
+        };
+        // Two batches: the first fills the cap-1 channel, the second's send blocks.
+        batch_tx.send(one_batch()).await.unwrap();
+        batch_tx.send(one_batch()).await.unwrap();
+
+        // First result is available.
+        let first = tokio::time::timeout(Duration::from_secs(5), execution_results_rx.recv()).await;
+        assert!(first.is_ok(), "first result must arrive");
+
+        // Draining the first unblocks the executor's parked send; the second arrives.
+        let second =
+            tokio::time::timeout(Duration::from_secs(5), execution_results_rx.recv()).await;
+        assert!(
+            matches!(second, Ok(Some(_))),
+            "second result must arrive once the channel drains (no deadlock, no poison)"
+        );
+
+        shutdown.cancel();
+    }
+
+    // A full results channel with no receiver must not wedge executor shutdown:
+    // the send is raced against the shutdown token.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn executor_exits_on_shutdown_with_full_results() {
+        let (_accounts_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+
+        let (batch_tx, batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
+        let (_settled_tx, settled_rx) = mpsc::unbounded_channel();
+        let (execution_results_tx, execution_results_rx) = mpsc::channel::<(
+            LoadAndExecuteSanitizedTransactionsOutput,
+            Vec<SanitizedTransaction>,
+        )>(1);
+        let shutdown = CancellationToken::new();
+
+        let handle = start_execution_worker(ExecutionArgs {
+            batch_rx,
+            settled_accounts_rx: settled_rx,
+            execution_results_tx,
+            accountsdb_connection_url: url,
+            shutdown_token: shutdown.clone(),
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: crate::health::StageHeartbeat::new(),
+            max_svm_workers: 1,
+            live_blockhashes: default_live_blockhashes(),
+        })
+        .await;
+
+        let one_batch = || ConflictFreeBatch {
+            transactions: vec![crate::scheduler::TransactionWithIndex {
+                transaction: Arc::new(create_test_transaction()),
+                index: 0,
+            }],
+        };
+        // Fill the cap-1 channel and leave a second batch whose send will block;
+        // never drain the results channel.
+        batch_tx.send(one_batch()).await.unwrap();
+        batch_tx.send(one_batch()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        shutdown.cancel();
+        let result = tokio::time::timeout(Duration::from_secs(2), handle.handle).await;
+        assert!(
+            result.is_ok(),
+            "executor must exit promptly even with a full results channel"
+        );
+        drop(execution_results_rx);
     }
 }

--- a/core/src/stages/sequencer.rs
+++ b/core/src/stages/sequencer.rs
@@ -15,7 +15,7 @@ use {
 pub struct SequencerArgs {
     pub max_tx_per_batch: usize,
     pub batch_deadline_ms: u64,
-    pub rx: mpsc::UnboundedReceiver<SanitizedTransaction>,
+    pub rx: mpsc::Receiver<SanitizedTransaction>,
     pub batch_tx: mpsc::Sender<ConflictFreeBatch>,
     pub shutdown_token: CancellationToken,
     pub metrics: SharedMetrics,
@@ -276,6 +276,8 @@ mod tests {
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
 
+    use crate::nodes::node::DEFAULT_SEQUENCER_QUEUE_CAPACITY as SEQ_CAP;
+
     #[tokio::test]
     async fn test_single_tx_produces_batch() {
         let mut scheduler = Scheduler::new_dag();
@@ -402,7 +404,7 @@ mod tests {
     // Closing the input channel with a pending tx causes the worker to flush it then exit.
     #[tokio::test]
     async fn worker_channel_closed_flushes_pending_and_exits() {
-        let (input_tx, input_rx) = mpsc::unbounded_channel();
+        let (input_tx, input_rx) = mpsc::channel(SEQ_CAP);
         let (batch_tx, mut batch_rx) = mpsc::channel(16);
         let shutdown = CancellationToken::new();
 
@@ -410,6 +412,7 @@ mod tests {
         let to = Pubkey::new_unique();
         input_tx
             .send(create_test_sanitized_transaction(&from, &to, 100))
+            .await
             .unwrap();
         drop(input_tx); // close the channel with a pending tx
 
@@ -436,7 +439,7 @@ mod tests {
     // Cancelling the shutdown token stops the worker without deadlock or panic.
     #[tokio::test]
     async fn worker_shutdown_signal_exits_cleanly() {
-        let (input_tx, input_rx) = mpsc::unbounded_channel();
+        let (input_tx, input_rx) = mpsc::channel(SEQ_CAP);
         let (batch_tx, mut batch_rx) = mpsc::channel(16);
         let shutdown = CancellationToken::new();
 
@@ -456,6 +459,7 @@ mod tests {
         let to = Pubkey::new_unique();
         input_tx
             .send(create_test_sanitized_transaction(&from, &to, 100))
+            .await
             .unwrap();
 
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -470,7 +474,7 @@ mod tests {
     // The worker's non-blocking drain loop stops collecting once max_tx_per_batch is reached.
     #[tokio::test]
     async fn worker_collects_up_to_max_tx_per_batch() {
-        let (input_tx, input_rx) = mpsc::unbounded_channel();
+        let (input_tx, input_rx) = mpsc::channel(SEQ_CAP);
         let (batch_tx, mut batch_rx) = mpsc::channel(16);
         let shutdown = CancellationToken::new();
         let max = 3usize;
@@ -483,6 +487,7 @@ mod tests {
             let to = Pubkey::new_unique();
             input_tx
                 .send(create_test_sanitized_transaction(&from, &to, 100))
+                .await
                 .unwrap();
         }
 

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -137,7 +137,7 @@ pub async fn warm_redis_cache(
 }
 
 pub struct SettleArgs {
-    pub execution_results_rx: mpsc::UnboundedReceiver<(
+    pub execution_results_rx: mpsc::Receiver<(
         LoadAndExecuteSanitizedTransactionsOutput,
         Vec<SanitizedTransaction>,
     )>,
@@ -169,7 +169,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
     let handle = tokio::spawn(async move {
         #[allow(clippy::too_many_arguments)]
         async fn run_settle_worker(
-            mut execution_results_rx: mpsc::UnboundedReceiver<(
+            mut execution_results_rx: mpsc::Receiver<(
                 LoadAndExecuteSanitizedTransactionsOutput,
                 Vec<SanitizedTransaction>,
             )>,
@@ -669,6 +669,8 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
+
+    use crate::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY as RESULTS_CAP;
 
     fn make_executed(
         accounts: Vec<(solana_sdk::pubkey::Pubkey, AccountSharedData)>,
@@ -1175,7 +1177,7 @@ mod tests {
         let (_db, _pg) = start_test_postgres().await;
         let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
 
-        let (_exec_tx, exec_rx) = mpsc::unbounded_channel();
+        let (_exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
         let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
         let (address_signatures_tx, _address_signatures_rx) = mpsc::channel(64);
@@ -1206,7 +1208,7 @@ mod tests {
         let (_db, _pg) = start_test_postgres().await;
         let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
 
-        let (exec_tx, exec_rx) = mpsc::unbounded_channel();
+        let (exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
         let (settled_accounts_tx, mut settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, mut settled_blockhashes_rx) = mpsc::unbounded_channel();
         let (address_signatures_tx, _address_signatures_rx) = mpsc::channel(64);
@@ -1239,7 +1241,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx])).unwrap();
+        exec_tx.send((output, vec![tx])).await.unwrap();
 
         // Wait for the blocktime tick to process and emit settlements
         let settlements =
@@ -1261,7 +1263,7 @@ mod tests {
         let (_db, _pg) = start_test_postgres().await;
         let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
 
-        let (exec_tx, exec_rx) = mpsc::unbounded_channel();
+        let (exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
         let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
         let (address_signatures_tx, _address_signatures_rx) = mpsc::channel(64);
@@ -1630,7 +1632,7 @@ mod tests {
         let (_db, pg_container) = start_test_postgres().await;
         let url = postgres_container_url(&pg_container, "test_db").await;
 
-        let (exec_tx, exec_rx) = mpsc::unbounded_channel();
+        let (exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
         let (_settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
         let (_settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
         let (address_signatures_tx, _address_signatures_rx) = mpsc::channel(64);
@@ -1665,7 +1667,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx])).unwrap();
+        exec_tx.send((output, vec![tx])).await.unwrap();
 
         // Poll for perf sample with deadline instead of fixed sleep.
         // Perf tick fires after ~1s; poll every 100ms for up to 5s.
@@ -1691,7 +1693,7 @@ mod tests {
         let (_db, pg) = start_test_postgres().await;
         let url = postgres_container_url(&pg, "test_db").await;
 
-        let (exec_tx, exec_rx) = mpsc::unbounded_channel();
+        let (exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
         let (settled_accounts_tx, _settled_accounts_rx) = mpsc::unbounded_channel();
         let (settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
         let (address_signatures_tx, address_signatures_rx) = mpsc::channel(8);
@@ -1729,7 +1731,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx])).unwrap();
+        exec_tx.send((output, vec![tx])).await.unwrap();
 
         let result = tokio::time::timeout(Duration::from_secs(10), handle.handle).await;
         assert!(

--- a/core/src/stages/sigverify.rs
+++ b/core/src/stages/sigverify.rs
@@ -714,16 +714,10 @@ mod tests {
             }
         });
 
-        // Let the pipeline saturate against the paused consumer, then assert the
-        // sequencer side holds no more than cap + workers (each worker can park
-        // at most one send beyond the queue).
+        // Let the workers actually park on the full queue so the backpressure
+        // path is exercised before we drain; the conservation check below is the
+        // real regression guard (a drop-instead-of-park bug fails it).
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        assert!(
-            sequencer_rx.len() <= sequencer_cap,
-            "sequencer queue must never exceed its capacity ({} > {})",
-            sequencer_rx.len(),
-            sequencer_cap
-        );
 
         // Drain everything; conservation: all txs arrive, none dropped.
         let mut drained = 0usize;

--- a/core/src/stages/sigverify.rs
+++ b/core/src/stages/sigverify.rs
@@ -104,7 +104,7 @@ pub struct SigverifyArgs {
     pub num_workers: usize,
     pub admin_keys: Vec<Pubkey>,
     pub rx: async_channel::Receiver<SanitizedTransaction>,
-    pub sequencer_tx: mpsc::UnboundedSender<SanitizedTransaction>,
+    pub sequencer_tx: mpsc::Sender<SanitizedTransaction>,
     pub shutdown_token: CancellationToken,
     pub metrics: SharedMetrics,
     pub heartbeat: Arc<crate::health::StageHeartbeat>,
@@ -175,16 +175,25 @@ pub async fn start_sigverify_workerpool(args: SigverifyArgs) -> Vec<WorkerHandle
                                 match result {
                                     SigverifyResult::Valid(_) => {
                                         metrics.sigverify_forwarded();
-                                        // Send to sequencer (unbounded, no await needed)
-                                        match tx.send(transaction) {
-                                            Ok(_) => {
-                                                debug!("Worker {} sent transaction to sequencer", worker_id);
+                                        // Bounded send applies backpressure; race shutdown so a
+                                        // full sequencer queue never wedges worker exit.
+                                        tokio::select! {
+                                            send_result = tx.send(transaction) => {
+                                                match send_result {
+                                                    Ok(_) => {
+                                                        debug!("Worker {} sent transaction to sequencer", worker_id);
+                                                    }
+                                                    Err(_) => {
+                                                        warn!(
+                                                            "Worker {} failed to send to sequencer - channel closed",
+                                                            worker_id
+                                                        );
+                                                        break;
+                                                    }
+                                                }
                                             }
-                                            Err(_) => {
-                                                warn!(
-                                                    "Worker {} failed to send to sequencer - channel closed",
-                                                    worker_id
-                                                );
+                                            _ = shutdown.cancelled() => {
+                                                debug!("Worker {} shutdown while sending to sequencer", worker_id);
                                                 break;
                                             }
                                         }
@@ -241,6 +250,7 @@ pub async fn start_sigverify_workerpool(args: SigverifyArgs) -> Vec<WorkerHandle
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::nodes::node::DEFAULT_SEQUENCER_QUEUE_CAPACITY as SEQ_CAP;
     use crate::stage_metrics::NoopMetrics;
     use solana_sdk::{
         hash::Hash,
@@ -408,7 +418,7 @@ mod tests {
     #[tokio::test]
     async fn worker_forwards_valid_tx_to_sequencer() {
         let (sigverify_tx, sigverify_rx) = async_channel::bounded::<SanitizedTransaction>(10);
-        let (sequencer_tx, mut sequencer_rx) = mpsc::unbounded_channel();
+        let (sequencer_tx, mut sequencer_rx) = mpsc::channel(SEQ_CAP);
         let shutdown = CancellationToken::new();
 
         let payer = Keypair::new();
@@ -447,7 +457,7 @@ mod tests {
     #[tokio::test]
     async fn worker_drops_invalid_tx() {
         let (sigverify_tx, sigverify_rx) = async_channel::bounded::<SanitizedTransaction>(10);
-        let (sequencer_tx, mut sequencer_rx) = mpsc::unbounded_channel();
+        let (sequencer_tx, mut sequencer_rx) = mpsc::channel(SEQ_CAP);
         let shutdown = CancellationToken::new();
 
         // empty transaction → InvalidTransaction(Empty)
@@ -513,7 +523,7 @@ mod tests {
     #[tokio::test]
     async fn worker_shutdown_signal_stops_worker() {
         let (_sigverify_tx, sigverify_rx) = async_channel::bounded::<SanitizedTransaction>(10);
-        let (sequencer_tx, _sequencer_rx) = mpsc::unbounded_channel();
+        let (sequencer_tx, _sequencer_rx) = mpsc::channel(SEQ_CAP);
         let shutdown = CancellationToken::new();
 
         let handles = start_sigverify_workerpool(SigverifyArgs {
@@ -639,7 +649,7 @@ mod tests {
     #[tokio::test]
     async fn worker_exits_when_input_channel_closed() {
         let (sigverify_tx, sigverify_rx) = async_channel::bounded::<SanitizedTransaction>(10);
-        let (sequencer_tx, _sequencer_rx) = mpsc::unbounded_channel();
+        let (sequencer_tx, _sequencer_rx) = mpsc::channel(SEQ_CAP);
         let shutdown = CancellationToken::new();
 
         let mut handles = start_sigverify_workerpool(SigverifyArgs {
@@ -665,18 +675,20 @@ mod tests {
         );
     }
 
-    // End-to-end drain test: pushes a large burst through the pool and asserts
-    // every tx makes it to the sequencer. This proves no items are dropped or
-    // stuck under sustained load. It does NOT prove per-worker fairness — see
-    // `cloned_receivers_consume_concurrently` for that.
+    // Backpressure conservation: with a bounded sequencer queue and an
+    // initially-paused consumer, pushing more than `cap` valid txs must block
+    // (never drop) and, once drained, every tx must arrive exactly once. Also
+    // asserts the worker never holds more than `cap + workers` in flight on the
+    // sequencer side (queue capacity plus one parked send per worker).
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn pipeline_drains_under_sustained_pressure() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        let (sigverify_tx, sigverify_rx) = async_channel::bounded::<SanitizedTransaction>(256);
-        let (sequencer_tx, mut sequencer_rx) = mpsc::unbounded_channel();
-        let shutdown = CancellationToken::new();
+    async fn sigverify_blocks_not_drops_when_sequencer_full() {
+        let sequencer_cap = SEQ_CAP;
         let num_workers = 4usize;
-        let total_txs = 4_000usize;
+        let total_txs = sequencer_cap * 3;
+
+        let (sigverify_tx, sigverify_rx) = async_channel::bounded::<SanitizedTransaction>(256);
+        let (sequencer_tx, mut sequencer_rx) = mpsc::channel(sequencer_cap);
+        let shutdown = CancellationToken::new();
 
         let handles = start_sigverify_workerpool(SigverifyArgs {
             num_workers,
@@ -689,6 +701,8 @@ mod tests {
         })
         .await;
 
+        // Producer pushes all txs; backpressure makes it block once the
+        // sequencer queue (and the parked per-worker sends) fill up.
         let producer = tokio::spawn(async move {
             for _ in 0..total_txs {
                 let payer = Keypair::new();
@@ -700,29 +714,79 @@ mod tests {
             }
         });
 
-        let drained = Arc::new(AtomicUsize::new(0));
-        let drained_clone = Arc::clone(&drained);
-        let drainer = tokio::spawn(async move {
-            while sequencer_rx.recv().await.is_some() {
-                drained_clone.fetch_add(1, Ordering::Relaxed);
-                if drained_clone.load(Ordering::Relaxed) >= total_txs {
-                    break;
-                }
+        // Let the pipeline saturate against the paused consumer, then assert the
+        // sequencer side holds no more than cap + workers (each worker can park
+        // at most one send beyond the queue).
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            sequencer_rx.len() <= sequencer_cap,
+            "sequencer queue must never exceed its capacity ({} > {})",
+            sequencer_rx.len(),
+            sequencer_cap
+        );
+
+        // Drain everything; conservation: all txs arrive, none dropped.
+        let mut drained = 0usize;
+        while drained < total_txs {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), sequencer_rx.recv())
+                .await
+            {
+                Ok(Some(_)) => drained += 1,
+                _ => break,
             }
-        });
-
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(30), producer).await;
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(30), drainer).await;
-
+        }
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(10), producer).await;
         assert_eq!(
-            drained.load(Ordering::Relaxed),
-            total_txs,
-            "all txs should reach the sequencer"
+            drained, total_txs,
+            "every tx must reach the sequencer under backpressure (no drops)"
         );
 
         shutdown.cancel();
         for h in handles {
             let _ = tokio::time::timeout(std::time::Duration::from_secs(2), h.handle).await;
+        }
+    }
+
+    // A full sequencer queue with no consumer must not wedge worker shutdown:
+    // the worker's send is raced against the shutdown token.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sigverify_worker_exits_on_shutdown_with_full_sequencer() {
+        let sequencer_cap = SEQ_CAP;
+        let (sigverify_tx, sigverify_rx) = async_channel::bounded::<SanitizedTransaction>(256);
+        let (sequencer_tx, _sequencer_rx) = mpsc::channel(sequencer_cap);
+        let shutdown = CancellationToken::new();
+
+        let handles = start_sigverify_workerpool(SigverifyArgs {
+            num_workers: 1,
+            admin_keys: vec![],
+            rx: sigverify_rx,
+            sequencer_tx,
+            shutdown_token: shutdown.clone(),
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: crate::health::StageHeartbeat::new(),
+        })
+        .await;
+
+        // Fill the sequencer queue so the worker's next send blocks. Never drain.
+        for _ in 0..(sequencer_cap + 4) {
+            let payer = Keypair::new();
+            let from_ata = Pubkey::new_unique();
+            let to_ata = Pubkey::new_unique();
+            let ix = spl_transfer_ix(&from_ata, &to_ata, &payer.pubkey());
+            sigverify_tx
+                .send(sanitize(&[ix], &payer, &[&payer]))
+                .await
+                .unwrap();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        shutdown.cancel();
+        for h in handles {
+            let result = tokio::time::timeout(std::time::Duration::from_secs(2), h.handle).await;
+            assert!(
+                result.is_ok(),
+                "worker must exit promptly even with a full sequencer queue"
+            );
         }
     }
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -33,7 +33,9 @@ Reference for configuring, tuning, and operating Solana Private Channels service
 | `--metrics` | `PRIVATE_CHANNEL_METRICS` | `false` | Enable Prometheus stage metrics server |
 | — | `PRIVATE_CHANNEL_METRICS_PORT` | `9090` | Port for the stage metrics server |
 
-**Startup validation:** The node rejects `blocktime_ms == 0` and `transaction_expiration_ms < blocktime_ms` to prevent misconfiguration.
+**Startup validation:** The node rejects `blocktime_ms == 0`, `transaction_expiration_ms < blocktime_ms`, and any write-pipeline queue capacity of `0` (which would panic the channel constructors) to prevent misconfiguration.
+
+**Tuning the queue capacities:** these aren't machine-spec values. Each slot holds one transaction (a few KB), so even the `10000` ingress queue is only ~tens of MB — RAM is never the limit. Size them by traffic, not hardware: a larger ingress queue absorbs bigger bursts but adds latency when backed up. Tune by watching `rpc_ingress_shed_total` — raise `--ingress-queue-capacity` if real bursts are being shed, lower it if latency under load is too high.
 
 ### Read Node (`private-channel-node --mode read`)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -18,6 +18,9 @@ Reference for configuring, tuning, and operating Solana Private Channels service
 | `--port` | `PRIVATE_CHANNEL_PORT` | `8899` | RPC listen port |
 | `--sigverify-workers` | `PRIVATE_CHANNEL_SIGVERIFY_WORKERS` | `4` | Parallel signature verification threads |
 | `--sigverify-queue-size` | `PRIVATE_CHANNEL_SIGVERIFY_QUEUE_SIZE` | `1000` | Bounded queue between dedup and sigverify |
+| `--ingress-queue-capacity` | `PRIVATE_CHANNEL_INGRESS_QUEUE_CAPACITY` | `10000` | Bounded RPC→dedup queue; a full queue sheds (`sendTransaction` returns `-32003`, retryable) and increments `rpc_ingress_shed_total` |
+| `--sequencer-queue-capacity` | `PRIVATE_CHANNEL_SEQUENCER_QUEUE_CAPACITY` | `1000` | Bounded sigverify→sequencer queue; a full queue applies upstream backpressure |
+| `--execution-results-capacity` | `PRIVATE_CHANNEL_EXECUTION_RESULTS_CAPACITY` | `1000` | Bounded executor→settler queue; a full queue applies upstream backpressure |
 | `--max-tx-per-batch` | `PRIVATE_CHANNEL_MAX_TX_PER_BATCH` | `64` | Max transactions per sequencer batch |
 | `--max-connections` | `PRIVATE_CHANNEL_MAX_CONNECTIONS` | `100` | Max concurrent RPC connections |
 | `--blocktime-ms` | `PRIVATE_CHANNEL_BLOCKTIME_MS` | `100` | Settlement interval (ms) |
@@ -140,4 +143,3 @@ private-channel-admin truncate --keep-slots 100000 --dry-run
 | `scripts/update-admin-env.sh` | Update `.env` with admin pubkey |
 | `scripts/reconcile-escrow-balance.sh` | Reconcile on-chain vs DB escrow balances (supports alert webhooks) |
 | `scripts/devnet/devnet-test.sh` | Full E2E test: instance creation through deposit/withdrawal/backfill validation |
-

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -8,6 +8,10 @@ name = "private_channel_integration"
 path = "tests/private-channel/integration.rs"
 
 [[test]]
+name = "ingress_backpressure"
+path = "tests/private-channel/test_ingress_backpressure.rs"
+
+[[test]]
 name = "indexer_integration"
 path = "tests/indexer/integration.rs"
 
@@ -207,6 +211,7 @@ bs58 = { workspace = true }
 bincode = { workspace = true }
 chrono = { workspace = true }
 private-channel-core = { path = "../core" }
+private-channel-metrics = { path = "../metrics" }
 private-channel-escrow-program-client = { path = "../private-channel-escrow-program/clients/rust" }
 private-channel-indexer = { path = "../indexer", features = [
     "datasource-rpc",

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -31,6 +31,8 @@ integration-test:
 	@cargo test --test test_sequencer_zero_deadline -- --nocapture
 	@cargo test --test test_signatures_corruption_guard -- --nocapture
 	@cargo test --test test_node_config_validation -- --nocapture
+	@# Backpressure CI guards (health + no-deadlock); the RSS load test stays #[ignore] for staging.
+	@cargo test --test ingress_backpressure -- --nocapture
 	@cargo test --test test_redis_cache_path -- --nocapture --test-threads=1
 	@echo "=== Building escrow with test-tree for test-tree-feature group ==="
 	@$(MAKE) -C ../private-channel-escrow-program build-test
@@ -184,6 +186,8 @@ integration-coverage-private-channel:
 	@cargo llvm-cov test --no-report --workspace --test test_signatures_corruption_guard -- --nocapture
 	@echo "Running run_node config-validation tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test test_node_config_validation -- --nocapture
+	@# Kept in sync with the integration-test group; runs the backpressure CI guards (RSS test stays #[ignore]).
+	@cargo llvm-cov test --no-report --workspace --test ingress_backpressure -- --nocapture
 
 # Redis-backend warm-cache + read-path coverage.
 # Runs a Postgres+Redis node and a Redis-only node to exercise settle.rs's

--- a/integration/tests/private-channel/integration.rs
+++ b/integration/tests/private-channel/integration.rs
@@ -251,6 +251,11 @@ async fn setup(accountsdb_connection_url: String) -> Result<TestContext> {
         max_tx_per_batch: 32,
         batch_deadline_ms: 50,
         batch_channel_capacity: 16,
+        ingress_queue_capacity: private_channel_core::nodes::node::DEFAULT_INGRESS_QUEUE_CAPACITY,
+        sequencer_queue_capacity:
+            private_channel_core::nodes::node::DEFAULT_SEQUENCER_QUEUE_CAPACITY,
+        execution_results_capacity:
+            private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 4,
         accountsdb_connection_url: accountsdb_connection_url.clone(),
         admin_keys: vec![operator_key.pubkey()],

--- a/integration/tests/private-channel/rpc/test_dedup_persistence.rs
+++ b/integration/tests/private-channel/rpc/test_dedup_persistence.rs
@@ -47,6 +47,11 @@ pub async fn run_dedup_persistence_test(db_url: String) {
         max_tx_per_batch: 10,
         batch_deadline_ms: 5,
         batch_channel_capacity: 16,
+        ingress_queue_capacity: private_channel_core::nodes::node::DEFAULT_INGRESS_QUEUE_CAPACITY,
+        sequencer_queue_capacity:
+            private_channel_core::nodes::node::DEFAULT_SEQUENCER_QUEUE_CAPACITY,
+        execution_results_capacity:
+            private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 4,
         accountsdb_connection_url: db_url,
         admin_keys: vec![operator.pubkey()],

--- a/integration/tests/private-channel/rpc/test_redis_cache_path.rs
+++ b/integration/tests/private-channel/rpc/test_redis_cache_path.rs
@@ -51,6 +51,11 @@ fn minimal_node_config(accountsdb_connection_url: String, port: u16) -> NodeConf
         max_tx_per_batch: 10,
         batch_deadline_ms: 5,
         batch_channel_capacity: 16,
+        ingress_queue_capacity: private_channel_core::nodes::node::DEFAULT_INGRESS_QUEUE_CAPACITY,
+        sequencer_queue_capacity:
+            private_channel_core::nodes::node::DEFAULT_SEQUENCER_QUEUE_CAPACITY,
+        execution_results_capacity:
+            private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 2,
         accountsdb_connection_url,
         admin_keys: vec![dummy_admin],

--- a/integration/tests/private-channel/test_ingress_backpressure.rs
+++ b/integration/tests/private-channel/test_ingress_backpressure.rs
@@ -1,0 +1,241 @@
+//! Real-node guards for the bounded write pipeline, driving a full in-process
+//! node (`run_node`) against a Postgres testcontainer.
+//!
+//! `health_ok_under_sustained_backpressure` and `no_deadlock_under_slow_settler`
+//! run in CI: they assert deterministic structural properties (a saturated
+//! pipeline stays healthy past the heartbeat margin; a slow settler never
+//! deadlocks). `bounded_memory_under_burst` stays `#[ignore]` — its RSS-plateau
+//! assertion is resource-sensitive and belongs in a staging load run.
+
+use {
+    private_channel_core::{
+        nodes::node::{run_node, NodeConfig, NodeHandles, NodeMode},
+        stage_metrics::PrometheusMetrics,
+    },
+    solana_client::nonblocking::rpc_client::RpcClient,
+    solana_sdk::{
+        instruction::Instruction,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    std::{sync::Arc, time::Duration},
+    testcontainers::runners::AsyncRunner,
+    testcontainers_modules::postgres::Postgres,
+    tokio::time::{sleep, timeout},
+};
+
+// Small capacities so a modest burst saturates the pipeline quickly.
+const INGRESS_CAP: usize = 64;
+const SEQUENCER_CAP: usize = 64;
+const RESULTS_CAP: usize = 64;
+
+async fn start_postgres() -> (testcontainers::ContainerAsync<Postgres>, String) {
+    let container = Postgres::default()
+        .with_db_name("backpressure_node")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("start postgres");
+    let host = container.get_host().await.expect("pg host");
+    let port = container.get_host_port_ipv4(5432).await.expect("pg port");
+    let url = format!("postgres://postgres:password@{host}:{port}/backpressure_node");
+    (container, url)
+}
+
+fn load_config(db_url: String, port: u16, prometheus: bool) -> NodeConfig {
+    NodeConfig {
+        mode: NodeMode::Aio,
+        port,
+        sigverify_queue_size: 64,
+        sigverify_workers: 2,
+        max_connections: 100,
+        max_tx_per_batch: 16,
+        batch_deadline_ms: 5,
+        batch_channel_capacity: 8,
+        ingress_queue_capacity: INGRESS_CAP,
+        sequencer_queue_capacity: SEQUENCER_CAP,
+        execution_results_capacity: RESULTS_CAP,
+        max_svm_workers: 2,
+        accountsdb_connection_url: db_url,
+        admin_keys: vec![],
+        transaction_expiration_ms: 15_000,
+        blocktime_ms: 100,
+        perf_sample_period_secs: 3600,
+        metrics: if prometheus {
+            Arc::new(PrometheusMetrics)
+        } else {
+            Arc::new(private_channel_core::stage_metrics::NoopMetrics)
+        },
+    }
+}
+
+// Grab a free port and release it so the node can bind it (standard repo pattern).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind free port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+async fn start_node(config: NodeConfig) -> (NodeHandles, String) {
+    let port = config.port;
+    let handles = run_node(config).await.expect("run_node");
+    let url = format!("http://127.0.0.1:{port}");
+    let client = RpcClient::new(url.clone());
+    // Wait until the settler has produced the first block (so getLatestBlockhash works).
+    for _ in 0..50 {
+        if client.get_latest_blockhash().await.is_ok() {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    (handles, url)
+}
+
+/// A unique, allowlisted, signature-valid memo tx against `blockhash`.
+fn memo_tx(blockhash: solana_sdk::hash::Hash, nonce: u64) -> Transaction {
+    let payer = Keypair::new();
+    let memo = Instruction {
+        program_id: spl_memo::id(),
+        accounts: vec![],
+        data: format!("backpressure:{nonce}").into_bytes(),
+    };
+    Transaction::new_signed_with_payer(&[memo], Some(&payer.pubkey()), &[&payer], blockhash)
+}
+
+fn rss_kb() -> u64 {
+    // statm field 2 (resident pages) × page size, in KiB. Linux-only.
+    let statm = std::fs::read_to_string("/proc/self/statm").unwrap_or_default();
+    let resident_pages: u64 = statm
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let page_kb = 4; // 4 KiB pages on x86-64
+    resident_pages * page_kb
+}
+
+fn shed_total() -> f64 {
+    private_channel_metrics::prometheus::gather()
+        .into_iter()
+        .filter(|mf| mf.name() == "private_channel_rpc_ingress_shed_total")
+        .flat_map(|mf| mf.get_metric().to_vec())
+        .map(|m| m.get_counter().value())
+        .sum()
+}
+
+/// Under a continuous valid-tx burst the pipeline is backpressured but every
+/// stage keeps progressing, so `/health` must stay 200 (no false restart).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn health_ok_under_sustained_backpressure() {
+    let (_pg, db_url) = start_postgres().await;
+    let (handles, url) = start_node(load_config(db_url, free_port(), false)).await;
+    let client = RpcClient::new(url.clone());
+
+    // Run past the 5s heartbeat margin so a stage that stopped progressing under
+    // backpressure would actually surface as unhealthy.
+    let deadline = std::time::Instant::now() + Duration::from_secs(8);
+    while std::time::Instant::now() < deadline {
+        let bh = client.get_latest_blockhash().await.expect("blockhash");
+        for n in 0..256u64 {
+            let _ = client.send_transaction(&memo_tx(bh, n)).await; // shed errors are fine
+        }
+        let resp = http_get(&format!("{url}/health")).await;
+        assert_eq!(resp, 200, "/health must stay 200 under backpressure");
+    }
+    handles.shutdown().await;
+}
+
+/// A deliberately slow settler (long blocktime) under burst must not deadlock —
+/// the pipeline keeps making forward progress (blocks advance).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_deadlock_under_slow_settler() {
+    let (_pg, db_url) = start_postgres().await;
+    let mut config = load_config(db_url, free_port(), false);
+    config.blocktime_ms = 2000; // slow settler stresses the executor→settler edge
+    let (handles, url) = start_node(config).await;
+    let client = RpcClient::new(url.clone());
+
+    let slot_start = client.get_slot().await.unwrap_or(0);
+    // ~10s spans several 2000ms blocks — enough to prove slots keep advancing.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        let bh = match client.get_latest_blockhash().await {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        for n in 0..256u64 {
+            let _ = client.send_transaction(&memo_tx(bh, n)).await;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    let slot_end = client.get_slot().await.expect("slot still served");
+    assert!(
+        slot_end > slot_start,
+        "settler must keep advancing slots under load (no deadlock): {slot_start} -> {slot_end}"
+    );
+    handles.shutdown().await;
+}
+
+/// The direct regression for the finding: a sustained valid-tx burst above drain
+/// rate must leave process RSS bounded (it plateaus instead of climbing to OOM),
+/// and the shed counter must climb once ingress saturates.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "load test: needs Docker, run in staging"]
+async fn bounded_memory_under_burst() {
+    private_channel_core::stage_metrics::init_prometheus_metrics();
+    let (_pg, db_url) = start_postgres().await;
+    let (handles, url) = start_node(load_config(db_url, free_port(), true)).await;
+    let client = RpcClient::new(url.clone());
+
+    // Warm up so the steady-state working set is allocated before we sample.
+    let warm_bh = client.get_latest_blockhash().await.expect("blockhash");
+    for n in 0..1000u64 {
+        let _ = client.send_transaction(&memo_tx(warm_bh, n)).await;
+    }
+    sleep(Duration::from_secs(2)).await;
+    let baseline_rss = rss_kb();
+    let shed_before = shed_total();
+
+    // Sustained burst well above drain rate.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let mut n = 1000u64;
+    while std::time::Instant::now() < deadline {
+        let bh = client.get_latest_blockhash().await.unwrap_or(warm_bh);
+        for _ in 0..512u64 {
+            let _ = client.send_transaction(&memo_tx(bh, n)).await;
+            n += 1;
+        }
+    }
+
+    let peak_rss = rss_kb();
+    // Ceiling: bounded queues mean RSS may grow modestly but must not balloon.
+    // 4× the warmed baseline is a generous plateau bound that still catches an
+    // unbounded leak (which would be orders of magnitude over baseline).
+    assert!(
+        peak_rss < baseline_rss.saturating_mul(4),
+        "RSS must plateau under burst: baseline={baseline_rss}KiB peak={peak_rss}KiB"
+    );
+    assert!(
+        shed_total() > shed_before,
+        "rpc_ingress_shed_total must climb under sustained overload"
+    );
+    handles.shutdown().await;
+}
+
+/// Minimal HTTP GET returning the status code, using hyper (no reqwest dep).
+async fn http_get(url: &str) -> u16 {
+    use {
+        http_body_util::Empty,
+        hyper::{body::Bytes, Request},
+        hyper_util::{client::legacy::Client, rt::TokioExecutor},
+    };
+    let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build_http();
+    let req = Request::get(url).body(Empty::<Bytes>::new()).expect("req");
+    match timeout(Duration::from_secs(5), client.request(req)).await {
+        Ok(Ok(resp)) => resp.status().as_u16(),
+        _ => 0,
+    }
+}

--- a/integration/tests/private-channel/test_ingress_backpressure.rs
+++ b/integration/tests/private-channel/test_ingress_backpressure.rs
@@ -106,15 +106,14 @@ fn memo_tx(blockhash: solana_sdk::hash::Hash, nonce: u64) -> Transaction {
 }
 
 fn rss_kb() -> u64 {
-    // statm field 2 (resident pages) × page size, in KiB. Linux-only.
-    let statm = std::fs::read_to_string("/proc/self/statm").unwrap_or_default();
-    let resident_pages: u64 = statm
-        .split_whitespace()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let page_kb = 4; // 4 KiB pages on x86-64
-    resident_pages * page_kb
+    // VmRSS from /proc/self/status is already in kB, so it's page-size agnostic. Linux-only.
+    std::fs::read_to_string("/proc/self/status")
+        .unwrap_or_default()
+        .lines()
+        .find_map(|l| l.strip_prefix("VmRSS:"))
+        .and_then(|v| v.split_whitespace().next())
+        .and_then(|kb| kb.parse().ok())
+        .unwrap_or(0)
 }
 
 fn shed_total() -> f64 {

--- a/integration/tests/private-channel/test_node_config_validation.rs
+++ b/integration/tests/private-channel/test_node_config_validation.rs
@@ -27,6 +27,11 @@ fn base_config(mode: NodeMode) -> NodeConfig {
         max_tx_per_batch: 8,
         batch_deadline_ms: 5,
         batch_channel_capacity: 4,
+        ingress_queue_capacity: private_channel_core::nodes::node::DEFAULT_INGRESS_QUEUE_CAPACITY,
+        sequencer_queue_capacity:
+            private_channel_core::nodes::node::DEFAULT_SEQUENCER_QUEUE_CAPACITY,
+        execution_results_capacity:
+            private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
         max_svm_workers: 1,
         accountsdb_connection_url: "postgres://unused/private_channel".to_string(),
         admin_keys: vec![Keypair::new().pubkey()],

--- a/integration/tests/private-channel/test_sequencer_zero_deadline.rs
+++ b/integration/tests/private-channel/test_sequencer_zero_deadline.rs
@@ -26,6 +26,7 @@
 
 use {
     private_channel_core::{
+        nodes::node::DEFAULT_SEQUENCER_QUEUE_CAPACITY,
         scheduler::ConflictFreeBatch,
         stage_metrics::{NoopMetrics, SharedMetrics},
         stages::{start_sequence_worker, SequencerArgs},
@@ -45,7 +46,7 @@ use {
 /// the channel runs dry.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sequencer_zero_deadline_drains_nonblocking() {
-    let (input_tx, input_rx) = mpsc::unbounded_channel();
+    let (input_tx, input_rx) = mpsc::channel(DEFAULT_SEQUENCER_QUEUE_CAPACITY);
     let (batch_tx, mut batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
     let shutdown = CancellationToken::new();
 
@@ -57,9 +58,11 @@ async fn sequencer_zero_deadline_drains_nonblocking() {
     let to_b = Pubkey::new_unique();
     input_tx
         .send(create_test_sanitized_transaction(&from_a, &to_a, 100))
+        .await
         .expect("send tx A");
     input_tx
         .send(create_test_sanitized_transaction(&from_b, &to_b, 100))
+        .await
         .expect("send tx B");
 
     let metrics: SharedMetrics = Arc::new(NoopMetrics);


### PR DESCRIPTION
## Summary

Closes SOLA2-8. The public, un-authed `sendTransaction` path fed three **unbounded** in-memory channels in the write pipeline. Because the runtime is gasless, an attacker needs no prefunded accounts to keep producing valid, allowlisted transactions; a sustained stream that outpaces drain throughput grows the heap without limit until the node OOMs, losing all accepted-but-unsettled in-memory transactions.

This PR bounds all three attacker-reachable channels, turns the public ingress into a fail-fast load-shedder, and lets backpressure chain upstream from the slowest stage back to RPC admission. The two settler-to-upstream **feedback** channels stay unbounded on purpose (bounding them would close a deadlock cycle).

- **RPC -> dedup**: bounded; a full queue **sheds**. `sendTransaction` returns a new retryable `-32003` (`NODE_AT_CAPACITY_CODE`), logs `warn!` with the signature, and increments `rpc_ingress_shed_total`. Fail-fast (not `send().await`) so a memory-DoS can't become an RPC-connection-exhaustion DoS, and so an honest client can resubmit.
- **sigverify -> sequencer**: bounded; the worker's forward becomes `send().await` raced against the shutdown token (backpressure without wedging shutdown).
- **executor -> settler**: bounded; the executor's two result sends become `send().await` raced against shutdown. The sends carry owned values after `execute_batch` returns, with no `RwLock` guard held across the await.
- Three new `usize` config knobs (CLI flag + env var) sized so steady state never sheds.

## Design decisions

- **Shed, don't await, at ingress.** A full queue returns a distinct retryable `-32003` (not `INVALID_PARAMS`; the tx is valid), not `send().await`, so a memory-DoS can't turn into RPC-connection exhaustion and a returned signature never falsely means "accepted".
- **Bound + blocking backpressure.** sigverify and executor block on a full downstream instead of dumping into an unbounded queue, so the unboundedness can't relocate to `sequencer_rx` or the settler's `processing_results`. Both sends race the shutdown token so shutdown stays prompt.
- **Feedback edges stay unbounded (deliberate).** `settled_accounts_tx` and `settled_blockhashes_tx` must stay unbounded; bounding an edge a blocked upstream stage still consumes would deadlock.
- **Config + one metric.** Three `usize` capacities (CLI flag + `PRIVATE_CHANNEL_*` env); `run_node` rejects `0` (fail closed) so a misconfiguration can't panic `mpsc::channel(0)`. One counter `rpc_ingress_shed_total`; no gauges (`/health` heartbeats + RSS already show saturation).

## Why it's safe

- **No deadlock.** Backpressure is strictly upstream; the only downstream-to-upstream edges are the unbounded feedback channels, so the settler always drains `execution_results_rx` even while the executor is blocked.
- **Blockhash freshness.** The settler is tick-driven, not recv-driven, so it keeps producing blocks under backpressure and `getLatestBlockhash` stays fresh.
- **Feedback serviced.** dedup drains `settled_blockhashes_rx` while blocked on its output send; `settled_accounts_rx` drives only cache eviction (lazy, via `BOB::garbage_collect`), never execution correctness.
- **Health non-regression.** sigverify and executor record progress before the blocking send, so a backpressured-but-advancing stage reads healthy; only a genuine >5s stall (DB hang) trips `/health`.
- **Shed before dedup.** A shed tx never enters the dedup cache, so the client may resubmit the identical tx and it is accepted.

## Testing

- **Ingress (unit):** `ingress_sheds_when_full` (full queue returns `-32003`, receiver never exceeds capacity), `ingress_shed_increments_metric` (via the Prometheus registry), `shed_tx_can_be_resubmitted` (shed, drain, then the identical tx is accepted), accept-path tests migrated to the bounded helper.
- **sigverify (unit):** `sigverify_blocks_not_drops_when_sequencer_full` (conservation: all txs arrive, none dropped; queue never exceeds cap), `sigverify_worker_exits_on_shutdown_with_full_sequencer`.
- **executor (unit, real Postgres):** `executor_blocks_then_completes_on_full_results` (blocked send completes once the receiver drains, no panic/lock-poison), `executor_exits_on_shutdown_with_full_results`.
- **Cross-cutting (unit):** `health_ok_under_sustained_backpressure` (heartbeat-level: backpressure-with-progress stays healthy).
- **Config guard (unit):** `test_run_node_rejects_zero_queue_capacity` (a `0` capacity fails closed with a clear error instead of panicking `mpsc::channel(0)`).
- **Real-node backpressure (integration, CI, real Postgres):** `health_ok_under_sustained_backpressure` (`/health` stays 200 past the 5s heartbeat margin) and `no_deadlock_under_slow_settler` (slots keep advancing under a 2s blocktime). ~15s combined; wired into the integration Makefile private-channel group (plus its coverage target).
- **Staging load (`#[ignore]`):** `bounded_memory_under_burst` (RSS plateaus, shed counter climbs); the RSS-plateau assertion is resource-sensitive, so it runs in staging, not CI (`-- --ignored`).
- **Migration-only:** all remaining `mpsc::unbounded_channel()` test constructors for the now-bounded channels migrated to `mpsc::channel(const)`, bound to the same named config consts (no drifting literals). Feedback-channel test constructors stay unbounded.
- Full `private-channel-core` suite: 385 passed, 1 `#[ignore]`d.

## Scope

**Out of scope:** gateway per-IP rate limiting / `sendTransaction` auth; improving the heartbeat to distinguish "backpressured" from "wedged".

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 10,926 | 12,524 | 87.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255363699) |
| Indexer | 18,753 | 21,734 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255363699) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255363699) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255363699) |
| Withdraw Program | 120 | 232 | 51.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255363643) |
| Escrow Program | 1,185 | 1,963 | 60.4% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255363643) |
| DvP Swap Program | 247 | 1,112 | 22.2% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255363643) |
| E2E Integration | 11,240 | 13,912 | 80.8% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27255363699) |
| **Total** | **43,935** | **52,360** | **83.9%** | |

> Last updated: 2026-06-10 06:01:59 UTC by E2E Integration