### PR TITLE
fix(indexer): write-ahead release signatures + boot SMT reconcile/val…

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -8,10 +8,11 @@ The two operators have different failure shapes: withdrawals can halt
 the pipeline (SMT nonce gap), deposits cannot. The dispatch table below
 routes by webhook + `transaction_type`.
 
-> **One halt has no dedicated alert.** The **SMT-root-mismatch startup
-> halt** fires no "pipeline halted" event - it surfaces as repeated
-> per-row `failed` webhooks whose `error_message` carries `SMT root
-> mismatch` (plus `SMT root mismatch detected` in the operator logs).
+> **One halt has no dedicated alert.** The **SMT-root-mismatch boot
+> pre-flight** fires no "pipeline halted" event and marks no row `failed`.
+> The common cause is auto-reconciled at boot; an unforeseen divergence the
+> reconcile cannot resolve makes the operator **refuse to start**, surfacing
+> as a boot-time crash-loop with `SMT root mismatch` in the operator logs.
 > Recognize it by that pattern, not a single alert, and not via this
 > dispatch table. See
 > [`withdrawal_pipeline_halt_runbook.md`](withdrawal_pipeline_halt_runbook.md).

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -237,12 +237,13 @@ committing the row to manual review. Sub-triggers below; same recovery.
 
 > **If the quarantined release actually landed** (verdict `LANDED`, but
 > the row was quarantined with `no broadcast signatures recorded; cannot
-> verify release landed` and never written `Completed`), expect an
-> `SmtRootMismatch` halt on the next operator boot - the consumed nonce
-> is missing from the DB. See
+> verify release landed` and never written `Completed`), the consumed
+> nonce is missing from the DB. The boot pre-flight normally reconciles
+> this from the durable release signature; only if it cannot will the
+> operator refuse to start. See
 > [`withdrawal_pipeline_halt_runbook.md`](withdrawal_pipeline_halt_runbook.md).
-> Marking the row `Completed` per Step 2 above also resolves
-> that halt by re-recording the nonce.
+> Marking the row `Completed` per Step 2 above re-records the nonce and
+> resolves any such refuse-to-start.
 
 ## Path F - corrupt withdrawal row (missing nonce)
 

--- a/docs/runbooks/withdrawal_pipeline_halt_runbook.md
+++ b/docs/runbooks/withdrawal_pipeline_halt_runbook.md
@@ -1,17 +1,20 @@
 # Runbook - Withdrawal Pipeline Halt
 
-This runbook covers the **SMT-root-mismatch startup halt**. It is a
-deliberate fail-stop: on boot, the first release dispatch finds the local
-SMT root != the on-chain root, and the operator refuses to start the
-withdrawal pipeline rather than consume nonces against a tree it cannot
-reason about.
+This runbook covers the **SMT-root-mismatch boot pre-flight**. On startup a
+withdraw operator first reconciles any in-flight releases, then validates the
+local SMT root against the on-chain `withdrawal_transactions_root` **before**
+spawning the pipeline. The common cause - a release that landed on-chain whose
+`Completed` write was lost - is now **auto-reconciled** at boot from the durable
+release signature. The operator only refuses to start on an **unforeseen**
+divergence that the reconcile cannot resolve.
 
-This halt has **no dedicated "pipeline halted" alert**. It surfaces as
-repeated per-row `failed` webhooks whose `error_message` carries `SMT root
-mismatch` (each withdrawal dispatched after boot is marked `Failed` by
-`send_fatal_error`), plus the operator error logs. You recognize it by
-that pattern, not a single halt event, and it is not routed by the
-dispatch table in [`README.md`](README.md).
+This halt has **no dedicated "pipeline halted" alert**. A refuse-to-start
+surfaces as the operator process exiting at boot (a crash-loop under the
+supervisor) with `SMT root mismatch` in the error logs, and - if the divergence
+came from an in-flight row the reconcile quarantined - a `manual_review` webhook
+for that row. No withdrawal is ever marked `failed` by this path. Recognize it by
+the boot-time crash-loop plus the log markers, not a single halt event, and it is
+not routed by the dispatch table in [`README.md`](README.md).
 
 As with every runbook here, the recovery `UPDATE` statements are
 **bookkeeping, not fund movement** - see
@@ -22,70 +25,63 @@ is human-in-the-loop".
 
 ## SMT root mismatch on startup
 
-The terminal state of the best-effort release-signature persistence
-tradeoff at `indexer/src/operator/sender/transaction.rs` (the
-`insert_release_signature` site). When a release **lands on-chain** (the
-nonce is consumed and the Instance's `withdrawal_transactions_root`
-advances) but the operator crashes before writing `Completed` - and the
-best-effort signature insert had also failed - recovery correctly
-quarantines the row (`no broadcast signatures recorded; cannot verify
-release landed`), but the DB now has no record of that consumed nonce.
-The next boot rebuilds the local SMT without it and refuses to start the
-withdrawal pipeline.
+### What the operator does automatically
+
+On boot, before any withdrawal is fetched, locked, or processed, the operator:
+
+1. **Reconciles in-flight releases.** Every consumed nonce has a release
+   signature persisted **write-ahead** (before broadcast), so a release that
+   landed but never reached `Completed` is detected by an on-chain finality
+   check and promoted to `Completed` - re-recording the nonce. A row with no
+   recorded signature, or one the RPC cannot classify, is quarantined to
+   `manual_review` (never `failed`).
+2. **Validates** the rebuilt local SMT root against the on-chain root.
+
+If validation passes, the pipeline starts normally
+(`SMT root verification passed` in the logs). A residual mismatch the reconcile
+could not resolve is a **fail-closed refuse-to-start**: the operator returns an
+error and exits without consuming nonces against a tree it cannot reason about.
+This should never fire under the known cause (the write-ahead signature plus the
+boot reconcile close that gap); it guards an unforeseen divergence such as a
+program bug or a manual on-chain admin operation.
 
 ### Symptom
 
-- New withdrawals stop reaching `completed` - the release pipeline is
-  stalled. (`completed` itself fires no webhook, so the visible signal is
-  the failures below, not a missing success alert.)
-- Each withdrawal dispatched after boot is marked `Failed` and fires a
-  per-row `failed` webhook whose `error_message` contains `SMT root
-  mismatch` (`send_fatal_error` on the lazy `initialize_smt_state`). There
-  is **no dedicated halt-level alert** - recognize the halt by the
-  repeated `failed` + `SMT root mismatch` pattern, not a single event.
-- These rows did **not** actually fail; they are collateral and must be
-  re-armed once the mismatch is resolved (see Resolution).
+- The withdraw operator does not stay up: it exits at boot and the supervisor
+  restarts it in a loop. New withdrawals never reach `completed`.
+- The operator error logs carry `SMT root mismatch` at boot (see Detection).
+- **No** withdrawal row is marked `failed`. If the divergence originated from an
+  in-flight row, that single row is in `manual_review` with a recovery-worker
+  alert; no collateral rows exist.
 
 ### Detection
 
-`initialize_smt_state` (`indexer/src/operator/sender/state.rs`) compares
-the local SMT root against the on-chain `withdrawal_transactions_root`
-and, on mismatch, emits these `error!` markers before returning
-`Err(SmtRootMismatch)` (state.rs:122-137):
+`validate_smt_root` (`indexer/src/operator/sender/state.rs`) compares the local
+SMT root against the on-chain `withdrawal_transactions_root` and, on mismatch,
+emits an `error!` log carrying the instance, tree index, both roots, and the
+DB-derived nonces, e.g.:
 
 ```
-SMT root mismatch detected! Database out of sync with on-chain state.
-  Instance PDA: <pda>
-  Tree Index: <n>
-  Nonces from DB: [...]
-  Local root:    [...]
-  On-chain root: [...]
+SMT root mismatch: database out of sync with on-chain state. ...
+  instance=<pda> tree_index=<n>
+  local_root=[...] onchain_root=[...] nonces=[...]
 ```
 
-```
-This typically means:
-  1. A withdrawal was successfully processed on-chain
-  2. But the operator crashed before updating the database
-  3. The database is now missing transaction records
-```
-
-Grep the operator logs for `SMT root mismatch detected` to confirm.
+Grep the operator logs for `SMT root mismatch` to confirm, and check that the
+process is crash-looping at boot (not running with a halted pipeline).
 
 ### Diagnosis - find the consumed-but-unrecorded nonce
 
-The divergence direction is always the same here: a nonce was
+The divergence direction is the same as the known cause: a nonce was
 **consumed on-chain** (the on-chain root advanced) but is **missing
-`Completed` in the DB** (the DB is behind the chain). You must identify
-which nonce landed.
+`Completed` in the DB**. The boot reconcile already tried and failed to resolve
+it, so identify the nonce by hand.
 
-1. Read `Tree Index` from the log. The current tree window is
+1. Read `tree_index` from the log. The current tree window is
    `tree_index * MAX_TREE_LEAVES ..< (tree_index + 1) * MAX_TREE_LEAVES`
-   - the same window `initialize_smt_state` rebuilds from
-   `get_completed_withdrawal_nonces` (state.rs:94-102). Only nonces in
-   this window matter.
-2. Pull the withdrawal rows in that window that are NOT `completed`
-   (the candidates whose release may have landed without a `Completed`
-   write). The recovery quarantine reason is the strongest hint:
+   - the same `[min, max)` window `validate_smt_root` rebuilds from
+   `get_completed_withdrawal_nonces`. Only nonces in this window matter.
+2. Pull the withdrawal rows in that window that are NOT `completed`:
 
    ```sql
    SELECT id, withdrawal_nonce, status, counterpart_signature, updated_at
@@ -113,9 +109,9 @@ which nonce landed.
 ### Resolution - record the landed nonce, then restart
 
 Once on-chain verification proves a specific nonce landed, mark that row
-`Completed` with the observed signature. This re-inserts the missing
-nonce into the set `initialize_smt_state` rebuilds from, so the local
-root re-matches the on-chain root on the next boot.
+`Completed` with the observed signature. This re-inserts the missing nonce into
+the set `validate_smt_root` rebuilds from, so the local root re-matches the
+on-chain root on the next boot.
 
 ```sql
 UPDATE transactions
@@ -125,39 +121,21 @@ UPDATE transactions
  WHERE id = :transaction_id;
 ```
 
