### PR TITLE
fix(escrow): make ResetSmtRoot idempotent (SOLA3-4)

### DIFF
--- a/admin-ui/src/components/OperatorFunctions.tsx
+++ b/admin-ui/src/components/OperatorFunctions.tsx
@@ -6,7 +6,7 @@ import { useCluster } from '../hooks/useCluster';
 import { address } from '@solana/addresses';
 import { useWalletAccountTransactionSendingSigner } from '@solana/react';
 import { getBase58Decoder } from '@solana/codecs-strings';
-import { getReleaseFundsInstructionAsync, getResetSmtRootInstructionAsync } from '@private-channel-escrow';
+import { getReleaseFundsInstructionAsync, getResetSmtRootInstructionAsync, fetchInstance } from '@private-channel-escrow';
 import { findAssociatedTokenPda } from '@solana-program/token';
 import {
   pipe,
@@ -157,11 +157,16 @@ function OperatorFunctionsContent({ instancePubkey, account, network }: Operator
       setError('');
       setSuccess(null);
 
+      // Bind the reset to the instance's current tree index so a replay (e.g. an
+      // ambiguously-confirmed retry) is rejected on-chain instead of rotating twice.
+      const instanceAccount = await fetchInstance(rpc, address(instancePubkey));
+
       // Get the reset SMT root instruction
       const instruction = await getResetSmtRootInstructionAsync({
         payer: transactionSigner,
         operator: transactionSigner,
         instance: address(instancePubkey),
+        expectedCurrentTreeIndex: instanceAccount.data.currentTreeIndex,
       });
 
       console.log('Created reset SMT root instruction:', instruction);

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -153,6 +153,26 @@ impl SenderState {
         Ok(())
     }
 
+    /// Read the authoritative current_tree_index from the on-chain instance.
+    pub(super) async fn fetch_onchain_tree_index(&self) -> Result<u64, OperatorError> {
+        let instance_pda = self.instance_pda.ok_or(AccountError::InstanceNotFound {
+            instance: Pubkey::default(),
+        })?;
+        let data = self
+            .rpc_client
+            .get_account_data(&instance_pda)
+            .await
+            .map_err(|_| AccountError::AccountNotFound {
+                pubkey: instance_pda,
+            })?;
+        let instance =
+            parse_instance(&data).map_err(|e| AccountError::AccountDeserializationFailed {
+                pubkey: instance_pda,
+                reason: e.to_string(),
+            })?;
+        Ok(instance.current_tree_index)
+    }
+
     /// Sends a ManualReview status update during startup recovery when a stored            
     /// transaction cannot be reconstructed (e.g. unparseable pubkey or signature).         
     /// Using send_guaranteed so the alert is never silently dropped.                       

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -110,12 +110,19 @@ impl SenderState {
                     compute_budget,
                 })
             }
