### PR TITLE
fix: harden restart blockhash expiry and node RPC port exposure (SOLA2-5, SOLA3-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,10 @@ Devnet variants exist for every target (`make docker-devnet-up`, `make docker-de
 
 ### Running with Auth (RBAC)
 
-Auth is opt-in. The gateway runs without it by default — all RPC methods are accessible without a token.
+Auth is opt-in. The gateway runs without it by default, and even when enabled the gateway's RBAC
+(account-gating and operator-only methods) protects **only the gateway port**. The read/write node RPC
+ports have **no node-side authentication** of their own, so the reference compose binds them to loopback
+(`127.0.0.1`): reachable from the host for local development, but not from other machines.
 
 To enable auth, set `JWT_SECRET` in your `.env.local` and start with the `auth` profile:
 
@@ -355,6 +358,7 @@ Container images used by integration tests (pulled automatically by
 | `redis:7`            | Warmed in CI before each integration run.      |
 
 Source of truth for tool versions:
+
 - **[`versions.env`](versions.env)** (consumed by Dockerfiles, `docker compose`, and `make install-toolchain` / `check-toolchain`): `SOLANA_VERSION`, `YELLOWSTONE_TAG`, `PNPM_VERSION`, `NODE_VERSION`, `GRAFANA_VERSION`, `PROMETHEUS_VERSION`, `BLACKBOX_VERSION`
 - Rust toolchain: [`rust-toolchain.toml`](rust-toolchain.toml)
 - Rust + `cargo-llvm-cov`: [`.github/actions/setup-environment/action.yml`](.github/actions/setup-environment/action.yml)
@@ -372,7 +376,7 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
 ## Acknowledgments
 
 Built with:
+
 - [Agave](https://github.com/anza-xyz/agave) - Solana Validator Client
 - [Yellowstone gRPC](https://github.com/rpcpool/yellowstone-grpc) - Real-time Geyser streaming
 - [Pinocchio](https://github.com/anza-xyz/pinocchio) - Efficient Solana program SDK
-

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -199,8 +199,12 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
             // duplicate transactions to execute after a restart.
             let db = AccountsDB::new(&config.accountsdb_connection_url, true).await?;
             repair_address_signatures(&db, Arc::clone(&config.metrics)).await?;
-            let (initial_live_blockhashes, initial_dedup_cache) =
-                load_dedup_state(&db, config.max_blockhashes()).await?;
+            let (initial_live_blockhashes, initial_dedup_cache) = load_dedup_state(
+                &db,
+                config.max_blockhashes(),
+                config.transaction_expiration_ms,
+            )
+            .await?;
 
             let dedup_hb = crate::health::StageHeartbeat::new();
             let sigverify_hb = crate::health::StageHeartbeat::new();

--- a/core/src/stages/dedup.rs
+++ b/core/src/stages/dedup.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        accounts::traits::AccountsDB, health::StageHeartbeat, nodes::node::WorkerHandle,
-        stage_metrics::SharedMetrics,
+        accounts::traits::AccountsDB, accounts::traits::BlockInfo, health::StageHeartbeat,
+        nodes::node::WorkerHandle, stage_metrics::SharedMetrics,
     },
     anyhow::{ensure, Result},
     solana_sdk::{hash::Hash, signature::Signature, transaction::SanitizedTransaction},
@@ -51,6 +51,7 @@ pub fn create_dedup_channel(
 pub async fn load_dedup_state(
     accounts_db: &AccountsDB,
     max_blockhashes: usize,
+    expiry_ms: u64,
 ) -> Result<DedupState> {
     let live_blockhashes: LinkedList<Hash> = LinkedList::new();
     let dedup_cache: HashMap<Hash, HashSet<Signature>> = HashMap::new();
@@ -69,19 +70,44 @@ pub async fn load_dedup_state(
         .get_blocks_in_range(start_slot, latest_slot)
         .await?;
 
+    let loaded = blocks.len();
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        // Checked cast; the i64::MAX fallback is unreachable
+        .map(|d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+    let blocks = prune_expired_blocks(blocks, now_secs, expiry_ms);
+    let pruned = loaded.saturating_sub(blocks.len());
+
     let (live_blockhashes, dedup_cache) = build_dedup_state(&blocks)?;
 
     info!(
-        "Dedup: restored {} live blockhashes and {} cache entries from {} blocks",
-        live_blockhashes.len(),
-        dedup_cache.values().map(|s| s.len()).sum::<usize>(),
-        blocks.len(),
+        loaded_blocks = loaded,
+        pruned_blocks = pruned,
+        kept_blocks = blocks.len(),
+        live_blockhashes = live_blockhashes.len(),
+        cache_entries = dedup_cache.values().map(|s| s.len()).sum::<usize>(),
+        "Dedup: restored dedup state; {pruned} restored blocks were pruned as older than the {expiry_ms}ms expiry window",
     );
 
     Ok((live_blockhashes, dedup_cache))
 }
 
 type DedupState = (LinkedList<Hash>, HashMap<Hash, HashSet<Signature>>);
+
+/// Drop restored blocks older than the expiry window.
+fn prune_expired_blocks(blocks: Vec<BlockInfo>, now_secs: i64, expiry_ms: u64) -> Vec<BlockInfo> {
+    // Checked: an oversized expiry clamps to i64::MAX, never wraps negative (drop all).
+    let expiry_secs = i64::try_from(expiry_ms / 1000).unwrap_or(i64::MAX);
+    blocks
+        .into_iter()
+        .filter(|block| match block.block_time {
+            Some(block_time) => now_secs.saturating_sub(block_time) <= expiry_secs,
+            // Age unknown means we cannot prove expiry, so keep the block.
+            None => true,
+        })
+        .collect()
+}
 
 /// Ingest pending blockhash updates into `live_blockhashes`
 ///
@@ -363,17 +389,30 @@ mod tests {
     }
 
     fn make_block(slot: u64, blockhash: Hash, sigs: &[(Signature, Hash)]) -> BlockInfo {
+        make_block_at(slot, blockhash, sigs, None)
+    }
+
+    fn make_block_at(
+        slot: u64,
+        blockhash: Hash,
+        sigs: &[(Signature, Hash)],
+        block_time: Option<i64>,
+    ) -> BlockInfo {
         BlockInfo {
             slot,
             blockhash,
             previous_blockhash: Hash::default(),
             parent_slot: slot.saturating_sub(1),
             block_height: Some(slot),
-            block_time: None,
+            block_time,
             transaction_signatures: sigs.iter().map(|(s, _)| *s).collect(),
             transaction_recent_blockhashes: sigs.iter().map(|(_, h)| *h).collect(),
         }
     }
+
+    // 15s window mirrored by the block ages below; bind both to one const so
+    // the prune boundary and the test fixtures can never drift apart.
+    const EXPIRY_MS: u64 = 15_000;
 
     const TEST_INGRESS_CAP: usize = 64;
 
@@ -573,6 +612,88 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("mismatched transaction_signatures"));
+    }
+
+    // --- prune_expired_blocks unit tests ---
+
+    #[test]
+    fn prune_drops_blocks_older_than_expiry() {
+        let now = 1_000_000i64;
+        let old = make_block_at(1, Hash::new_unique(), &[], Some(now - 20));
+        let fresh = make_block_at(2, Hash::new_unique(), &[], Some(now - 5));
+        let fresh_hash = fresh.blockhash;
+
+        let kept = prune_expired_blocks(vec![old, fresh], now, EXPIRY_MS);
+
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].blockhash, fresh_hash);
+    }
+
+    #[test]
+    fn prune_keeps_all_when_within_expiry() {
+        let now = 1_000_000i64;
+        let blocks = vec![
+            make_block_at(1, Hash::new_unique(), &[], Some(now - 1)),
+            make_block_at(2, Hash::new_unique(), &[], Some(now - 1)),
+        ];
+
+        let kept = prune_expired_blocks(blocks, now, EXPIRY_MS);
+
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn prune_keeps_none_when_all_stale() {
+        let now = 1_000_000i64;
+        let blocks = vec![
+            make_block_at(1, Hash::new_unique(), &[], Some(now - 3600)),
+            make_block_at(2, Hash::new_unique(), &[], Some(now - 3600)),
+        ];
+
+        let kept = prune_expired_blocks(blocks, now, EXPIRY_MS);
+
+        assert!(kept.is_empty());
+    }
+
+    #[test]
+    fn prune_keeps_block_time_none() {
+        let now = 1_000_000i64;
+        let blocks = vec![make_block_at(1, Hash::new_unique(), &[], None)];
+
+        let kept = prune_expired_blocks(blocks, now, EXPIRY_MS);
+
+        assert_eq!(kept.len(), 1);
+    }
+
+    #[test]
+    fn prune_handles_future_block_time() {
+        let now = 1_000_000i64;
+        let blocks = vec![make_block_at(1, Hash::new_unique(), &[], Some(now + 3600))];
+
+        let kept = prune_expired_blocks(blocks, now, EXPIRY_MS);
+
+        assert_eq!(kept.len(), 1);
+    }
+
+    #[test]
+    fn prune_then_build_drops_orphan_signatures() {
+        let now = 1_000_000i64;
+        let stale_hash = Hash::new_unique();
+        let fresh_hash = Hash::new_unique();
+        let stale_sig = Signature::new_unique();
+        let fresh_sig = Signature::new_unique();
+
+        // Stale block carries a self-referencing signature; fresh block too.
+        let stale = make_block_at(1, stale_hash, &[(stale_sig, stale_hash)], Some(now - 3600));
+        let fresh = make_block_at(2, fresh_hash, &[(fresh_sig, fresh_hash)], Some(now - 1));
+
+        let kept = prune_expired_blocks(vec![stale, fresh], now, EXPIRY_MS);
+        let (live, cache) = build_dedup_state(&kept).unwrap();
+
+        assert_eq!(live.len(), 1);
+        assert_eq!(*live.front().unwrap(), fresh_hash);
+        assert!(!cache.contains_key(&stale_hash));
+        assert!(cache.get(&fresh_hash).unwrap().contains(&fresh_sig));
     }
 
     #[test]

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -123,7 +123,7 @@ services:
       - PRIVATE_CHANNEL_METRICS=${PRIVATE_CHANNEL_METRICS:-false}
       - PRIVATE_CHANNEL_METRICS_PORT=${PRIVATE_CHANNEL_METRICS_PORT:-9090}
     ports:
-      - "${PRIVATE_CHANNEL_WRITE_PORT}:${PRIVATE_CHANNEL_WRITE_PORT}"
+      - "127.0.0.1:${PRIVATE_CHANNEL_WRITE_PORT}:${PRIVATE_CHANNEL_WRITE_PORT}"
     command: ["/usr/local/bin/private-channel-node"]
     networks:
       - private-channel-network
@@ -208,7 +208,7 @@ services:
       - PRIVATE_CHANNEL_JSON_LOGS=false
       - PRIVATE_CHANNEL_MODE=read
     ports:
-      - "${PRIVATE_CHANNEL_READ_PORT}:${PRIVATE_CHANNEL_READ_PORT}"
+      - "127.0.0.1:${PRIVATE_CHANNEL_READ_PORT}:${PRIVATE_CHANNEL_READ_PORT}"
     command: ["/usr/local/bin/private-channel-node"]
     networks:
       - private-channel-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - PRIVATE_CHANNEL_METRICS=${PRIVATE_CHANNEL_METRICS:-false}
       - PRIVATE_CHANNEL_METRICS_PORT=${PRIVATE_CHANNEL_METRICS_PORT:-9090}
     ports:
-      - "${PRIVATE_CHANNEL_WRITE_PORT}:${PRIVATE_CHANNEL_WRITE_PORT}"
+      - "127.0.0.1:${PRIVATE_CHANNEL_WRITE_PORT}:${PRIVATE_CHANNEL_WRITE_PORT}"
     command: ["/usr/local/bin/private-channel-node"]
     networks:
       - private-channel-network
@@ -214,7 +214,7 @@ services:
       - PRIVATE_CHANNEL_JSON_LOGS=false
       - PRIVATE_CHANNEL_MODE=read
     ports:
-      - "${PRIVATE_CHANNEL_READ_PORT}:${PRIVATE_CHANNEL_READ_PORT}"
+      - "127.0.0.1:${PRIVATE_CHANNEL_READ_PORT}:${PRIVATE_CHANNEL_READ_PORT}"
     command: ["/usr/local/bin/private-channel-node"]
     networks:
       - private-channel-network

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -68,14 +68,12 @@ Open [http://localhost:5173](http://localhost:5173) in your browser.
 ## Step 3: Create an Escrow Instance
 
 1. **Connect Wallet**  
-     
+
    - Set your browser wallet to **Devnet** network  
    - Ensure you have Devnet SOL for transaction fees (use the [Solana Faucet](https://faucet.solana.com/) if needed)
 
-   
-
 2. **Create Instance**  
-     
+
    - In the Admin UI, click **"Create New Instance"**  
    - Approve the transaction in your wallet  
    - **Copy the Instance Address** — you'll need this for configuration
@@ -111,7 +109,6 @@ Back in the Admin UI:
 1. Go to **Admin Functions** → **Operator Management**  
 2. Enter your operator's public key (from Step 4)  
 3. Click **"Add Operator"** and approve the transaction
-
 
 ## Step 6: Configure Environment Variables
 
@@ -149,7 +146,7 @@ INDEXER_YELLOWSTONE_TOKEN=<your_yellowstone_auth_token>
 
 ## Step 7: Start All Services
 
-Once your docker build (Step 1) is complete, run: 
+Once your docker build (Step 1) is complete, run:
 
 ```shell
 docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet up -d
@@ -198,7 +195,14 @@ For reference, here are the ports and endpoints that are now running:
 | Prometheus | `9090` | Metrics collection |
 | cAdvisor | `8080` | Container metrics |
 
-## 
+### Node RPC ports and the RBAC boundary
+
+The gateway (`8899`) is the only port that enforces RBAC (account-gating and operator-only methods). The
+write-node (`8900`) and read-node (`8901`) RPC ports have **no node-side authentication**. Because of that, the
+reference compose binds these node ports to loopback (`127.0.0.1`), so they are reachable from the host
+but not from other machines. RBAC is an application-layer control on the gateway, not a network boundary.
+
+##
 
 ## Step 8: Test Deposits and Withdrawals
 
@@ -225,7 +229,6 @@ After your balance has been verified on Solana Private Channels, you should now 
 2. Enter a user destination address and amount (with decimal precision)
 3. Click send and confirm the transaction in your wallet!
 4. You can check your Solana Private Channels balance again and notice that the funds have been debited by your transfer amount.
-
 
 ### Withdraw (Solana Private Channels → Solana)
 
@@ -294,7 +297,7 @@ docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .
 
 ## Get Help
 
-Solana Private Channels is still in the early stages of development. If you run into issues or bugs, please [create an issue](https://github.com/solana-foundation/solana-private-channels/issues) and outline your steps to reproduce it. 
+Solana Private Channels is still in the early stages of development. If you run into issues or bugs, please [create an issue](https://github.com/solana-foundation/solana-private-channels/issues) and outline your steps to reproduce it.
 
 ## Configuration Reference
 


### PR DESCRIPTION
## Summary

Two node/deploy audit fixes.

SOLA2-5: the write node measured blockhash freshness by a count of locally produced blocks and restored
that window verbatim on restart. Block production is tick-driven, so nothing ages out while the node is
offline; a blockhash live at shutdown stayed valid after arbitrary downtime. This broke the documented "transactions expire after ~15s"
guarantee (invariant C4).

SOLA3-10: the read/write node RPC ports were published on `0.0.0.0` with no node-side auth while the
gateway was documented as the RBAC layer, so anyone reaching the node ports bypassed gateway RBAC and hit
operator-only and account-gated methods directly.

## What's changed

- Wall-clock blockhash prune (SOLA2-5). On restart, `load_dedup_state` drops any restored block whose
  persisted `block_time` is older than `transaction_expiration_ms` before rebuilding the live set; the
  dropped blocks' dedup-cache signatures fall away with them. Startup logs loaded/pruned/kept counts.
- Loopback-bind node ports (SOLA3-10). The reference compose binds write-node (`8900`) and read-node
  (`8901`) to `127.0.0.1` instead of `0.0.0.0`: reachable from the host, not from other machines. README
  and `DEVNET_QUICKSTART` note that gateway RBAC protects only the gateway port and the node ports have no
  node-side auth.

## Tests

- Blockhash prune (unit, core): six cases over a shared `EXPIRY_MS` constant: drops older-than-expiry,
  keeps within-expiry, prunes to empty when all stale (the revival fix), keeps `None` block_time, keeps
  future-dated without underflow, and an end-to-end case asserting a stale block's signatures are absent
  from the rebuilt cache. Core lib: 360 passed.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,036 | 12,647 | 87.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27349301836) |
| Indexer | 19,397 | 22,318 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27349301836) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27349301836) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27349301836) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,368 | 14,095 | 80.7% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27349301836) |
| **Total** | **43,512** | **51,055** | **85.2%** | |

> Last updated: 2026-06-11 13:37:19 UTC by E2E Integration