-Then restart the withdraw operator. On boot, `initialize_smt_state`
-rebuilds the SMT - now including the recorded nonce - and the root
-verification passes (`SMT root verification passed`).
+Then restart the withdraw operator. On boot, the pre-flight rebuilds the SMT -
+now including the recorded nonce - the root verification passes
+(`SMT root verification passed`), and the pipeline starts.
 
-This `UPDATE` is bookkeeping only: it does not move funds. The release
-already landed on-chain (that is what you verified); this statement only
-makes the operator's record agree with the chain so the pipeline can
-resume. Never run it without a `LANDED` verdict.
+This `UPDATE` is bookkeeping only: it does not move funds. The release already
+landed on-chain (that is what you verified); this statement only makes the
+operator's record agree with the chain so the pipeline can resume. Never run it
+without a `LANDED` verdict.
 
-**Re-arm the collateral rows.** Withdrawals dispatched during the halt
-were marked `Failed` by `send_fatal_error` but did not actually fail
-on-chain. Their failure reason is only in the alert webhook payload -
-`transactions` has no `error_message` column - so identify them by the
-halt window instead: `failed` withdrawals whose `processed_at` falls
-between the halting boot (the first `SMT root mismatch detected` log line)
-and this fix. Review the list before acting:
-
-```sql
-SELECT id, withdrawal_nonce, processed_at
-  FROM transactions
- WHERE transaction_type = 'withdrawal'
-   AND status = 'failed'
-   AND processed_at >= :halt_start_ts
- ORDER BY processed_at ASC;
-```
-
-Confirm each is a halt casualty (not a genuine on-chain failure), then
-re-arm the reviewed ids:
-
-```sql
-UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
- WHERE id = ANY(:reviewed_ids);
-```
+> **No collateral re-arm needed.** This path never marks withdrawals `failed`
+> (the SOLA2-21 fix routes SMT-init errors to leave the row `Processing`, never
+> `send_fatal_error`). There is no halt-window casualty list to re-arm - the only
+> row to act on is the verified-landed nonce above (and any single in-flight row
+> the reconcile quarantined to `manual_review`, handled by
+> [`withdrawal_manual_review.md`](withdrawal_manual_review.md)).
 
 ### Escalation
 