-            TransactionBuilder::ResetSmtRoot(ref builder) => {
-                let in_flight_count = self
+            TransactionBuilder::ResetSmtRoot(mut builder) => {
+                // Bind the reset to our local tree index so the on-chain program
+                // rejects a replay. Initialize SMT state first in case a reset is
+                // the first thing we process after a restart.
+                if self.smt_state.is_none() {
+                    self.initialize_smt_state().await?;
+                }
+                let smt = self
                     .smt_state
                     .as_ref()
-                    .map(|s| s.nonce_to_builder.len())
-                    .unwrap_or(0);
+                    .ok_or(ProgramError::SmtNotInitialized)?;
+                let in_flight_count = smt.nonce_to_builder.len();
+                let expected_current_tree_index = smt.smt_state.tree_index();
 
                 if in_flight_count > 0 {
                     info!(
@@ -123,14 +130,15 @@ impl SenderState {
                         in_flight_count
                     );
 
-                    self.pending_rotation = Some(builder.clone());
+                    self.pending_rotation = Some(builder);
 
                     return Err(ProgramError::RotationPending { in_flight_count }.into());
                 }
 
                 // No in-flight transactions - process immediately
+                builder.expected_current_tree_index(expected_current_tree_index);
                 Ok(InstructionWithSigners {
-                    instructions: tx_builder.instructions()?,
+                    instructions: vec![builder.instruction()],
                     fee_payer,
                     signers,
                     compute_budget,
@@ -539,6 +547,27 @@ pub(super) fn handle_confirmation_result<'a>(
                     .await;
                 }
             },
+            Ok(ConfirmationResult::Failed(Some(
+                PrivateChannelEscrowProgramError::UnexpectedTreeIndex,
+            ))) => {
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[pt, "reset_tree_already_advanced"])
+                    .inc();
+                // Rejected because a reset already advanced the tree on-chain. Sync
+                // local SMT to the authoritative index. On fetch failure, leave it
+                // unchanged rather than guess; a restart re-syncs from chain.
+                match state.fetch_onchain_tree_index().await {
+                    Ok(idx) => {
+                        if let Some(ref mut smt_state) = state.smt_state {
+                            smt_state.smt_state.reset(idx);
+                        }
+                        warn!("ResetSmtRoot rejected - synced local SMT to on-chain tree_index {idx}");
+                    }
+                    Err(e) => error!(
+                        "ResetSmtRoot rejected but tree index re-fetch failed: {e} - local SMT left unchanged"
+                    ),
+                }
+            }
             Ok(ConfirmationResult::Failed(program_error)) => {
                 metrics::OPERATOR_TRANSACTION_ERRORS
                     .with_label_values(&[pt, "program_error"])
@@ -1264,8 +1293,14 @@ mod tests {
     use crate::operator::MintCache;
     use crate::storage::common::storage::mock::MockStorage;
     use crate::storage::common::storage::Storage;
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+    use borsh::BorshSerialize;
     use private_channel_escrow_program_client::errors::PrivateChannelEscrowProgramError;
     use private_channel_escrow_program_client::instructions::ReleaseFundsBuilder;
+    use private_channel_escrow_program_client::Instance;
+    use solana_client::nonblocking::rpc_client::RpcClient;
+    use solana_client::rpc_request::RpcRequest;
     use solana_keychain::Signer;
     use solana_sdk::commitment_config::CommitmentConfig;
     use solana_sdk::pubkey::Pubkey;
@@ -1918,6 +1953,151 @@ mod tests {
         let update = rx.recv().await.unwrap();
         assert_eq!(update.transaction_id, 11);
         assert_eq!(update.status, TransactionStatus::Failed);
+    }
+
+    /// A reset rejected with UnexpectedTreeIndex means a reset already landed on-chain.
+    /// The sender must re-fetch the authoritative tree index, sync local SMT to it, and
+    /// write nothing to the storage channel (a reset has no DB row).
+    #[tokio::test]
+    async fn confirmation_result_unexpected_tree_index_resyncs_local_smt() {
+        let local_index = 4u64;
+        let onchain_index = 5u64;
+
+        let instance = Instance {
+            discriminator: 0,
+            bump: 0,
+            version: 0,
+            instance_seed: Pubkey::new_unique(),
+            admin: Pubkey::new_unique(),
+            withdrawal_transactions_root: [0u8; 32],
+            current_tree_index: onchain_index,
+        };
+        let mut instance_bytes = Vec::new();
+        instance.serialize(&mut instance_bytes).unwrap();
+
+        let account_response = serde_json::json!({
+            "context": {"slot": 1},
+            "value": {
+                "owner": Pubkey::new_unique().to_string(),
+                "lamports": 1_000_000u64,
+                "data": [STANDARD.encode(&instance_bytes), "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        });
+        let mut mocks = HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, account_response);
+
+        let mut state = make_sender_state();
+        state.instance_pda = Some(Pubkey::new_unique());
+        state.rpc_client = Arc::new(RpcClientWithRetry {
+            rpc_client: Arc::new(RpcClient::new_mock_with_mocks(
+                "http://127.0.0.1:8899".to_string(),
+                mocks,
+            )),
+            retry_config: RetryConfig::default(),
+        });
+        state.smt_state = Some(SenderSMTState {
+            smt_state: SmtState::new(local_index),
+            nonce_to_builder: HashMap::new(),
+        });
+
+        let (tx, mut rx) = mpsc::channel(10);
+        let ctx = TransactionContext {
+            transaction_id: None,
+            withdrawal_nonce: None,
+            trace_id: None,
+        };
+
+        handle_confirmation_result(
+            &mut state,
+            Ok(ConfirmationResult::Failed(Some(
+                PrivateChannelEscrowProgramError::UnexpectedTreeIndex,
+            ))),
+            Signature::new_unique(),
+            None,
+            &ctx,
+            dummy_instruction(),
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &tx,
+        )
+        .await;
+
+        assert_eq!(
+            state.smt_state.as_ref().unwrap().smt_state.tree_index(),
+            onchain_index
+        );
+        drop(tx);
+        assert!(
+            rx.recv().await.is_none(),
+            "no status update expected for reset"
+        );
+    }
+
+    /// If the on-chain re-fetch fails (here: an undeserializable instance account), the
+    /// sender must leave local SMT unchanged (fail-closed) rather than guessing the index.
+    #[tokio::test]
+    async fn confirmation_result_unexpected_tree_index_fetch_failure_leaves_smt_unchanged() {
+        let local_index = 4u64;
+
+        // Too-short account data so parse_instance fails after a successful fetch.
+        let account_response = serde_json::json!({
+            "context": {"slot": 1},
+            "value": {
+                "owner": Pubkey::new_unique().to_string(),
+                "lamports": 1_000_000u64,
+                "data": [STANDARD.encode([0u8; 4]), "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        });
+        let mut mocks = HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, account_response);
+
+        let mut state = make_sender_state();
+        state.instance_pda = Some(Pubkey::new_unique());
+        state.rpc_client = Arc::new(RpcClientWithRetry {
+            rpc_client: Arc::new(RpcClient::new_mock_with_mocks(
+                "http://127.0.0.1:8899".to_string(),
+                mocks,
+            )),
+            retry_config: RetryConfig::default(),
+        });
+        state.smt_state = Some(SenderSMTState {
+            smt_state: SmtState::new(local_index),
+            nonce_to_builder: HashMap::new(),
+        });
+
+        let (tx, mut rx) = mpsc::channel(10);
+        let ctx = TransactionContext {
+            transaction_id: None,
+            withdrawal_nonce: None,
+            trace_id: None,
+        };
+
+        handle_confirmation_result(
+            &mut state,
+            Ok(ConfirmationResult::Failed(Some(
+                PrivateChannelEscrowProgramError::UnexpectedTreeIndex,
+            ))),
+            Signature::new_unique(),
+            None,
+            &ctx,
+            dummy_instruction(),
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &tx,
+        )
+        .await;
+
+        assert_eq!(
+            state.smt_state.as_ref().unwrap().smt_state.tree_index(),
+            local_index,
+            "local SMT must be unchanged when re-fetch fails"
+        );
+        drop(tx);
+        assert!(rx.recv().await.is_none());
     }
 
     /// A `Retry` result with `RetryPolicy::None` (non-idempotent operation) cannot be safely

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -556,13 +556,13 @@ pub(super) fn handle_confirmation_result<'a>(
                 // Rejected because a reset already advanced the tree on-chain. Sync
                 // local SMT to the authoritative index. On fetch failure, leave it
                 // unchanged rather than guess; a restart re-syncs from chain.
+                // smt_state is always Some here: the reset submit path initializes
+                // it before sending, and nothing clears it back to None.
                 match state.fetch_onchain_tree_index().await {
                     Ok(idx) => {
                         if let Some(ref mut smt_state) = state.smt_state {
                             smt_state.smt_state.reset(idx);
                             warn!("ResetSmtRoot rejected - synced local SMT to on-chain tree_index {idx}");
-                        } else {
-                            warn!("ResetSmtRoot rejected - on-chain tree_index is {idx} but smt_state is None, sync skipped");
                         }
                     }
                     Err(e) => error!(

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -560,8 +560,10 @@ pub(super) fn handle_confirmation_result<'a>(
                     Ok(idx) => {
                         if let Some(ref mut smt_state) = state.smt_state {
                             smt_state.smt_state.reset(idx);
+                            warn!("ResetSmtRoot rejected - synced local SMT to on-chain tree_index {idx}");
+                        } else {
+                            warn!("ResetSmtRoot rejected - on-chain tree_index is {idx} but smt_state is None, sync skipped");
                         }
-                        warn!("ResetSmtRoot rejected - synced local SMT to on-chain tree_index {idx}");
                     }
                     Err(e) => error!(
                         "ResetSmtRoot rejected but tree index re-fetch failed: {e} - local SMT left unchanged"

--- a/indexer/src/operator/utils/instruction_util.rs
+++ b/indexer/src/operator/utils/instruction_util.rs
@@ -151,8 +151,9 @@ impl TransactionBuilder {
     ///   verification to prevent duplicate issuance.
     /// - **ReleaseFunds**: Idempotent retry - Uses transaction nonce to prevent duplicates.
     ///   Safe to retry on transient network failures.
-    /// - **ResetSmtRoot**: Idempotent retry - tree_index increments ensure idempotency.
-    ///   Safe to retry on transient network failures.
+    /// - **ResetSmtRoot**: Idempotent retry - carries expected_current_tree_index, so a
+    ///   replay after the first reset lands is rejected on-chain (UnexpectedTreeIndex)
+    ///   rather than advancing the tree twice; the sender then syncs local SMT.
     pub fn retry_policy(&self) -> RetryPolicy {
         match self {
             Self::Mint(_) => RetryPolicy::None,

--- a/indexer/src/operator/utils/transaction_util.rs
+++ b/indexer/src/operator/utils/transaction_util.rs
@@ -202,6 +202,7 @@ pub fn parse_program_error(
                 12 => Some(
                     PrivateChannelEscrowProgramError::InvalidTransactionNonceForCurrentTreeIndex,
                 ),
+                13 => Some(PrivateChannelEscrowProgramError::UnexpectedTreeIndex),
                 _ => None, // Ignore other program errors
             }
         }
@@ -307,6 +308,16 @@ mod tests {
         assert!(matches!(
             result,
             Some(PrivateChannelEscrowProgramError::InvalidTransactionNonceForCurrentTreeIndex)
+        ));
+    }
+
+    #[test]
+    fn parse_custom_13_unexpected_tree_index() {
+        let err = TransactionError::InstructionError(0, InstructionError::Custom(13));
+        let result = parse_program_error(&err);
+        assert!(matches!(
+            result,
+            Some(PrivateChannelEscrowProgramError::UnexpectedTreeIndex)
         ));
     }
 

--- a/private-channel-escrow-program/clients/typescript/tests/unit/instructions/resetSmtRoot.test.ts
+++ b/private-channel-escrow-program/clients/typescript/tests/unit/instructions/resetSmtRoot.test.ts
@@ -19,6 +19,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
             });
 
             const decodedData = getResetSmtRootInstructionDataCodec().decode(instruction.data);
@@ -28,7 +29,7 @@ describe('resetSmtRoot', () => {
             expect(decodedData.discriminator).toBe(8);
         });
 
-        it('should have no additional parameters beyond discriminator', async () => {
+        it('should encode discriminator and expectedCurrentTreeIndex', async () => {
             const payer = mockTransactionSigner(TEST_ADDRESSES.PAYER);
             const operator = mockTransactionSigner(TEST_ADDRESSES.OPERATOR);
 
@@ -36,13 +37,15 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
             });
 
             const decodedData = getResetSmtRootInstructionDataCodec().decode(instruction.data);
 
-            // ResetSmtRoot instruction should only have discriminator field
-            expect(Object.keys(decodedData)).toEqual(['discriminator']);
+            // ResetSmtRoot carries the discriminator plus the expected tree index
+            expect(Object.keys(decodedData)).toEqual(['discriminator', 'expectedCurrentTreeIndex']);
             expect(typeof decodedData.discriminator).toBe('number');
+            expect(decodedData.expectedCurrentTreeIndex).toBe(0n);
         });
 
         it('should decode instruction data correctly', async () => {
@@ -53,6 +56,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
             });
 
             // Decode the instruction data
@@ -63,7 +67,7 @@ describe('resetSmtRoot', () => {
             expect(typeof decodedData.discriminator).toBe('number');
 
             // Re-encode and verify it matches
-            const reEncodedData = getResetSmtRootInstructionDataCodec().encode({});
+            const reEncodedData = getResetSmtRootInstructionDataCodec().encode({ expectedCurrentTreeIndex: 0n });
             expect(reEncodedData).toEqual(instruction.data);
         });
     });
@@ -77,6 +81,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
             });
 
             // Based on program instruction definition, ResetSmtRoot should have 6 accounts
@@ -115,6 +120,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
             });
 
             // Account 0: payer - should be WritableSigner
@@ -150,6 +156,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
             });
 
             // Verify the instruction uses the correct program address
@@ -182,6 +189,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
                 // Not providing operatorPda - should be auto-derived
             });
 
@@ -197,6 +205,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
                 // Not providing eventAuthority or privateChannelEscrowProgram - should use defaults
             });
 
@@ -222,6 +231,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
                 operatorPda: overriddenOperatorPda,
                 eventAuthority: overriddenEventAuthority,
                 privateChannelEscrowProgram: overriddenPrivateChannelEscrowProgram,
@@ -243,6 +253,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
             });
 
             // Verify operator account is a signer
@@ -266,6 +277,7 @@ describe('resetSmtRoot', () => {
                     payer,
                     operator,
                     instance: TEST_ADDRESSES.INSTANCE,
+                    expectedCurrentTreeIndex: 0n,
                 });
 
                 // Verify operator account uses the correct address
@@ -295,6 +307,7 @@ describe('resetSmtRoot', () => {
                     payer,
                     operator,
                     instance: TEST_ADDRESSES.INSTANCE,
+                    expectedCurrentTreeIndex: 0n,
                 });
 
                 // Verify operatorPda is derived correctly for this operator
@@ -321,6 +334,7 @@ describe('resetSmtRoot', () => {
                     payer,
                     operator,
                     instance: instanceAddress,
+                    expectedCurrentTreeIndex: 0n,
                 });
 
                 // Verify instance account uses the correct address
@@ -338,6 +352,7 @@ describe('resetSmtRoot', () => {
                 payer,
                 operator,
                 instance: TEST_ADDRESSES.INSTANCE,
+                expectedCurrentTreeIndex: 0n,
             });
 
             // Verify account ordering is consistent
@@ -367,6 +382,7 @@ describe('resetSmtRoot', () => {
                     payer,
                     operator,
                     instance: TEST_ADDRESSES.INSTANCE,
+                    expectedCurrentTreeIndex: 0n,
                 });
 
                 // Verify payer account uses the correct address