--- a/indexer/src/error/transaction.rs
+++ b/indexer/src/error/transaction.rs
@@ -11,6 +11,9 @@ pub enum TransactionError {
 
     #[error("Program execution failed: {0}")]
     Program(#[from] ProgramError),
+
+    #[error("Failed to persist release signature before broadcast: {reason}")]
+    PreSendPersistFailed { reason: String },
 }
 
 /// Errors from Solana program execution

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -106,7 +106,10 @@ pub async fn run(
                 cancellation_token.cancel();
                 drop(storage_tx);
                 if let Err(join_err) = storage_writer_handle.await {
-                    error!("Storage writer join error during refuse-to-start: {}", join_err);
+                    error!(
+                        "Storage writer join error during refuse-to-start: {}",
+                        join_err
+                    );
                 }
                 return Err(e);
             }
@@ -336,7 +339,8 @@ pub async fn run(
     Ok(())
 }
 
-/// Reconcile in-flight releases, then assert the local SMT matches the on-chain root; `Err` refuses to start.
+/// Reconcile in-flight releases, then validate the local SMT against the on-chain root.
+/// Only a genuine `SmtRootMismatch` returns `Err` (refuse to start).
 async fn run_withdraw_preflight(
     storage: &Arc<Storage>,
     rpc_client: &Arc<RpcClientWithRetry>,
@@ -348,7 +352,9 @@ async fn run_withdraw_preflight(
     // Idempotent passes absorb rows that flip Processing to terminal across iterations.
     const MAX_RECONCILE_PASSES: u32 = 8;
 
-    recovery::boot_reconcile_processing(
+    // Best-effort: a reconcile error must not block startup. Validation is the gate,
+    // and a transient DB error here would otherwise crash-loop the operator at boot.
+    if let Err(e) = recovery::boot_reconcile_processing(
         storage,
         rpc_client,
         admin_pubkey,
@@ -357,10 +363,34 @@ async fn run_withdraw_preflight(
         cancellation_token,
         MAX_RECONCILE_PASSES,
     )
-    .await?;
+    .await
+    {
+        warn!("Boot reconcile failed, proceeding to SMT validation: {}", e);
+    }
 
-    sender::validate_smt_root(storage, rpc_client, Some(instance_pda)).await?;
-    Ok(())
+    // Only a genuine root mismatch is a refuse-to-start. Any other error (instance
+    // not yet on-chain, RPC failure, DB read failure) means we could not run the
+    // check; start anyway and let the sender's lazy init plus the recovery worker
+    // re-validate, neither of which marks a row Failed. Refusing on those would
+    // crash-loop the operator on any transient boot condition.
+    match sender::validate_smt_root(storage, rpc_client, Some(instance_pda)).await {
+        Ok(_) => Ok(()),
+        Err(e)
+            if matches!(
+                e,
+                OperatorError::Program(crate::error::ProgramError::SmtRootMismatch { .. })
+            ) =>
+        {
+            Err(e)
+        }
+        Err(e) => {
+            warn!(
+                "Could not validate SMT root at boot, starting anyway (lazy init will re-check): {}",
+                e
+            );
+            Ok(())
+        }
+    }
 }
 
 /// Log + metric for a critical task that exited before cancellation.
@@ -377,4 +407,142 @@ fn critical_exit(program_type_label: &str, task_name: &str) {
     metrics::OPERATOR_TASK_EXIT
         .with_label_values(&[program_type_label, task_name])
         .inc();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operator::utils::rpc_util::RetryConfig;
+    use crate::operator::utils::smt_util::SmtState;
+    use crate::storage::common::storage::mock::MockStorage;
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+    use borsh::BorshSerialize;
+    use private_channel_escrow_program_client::Instance;
+    use solana_sdk::pubkey::Pubkey;
+    use std::time::Duration;
+
+    // Single attempt with negligible backoff so an AccountNotFound resolves fast.
+    fn make_rpc_client(url: &str) -> RpcClientWithRetry {
+        RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        )
+    }
+
+    fn mock_instance_account(server: &mut mockito::ServerGuard, root: [u8; 32]) -> mockito::Mock {
+        let instance = Instance {
+            discriminator: 0,
+            bump: 0,
+            version: 0,
+            instance_seed: Pubkey::new_unique(),
+            admin: Pubkey::new_unique(),
+            withdrawal_transactions_root: root,
+            current_tree_index: 0,
+        };
+        let mut bytes = Vec::new();
+        instance.serialize(&mut bytes).unwrap();
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getAccountInfo""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 1},
+                        "value": {
+                            "owner": Pubkey::new_unique().to_string(),
+                            "lamports": 1_000_000u64,
+                            "data": [STANDARD.encode(&bytes), "base64"],
+                            "executable": false,
+                            "rentEpoch": 0
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create()
+    }
+
+    // getAccountInfo with a null value: the instance does not exist on-chain yet.
+    fn mock_instance_not_found(server: &mut mockito::ServerGuard) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getAccountInfo""#.into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":null}}"#)
+            .create()
+    }
+
+    async fn run_preflight(client: RpcClientWithRetry) -> Result<(), OperatorError> {
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let client = Arc::new(client);
+        let (storage_tx, _rx) = mpsc::channel::<sender::TransactionStatusUpdate>(8);
+        let token = CancellationToken::new();
+        run_withdraw_preflight(
+            &storage,
+            &client,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            &storage_tx,
+            &token,
+        )
+        .await
+    }
+
+    /// Matching local and on-chain roots: the pre-flight passes and the operator starts.
+    #[tokio::test]
+    async fn preflight_starts_when_root_matches() {
+        let mut server = mockito::Server::new_async().await;
+        // Empty DB rebuilds an empty tree, so the on-chain root must be the empty-tree root.
+        let _account = mock_instance_account(&mut server, SmtState::new(0).current_root());
+        let result = run_preflight(make_rpc_client(&server.url())).await;
+        assert!(result.is_ok(), "matching root must start: {result:?}");
+    }
+
+    /// Regression guard (the integration failure): an instance not yet on-chain surfaces
+    /// as AccountNotFound, which must NOT refuse to start (only a real mismatch does).
+    /// Refusing here would crash-loop the operator at boot.
+    #[tokio::test]
+    async fn preflight_starts_when_instance_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _account = mock_instance_not_found(&mut server);
+        let result = run_preflight(make_rpc_client(&server.url())).await;
+        assert!(
+            result.is_ok(),
+            "AccountNotFound must start anyway, not refuse: {result:?}"
+        );
+    }
+
+    /// A genuine root divergence is the only refuse-to-start: the operator returns
+    /// `Err(SmtRootMismatch)` so it never consumes nonces against a tree it cannot reason about.
+    #[tokio::test]
+    async fn preflight_refuses_to_start_on_root_mismatch() {
+        let mut server = mockito::Server::new_async().await;
+        // On-chain root carries a nonce the empty DB will never reconcile.
+        let mut onchain = SmtState::new(0);
+        onchain.insert_nonce(7);
+        let _account = mock_instance_account(&mut server, onchain.current_root());
+        let result = run_preflight(make_rpc_client(&server.url())).await;
+        assert!(
+            matches!(
+                result,
+                Err(OperatorError::Program(
+                    crate::error::ProgramError::SmtRootMismatch { .. }
+                ))
+            ),
+            "a real mismatch must refuse to start: {result:?}"
+        );
+    }
 }

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -58,6 +58,63 @@ pub async fn run(
     let (sender_tx, sender_rx) = mpsc::channel(config.channel_buffer_size);
     let (storage_tx, storage_rx) = mpsc::channel::<sender::TransactionStatusUpdate>(100);
 
+    let program_type = common_config.program_type;
+    let instance_pda = common_config.escrow_instance_id;
+
+    // Started first so the boot pre-flight's reconcile can drain its quarantine sends.
+    let writer_storage = storage.clone();
+    let storage_writer = DbTransactionWriter::new(
+        writer_storage,
+        storage_rx,
+        config.alert_webhook_url.clone(),
+        common_config.program_type,
+    );
+    let storage_writer_handle = tokio::spawn(async move {
+        if let Err(e) = storage_writer.start().await {
+            tracing::error!("Storage writer error: {}", e);
+        }
+    });
+
+    // Boot pre-flight for withdraw operators: reconcile in-flight releases, then
+    // validate the local SMT against the on-chain root BEFORE any row is fetched,
+    // locked, or processed. A residual mismatch the reconcile cannot resolve is a
+    // fail-closed refuse-to-start; it should never fire once the write-ahead
+    // signatures and this reconcile have run, and guards an unforeseen divergence.
+    if program_type == crate::config::ProgramType::Withdraw {
+        if let Some(preflight_instance) = instance_pda {
+            let admin_pubkey = SignerUtil::get_admin_pubkey();
+            // The main rpc_client is the chain where the instance and releases live.
+            let preflight = run_withdraw_preflight(
+                &storage,
+                &rpc_client,
+                admin_pubkey,
+                preflight_instance,
+                &storage_tx,
+                &cancellation_token,
+            )
+            .await;
+
+            if let Err(e) = preflight {
+                error!("Withdraw boot pre-flight failed, refusing to start: {}", e);
+                // Drop the sole storage_tx so the writer's recv() returns None and
+                // the task exits, then await it so the reconcile's queued
+                // ManualReview alerts are flushed before we return. The writer
+                // watches only its channel, not the cancellation token, so without
+                // this drop the await would block forever. No storage_tx clones
+                // exist yet: the processor/sender/recovery senders are created
+                // after this block.
+                cancellation_token.cancel();
+                drop(storage_tx);
+                if let Err(join_err) = storage_writer_handle.await {
+                    error!("Storage writer join error during refuse-to-start: {}", join_err);
+                }
+                return Err(e);
+            }
+        } else {
+            warn!("Withdraw operator has no escrow_instance_id; skipping boot pre-flight");
+        }
+    }
+
     // Start fetcher task
     let fetcher_storage = storage.clone();
     let fetcher_config = config.clone();
@@ -83,8 +140,6 @@ pub async fn run(
     // storage_tx is cloned into the processor so per-transaction quarantine
     // updates (ManualReview) flow through the same DbTransactionWriter path
     // the sender uses for status updates.
-    let program_type = common_config.program_type;
-    let instance_pda = common_config.escrow_instance_id;
     let processor_storage = storage.clone();
     let processor_rpc = rpc_client.clone();
     let processor_source_rpc = source_rpc_client.clone();
@@ -101,20 +156,6 @@ pub async fn run(
             processor_source_rpc,
         )
         .await;
-    });
-
-    // Start storage writer task (receives updates from sender + processor)
-    let writer_storage = storage.clone();
-    let storage_writer = DbTransactionWriter::new(
-        writer_storage,
-        storage_rx,
-        config.alert_webhook_url.clone(),
-        common_config.program_type,
-    );
-    let storage_writer_handle = tokio::spawn(async move {
-        if let Err(e) = storage_writer.start().await {
-            tracing::error!("Storage writer error: {}", e);
-        }
     });
 
     // Start sender task
@@ -292,6 +333,33 @@ pub async fn run(
     .map_err(|_| OperatorError::ShutdownChannelSend)?;
 
     info!("Operator shutdown complete");
+    Ok(())
+}
+
+/// Reconcile in-flight releases, then assert the local SMT matches the on-chain root; `Err` refuses to start.
+async fn run_withdraw_preflight(
+    storage: &Arc<Storage>,
+    rpc_client: &Arc<RpcClientWithRetry>,
+    admin_pubkey: solana_sdk::pubkey::Pubkey,
+    instance_pda: solana_sdk::pubkey::Pubkey,
+    storage_tx: &mpsc::Sender<sender::TransactionStatusUpdate>,
+    cancellation_token: &CancellationToken,
+) -> Result<(), OperatorError> {
+    // Idempotent passes absorb rows that flip Processing to terminal across iterations.
+    const MAX_RECONCILE_PASSES: u32 = 8;
+
+    recovery::boot_reconcile_processing(
+        storage,
+        rpc_client,
+        admin_pubkey,
+        crate::config::ProgramType::Withdraw,
+        storage_tx,
+        cancellation_token,
+        MAX_RECONCILE_PASSES,
+    )
+    .await?;
+
+    sender::validate_smt_root(storage, rpc_client, Some(instance_pda)).await?;
     Ok(())
 }
 

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -439,7 +439,9 @@ async fn route_outcome(
 /// `Duration::ZERO` threshold (so even a fresh crash row is reconciled) until no
 /// `Processing` rows remain, bounded by `max_passes`. A withdraw operator is
 /// single-active (SMT nonce ordering forbids a second sender), so at boot there
-/// is no live sibling whose not-yet-stale work this could disrupt.
+/// is no live sibling whose not-yet-stale work this could disrupt. Exhausting
+/// `max_passes` with rows still `Processing` returns `Ok`: the caller's
+/// `validate_smt_root` is the terminal gate that refuses to start on a real mismatch.
 pub async fn boot_reconcile_processing(
     storage: &Storage,
     rpc_client: &RpcClientWithRetry,
@@ -1332,8 +1334,7 @@ mod tests {
         .await
         .unwrap();
 
-        let validated =
-            validate_smt_root(&storage, &client, Some(Pubkey::new_unique())).await;
+        let validated = validate_smt_root(&storage, &client, Some(Pubkey::new_unique())).await;
         assert!(
             validated.is_ok(),
             "validate must pass once the landed nonce is reconciled: {validated:?}"
@@ -1381,8 +1382,7 @@ mod tests {
         .await
         .unwrap();
 
-        let validated =
-            validate_smt_root(&storage, &client, Some(Pubkey::new_unique())).await;
+        let validated = validate_smt_root(&storage, &client, Some(Pubkey::new_unique())).await;
         assert!(
             matches!(
                 validated,

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -493,9 +493,10 @@ pub mod test_hooks {
         admin_pubkey: Pubkey,
         program_type: ProgramType,
         storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
-        threshold: Duration,
     ) -> Result<(), OperatorError> {
-        // Fresh, never-cancelled token; tests run to completion.
+        // Fresh, never-cancelled token; tests run to completion. Uses the periodic
+        // worker's STALE_THRESHOLD; the ZERO boot threshold is exercised by calling
+        // recover_once directly.
         let token = CancellationToken::new();
         recover_once(
             storage,
@@ -504,7 +505,7 @@ pub mod test_hooks {
             program_type,
             storage_tx,
             &token,
-            threshold,
+            STALE_THRESHOLD,
         )
         .await
     }
@@ -1058,7 +1059,6 @@ mod tests {
             Pubkey::new_unique(),
             ProgramType::Escrow,
             &storage_tx,
-            STALE_THRESHOLD,
         )
         .await
         .unwrap();
@@ -1107,7 +1107,6 @@ mod tests {
             Pubkey::new_unique(),
             ProgramType::Escrow,
             &storage_tx,
-            STALE_THRESHOLD,
         )
         .await
         .unwrap();
@@ -1277,12 +1276,13 @@ mod tests {
         let client = make_rpc_client(&server.url());
         let (storage_tx, _rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(
+        recover_once(
             &storage,
             &client,
             Pubkey::new_unique(),
             ProgramType::Withdraw,
             &storage_tx,
+            &CancellationToken::new(),
             Duration::ZERO,
         )
         .await

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -97,6 +97,7 @@ pub async fn run_recovery_worker(
                     program_type,
                     &storage_tx,
                     &cancellation_token,
+                    STALE_THRESHOLD,
                 )
                 .await
                 {
@@ -116,6 +117,7 @@ async fn recover_once(
     program_type: ProgramType,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: &CancellationToken,
+    threshold: Duration,
 ) -> Result<(), OperatorError> {
     // Best-effort GC of release signatures whose parent is no longer Processing;
     // a failure here must not block recovery.
@@ -125,7 +127,7 @@ async fn recover_once(
     }
 
     let stale = storage
-        .get_stale_processing_transactions(STALE_THRESHOLD, RECOVERY_BATCH_LIMIT)
+        .get_stale_processing_transactions(threshold, RECOVERY_BATCH_LIMIT)
         .await?;
 
     if stale.is_empty() {
@@ -433,6 +435,51 @@ async fn route_outcome(
     }
 }
 
+/// Synchronous boot pre-flight reconcile: repeatedly run `recover_once` with a
+/// `Duration::ZERO` threshold (so even a fresh crash row is reconciled) until no
+/// `Processing` rows remain, bounded by `max_passes`. A withdraw operator is
+/// single-active (SMT nonce ordering forbids a second sender), so at boot there
+/// is no live sibling whose not-yet-stale work this could disrupt.
+pub async fn boot_reconcile_processing(
+    storage: &Storage,
+    rpc_client: &RpcClientWithRetry,
+    admin_pubkey: Pubkey,
+    program_type: ProgramType,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    cancellation_token: &CancellationToken,
+    max_passes: u32,
+) -> Result<(), OperatorError> {
+    for pass in 0..max_passes {
+        recover_once(
+            storage,
+            rpc_client,
+            admin_pubkey,
+            program_type,
+            storage_tx,
+            cancellation_token,
+            Duration::ZERO,
+        )
+        .await?;
+
+        let remaining = storage
+            .get_stale_processing_transactions(Duration::ZERO, RECOVERY_BATCH_LIMIT)
+            .await?;
+        if remaining.is_empty() {
+            return Ok(());
+        }
+        debug!(
+            pass,
+            remaining = remaining.len(),
+            "Boot reconcile still has Processing rows; iterating"
+        );
+    }
+    warn!(
+        max_passes,
+        "Boot reconcile exhausted its pass budget with Processing rows remaining"
+    );
+    Ok(())
+}
+
 #[cfg(any(test, feature = "test-mock-storage"))]
 pub mod test_hooks {
     //! Test-only entry to drive a single recovery tick deterministically.
@@ -444,6 +491,7 @@ pub mod test_hooks {
         admin_pubkey: Pubkey,
         program_type: ProgramType,
         storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+        threshold: Duration,
     ) -> Result<(), OperatorError> {
         // Fresh, never-cancelled token; tests run to completion.
         let token = CancellationToken::new();
@@ -454,6 +502,7 @@ pub mod test_hooks {
             program_type,
             storage_tx,
             &token,
+            threshold,
         )
         .await
     }
@@ -1007,6 +1056,7 @@ mod tests {
             Pubkey::new_unique(),
             ProgramType::Escrow,
             &storage_tx,
+            STALE_THRESHOLD,
         )
         .await
         .unwrap();
@@ -1055,6 +1105,7 @@ mod tests {
             Pubkey::new_unique(),
             ProgramType::Escrow,
             &storage_tx,
+            STALE_THRESHOLD,
         )
         .await
         .unwrap();
@@ -1136,5 +1187,216 @@ mod tests {
 
         let after = mock.pending_transactions.lock().unwrap();
         assert_eq!(after[0].status, TransactionStatus::Processing);
+    }
+
+    // ── boot pre-flight (reconcile then validate) ──────────────────
+
+    use crate::operator::sender::validate_smt_root;
+    use crate::operator::utils::smt_util::SmtState;
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+    use borsh::BorshSerialize;
+    use private_channel_escrow_program_client::Instance;
+
+    /// Mock a finalized-success `getSignatureStatuses` so the classifier reports the release landed.
+    fn mock_finalized_status(server: &mut mockito::ServerGuard) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":null,"status":{"Ok":null},"confirmationStatus":"finalized"}]},"id":1}"#,
+            )
+            .expect_at_least(1)
+            .create()
+    }
+
+    /// Mock `getAccountInfo` to return an Instance carrying `root`.
+    fn mock_instance_account(server: &mut mockito::ServerGuard, root: [u8; 32]) -> mockito::Mock {
+        let instance = Instance {
+            discriminator: 0,
+            bump: 0,
+            version: 0,
+            instance_seed: Pubkey::new_unique(),
+            admin: Pubkey::new_unique(),
+            withdrawal_transactions_root: root,
+            current_tree_index: 0,
+        };
+        let mut bytes = Vec::new();
+        instance.serialize(&mut bytes).unwrap();
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getAccountInfo""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 1},
+                        "value": {
+                            "owner": Pubkey::new_unique().to_string(),
+                            "lamports": 1_000_000u64,
+                            "data": [STANDARD.encode(&bytes), "base64"],
+                            "executable": false,
+                            "rentEpoch": 0
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create()
+    }
+
+    fn processing_withdrawal(id: i64, nonce: i64) -> DbTransaction {
+        let mut row = make_withdrawal_row(id, Some(nonce));
+        row.status = TransactionStatus::Processing;
+        row
+    }
+
+    /// A fresh `Processing` row with a landed signature is promoted to `Completed` under `Duration::ZERO` (the 5-minute default would skip it).
+    #[tokio::test]
+    async fn recover_once_zero_threshold_picks_up_fresh_processing_row() {
+        let mut server = mockito::Server::new_async().await;
+        let landed_sig = Signature::new_unique();
+        let _status = mock_finalized_status(&mut server);
+
+        let mock = MockStorage::new();
+        let row = processing_withdrawal(1, 42);
+        mock.pending_transactions.lock().unwrap().push(row.clone());
+        mock.insert_release_signature(row.id, landed_sig.to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        test_hooks::run_recovery_once(
+            &storage,
+            &client,
+            Pubkey::new_unique(),
+            ProgramType::Withdraw,
+            &storage_tx,
+            Duration::ZERO,
+        )
+        .await
+        .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Completed,
+            "fresh landed row must be promoted under ZERO threshold"
+        );
+        assert_eq!(
+            after[0].counterpart_signature.as_deref(),
+            Some(landed_sig.to_string().as_str())
+        );
+    }
+
+    /// Pre-flight happy path: a landed-but-uncompleted nonce is reconciled to Completed, then `validate_smt_root` agrees; zero rows Failed.
+    #[tokio::test]
+    async fn preflight_reconciles_landed_nonce_then_validates_ok() {
+        let landed_nonce: u64 = 3;
+        let mut onchain_tree = SmtState::new(0);
+        onchain_tree.insert_nonce(landed_nonce);
+
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_finalized_status(&mut server);
+        let _account = mock_instance_account(&mut server, onchain_tree.current_root());
+
+        let mock = MockStorage::new();
+        let row = processing_withdrawal(1, landed_nonce as i64);
+        mock.pending_transactions.lock().unwrap().push(row.clone());
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+        let (storage_tx, _rx) = mpsc::channel(8);
+        let token = CancellationToken::new();
+
+        boot_reconcile_processing(
+            &storage,
+            &client,
+            Pubkey::new_unique(),
+            ProgramType::Withdraw,
+            &storage_tx,
+            &token,
+            5,
+        )
+        .await
+        .unwrap();
+
+        let validated =
+            validate_smt_root(&storage, &client, Some(Pubkey::new_unique())).await;
+        assert!(
+            validated.is_ok(),
+            "validate must pass once the landed nonce is reconciled: {validated:?}"
+        );
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Completed);
+        assert!(
+            after.iter().all(|t| t.status != TransactionStatus::Failed),
+            "no row may be Failed by the pre-flight"
+        );
+    }
+
+    /// Pre-flight refuse-to-start path: a divergence the reconcile cannot resolve
+    /// (a no-signature Processing row goes to ManualReview, leaving the DB one nonce
+    /// behind an on-chain root) makes `validate_smt_root` return Err. No row is
+    /// Failed (the anti-SOLA2-21 assertion).
+    #[tokio::test]
+    async fn preflight_refuses_start_on_unreconcilable_mismatch() {
+        // On-chain root includes nonce 7 that the DB will never record.
+        let mut onchain_tree = SmtState::new(0);
+        onchain_tree.insert_nonce(7);
+
+        let mut server = mockito::Server::new_async().await;
+        let _account = mock_instance_account(&mut server, onchain_tree.current_root());
+
+        let mock = MockStorage::new();
+        // A no-signature Processing withdrawal is quarantined to ManualReview, not Failed.
+        let row = processing_withdrawal(1, 7);
+        mock.pending_transactions.lock().unwrap().push(row);
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+        let (storage_tx, _rx) = mpsc::channel(8);
+        let token = CancellationToken::new();
+
+        boot_reconcile_processing(
+            &storage,
+            &client,
+            Pubkey::new_unique(),
+            ProgramType::Withdraw,
+            &storage_tx,
+            &token,
+            5,
+        )
+        .await
+        .unwrap();
+
+        let validated =
+            validate_smt_root(&storage, &client, Some(Pubkey::new_unique())).await;
+        assert!(
+            matches!(
+                validated,
+                Err(OperatorError::Program(
+                    crate::error::ProgramError::SmtRootMismatch { .. }
+                ))
+            ),
+            "unreconcilable divergence must refuse to start: {validated:?}"
+        );
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert!(
+            after.iter().all(|t| t.status != TransactionStatus::Failed),
+            "refuse-to-start must never mark a row Failed"
+        );
     }
 }

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -7,6 +7,7 @@ pub mod types;
 
 pub use mint::{find_existing_mint_signature, find_existing_mint_signature_with_memo, JitOutcome};
 pub(crate) use remint::{classify_release_signatures, SigFinality};
+pub(crate) use state::validate_smt_root;
 pub use types::TransactionStatusUpdate;
 
 #[cfg(any(test, feature = "test-mock-storage"))]

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -68,82 +68,8 @@ impl SenderState {
     /// Initialize SMT state lazily on first use
     /// Fetches tree_index from chain and populates SMT with completed withdrawals from DB
     pub(super) async fn initialize_smt_state(&mut self) -> Result<(), OperatorError> {
-        let instance_pda = self
-            .instance_pda
-            .ok_or_else(|| AccountError::InstanceNotFound {
-                instance: Pubkey::default(),
-            })?;
-
-        info!("Initializing SMT state for instance {}", instance_pda);
-
-        let instance_data = self
-            .rpc_client
-            .get_account_data(&instance_pda)
-            .await
-            .map_err(|_| AccountError::AccountNotFound {
-                pubkey: instance_pda,
-            })?;
-
-        let instance = parse_instance(&instance_data).map_err(|e| {
-            AccountError::AccountDeserializationFailed {
-                pubkey: instance_pda,
-                reason: e.to_string(),
-            }
-        })?;
-
-        let tree_index = instance.current_tree_index;
-        let min_nonce = tree_index * MAX_TREE_LEAVES as u64;
-        let max_nonce = (tree_index + 1) * MAX_TREE_LEAVES as u64;
-
-        // Fetch completed withdrawal nonces for current tree from DB
-        let nonces = self
-            .storage
-            .get_completed_withdrawal_nonces(min_nonce, max_nonce)
-            .await?;
-
-        // Create SMT and populate with existing nonces
-        let mut smt_state = SmtState::new(tree_index);
-        for nonce in &nonces {
-            smt_state.insert_nonce(*nonce);
-        }
-
-        info!(
-            "SMT state initialized with tree_index {}, populated {} existing nonces",
-            tree_index,
-            nonces.len()
-        );
-
-        // CRITICAL: Verify local SMT root matches on-chain root
-        // This ensures database is in sync with on-chain state
-        let computed_root = smt_state.current_root();
-        let onchain_root = instance.withdrawal_transactions_root;
-
-        if computed_root != onchain_root {
-            error!("SMT root mismatch detected! Database out of sync with on-chain state.");
-            error!("  Instance PDA: {}", instance_pda);
-            error!("  Tree Index: {}", tree_index);
-            error!("  Nonces from DB: {:?}", nonces);
-            error!("  Local root:    {:?}", computed_root);
-            error!("  On-chain root: {:?}", onchain_root);
-            error!("");
-            error!("This typically means:");
-            error!("  1. A withdrawal was successfully processed on-chain");
-            error!("  2. But the operator crashed before updating the database");
-            error!("  3. The database is now missing transaction records");
-            error!("");
-            error!("Resolution options:");
-            error!("  1. Reset and resync the database from on-chain events");
-            error!("  2. Manually reconcile missing transactions");
-            error!("  3. Reset the on-chain SMT tree (requires admin)");
-
-            return Err(crate::error::ProgramError::SmtRootMismatch {
-                local_root: computed_root,
-                onchain_root,
-            }
-            .into());
-        }
-
-        info!("SMT root verification passed: {:?}", computed_root);
+        let smt_state =
+            validate_smt_root(&self.storage, &self.rpc_client, self.instance_pda).await?;
 
         self.smt_state = Some(SenderSMTState {
             smt_state,
@@ -152,8 +78,83 @@ impl SenderState {
 
         Ok(())
     }
+}
 
-    /// Sends a ManualReview status update during startup recovery when a stored            
+/// Build the local SMT for the current tree window from DB-completed nonces and
+/// assert it matches the on-chain root, returning the built tree on agreement.
+///
+/// Shared by the sender's lazy `initialize_smt_state` (which needs the tree for
+/// proofs) and the boot pre-flight (which uses it purely as a consistency gate).
+pub(crate) async fn validate_smt_root(
+    storage: &Storage,
+    rpc_client: &RpcClientWithRetry,
+    instance_pda: Option<Pubkey>,
+) -> Result<SmtState, OperatorError> {
+    let instance_pda = instance_pda.ok_or_else(|| AccountError::InstanceNotFound {
+        instance: Pubkey::default(),
+    })?;
+
+    info!("Validating SMT root for instance {}", instance_pda);
+
+    let instance_data = rpc_client
+        .get_account_data(&instance_pda)
+        .await
+        .map_err(|_| AccountError::AccountNotFound {
+            pubkey: instance_pda,
+        })?;
+
+    let instance =
+        parse_instance(&instance_data).map_err(|e| AccountError::AccountDeserializationFailed {
+            pubkey: instance_pda,
+            reason: e.to_string(),
+        })?;
+
+    let tree_index = instance.current_tree_index;
+    let min_nonce = tree_index * MAX_TREE_LEAVES as u64;
+    let max_nonce = (tree_index + 1) * MAX_TREE_LEAVES as u64;
+
+    let nonces = storage
+        .get_completed_withdrawal_nonces(min_nonce, max_nonce)
+        .await?;
+
+    let mut smt_state = SmtState::new(tree_index);
+    for nonce in &nonces {
+        smt_state.insert_nonce(*nonce);
+    }
+
+    let computed_root = smt_state.current_root();
+    let onchain_root = instance.withdrawal_transactions_root;
+
+    if computed_root != onchain_root {
+        error!(
+            instance = %instance_pda,
+            tree_index,
+            local_root = ?computed_root,
+            onchain_root = ?onchain_root,
+            nonces = ?nonces,
+            "SMT root mismatch: database out of sync with on-chain state. \
+             A release likely landed on-chain but its Completed write was lost; \
+             resync the database from on-chain events to reconcile."
+        );
+
+        return Err(crate::error::ProgramError::SmtRootMismatch {
+            local_root: computed_root,
+            onchain_root,
+        }
+        .into());
+    }
+
+    info!(
+        tree_index,
+        nonces = nonces.len(),
+        "SMT root verification passed"
+    );
+
+    Ok(smt_state)
+}
+
+impl SenderState {
+    /// Sends a ManualReview status update during startup recovery when a stored
     /// transaction cannot be reconstructed (e.g. unparseable pubkey or signature).         
     /// Using send_guaranteed so the alert is never silently dropped.                       
     async fn send_recovery_manual_review(
@@ -963,13 +964,12 @@ mod tests {
         }
     }
 
-    /// `initialize_smt_state` requires a PDA to look up the on-chain SMT root; without one
-    /// it must return an `AccountError::InstanceNotFound` wrapped as `OperatorError::Account`.
+    /// `validate_smt_root` without a PDA must return `AccountError::InstanceNotFound` (as `OperatorError::Account`).
     #[tokio::test]
-    async fn initialize_smt_state_fails_without_instance_pda() {
-        let mut state = make_sender_state_with_pda(None);
+    async fn validate_smt_root_fails_without_instance_pda() {
+        let state = make_sender_state_with_pda(None);
 
-        let result = state.initialize_smt_state().await;
+        let result = super::validate_smt_root(&state.storage, &state.rpc_client, None).await;
         let err = result.unwrap_err();
         assert!(
             matches!(
@@ -1031,13 +1031,12 @@ mod tests {
         assert_eq!(state.retry_max_attempts, 5);
     }
 
-    /// Pins the SmtRootMismatch wedge (see
-    /// `docs/runbooks/withdrawal_pipeline_halt_runbook.md`): a landed release
-    /// whose nonce never reaches `Completed` leaves the DB one nonce behind the
-    /// chain, so next-boot `initialize_smt_state` MUST diverge and halt with
-    /// `Err(SmtRootMismatch)`. A change that silently absorbs it breaks here.
+    /// Pins the SmtRootMismatch wedge: a landed release whose nonce never reaches
+    /// `Completed` leaves the DB one nonce behind the chain, so `validate_smt_root`
+    /// MUST diverge and return `Err(SmtRootMismatch)`. A change that silently
+    /// absorbs it breaks here.
     #[tokio::test]
-    async fn initialize_smt_state_halts_on_consumed_but_unrecorded_nonce() {
+    async fn validate_smt_root_halts_on_consumed_but_unrecorded_nonce() {
         let landed_nonce: u64 = 1;
         let tree_index: u64 = 0;
 
@@ -1088,7 +1087,9 @@ mod tests {
         let mut state = make_sender_state_with_pda(Some(Pubkey::new_unique()));
         state.rpc_client = Arc::new(mock_rpc);
 
-        let err = state.initialize_smt_state().await.unwrap_err();
+        let err = super::validate_smt_root(&state.storage, &state.rpc_client, state.instance_pda)
+            .await
+            .unwrap_err();
 
         match err {
             OperatorError::Program(crate::error::ProgramError::SmtRootMismatch {

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -354,54 +354,52 @@ pub(super) async fn send_and_confirm(
             }
         };
 
-    // Persist the signature write-ahead, fail-closed. A withdrawal nonce is
-    // consumed on broadcast, so every consumed nonce must already have a durable
-    // signature record. On persist failure we abort before broadcasting (the
-    // nonce stays unconsumed) and leave the row Processing for the recovery worker.
-    if let Some(nonce) = ctx.withdrawal_nonce {
-        // The durable write needs a transaction_id; the in-memory stash does not.
-        if let Some(txid) = ctx.transaction_id {
-            if let Err(e) = state
-                .storage
-                .insert_release_signature(
-                    txid,
-                    signature.to_string(),
-                    last_valid_block_height as i64,
-                )
-                .await
-            {
-                metrics::OPERATOR_TRANSACTION_ERRORS
-                    .with_label_values(&[pt, "pre_send_persist_error"])
-                    .inc();
-                let abort = TransactionError::PreSendPersistFailed {
-                    reason: e.to_string(),
-                };
-                error!(
-                    transaction_id = txid,
-                    signature = %signature,
-                    "Aborting release before broadcast, leaving row Processing for recovery: {}",
-                    abort
-                );
-                return;
-            }
+    // Persist the release signature write-ahead (DB only), fail-closed. A withdrawal
+    // nonce is consumed on broadcast, so a release that lands must already have a
+    // durable signature record for crash recovery to reconcile against. On persist
+    // failure we abort before broadcasting (the nonce stays unconsumed) and leave the
+    // row Processing for the recovery worker.
+    if let (Some(_nonce), Some(txid)) = (ctx.withdrawal_nonce, ctx.transaction_id) {
+        if let Err(e) = state
+            .storage
+            .insert_release_signature(txid, signature.to_string(), last_valid_block_height as i64)
+            .await
+        {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "pre_send_persist_error"])
+                .inc();
+            let abort = TransactionError::PreSendPersistFailed {
+                reason: e.to_string(),
+            };
+            error!(
+                transaction_id = txid,
+                signature = %signature,
+                "Aborting release before broadcast, leaving row Processing for recovery: {}",
+                abort
+            );
+            return;
         }
-
-        // Stash keyed by nonce (the in-process remint key), after any durable write
-        // so a persist failure rolls back nothing.
-        state
-            .pending_signatures
-            .entry(nonce)
-            .or_default()
-            .push(PendingSig {
-                signature,
-                last_valid_block_height,
-            });
     }
 
     match send_signed(&state.rpc_client, &transaction, retry_policy).await {
         // send_signed returns the same signature we already persisted; keep using it.
         Ok(_) => {
             info!("Transaction sent with signature: {}", signature);
+
+            // Stash the in-flight signature only after a successful broadcast. A send
+            // that never reached the network (e.g. a failed simulation) thus leaves no
+            // stashed signature, so a permanent failure routes to ManualReview rather
+            // than a deferred remint, preserving the pre-existing failure semantics.
+            if let Some(nonce) = ctx.withdrawal_nonce {
+                state
+                    .pending_signatures
+                    .entry(nonce)
+                    .or_default()
+                    .push(PendingSig {
+                        signature,
+                        last_valid_block_height,
+                    });
+            }
 
             let commitment_config = CommitmentConfig::confirmed();
 
@@ -1877,9 +1875,12 @@ mod tests {
         );
     }
 
-    /// With the signature stashed write-ahead, a send failure routes to the finality-checked PendingRemint path, not zero-sig ManualReview.
+    /// The in-memory stash happens only after a successful broadcast, so a send that
+    /// never reached the network leaves no signature to verify and routes to
+    /// ManualReview, not a deferred remint. The write-ahead DB persist (for crash
+    /// recovery) does not change this.
     #[tokio::test]
-    async fn send_failure_after_persist_routes_to_pending_remint() {
+    async fn send_failure_routes_to_manual_review() {
         let mut server = mockito::Server::new_async().await;
         let _hash = mock_blockhash(&mut server);
         let _send = server
@@ -1915,16 +1916,14 @@ mod tests {
         )
         .await;
 
-        assert_eq!(
-            state.pending_remints.len(),
-            1,
-            "send failure with a stashed signature must defer to PendingRemint"
-        );
-        assert_eq!(state.pending_remints[0].ctx.transaction_id, Some(10));
         assert!(
-            storage_rx.try_recv().is_err(),
-            "no immediate ManualReview; remint is deferred for finality check"
+            state.pending_remints.is_empty(),
+            "a never-broadcast send must not defer a remint"
         );
+        let update = storage_rx
+            .try_recv()
+            .expect("send failure must surface a status update");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
     }
 
     // ── set_pending_remint persistence ───────────────────────────────

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -358,28 +358,36 @@ pub(super) async fn send_and_confirm(
     // consumed on broadcast, so every consumed nonce must already have a durable
     // signature record. On persist failure we abort before broadcasting (the
     // nonce stays unconsumed) and leave the row Processing for the recovery worker.
-    if let (Some(nonce), Some(txid)) = (ctx.withdrawal_nonce, ctx.transaction_id) {
-        if let Err(e) = state
-            .storage
-            .insert_release_signature(txid, signature.to_string(), last_valid_block_height as i64)
-            .await
-        {
-            metrics::OPERATOR_TRANSACTION_ERRORS
-                .with_label_values(&[pt, "pre_send_persist_error"])
-                .inc();
-            let abort = TransactionError::PreSendPersistFailed {
-                reason: e.to_string(),
-            };
-            error!(
-                transaction_id = txid,
-                signature = %signature,
-                "Aborting release before broadcast, leaving row Processing for recovery: {}",
-                abort
-            );
-            return;
+    if let Some(nonce) = ctx.withdrawal_nonce {
+        // The durable write needs a transaction_id; the in-memory stash does not.
+        if let Some(txid) = ctx.transaction_id {
+            if let Err(e) = state
+                .storage
+                .insert_release_signature(
+                    txid,
+                    signature.to_string(),
+                    last_valid_block_height as i64,
+                )
+                .await
+            {
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[pt, "pre_send_persist_error"])
+                    .inc();
+                let abort = TransactionError::PreSendPersistFailed {
+                    reason: e.to_string(),
+                };
+                error!(
+                    transaction_id = txid,
+                    signature = %signature,
+                    "Aborting release before broadcast, leaving row Processing for recovery: {}",
+                    abort
+                );
+                return;
+            }
         }
 
-        // Stash in-memory after the durable write so a persist failure rolls back nothing.
+        // Stash keyed by nonce (the in-process remint key), after any durable write
+        // so a persist failure rolls back nothing.
         state
             .pending_signatures
             .entry(nonce)
@@ -391,7 +399,8 @@ pub(super) async fn send_and_confirm(
     }
 
     match send_signed(&state.rpc_client, &transaction, retry_policy).await {
-        Ok(signature) => {
+        // send_signed returns the same signature we already persisted; keep using it.
+        Ok(_) => {
             info!("Transaction sent with signature: {}", signature);
 
             let commitment_config = CommitmentConfig::confirmed();

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1,11 +1,13 @@
 use crate::channel_utils::send_guaranteed;
 use crate::config::ProgramType;
+use crate::error::TransactionError;
 use crate::error::{OperatorError, ProgramError};
 use crate::metrics;
 use crate::operator::utils::instruction_util::TransactionBuilder;
 use crate::operator::utils::transaction_util::parse_program_error;
 use crate::operator::utils::transaction_util::{
-    check_transaction_status, ConfirmationResult, MAX_POLL_ATTEMPTS_CONFIRMATION,
+    build_and_sign, check_transaction_status, send_signed, ConfirmationResult,
+    MAX_POLL_ATTEMPTS_CONFIRMATION,
 };
 use crate::operator::{
     sign_and_send_transaction, ExtraErrorCheckPolicy, RetryPolicy, RpcClientWithRetry,
@@ -172,7 +174,7 @@ pub async fn handle_transaction_submission(
                 }
                 Ok(None) => {}
                 // Deliberately fail-closed: an unverifiable lookup halts to
-                // manual review rather than risk a blind double-mint. 
+                // manual review rather than risk a blind double-mint.
                 Err(e) => {
                     error!(
                         "Mint idempotency lookup failed for transaction_id {}: {}",
@@ -217,45 +219,79 @@ pub async fn handle_transaction_submission(
                     }
                 }
             }
-            Err(OperatorError::Program(ProgramError::RotationPending { in_flight_count })) => {
-                info!(
-                    "Rotation pending, waiting for {} in-flight txs to settle",
-                    in_flight_count
-                );
-            }
-            Err(OperatorError::Program(ProgramError::TreeIndexMismatch {
-                nonce,
-                expected_tree_index,
-                current_tree_index,
-            })) => {
-                if let TransactionBuilder::ReleaseFunds(builder_with_nonce) = tx_builder {
-                    info!(
-                        "Tree index mismatch: nonce {} expects {} but current is {} - queuing for retry",
-                        nonce, expected_tree_index, current_tree_index
-                    );
-                    state.rotation_retry_queue.push((
-                        TransactionContext {
-                            transaction_id: Some(builder_with_nonce.transaction_id),
-                            withdrawal_nonce: Some(builder_with_nonce.nonce),
-                            trace_id: Some(builder_with_nonce.trace_id),
-                        },
-                        builder_with_nonce.builder,
-                    ));
-                } else {
-                    error!("TreeIndexMismatch for non-ReleaseFunds transaction");
-                }
-            }
             Err(e) => {
-                metrics::OPERATOR_TRANSACTION_ERRORS
-                    .with_label_values(&[state.program_type.as_label(), "build_error"])
-                    .inc();
-                error!("Failed to build transaction: {}", e);
-                send_fatal_error(storage_tx, &ctx, &e.to_string()).await;
+                route_builder_error(state, &ctx, tx_builder, storage_tx, e).await;
             }
         }
     }
     .instrument(span)
     .await;
+}
+
+/// Route a `handle_transaction_builder` error to its non-success path; separate from `handle_transaction_submission` so it is testable without real signers.
+pub(super) async fn route_builder_error(
+    state: &mut SenderState,
+    ctx: &TransactionContext,
+    tx_builder: TransactionBuilder,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    err: OperatorError,
+) {
+    match err {
+        OperatorError::Program(ProgramError::RotationPending { in_flight_count }) => {
+            info!(
+                "Rotation pending, waiting for {} in-flight txs to settle",
+                in_flight_count
+            );
+        }
+        OperatorError::Program(ProgramError::TreeIndexMismatch {
+            nonce,
+            expected_tree_index,
+            current_tree_index,
+        }) => {
+            if let TransactionBuilder::ReleaseFunds(builder_with_nonce) = tx_builder {
+                info!(
+                    "Tree index mismatch: nonce {} expects {} but current is {} - queuing for retry",
+                    nonce, expected_tree_index, current_tree_index
+                );
+                state.rotation_retry_queue.push((
+                    TransactionContext {
+                        transaction_id: Some(builder_with_nonce.transaction_id),
+                        withdrawal_nonce: Some(builder_with_nonce.nonce),
+                        trace_id: Some(builder_with_nonce.trace_id),
+                    },
+                    builder_with_nonce.builder,
+                ));
+            } else {
+                error!("TreeIndexMismatch for non-ReleaseFunds transaction");
+            }
+        }
+        e @ OperatorError::Program(ProgramError::SmtRootMismatch { .. })
+        | e @ OperatorError::Program(ProgramError::SmtNotInitialized)
+        | e @ OperatorError::Account(_)
+        | e @ OperatorError::Storage(_) => {
+            // SMT-init-class failure: a root mismatch, an uninitialized tree, an
+            // RPC/account error fetching the instance, or a DB error reading the
+            // completed nonces during lazy init. The local SMT stays
+            // uninitialized, so this row never released: leave it Processing for
+            // the recovery worker and never mark it Failed.
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[state.program_type.as_label(), "smt_init_error"])
+                .inc();
+            error!(
+                transaction_id = ctx.transaction_id,
+                nonce = ctx.withdrawal_nonce.map(|n| n as i64),
+                "SMT init failed; leaving row Processing for recovery: {}",
+                e
+            );
+        }
+        e => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[state.program_type.as_label(), "build_error"])
+                .inc();
+            error!("Failed to build transaction: {}", e);
+            send_fatal_error(storage_tx, ctx, &e.to_string()).await;
+        }
+    }
 }
 
 /// Sign, send, confirm, and handle the result
@@ -301,42 +337,62 @@ pub(super) async fn send_and_confirm(
     let pt = state.program_type.as_label();
     let send_start = std::time::Instant::now();
 
-    match sign_and_send_transaction(state.rpc_client.clone(), instruction.clone(), retry_policy)
-        .await
-    {
-        Ok((signature, last_valid_block_height)) => {
-            info!("Transaction sent with signature: {}", signature);
-
-            // Stash signature for finality check on withdrawal failure path
-            if let Some(nonce) = ctx.withdrawal_nonce {
-                state
-                    .pending_signatures
-                    .entry(nonce)
-                    .or_default()
-                    .push(PendingSig {
-                        signature,
-                        last_valid_block_height,
-                    });
-
-                // Record the broadcast signature for recovery's finality check.
-                // Best-effort: a failed insert only quarantines later, so never fail
-                // the send. Accepted tradeoff: if the release already landed and we
-                // crash before the Completed write, that gap triggers a next-boot
-                // SmtRootMismatch halt. See docs/runbooks/withdrawal_pipeline_halt_runbook.md.
-                if let Some(txid) = ctx.transaction_id {
-                    if let Err(e) = state
-                        .storage
-                        .insert_release_signature(
-                            txid,
-                            signature.to_string(),
-                            last_valid_block_height as i64,
-                        )
-                        .await
-                    {
-                        warn!("failed to persist release signature for tx {txid}: {e}");
-                    }
-                }
+    // Build and sign before broadcasting so the signature can be persisted write-ahead.
+    let (transaction, signature, last_valid_block_height) =
+        match build_and_sign(&state.rpc_client, instruction.clone()).await {
+            Ok(signed) => signed,
+            Err(e) => {
+                metrics::OPERATOR_RPC_SEND_DURATION
+                    .with_label_values(&[pt, "error"])
+                    .observe(send_start.elapsed().as_secs_f64());
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[pt, "build_sign_error"])
+                    .inc();
+                error!("Failed to build/sign transaction: {}", e);
+                handle_permanent_failure(state, ctx, storage_tx, &e.to_string()).await;
+                return;
             }
+        };
+
+    // Persist the signature write-ahead, fail-closed. A withdrawal nonce is
+    // consumed on broadcast, so every consumed nonce must already have a durable
+    // signature record. On persist failure we abort before broadcasting (the
+    // nonce stays unconsumed) and leave the row Processing for the recovery worker.
+    if let (Some(nonce), Some(txid)) = (ctx.withdrawal_nonce, ctx.transaction_id) {
+        if let Err(e) = state
+            .storage
+            .insert_release_signature(txid, signature.to_string(), last_valid_block_height as i64)
+            .await
+        {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "pre_send_persist_error"])
+                .inc();
+            let abort = TransactionError::PreSendPersistFailed {
+                reason: e.to_string(),
+            };
+            error!(
+                transaction_id = txid,
+                signature = %signature,
+                "Aborting release before broadcast, leaving row Processing for recovery: {}",
+                abort
+            );
+            return;
+        }
+
+        // Stash in-memory after the durable write so a persist failure rolls back nothing.
+        state
+            .pending_signatures
+            .entry(nonce)
+            .or_default()
+            .push(PendingSig {
+                signature,
+                last_valid_block_height,
+            });
+    }
+
+    match send_signed(&state.rpc_client, &transaction, retry_policy).await {
+        Ok(signature) => {
+            info!("Transaction sent with signature: {}", signature);
 
             let commitment_config = CommitmentConfig::confirmed();
 
@@ -1256,7 +1312,6 @@ pub(super) async fn send_fatal_error(
 mod tests {
     use super::*;
     use crate::config::ProgramType;
-    use crate::error::TransactionError;
     use crate::operator::sender::types::SenderSMTState;
     use crate::operator::utils::instruction_util::WithdrawalRemintInfo;
     use crate::operator::utils::rpc_util::{RetryConfig, RpcClientWithRetry};
@@ -1449,7 +1504,7 @@ mod tests {
         let mut state = make_sender_state();
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
-        // Remint cache present but NO pending signatures (sign_and_send itself failed)
+        // With write-ahead, the only zero-signature case is a build/sign failure; it still escalates to ManualReview (a blind remint is unsafe).
         state.remint_cache.insert(5, make_remint_info(10));
         // Note: not inserting into pending_signatures
 
@@ -1478,6 +1533,107 @@ mod tests {
             state.pending_remints.is_empty(),
             "should not queue deferred remint with zero sigs"
         );
+    }
+
+    // ── SMT-init errors must not mark a row Failed ────────────────
+
+    fn release_funds_builder(txn_id: i64, nonce: u64) -> TransactionBuilder {
+        TransactionBuilder::ReleaseFunds(Box::new(
+            crate::operator::utils::instruction_util::ReleaseFundsBuilderWithNonce {
+                builder: ReleaseFundsBuilder::new(),
+                nonce,
+                transaction_id: txn_id,
+                trace_id: format!("trace-{txn_id}"),
+                remint_info: None,
+            },
+        ))
+    }
+
+    /// Asserts no status update was sent (the row is left Processing, never Failed).
+    fn assert_no_status_update(rx: &mut mpsc::Receiver<TransactionStatusUpdate>) {
+        assert!(
+            rx.try_recv().is_err(),
+            "SMT-init error must not produce any status update (row stays Processing)"
+        );
+    }
+
+    /// An SMT-init-class error from lazy init (SmtRootMismatch, SmtNotInitialized,
+    /// an OperatorError::Account from the instance fetch, or an OperatorError::Storage
+    /// from reading the completed nonces) must leave the triggering withdrawal
+    /// Processing, never Failed.
+    #[tokio::test]
+    async fn smt_init_error_leaves_row_processing_not_failed() {
+        let ctx = withdrawal_ctx(10, 7);
+
+        // Case 1: SmtRootMismatch.
+        let mut state = make_sender_state();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        route_builder_error(
+            &mut state,
+            &ctx,
+            release_funds_builder(10, 7),
+            &storage_tx,
+            ProgramError::SmtRootMismatch {
+                local_root: [0u8; 32],
+                onchain_root: [1u8; 32],
+            }
+            .into(),
+        )
+        .await;
+        assert_no_status_update(&mut storage_rx);
+
+        // Case 2: OperatorError::Account (e.g. RPC/account error during init).
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        route_builder_error(
+            &mut state,
+            &ctx,
+            release_funds_builder(10, 7),
+            &storage_tx,
+            crate::error::AccountError::InstanceNotFound {
+                instance: Pubkey::default(),
+            }
+            .into(),
+        )
+        .await;
+        assert_no_status_update(&mut storage_rx);
+
+        // Case 3: OperatorError::Storage (a transient DB read error during init) must also leave the row Processing.
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        route_builder_error(
+            &mut state,
+            &ctx,
+            release_funds_builder(10, 7),
+            &storage_tx,
+            crate::error::StorageError::DatabaseError {
+                message: "transient".to_string(),
+            }
+            .into(),
+        )
+        .await;
+        assert_no_status_update(&mut storage_rx);
+    }
+
+    /// A genuine build error (not SMT-init-class) MUST still mark the row Failed, so the exemption doesn't swallow real failures.
+    #[tokio::test]
+    async fn non_smt_build_error_still_marks_failed() {
+        let mut state = make_sender_state();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        route_builder_error(
+            &mut state,
+            &withdrawal_ctx(10, 7),
+            release_funds_builder(10, 7),
+            &storage_tx,
+            ProgramError::InvalidBuilder {
+                reason: "bad".to_string(),
+            }
+            .into(),
+        )
+        .await;
+
+        let update = storage_rx
+            .try_recv()
+            .expect("non-SMT build error must send a Failed status");
+        assert_eq!(update.status, TransactionStatus::Failed);
     }
 
     // ── handle_success ──────────────────────────────────────────────
@@ -1563,6 +1719,203 @@ mod tests {
                 last_valid_block_height: 0,
             });
         assert_eq!(state.pending_signatures[&nonce].len(), 2);
+    }
+
+    // ── write-ahead release signature ─────────────────────────────
+
+    fn withdrawal_ctx(txn_id: i64, nonce: u64) -> TransactionContext {
+        TransactionContext {
+            transaction_id: Some(txn_id),
+            withdrawal_nonce: Some(nonce),
+            trace_id: Some(format!("trace-{txn_id}")),
+        }
+    }
+
+    fn mock_blockhash(server: &mut mockito::ServerGuard) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getLatestBlockhash"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 1},
+                        "value": {
+                            "blockhash": "GHtXQBsoZHjzkAm2Sdm6FTyFHBCqBnLanJJhZFCFJXoe",
+                            "lastValidBlockHeight": 100
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create()
+    }
+
+    fn mock_get_signature_statuses_null(server: &mut mockito::ServerGuard) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"context": {"slot": 1}, "value": [null]}
+                })
+                .to_string(),
+            )
+            .create()
+    }
+
+    /// A successful send_and_confirm persists the signed transaction's signature (via `insert_release_signature`) before the broadcast.
+    #[tokio::test]
+    async fn release_persists_signature_before_send() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let _send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": Signature::default().to_string()
+                })
+                .to_string(),
+            )
+            .create();
+        // Confirmation polls return null (Retry), but the persist already happened.
+        let _status = mock_get_signature_statuses_null(&mut server);
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let ctx = withdrawal_ctx(10, 5);
+
+        send_and_confirm(
+            &mut state,
+            dummy_instruction(),
+            None,
+            &ctx,
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &mpsc::channel(10).0,
+        )
+        .await;
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let stored = mock.get_release_signatures(10).await.unwrap();
+        assert_eq!(stored.len(), 1, "exactly one release signature persisted");
+        assert_eq!(
+            stored[0].0,
+            Signature::default().to_string(),
+            "persisted signature must be the signed transaction's signature"
+        );
+        assert_eq!(stored[0].1, 100, "persisted lvbh must match the blockhash");
+    }
+
+    /// A failed write-ahead persist must NOT broadcast, must write no terminal status (row left Processing), and must stash nothing.
+    #[tokio::test]
+    async fn release_aborts_send_when_persist_fails() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        // sendTransaction must never be called once persist fails.
+        let send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .expect(0)
+            .create();
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.set_should_fail("insert_release_signature", true);
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        let ctx = withdrawal_ctx(10, 5);
+
+        send_and_confirm(
+            &mut state,
+            dummy_instruction(),
+            None,
+            &ctx,
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        send.assert();
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update must be sent; row stays Processing for recovery"
+        );
+        assert!(
+            !state.pending_signatures.contains_key(&5),
+            "nothing stashed when persist failed"
+        );
+    }
+
+    /// With the signature stashed write-ahead, a send failure routes to the finality-checked PendingRemint path, not zero-sig ManualReview.
+    #[tokio::test]
+    async fn send_failure_after_persist_routes_to_pending_remint() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let _send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32600, "message": "Internal error"}
+                })
+                .to_string(),
+            )
+            .create();
+
+        let mut state = make_sender_state_with_server(&server.url());
+        state.remint_cache.insert(5, make_remint_info(10));
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        let ctx = withdrawal_ctx(10, 5);
+
+        send_and_confirm(
+            &mut state,
+            dummy_instruction(),
+            None,
+            &ctx,
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        assert_eq!(
+            state.pending_remints.len(),
+            1,
+            "send failure with a stashed signature must defer to PendingRemint"
+        );
+        assert_eq!(state.pending_remints[0].ctx.transaction_id, Some(10));
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no immediate ManualReview; remint is deferred for finality check"
+        );
     }
 
     // ── set_pending_remint persistence ───────────────────────────────

--- a/indexer/src/operator/utils/transaction_util.rs
+++ b/indexer/src/operator/utils/transaction_util.rs
@@ -41,9 +41,24 @@ pub enum ConfirmationResult {
 /// * ReleaseFunds: Dual signers (admin as fee payer, operator for authorization)
 pub async fn sign_and_send_transaction(
     rpc_client: Arc<RpcClientWithRetry>,
-    mut ix_with_signers: InstructionWithSigners,
+    ix_with_signers: InstructionWithSigners,
     retry_policy: RetryPolicy,
 ) -> Result<(Signature, u64), TransactionError> {
+    let (transaction, signature, last_valid_block_height) =
+        build_and_sign(&rpc_client, ix_with_signers).await?;
+    send_signed(&rpc_client, &transaction, retry_policy).await?;
+    Ok((signature, last_valid_block_height))
+}
+
+/// Build and sign a transaction without broadcasting it.
+///
+/// Returns the signed transaction, its signature and the blockhash's
+/// `last_valid_block_height`. Splitting this from the send lets the release path
+/// persist the signature write-ahead before the broadcast.
+pub async fn build_and_sign(
+    rpc_client: &RpcClientWithRetry,
+    mut ix_with_signers: InstructionWithSigners,
+) -> Result<(Transaction, Signature, u64), TransactionError> {
     if let Some(compute_unit_price) = ix_with_signers.compute_unit_price {
         let compute_budget_ix =
             ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price);
@@ -76,12 +91,21 @@ pub async fn sign_and_send_transaction(
             .map_err(TransactionError::Signer)?;
     }
 
-    let signature = rpc_client
-        .send_transaction(&transaction, retry_policy)
-        .await
-        .map_err(TransactionError::Rpc)?;
+    let signature = transaction.signatures[0];
 
-    Ok((signature, last_valid_block_height))
+    Ok((transaction, signature, last_valid_block_height))
+}
+
+/// Broadcast an already-signed transaction.
+pub async fn send_signed(
+    rpc_client: &RpcClientWithRetry,
+    transaction: &Transaction,
+    retry_policy: RetryPolicy,
+) -> Result<Signature, TransactionError> {
+    rpc_client
+        .send_transaction(transaction, retry_policy)
+        .await
+        .map_err(TransactionError::Rpc)
 }
 
 /// Check transaction status with polling.
@@ -582,6 +606,46 @@ mod tests {
             matches!(result, Err(crate::error::TransactionError::Rpc(_))),
             "expected TransactionError::Rpc, got: {:?}",
             result
+        );
+    }
+
+    /// `build_and_sign` must return the signature embedded in the signed transaction (`signatures[0]`), so the write-ahead persist records the real on-chain signature.
+    #[tokio::test]
+    async fn build_and_sign_returns_first_transaction_signature() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _m_hash = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getLatestBlockhash"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 1},
+                        "value": {
+                            "blockhash": "GHtXQBsoZHjzkAm2Sdm6FTyFHBCqBnLanJJhZFCFJXoe",
+                            "lastValidBlockHeight": 100
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        let rpc_client = make_rpc_client_for_test(server.url());
+        let ix = make_instruction_with_empty_signers();
+
+        let (transaction, signature, _lvbh) = build_and_sign(&rpc_client, ix)
+            .await
+            .expect("build_and_sign");
+
+        assert_eq!(
+            signature, transaction.signatures[0],
+            "returned signature must be the transaction's first signature"
         );
     }
 }

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -1183,11 +1183,9 @@ async fn test_operator_aborts_on_smt_root_mismatch_at_startup(
     .execute(&pool)
     .await?;
 
-    // Step 2: add a PENDING withdrawal at nonce 1 so the operator has
-    // something to process. SMT init runs lazily on the first ReleaseFunds
-    // transaction (see `handle_transaction_builder` in
-    // `sender/transaction.rs`); without this trigger the mismatch branch
-    // is never reached.
+    // Step 2: add a PENDING withdrawal at nonce 1. The boot pre-flight validates the
+    // SMT root BEFORE any row is fetched, so on a mismatch the operator refuses to
+    // start and this row is never processed; it must stay `pending`.
     let trigger_sig = Signature::new_unique().to_string();
     let trigger_withdrawal = make_withdrawal_transaction(
         trigger_sig.clone(),
@@ -1198,10 +1196,9 @@ async fn test_operator_aborts_on_smt_root_mismatch_at_startup(
     );
     storage.insert_db_transaction(&trigger_withdrawal).await?;
 
-    // Start the withdrawal-side operator. When it picks up the pending
-    // nonce-1 withdrawal, `initialize_smt_state` runs, detects the
-    // mismatch, and triggers the `send_fatal_error` path for that
-    // transaction.
+    // Start the withdrawal-side operator. Its boot pre-flight rebuilds the SMT from
+    // the poisoned `completed` nonce, finds it diverges from the empty on-chain root,
+    // and refuses to start (returns Err); the operator task then exits.
     let operator_keypair = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..])?;
     let operator_handle = start_private_channel_to_solana_operator(
         test_validator.rpc_url(),
@@ -1211,30 +1208,31 @@ async fn test_operator_aborts_on_smt_root_mismatch_at_startup(
     )
     .await?;
 
-    // Wait for the pending nonce-1 withdrawal to transition out of
-    // Pending. A healthy operator would mark it `completed`; a
-    // mismatch-poisoned operator's fatal-error path must mark it
-    // `failed` (or some other terminal non-pending state).
+    // The operator must refuse to start: the task exits without processing any row.
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    let mut terminal_status = String::from("pending");
+    let mut exited = false;
     while std::time::Instant::now() < deadline {
-        if let Some(tx) = db::get_transaction(&pool, &trigger_sig).await? {
-            if tx.status != "pending" {
-                terminal_status = tx.status;
-                break;
-            }
+        if operator_handle._handle.is_finished() {
+            exited = true;
+            break;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
-
-    assert_ne!(
-        terminal_status, "pending",
-        "operator must have moved the trigger tx out of 'pending'; SMT mismatch path never ran"
+    assert!(
+        exited,
+        "operator must refuse to start (the task exits) on a startup SMT root mismatch"
     );
-    assert_ne!(
-        terminal_status, "completed",
-        "SMT-poisoned pending withdrawal must NOT reach 'completed'; the mismatch \
-         detection branch in `initialize_smt_state` was bypassed. Got: {terminal_status}"
+
+    // SOLA2-21: the innocent trigger withdrawal is never moved out of `pending`
+    // (never `failed`, never `completed`) because the pre-flight gates before the
+    // pipeline runs.
+    let trigger = db::get_transaction(&pool, &trigger_sig)
+        .await?
+        .expect("trigger withdrawal row must exist");
+    assert_eq!(
+        trigger.status, "pending",
+        "trigger withdrawal must stay pending on refuse-to-start; got {}",
+        trigger.status
     );
 
     operator_handle.shutdown().await;


### PR DESCRIPTION
## Summary

Closes SOLA2-21. The withdraw operator built its local SMT lazily on the first `ReleaseFunds` and, on a root mismatch, routed `SmtRootMismatch` through the generic build-error arm, marking whatever withdrawal triggered the lazy init terminally `Failed` (no release, no remint). Because the tree never initialized, every later withdrawal repeated the path, silently poisoning users. 
The single trigger is a release that lands on-chain while the operator crashes before writing `Completed` **and** the best-effort signature persist also failed.

This PR closes that window and stops the misrouting:

- **Write-ahead release signature (fail-closed):** the broadcast signature is persisted **before** the release is sent, so every consumed nonce has a durable record. If the persist fails, the operator does not broadcast (the nonce is never consumed).
- **Boot pre-flight (withdraw only):** before any row is fetched or locked, the operator reconciles in-flight releases to a finality-checked terminal state, then validates the local SMT against the on-chain root. A residual mismatch the reconcile cannot resolve is a fail-closed refuse-to-start (it should never fire once write-ahead signatures + the reconcile are in place; it guards an unforeseen divergence).
- **SMT-init errors leave the row `Processing`, never `Failed`** (root mismatch, uninitialized tree, an account-fetch error, or a transient DB read), so an innocent withdrawal is never terminally failed by an operator-wide condition.

## Design decisions

- **Close the window, don't reconcile after the fact.** Persisting the signature before the send (and aborting the send if the persist fails) makes "release landed but unrecorded" impossible for new rows; the existing signature-based recovery then reconciles with the **real** signature. No root-match brute-force is needed.
- **Pre-flight in `operator::run`, before the pipeline spawns.** Nothing leaves `pending` until the operator's view agrees with the chain. The reconcile reuses the recovery worker's per-row finality logic (`recover_once`).
- **No SMT-state injection into the sender.** The sender must build the tree for proofs anyway, so the pre-flight is the gate and the sender's lazy build is a free re-assertion.
- **Refuse-to-start is the only residual.** The design is fail-closed, so a residual mismatch should never occur; if it does, the operator refuses to boot rather than re-introduce the per-row `Failed` poisoning. 

## Testing

- **Write-ahead:** persist precedes broadcast; a persist failure aborts the send (row not Failed); a send failure routes to the finality-checked remint path.
- **Misrouting:** SMT-init errors (root mismatch, account, transient `Storage`) leave the row `Processing`; a genuine build error still marks `Failed`.
- **Validation + reconcile:** `validate_smt_root` mismatch and missing-PDA paths; `recover_once` reconciles a fresh row under the `ZERO` boot threshold.
- **Boot policy** (`operator::run`, mock RPC, no validator): matching root starts; AccountNotFound starts anyway (the regression guard); only a real `SmtRootMismatch` refuses to start.


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 10,715 | 12,322 | 87.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27292081780) |
| Indexer | 19,341 | 22,265 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27292081780) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27292081780) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27292081780) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,250 | 14,007 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27292081780) |
| **Total** | **43,017** | **50,589** | **85.0%** | |

> Last updated: 2026-06-10 17:24:41 UTC by E2E Integration