--- a/private-channel-escrow-program/idl/private_channel_escrow_program.json
+++ b/private-channel-escrow-program/idl/private_channel_escrow_program.json
@@ -552,6 +552,12 @@
         "kind": "errorNode",
         "message": "Invalid transaction nonce for current tree index",
         "name": "invalidTransactionNonceForCurrentTreeIndex"
+      },
+      {
+        "code": 13,
+        "kind": "errorNode",
+        "message": "Unexpected current tree index for SMT root reset",
+        "name": "unexpectedTreeIndex"
       }
     ],
     "instructions": [
@@ -1612,6 +1618,15 @@
             "type": {
               "endian": "le",
               "format": "u8",
+              "kind": "numberTypeNode"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "expectedCurrentTreeIndex",
+            "type": {
+              "endian": "le",
+              "format": "u64",
               "kind": "numberTypeNode"
             }
           }

--- a/private-channel-escrow-program/program/src/error.rs
+++ b/private-channel-escrow-program/program/src/error.rs
@@ -56,6 +56,10 @@ pub enum PrivateChannelEscrowProgramError {
     /// (12) Invalid transaction nonce for current tree index
     #[error("Invalid transaction nonce for current tree index")]
     InvalidTransactionNonceForCurrentTreeIndex,
+
+    /// (13) ResetSmtRoot pre-state mismatch. Blocks replaying a landed reset.
+    #[error("Unexpected current tree index for SMT root reset")]
+    UnexpectedTreeIndex,
 }
 
 impl From<PrivateChannelEscrowProgramError> for ProgramError {
@@ -90,6 +94,7 @@ mod tests {
             (InvalidAllowedMint, 10),
             (InvalidSmtProof, 11),
             (InvalidTransactionNonceForCurrentTreeIndex, 12),
+            (UnexpectedTreeIndex, 13),
         ];
 
         for (error, expected_code) in cases {

--- a/private-channel-escrow-program/program/src/instructions.rs
+++ b/private-channel-escrow-program/program/src/instructions.rs
@@ -232,7 +232,11 @@ pub enum PrivateChannelEscrowProgramInstruction {
         name = "private_channel_escrow_program",
         docs = "Current program for CPI"
     ))]
-    ResetSmtRoot {} = 8,
+    ResetSmtRoot {
+        /// Tree index the caller expects the instance to be at. Rejected if it
+        /// no longer matches, so a replayed reset cannot advance the tree twice.
+        expected_current_tree_index: u64,
+    } = 8,
 
     /// Invoked via CPI from another program to log event via instruction data.
     #[codama(account(

--- a/private-channel-escrow-program/program/src/processor/reset_smt_root.rs
+++ b/private-channel-escrow-program/program/src/processor/reset_smt_root.rs
@@ -25,13 +25,21 @@ use pinocchio::{account::AccountView, error::ProgramError, Address, ProgramResul
 pub fn process_reset_smt_root(
     program_id: &Address,
     accounts: &[AccountView],
-    _instruction_data: &[u8],
+    instruction_data: &[u8],
 ) -> ProgramResult {
     let [payer_info, operator_info, instance_info, operator_pda_info, event_authority_info, program_info] =
         accounts
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
+
+    let expected_current_tree_index = u64::from_le_bytes(
+        instruction_data
+            .get(..8)
+            .ok_or(ProgramError::InvalidInstructionData)?
+            .try_into()
+            .map_err(|_| ProgramError::InvalidInstructionData)?,
+    );
 
     verify_signer(payer_info, true)?;
     verify_signer(operator_info, false)?;
@@ -61,6 +69,12 @@ pub fn process_reset_smt_root(
         .map_err(|_| PrivateChannelEscrowProgramError::InvalidOperatorPda)?;
 
     drop(instance_data);
+
+    // Reject a stale replay: the reset is not idempotent, so a second landing
+    // would advance current_tree_index again and skip a whole tree generation.
+    if instance.current_tree_index != expected_current_tree_index {
+        return Err(PrivateChannelEscrowProgramError::UnexpectedTreeIndex.into());
+    }
 
     instance.withdrawal_transactions_root = EMPTY_TREE_ROOT;
     instance.current_tree_index = instance

--- a/private-channel-escrow-program/tests/integration-tests/src/state_utils.rs
+++ b/private-channel-escrow-program/tests/integration-tests/src/state_utils.rs
@@ -532,6 +532,7 @@ pub fn assert_get_or_reset_smt_root(
         .operator_pda(*operator_pda)
         .event_authority(event_authority_pda)
         .private_channel_escrow_program(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID)
+        .expected_current_tree_index(previous_tree_index)
         .instruction();
 
     let transaction_metadata = context.send_transaction_with_signers_with_transaction_result(

--- a/private-channel-escrow-program/tests/integration-tests/src/test_reset_smt_root/mod.rs
+++ b/private-channel-escrow-program/tests/integration-tests/src/test_reset_smt_root/mod.rs
@@ -6,9 +6,11 @@ use crate::{
     utils::{
         assert_program_error, TestContext, INVALID_OPERATOR_ERROR,
         MISSING_REQUIRED_SIGNATURE_ERROR, PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
+        UNEXPECTED_TREE_INDEX_ERROR,
     },
 };
 
+use private_channel_escrow_program_client::{instructions::ResetSmtRootBuilder, Instance};
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     signature::{Keypair, Signer},
@@ -93,7 +95,8 @@ fn test_reset_smt_root_not_operator() {
         AccountMeta::new_readonly(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID, false), // private_channel_escrow_program
     ];
 
-    let data = vec![8]; // discriminator for ResetSmtRoot
+    let mut data = vec![8]; // discriminator for ResetSmtRoot
+    data.extend_from_slice(&0u64.to_le_bytes()); // expected_current_tree_index
 
     let instruction = Instruction {
         program_id: PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
@@ -138,7 +141,8 @@ fn test_reset_smt_root_operator_not_signer() {
         AccountMeta::new_readonly(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID, false), // private_channel_escrow_program
     ];
 
-    let data = vec![8]; // discriminator for ResetSmtRoot
+    let mut data = vec![8]; // discriminator for ResetSmtRoot
+    data.extend_from_slice(&0u64.to_le_bytes()); // expected_current_tree_index
 
     let instruction = Instruction {
         program_id: PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
@@ -202,4 +206,58 @@ fn test_reset_smt_root_updates_nonce() {
         false,
     )
     .expect("Second ResetSmtRoot should succeed");
+}
+
+/// A reset is not idempotent: every success advances current_tree_index. A
+/// replay carrying the now-stale expected index must be rejected so an
+/// ambiguously-confirmed rotation cannot skip a whole tree generation.
+#[test]
+fn test_reset_smt_root_replay_with_stale_index_rejected() {
+    let mut context = TestContext::new();
+    let admin = Keypair::new();
+    let operator = Keypair::new();
+    let instance_seed = Keypair::new();
+
+    let (instance_pda, _) =
+        assert_get_or_create_instance(&mut context, &admin, &instance_seed, false, false)
+            .expect("CreateInstance should succeed");
+
+    let (operator_pda, _) = assert_get_or_add_operator(
+        &mut context,
+        &admin,
+        &instance_pda,
+        &operator.pubkey(),
+        false,
+        false,
+    )
+    .expect("AddOperator should succeed");
+
+    // First reset lands: current_tree_index 0 -> 1.
+    assert_get_or_reset_smt_root(&mut context, &operator, &instance_pda, &operator_pda, false)
+        .expect("first ResetSmtRoot should succeed");
+
+    context.svm.expire_blockhash();
+
+    // Replay the same reset, still carrying expected_current_tree_index = 0.
+    // The instance is already at 1, so the precondition must reject it.
+    let (event_authority_pda, _) = find_event_authority_pda();
+    let replay = ResetSmtRootBuilder::new()
+        .payer(context.payer.pubkey())
+        .operator(operator.pubkey())
+        .instance(instance_pda)
+        .operator_pda(operator_pda)
+        .event_authority(event_authority_pda)
+        .private_channel_escrow_program(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID)
+        .expected_current_tree_index(0)
+        .instruction();
+
+    let result = context.send_transaction_with_signers(replay, &[&operator]);
+    assert_program_error(result, UNEXPECTED_TREE_INDEX_ERROR);
+
+    // The rejected replay must not have advanced the tree: still 1.
+    let account = context
+        .get_account(&instance_pda)
+        .expect("Instance account should exist");
+    let instance = Instance::from_bytes(&account.data).expect("Should deserialize instance");
+    assert_eq!(instance.current_tree_index, 1);
 }

--- a/private-channel-escrow-program/tests/integration-tests/src/utils.rs
+++ b/private-channel-escrow-program/tests/integration-tests/src/utils.rs
@@ -55,6 +55,8 @@ pub const TRANSFER_HOOK_NOT_ALLOWED_ERROR: u32 =
     PrivateChannelEscrowProgramError::TransferHookNotAllowed as u32;
 pub const INVALID_TRANSACTION_NONCE_FOR_CURRENT_TREE_INDEX_ERROR: u32 =
     PrivateChannelEscrowProgramError::InvalidTransactionNonceForCurrentTreeIndex as u32;
+pub const UNEXPECTED_TREE_INDEX_ERROR: u32 =
+    PrivateChannelEscrowProgramError::UnexpectedTreeIndex as u32;
 
 // Standard Solana Program Error Codes
 pub const INVALID_ARGUMENT_ERROR: u32 = 5; // ProgramError::InvalidArgument

--- a/private-channel-escrow-program/tests/trident-tests/fuzz_reset_smt.rs
+++ b/private-channel-escrow-program/tests/trident-tests/fuzz_reset_smt.rs
@@ -222,6 +222,7 @@ impl FuzzTest {
             .operator_pda(operator_pda)
             .event_authority(event_authority)
             .private_channel_escrow_program(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID)
+            .expected_current_tree_index(self.current_tree_index)
             .instruction();
 
         let res = self


### PR DESCRIPTION
fix(escrow): make ResetSmtRoot idempotent (SOLA3-4)

Summary

ResetSmtRoot was retried as idempotent on confirmation timeout, but the on-chain instruction was
not: every success unconditionally bumped current_tree_index. An ambiguously-confirmed boundary
rotation could land twice, advancing the escrow two generations while the operator advanced one —
stranding every withdrawal in the skipped generation. (SOLA3-4)

Changes

On-chain (escrow program)
- ResetSmtRoot now carries expected_current_tree_index: u64 and rejects with a new
UnexpectedTreeIndex error when it no longer matches the instance. A replayed reset can no longer
advance the tree twice.

Operator
- Stamps the reset with its local tree index when building the instruction.
- Self-heals on UnexpectedTreeIndex: re-fetches the authoritative on-chain index and syncs local SMT
(fail-closed if the fetch fails), so the boundary withdrawal proceeds instead of stalling.

Testing

- New escrow integration test: a replay with a stale expected index is rejected and
current_tree_index stays put.
- New operator unit tests: self-heal happy path (re-sync to chain), fail-closed path (left unchanged), and Custom(13) decode.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 10,965 | 12,563 | 87.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27361398682) |
| Indexer | 19,605 | 22,657 | 86.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27361398682) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27361398682) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27361398682) |
| Withdraw Program | 120 | 232 | 51.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27361398699) |
| Escrow Program | 1,186 | 1,973 | 60.1% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27361398699) |
| DvP Swap Program | 247 | 1,112 | 22.2% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27361398699) |
| E2E Integration | 11,385 | 14,186 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27361398682) |
| **Total** | **44,972** | **53,606** | **83.9%** | |

> Last updated: 2026-06-11 16:45:02 UTC by DvP Swap Program