### PR TITLE
fix(indexer): full-range u64 amounts and on-chain-driven startup reconciliation, plus gitignored env secrets (SOLA2-1,    SOLA2-17, SOLA3-7, SOLA3-12)

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -3,6 +3,7 @@
 
 # Instance
 ESCROW_INSTANCE_ID=
+# Keep blank here: `make build-devnet` writes the live key to the gitignored `.env`.
 ADMIN_PRIVATE_KEY=
 
 # Devnet RPC endpoints

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Instance
 ESCROW_INSTANCE_ID=instance_pubkey
-ADMIN_PRIVATE_KEY=base58_private_key
+# Keep blank here: `make build-*` writes the live key to the gitignored `.env`.
+ADMIN_PRIVATE_KEY=
 
 # RPC endpoints
 DEVNET_RPC_URL=solana_rpc_url

--- a/.env.local
+++ b/.env.local
@@ -3,7 +3,8 @@
 
 # Instance
 ESCROW_INSTANCE_ID=
-ADMIN_PRIVATE_KEY=your_admin_key # Private key under keypairs/admin.json
+# Keep blank here: `make build-localnet` writes the live key to the gitignored `.env`.
+ADMIN_PRIVATE_KEY=
 
 # PostgreSQL
 POSTGRES_DB=private_channel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6504,6 +6515,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
+ "bigdecimal",
  "borsh 1.5.7",
  "bs58",
  "chrono",
@@ -6546,6 +6558,7 @@ dependencies = [
  "tokio-util 0.7.16",
  "tracing",
  "tracing-subscriber",
+ "url 2.5.7",
  "uuid",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",
@@ -15732,6 +15745,7 @@ checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
  "ahash 0.8.12",
  "atoi",
+ "bigdecimal",
  "byteorder",
  "bytes",
  "chrono",
@@ -15815,6 +15829,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
+ "bigdecimal",
  "bitflags 2.9.4",
  "byteorder",
  "bytes",
@@ -15859,6 +15874,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
+ "bigdecimal",
  "bitflags 2.9.4",
  "byteorder",
  "chrono",
@@ -15877,6 +15893,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
+ "num-bigint 0.4.6",
  "once_cell",
  "rand 0.8.5",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -540,16 +540,20 @@ check-buildkit-cache:
 #     still run if Docker / BuildKit configuration is in a degraded state.
 COMPOSE_LOCAL    := docker-compose.yml
 COMPOSE_DEVNET   := docker-compose.devnet.yml
-ENV_FILES_LOCAL  ?= --env-file versions.env --env-file .env.local
-ENV_FILES_DEVNET ?= --env-file versions.env --env-file .env.devnet
+# The gitignored `.env` is loaded last (later --env-file wins), so `make build-*`
+# writes live private keys there and the tracked templates stay secret-free.
+# $(wildcard) drops the flag when `.env` is absent; compose errors on missing files.
+ENV_FILES_LOCAL  ?= --env-file versions.env --env-file .env.local $(if $(wildcard .env),--env-file .env)
+ENV_FILES_DEVNET ?= --env-file versions.env --env-file .env.devnet $(if $(wildcard .env),--env-file .env)
 
 # Fail closed before starting the stack if required secrets are blank. The
-# check script takes plain file paths, so pass the raw chain (no --env-file).
+# check script takes plain file paths, so pass the raw chain (no --env-file),
+# including the gitignored `.env` so it validates what compose actually resolves.
 check-env-local:
-	@./scripts/check-required-env.sh versions.env .env.local
+	@./scripts/check-required-env.sh versions.env .env.local $(wildcard .env)
 
 check-env-devnet:
-	@./scripts/check-required-env.sh versions.env .env.devnet
+	@./scripts/check-required-env.sh versions.env .env.devnet $(wildcard .env)
 
 # --- Local stack (local validator) ---
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ make integration-test
 
 ### Docker stack
 
-The Makefile wraps the full compose stack so you don't have to remember the `--env-file` chain. Precondition: copy the env template once (`cp .env.example .env.local`) and fill in the required secrets. No defaults are shipped: `POSTGRES_PASSWORD` and `POSTGRES_REPLICATION_PASSWORD` MUST be set (and `JWT_SECRET` if you enable auth, `ADMIN_PRIVATE_KEY` for the operator) or the stack fails to start. Generate strong values with `openssl rand -hex 32`.
+The Makefile wraps the full compose stack so you don't have to remember the `--env-file` chain. Precondition: copy the env template once (`cp .env.example .env.local`) and fill in the required secrets. No defaults are shipped: `POSTGRES_PASSWORD` and `POSTGRES_REPLICATION_PASSWORD` MUST be set (and `JWT_SECRET` if you enable auth) or the stack fails to start. Generate strong values with `openssl rand -hex 32`. Put secrets in the gitignored `.env` (loaded last, overrides the templates) rather than the tracked `.env.local`; `make build-localnet` writes `ADMIN_PRIVATE_KEY` there for you.
 
 ```bash
 # Build all images

--- a/core/src/bin/streamer.rs
+++ b/core/src/bin/streamer.rs
@@ -419,7 +419,9 @@ struct IndexerTxRow {
     initiator: String,
     recipient: String,
     mint: String,
-    amount: i64,
+    // Read as text: the column is NUMERIC(20,0) (full u64 range) and this crate's sqlx has no
+    // numeric decoder, so casting to text keeps the exact value without a BigDecimal dependency.
+    amount: String,
     transaction_type: String,
     status: String,
     created_at_epoch: i64,
@@ -452,7 +454,7 @@ async fn poll_indexer(
 
         let rows = match sqlx::query_as::<_, IndexerTxRow>(
             r#"
-            SELECT id, signature, slot, initiator, recipient, mint, amount,
+            SELECT id, signature, slot, initiator, recipient, mint, amount::text as amount,
                    transaction_type::text as transaction_type,
                    status::text as status,
                    EXTRACT(EPOCH FROM created_at)::bigint as created_at_epoch
@@ -495,7 +497,7 @@ async fn poll_indexer(
                 tx_type: tx_type.to_string(),
                 from: row.initiator,
                 to: row.recipient,
-                amount: Some(row.amount.to_string()),
+                amount: Some(row.amount),
                 mint: Some(row.mint),
                 timestamp: row.created_at_epoch,
                 status: row.status,

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -115,20 +115,20 @@ Back in the Admin UI:
 
 ## Step 6: Configure Environment Variables
 
-Update `.env.devnet` file in the project root. Replace the following environment variables:
+Update `.env.devnet` (tracked template) for non-secret values, and put all secrets in the gitignored `.env` in the project root — it is loaded last and overrides the templates, so live keys never touch a tracked file. `make build-devnet` writes `ADMIN_PRIVATE_KEY` to `.env` for you.
 
 > **Required secrets — no defaults are shipped.** `POSTGRES_PASSWORD`, `POSTGRES_REPLICATION_PASSWORD`, and `ADMIN_PRIVATE_KEY` (and `JWT_SECRET` if you enable auth) MUST be set or the services fail to start. Generate strong passwords with `openssl rand -hex 32`.
 
 ```shell
-# Required: database credentials (services fail closed if blank)
+# Required secrets: put these in the gitignored `.env`, NOT in .env.devnet
 POSTGRES_PASSWORD=<openssl rand -hex 32>
 POSTGRES_REPLICATION_PASSWORD=<openssl rand -hex 32>
+# Operator keypair (written to `.env` automatically by `make build-devnet`)
+ADMIN_PRIVATE_KEY=<your_operator_private_key_u8array_or_b58>
 
+# Non-secret values below go in .env.devnet
 # Escrow instance (from Step 3)
 ESCROW_INSTANCE_ID=<your_instance_address>
-
-# Operator keypair (the contents of operator-keypair.json from Step 4)
-ADMIN_PRIVATE_KEY=<your_operator_private_key_u8array_or_b58>
 
 # Keys allowed to mint on the Solana Private Channels payment channel (comma-separated public keys)
 # For testing, use your operator's public key

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -44,6 +44,7 @@ sqlx = { workspace = true, features = [
     "runtime-tokio-rustls",
     "postgres",
     "chrono",
+    "bigdecimal",
 ] }
 spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 tokio = { workspace = true, features = ["full"] }
@@ -52,6 +53,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 futures = { workspace = true }
 async-trait = "0.1"
+bigdecimal = "0.3"
 borsh = { workspace = true }
 const-crypto = { workspace = true }
 private-channel-core = { workspace = true }
@@ -78,6 +80,7 @@ rustls = { workspace = true, optional = true }
 solana-keychain = { version = "0.1.0", features = ["all"] }
 
 [dev-dependencies]
+bigdecimal = "0.3"
 tokio = { workspace = true, features = ["test-util"] }
 spl-associated-token-account = { workspace = true }
 

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -46,6 +46,9 @@ pub enum ReconciliationError {
 
     #[error("Invalid pubkey '{pubkey}': {reason}")]
     InvalidPubkey { pubkey: String, reason: String },
+
+    #[error("DB net balance for mint {mint} exceeds u64::MAX ({net}); the escrow ATA cannot hold this, so the DB is corrupt")]
+    DbBalanceOverflow { mint: String, net: String },
 }
 
 /// Errors from data sources (RPC polling, Yellowstone, backfill operations)

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -12,24 +12,25 @@
 //! Only completed withdrawals (`release_funds`) reduce the ATA balance.
 //!
 //! Flow:
-//! 1. Query the DB for per-mint aggregate balances (all deposits − completed withdrawals).
-//! 2. Derive the escrow ATA for each mint (instance PDA + mint + token program).
-//! 3. Fetch the live ATA balance via RPC.
+//! 1. Sweep the escrow instance's on-chain token accounts, summed per mint.
+//! 2. Query the DB for per-mint aggregate balances (all deposits − completed withdrawals).
+//! 3. Compare the union of both mint sets; a mint on only one side compares against 0.
 //! 4. If any |on_chain - db_expected| > threshold → log error, emit alert, abort startup.
 //! 5. If any mismatch ≤ threshold (but > 0) → log warning, continue.
-//! 6. If all balanced → log info, continue.
+//! 6. If all balanced (or both sides empty) → log info, continue.
 
 use crate::{
     config::{ProgramType, ReconciliationConfig},
     error::{IndexerError, ReconciliationError},
-    operator::{rpc_util::RpcClientWithRetry, RetryConfig, RetryPolicy},
+    operator::{
+        escrow_sweep::fetch_escrow_balances_by_mint, rpc_util::RpcClientWithRetry, RetryConfig,
+    },
     storage::common::amount::{net_to_u64, NetBalance},
+    storage::common::models::MintDbBalance,
     storage::Storage,
 };
-use private_channel_core::rpc::error::INVALID_PARAMS_CODE;
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
-use spl_associated_token_account::get_associated_token_address_with_program_id;
-use std::str::FromStr;
+use std::collections::{BTreeMap, HashMap};
 use tracing::{error, info, warn};
 
 /// Per-mint result produced during reconciliation.
@@ -97,58 +98,62 @@ pub async fn run_startup_reconciliation(
         CommitmentConfig::finalized(),
     );
 
+    // The on-chain sweep is the authoritative custody view.
+    let on_chain_balances = fetch_escrow_balances_by_mint(&rpc_client, instance_pda)
+        .await
+        .map_err(|e| ReconciliationError::Rpc {
+            mint: instance_pda.to_string(),
+            reason: e.reason,
+        })?;
+
     let mint_balances = storage
         .get_mint_balances_for_reconciliation()
         .await
         .map_err(ReconciliationError::Storage)?;
 
-    if mint_balances.is_empty() {
-        info!("No mints in storage; reconciliation passed (empty state)");
+    let results = build_reconciliation_set(&mint_balances, &on_chain_balances);
+
+    if results.is_empty() {
+        // Reached only when both the escrow sweep and the DB are genuinely empty, i.e. a truly-first deploy.
+        info!("Both on-chain escrow and DB are empty; reconciliation passed (empty state)");
         return Ok(());
     }
 
     info!(
-        mint_count = mint_balances.len(),
-        "Comparing DB totals against on-chain escrow ATA balances"
+        mint_count = results.len(),
+        "Comparing DB totals against on-chain escrow balances"
     );
 
-    let mut results = Vec::with_capacity(mint_balances.len());
+    classify_and_report(config, &results)
+}
 
-    for balance in &mint_balances {
-        let mint_pk = Pubkey::from_str(&balance.mint_address).map_err(|e| {
-            ReconciliationError::InvalidPubkey {
-                pubkey: balance.mint_address.clone(),
-                reason: e.to_string(),
-            }
-        })?;
+/// Build the per-mint reconciliation set from the union of (DB mints) and
+/// (on-chain escrow mints). A mint present on only one side compares against 0
+/// on the other; an empty result means both sides are genuinely empty.
+fn build_reconciliation_set(
+    db_balances: &[MintDbBalance],
+    on_chain_balances: &HashMap<Pubkey, u64>,
+) -> Vec<MintReconciliation> {
+    // Keyed by mint string so the DB side (String addresses) and on-chain side
+    // (Pubkey) merge into one universe; BTreeMap keeps the order deterministic.
+    let mut by_mint: BTreeMap<String, (u64, u64)> = BTreeMap::new();
 
-        let token_program_pk = Pubkey::from_str(&balance.token_program).map_err(|e| {
-            ReconciliationError::InvalidPubkey {
-                pubkey: balance.token_program.clone(),
-                reason: e.to_string(),
-            }
-        })?;
-
-        let instance_ata = get_associated_token_address_with_program_id(
-            &instance_pda,
-            &mint_pk,
-            &token_program_pk,
-        );
-
-        let on_chain_actual =
-            fetch_ata_balance(&rpc_client, &instance_ata, &balance.mint_address).await?;
-
+    for balance in db_balances {
         let net = &balance.total_deposits - &balance.total_withdrawals;
-        let db_expected = net_db_expected(&net, &balance.mint_address);
-
-        results.push(MintReconciliation::new(
-            balance.mint_address.clone(),
-            db_expected,
-            on_chain_actual,
-        ));
+        by_mint.entry(balance.mint_address.clone()).or_default().0 =
+            net_db_expected(&net, &balance.mint_address);
     }
 
-    classify_and_report(config, &results)
+    for (mint, on_chain) in on_chain_balances {
+        by_mint.entry(mint.to_string()).or_default().1 = *on_chain;
+    }
+
+    by_mint
+        .into_iter()
+        .map(|(mint, (db_expected, on_chain_actual))| {
+            MintReconciliation::new(mint, db_expected, on_chain_actual)
+        })
+        .collect()
 }
 
 /// Log deposit rows whose mint was not allowed at the deposit's slot.
@@ -173,76 +178,6 @@ async fn log_orphan_deposit_rows_at_startup(storage: &Storage) {
                 e
             );
         }
-    }
-}
-
-/// Fetch the raw token balance for an ATA.
-///
-/// Returns `Ok(0)` if the account does not exist yet (valid before the first
-/// deposit for that mint). "Not found" is handled inside the retry closure as
-/// `Ok(None)` so it is never retried — only genuine transient failures are
-/// retried with exponential backoff.
-async fn fetch_ata_balance(
-    rpc_client: &RpcClientWithRetry,
-    ata: &Pubkey,
-    mint_address: &str,
-) -> Result<u64, IndexerError> {
-    let rpc = rpc_client.rpc_client.clone();
-    let ata = *ata;
-
-    let result = rpc_client
-        .with_retry("get_token_account_balance", RetryPolicy::Idempotent, || {
-            let rpc = rpc.clone();
-            async move {
-                match rpc.get_token_account_balance(&ata).await {
-                    Ok(ui_amount) => Ok(Some(ui_amount)),
-                    Err(e) if is_account_not_found(&e) => Ok(None),
-                    Err(e) => Err(e),
-                }
-            }
-        })
-        .await;
-
-    match result {
-        Ok(Some(ui_amount)) => ui_amount.amount.parse::<u64>().map_err(|e| {
-            IndexerError::Reconciliation(ReconciliationError::Rpc {
-                mint: mint_address.to_string(),
-                reason: format!(
-                    "Failed to parse token balance '{}': {}",
-                    ui_amount.amount, e
-                ),
-            })
-        }),
-        Ok(None) => Ok(0),
-        Err(e) => Err(IndexerError::Reconciliation(ReconciliationError::Rpc {
-            mint: mint_address.to_string(),
-            reason: e.to_string(),
-        })),
-    }
-}
-
-/// Returns true when the RPC error indicates the account simply does not exist.
-///
-/// Uses structured `ErrorKind` inspection rather than raw string matching:
-/// - Primary: `INVALID_PARAMS_CODE` (`-32602`, JSON-RPC "Invalid params"), which
-///   is what Solana validators return for a missing account.
-/// - Fallback: substring match on the error message for non-standard RPC
-///   providers that may emit the same wording with a different code.
-///
-/// This function only receives errors from `rpc.get_token_account_balance`, so
-/// it cannot be triggered by a DB error — DB failures propagate as a different
-/// error type entirely and never reach this function.
-fn is_account_not_found(e: &solana_rpc_client_api::client_error::Error) -> bool {
-    use solana_rpc_client_api::{client_error::ErrorKind, request::RpcError};
-
-    if let ErrorKind::RpcError(RpcError::RpcResponseError { code, message, .. }) = &e.kind {
-        if *code == INVALID_PARAMS_CODE as i64 {
-            return true;
-        }
-        let msg = message.to_lowercase();
-        msg.contains("could not find account") || msg.contains("account not found")
-    } else {
-        false
     }
 }
 
@@ -400,74 +335,6 @@ mod tests {
     }
 
     // =========================================================================
-    // is_account_not_found tests
-    // =========================================================================
-
-    fn make_rpc_response_error(
-        code: i64,
-        message: &str,
-    ) -> solana_rpc_client_api::client_error::Error {
-        use solana_rpc_client_api::{
-            client_error::ErrorKind,
-            request::{RpcError, RpcResponseErrorData},
-        };
-        ErrorKind::RpcError(RpcError::RpcResponseError {
-            code,
-            message: message.to_string(),
-            data: RpcResponseErrorData::Empty,
-        })
-        .into()
-    }
-
-    #[test]
-    fn test_is_account_not_found_by_code() {
-        // INVALID_PARAMS_CODE matches regardless of message wording
-        let err = make_rpc_response_error(
-            INVALID_PARAMS_CODE as i64,
-            "Invalid param: some unrecognized wording",
-        );
-        assert!(is_account_not_found(&err));
-    }
-
-    #[test]
-    fn test_is_account_not_found_standard_message() {
-        // Standard Solana validator message — also matches via INVALID_PARAMS_CODE
-        let err = make_rpc_response_error(
-            INVALID_PARAMS_CODE as i64,
-            "Invalid param: could not find account",
-        );
-        assert!(is_account_not_found(&err));
-    }
-
-    #[test]
-    fn test_is_account_not_found_message_fallback() {
-        // Non-standard provider: different code but recognizable message
-        let err = make_rpc_response_error(-32000, "could not find account");
-        assert!(is_account_not_found(&err));
-    }
-
-    #[test]
-    fn test_is_account_not_found_account_not_found_variant() {
-        // Alternative message wording — message fallback
-        let err = make_rpc_response_error(-32000, "account not found");
-        assert!(is_account_not_found(&err));
-    }
-
-    #[test]
-    fn test_is_account_not_found_unrelated_error() {
-        // Unrelated RPC error — should not match
-        let err = make_rpc_response_error(-32005, "Node is unhealthy");
-        assert!(!is_account_not_found(&err));
-    }
-
-    #[test]
-    fn test_is_account_not_found_non_rpc_error() {
-        use solana_rpc_client_api::client_error::ErrorKind;
-        let err = ErrorKind::Custom("connection refused".to_string()).into();
-        assert!(!is_account_not_found(&err));
-    }
-
-    // =========================================================================
     // classify_and_report tests
     // =========================================================================
 
@@ -588,170 +455,78 @@ mod tests {
     }
 
     // =========================================================================
-    // run_startup_reconciliation skip / pass tests
+    // build_reconciliation_set (union) tests
     // =========================================================================
 
-    #[tokio::test]
-    async fn test_reconciliation_skipped_for_withdraw_program() {
-        let config = ReconciliationConfig {
-            mismatch_threshold_raw: 0,
-        };
-
-        #[cfg(test)]
-        {
-            use crate::storage::common::storage::mock::MockStorage;
-            let storage = Storage::Mock(MockStorage::new());
-            let seed = Pubkey::new_unique();
-
-            let result = run_startup_reconciliation(
-                &config,
-                ProgramType::Withdraw,
-                &storage,
-                "http://localhost:8899",
-                &seed,
-            )
-            .await;
-
-            assert!(result.is_ok());
-        }
-    }
-
-    #[tokio::test]
-    async fn test_reconciliation_empty_mints_passes() {
-        let config = ReconciliationConfig {
-            mismatch_threshold_raw: 0,
-        };
-
-        #[cfg(test)]
-        {
-            use crate::storage::common::storage::mock::MockStorage;
-            // Empty mock: no mints → should pass immediately
-            let storage = Storage::Mock(MockStorage::new());
-            let seed = Pubkey::new_unique();
-
-            let result = run_startup_reconciliation(
-                &config,
-                ProgramType::Escrow,
-                &storage,
-                "http://localhost:8899",
-                &seed,
-            )
-            .await;
-
-            // Empty state always passes (no mints to compare)
-            assert!(result.is_ok());
-        }
-    }
-
-    // =========================================================================
-    // InvalidPubkey error path tests (comment 4)
-    // =========================================================================
-
-    #[tokio::test]
-    async fn test_reconciliation_invalid_mint_pubkey_returns_error() {
-        use crate::storage::common::storage::mock::MockStorage;
-
-        let mock_storage = MockStorage::new();
-        mock_storage.set_mint_balances(vec![crate::storage::common::models::MintDbBalance {
-            mint_address: "not-a-valid-pubkey".to_string(),
+    fn db_balance(mint: &str, deposits: u64, withdrawals: u64) -> MintDbBalance {
+        MintDbBalance {
+            mint_address: mint.to_string(),
             token_program: spl_token::id().to_string(),
-            total_deposits: bigdecimal::BigDecimal::from(1000u64),
-            total_withdrawals: bigdecimal::BigDecimal::from(0u64),
-        }]);
-        let storage = Storage::Mock(mock_storage);
-        let config = ReconciliationConfig {
-            mismatch_threshold_raw: 0,
-        };
-        let seed = Pubkey::new_unique();
-
-        let result = run_startup_reconciliation(
-            &config,
-            ProgramType::Escrow,
-            &storage,
-            "http://localhost:8899",
-            &seed,
-        )
-        .await;
-
-        match result {
-            Err(IndexerError::Reconciliation(ReconciliationError::InvalidPubkey {
-                pubkey,
-                reason: _,
-            })) => {
-                assert_eq!(pubkey, "not-a-valid-pubkey");
-            }
-            other => panic!("Expected InvalidPubkey error, got: {:?}", other),
+            total_deposits: bigdecimal::BigDecimal::from(deposits),
+            total_withdrawals: bigdecimal::BigDecimal::from(withdrawals),
         }
     }
 
-    #[tokio::test]
-    async fn test_reconciliation_invalid_token_program_pubkey_returns_error() {
-        use crate::storage::common::storage::mock::MockStorage;
+    #[test]
+    fn union_empty_both_sides_is_empty() {
+        assert!(build_reconciliation_set(&[], &HashMap::new()).is_empty());
+    }
 
-        let mock_storage = MockStorage::new();
-        mock_storage.set_mint_balances(vec![crate::storage::common::models::MintDbBalance {
-            mint_address: Pubkey::new_unique().to_string(),
-            token_program: "not-a-valid-token-program".to_string(),
-            total_deposits: bigdecimal::BigDecimal::from(500u64),
-            total_withdrawals: bigdecimal::BigDecimal::from(0u64),
-        }]);
-        let storage = Storage::Mock(mock_storage);
-        let config = ReconciliationConfig {
-            mismatch_threshold_raw: 0,
-        };
-        let seed = Pubkey::new_unique();
+    #[test]
+    fn union_db_only_mint_compares_against_zero_on_chain() {
+        let results =
+            build_reconciliation_set(&[db_balance("MintAAAA", 1000, 200)], &HashMap::new());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].mint, "MintAAAA");
+        assert_eq!(results[0].db_expected, 800);
+        assert_eq!(results[0].on_chain_actual, 0);
+        assert_eq!(results[0].mismatch, 800);
+    }
 
-        let result = run_startup_reconciliation(
-            &config,
-            ProgramType::Escrow,
-            &storage,
-            "http://localhost:8899",
-            &seed,
-        )
-        .await;
+    #[test]
+    fn union_on_chain_only_mint_compares_against_zero_db() {
+        let mint = Pubkey::new_unique();
+        let on_chain = HashMap::from([(mint, 1234u64)]);
+        let results = build_reconciliation_set(&[], &on_chain);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].mint, mint.to_string());
+        assert_eq!(results[0].db_expected, 0);
+        assert_eq!(results[0].on_chain_actual, 1234);
+        assert_eq!(results[0].mismatch, 1234);
+    }
 
-        match result {
-            Err(IndexerError::Reconciliation(ReconciliationError::InvalidPubkey {
-                pubkey,
-                reason: _,
-            })) => {
-                assert_eq!(pubkey, "not-a-valid-token-program");
-            }
-            other => panic!("Expected InvalidPubkey error, got: {:?}", other),
-        }
+    #[test]
+    fn union_merges_same_mint_on_both_sides() {
+        let mint = Pubkey::new_unique();
+        let on_chain = HashMap::from([(mint, 1000u64)]);
+        let results =
+            build_reconciliation_set(&[db_balance(&mint.to_string(), 1000, 0)], &on_chain);
+        assert_eq!(results.len(), 1, "same mint must merge to one entry");
+        assert_eq!(results[0].mismatch, 0);
+    }
+
+    #[test]
+    fn union_includes_disjoint_mints_from_both_sides() {
+        let db_mint = Pubkey::new_unique();
+        let chain_mint = Pubkey::new_unique();
+        let on_chain = HashMap::from([(chain_mint, 700u64)]);
+        let results =
+            build_reconciliation_set(&[db_balance(&db_mint.to_string(), 500, 0)], &on_chain);
+        assert_eq!(results.len(), 2, "union must contain both mints");
     }
 
     // =========================================================================
-    // RPC integration tests (mockito)
+    // run_startup_reconciliation contract tests (mockito escrow sweep)
     // =========================================================================
 
     use crate::storage::common::storage::mock::MockStorage;
-
-    fn token_account_balance_response(amount: u64) -> String {
-        format!(
-            r#"{{
-                "context": {{"slot": 100}},
-                "value": {{
-                    "amount": "{}",
-                    "decimals": 6,
-                    "uiAmount": null,
-                    "uiAmountString": "{}"
-                }}
-            }}"#,
-            amount, amount
-        )
-    }
-
-    fn account_not_found_error() -> (i32, &'static str) {
-        (-32602, "Invalid param: could not find account")
-    }
 
     fn make_mint_balance(
         mint_address: &str,
         total_deposits: u64,
         total_withdrawals: u64,
-    ) -> crate::storage::common::models::MintDbBalance {
-        crate::storage::common::models::MintDbBalance {
+    ) -> MintDbBalance {
+        MintDbBalance {
             mint_address: mint_address.to_string(),
             token_program: spl_token::id().to_string(),
             total_deposits: bigdecimal::BigDecimal::from(total_deposits),
@@ -759,32 +534,145 @@ mod tests {
         }
     }
 
+    /// `get_token_accounts_by_owner` returns jsonParsed token accounts; the sweep
+    /// sums them per mint. Build one such account entry for the mock RPC response.
+    fn token_account_entry(mint: &str, amount: u64) -> String {
+        format!(
+            r#"{{"pubkey":"{ata}","account":{{"lamports":2039280,"owner":"{owner}",
+                "executable":false,"rentEpoch":0,"space":165,
+                "data":{{"program":"spl-token","space":165,
+                    "parsed":{{"type":"account","info":{{"mint":"{mint}","owner":"{owner}",
+                        "tokenAmount":{{"amount":"{amount}","decimals":6,"uiAmount":null,
+                            "uiAmountString":"{amount}"}}}}}}}}}}}}"#,
+            ata = Pubkey::new_unique(),
+            owner = Pubkey::new_unique(),
+            mint = mint,
+            amount = amount,
+        )
+    }
+
+    /// Mock both sweep calls (SPL Token and Token-2022). The SPL Token call (matched
+    /// by its program id in the request body) returns `entries`; the Token-2022 call
+    /// returns an empty list so balances are not double-counted.
+    async fn mock_escrow_sweep(server: &mut mockito::Server, entries: &[(String, u64)]) {
+        let value: Vec<String> = entries
+            .iter()
+            .map(|(mint, amount)| token_account_entry(mint, *amount))
+            .collect();
+        let token_body = format!(
+            r#"{{"jsonrpc":"2.0","result":{{"context":{{"slot":100}},"value":[{}]}},"id":1}}"#,
+            value.join(",")
+        );
+        let empty_body =
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":100},"value":[]},"id":1}"#.to_string();
+
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(spl_token::id().to_string()))
+            .with_status(200)
+            .with_body(token_body)
+            .create_async()
+            .await;
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(spl_token_2022::id().to_string()))
+            .with_status(200)
+            .with_body(empty_body)
+            .create_async()
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_skipped_for_withdraw_program() {
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let storage = Storage::Mock(MockStorage::new());
+        let seed = Pubkey::new_unique();
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Withdraw,
+            &storage,
+            "http://localhost:8899",
+            &seed,
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_empty_db_and_empty_escrow_passes() {
+        let mut server = mockito::Server::new_async().await;
+        mock_escrow_sweep(&mut server, &[]).await;
+
+        let storage = Storage::Mock(MockStorage::new());
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &server.url(),
+            &seed,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "truly-empty state (no DB mints, no escrow balance) must pass: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reconciliation_empty_db_with_nonempty_escrow_blocks() {
+        // The SOLA3-7 regression: a fresh/partial DB (no `mints` rows) against a
+        // live escrow balance must fail closed instead of passing blind.
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
+
+        let storage = Storage::Mock(MockStorage::new());
+        let config = ReconciliationConfig {
+            mismatch_threshold_raw: 0,
+        };
+        let seed = Pubkey::new_unique();
+        let result = run_startup_reconciliation(
+            &config,
+            ProgramType::Escrow,
+            &storage,
+            &server.url(),
+            &seed,
+        )
+        .await;
+
+        match result {
+            Err(IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
+                count,
+                ..
+            })) => assert_eq!(count, 1),
+            other => panic!(
+                "live escrow with empty DB must block startup, got: {:?}",
+                other
+            ),
+        }
+    }
+
     #[tokio::test]
     async fn test_reconciliation_balanced_passes() {
         let mut server = mockito::Server::new_async().await;
-        let _mock = server
-            .mock("POST", "/")
-            .with_status(200)
-            .with_body(format!(
-                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
-                token_account_balance_response(1000)
-            ))
-            .create_async()
-            .await;
+        let mint = Pubkey::new_unique();
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
 
         let mock_storage = MockStorage::new();
-        mock_storage.set_mint_balances(vec![make_mint_balance(
-            &Pubkey::new_unique().to_string(),
-            1000,
-            0,
-        )]);
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1000, 0)]);
         let storage = Storage::Mock(mock_storage);
 
         let config = ReconciliationConfig {
             mismatch_threshold_raw: 0,
         };
         let seed = Pubkey::new_unique();
-
         let result = run_startup_reconciliation(
             &config,
             ProgramType::Escrow,
@@ -793,37 +681,24 @@ mod tests {
             &seed,
         )
         .await;
-
         assert!(result.is_ok(), "balanced state should pass: {:?}", result);
     }
 
     #[tokio::test]
     async fn test_reconciliation_mismatch_within_threshold_passes() {
         let mut server = mockito::Server::new_async().await;
-        // DB expects 1000, on-chain has 1005 → mismatch = 5 ≤ threshold 10 → ok
-        let _mock = server
-            .mock("POST", "/")
-            .with_status(200)
-            .with_body(format!(
-                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
-                token_account_balance_response(1005)
-            ))
-            .create_async()
-            .await;
+        let mint = Pubkey::new_unique();
+        // DB expects 1000, on-chain has 1005 => mismatch 5 <= threshold 10 => ok
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_005)]).await;
 
         let mock_storage = MockStorage::new();
-        mock_storage.set_mint_balances(vec![make_mint_balance(
-            &Pubkey::new_unique().to_string(),
-            1000,
-            0,
-        )]);
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1000, 0)]);
         let storage = Storage::Mock(mock_storage);
 
         let config = ReconciliationConfig {
             mismatch_threshold_raw: 10,
         };
         let seed = Pubkey::new_unique();
-
         let result = run_startup_reconciliation(
             &config,
             ProgramType::Escrow,
@@ -832,7 +707,6 @@ mod tests {
             &seed,
         )
         .await;
-
         assert!(
             result.is_ok(),
             "mismatch within threshold should pass: {:?}",
@@ -843,30 +717,18 @@ mod tests {
     #[tokio::test]
     async fn test_reconciliation_mismatch_exceeds_threshold_blocks() {
         let mut server = mockito::Server::new_async().await;
-        // DB expects 1000, on-chain has 1020 → mismatch = 20 > threshold 10 → err
-        let _mock = server
-            .mock("POST", "/")
-            .with_status(200)
-            .with_body(format!(
-                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
-                token_account_balance_response(1020)
-            ))
-            .create_async()
-            .await;
+        let mint = Pubkey::new_unique();
+        // DB expects 1000, on-chain has 1020 => mismatch 20 > threshold 10 => err
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_020)]).await;
 
         let mock_storage = MockStorage::new();
-        mock_storage.set_mint_balances(vec![make_mint_balance(
-            &Pubkey::new_unique().to_string(),
-            1000,
-            0,
-        )]);
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1000, 0)]);
         let storage = Storage::Mock(mock_storage);
 
         let config = ReconciliationConfig {
             mismatch_threshold_raw: 10,
         };
         let seed = Pubkey::new_unique();
-
         let result = run_startup_reconciliation(
             &config,
             ProgramType::Escrow,
@@ -875,7 +737,6 @@ mod tests {
             &seed,
         )
         .await;
-
         match result {
             Err(IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
                 count,
@@ -889,121 +750,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reconciliation_ata_not_found_treated_as_zero() {
-        let mut server = mockito::Server::new_async().await;
-        let (code, message) = account_not_found_error();
-        // Return "account not found" error → treated as balance 0
-        let _mock = server
-            .mock("POST", "/")
-            .with_status(200)
-            .with_body(format!(
-                r#"{{"jsonrpc":"2.0","error":{{"code":{},"message":"{}"}},"id":1}}"#,
-                code, message
-            ))
-            .create_async()
-            .await;
-
-        let mock_storage = MockStorage::new();
-        // DB also expects 0 (no completed deposits) → balanced → should pass
-        mock_storage.set_mint_balances(vec![make_mint_balance(
-            &Pubkey::new_unique().to_string(),
-            0,
-            0,
-        )]);
-        let storage = Storage::Mock(mock_storage);
-
-        let config = ReconciliationConfig {
-            mismatch_threshold_raw: 0,
-        };
-        let seed = Pubkey::new_unique();
-
-        let result = run_startup_reconciliation(
-            &config,
-            ProgramType::Escrow,
-            &storage,
-            &server.url(),
-            &seed,
-        )
-        .await;
-
-        assert!(
-            result.is_ok(),
-            "account not found should be treated as 0 balance: {:?}",
-            result
-        );
-    }
-
-    #[tokio::test]
     async fn test_reconciliation_with_nonzero_withdrawals_balanced() {
-        // Exercises total_deposits - total_withdrawals: 1500 deposits, 500 withdrawals → db_expected 1000
+        // 1500 deposits, 500 withdrawals => db_expected 1000; on-chain 1000 => balanced.
         let mut server = mockito::Server::new_async().await;
-        let _mock = server
-            .mock("POST", "/")
-            .with_status(200)
-            .with_body(format!(
-                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
-                token_account_balance_response(1000)
-            ))
-            .create_async()
-            .await;
+        let mint = Pubkey::new_unique();
+        mock_escrow_sweep(&mut server, &[(mint.to_string(), 1_000)]).await;
 
         let mock_storage = MockStorage::new();
-        mock_storage.set_mint_balances(vec![make_mint_balance(
-            &Pubkey::new_unique().to_string(),
-            1500,
-            500,
-        )]);
-        let storage = Storage::Mock(mock_storage);
-
-        let config = ReconciliationConfig {
-            mismatch_threshold_raw: 0,
-        };
-        let seed = Pubkey::new_unique();
-
-        let result = run_startup_reconciliation(
-            &config,
-            ProgramType::Escrow,
-            &storage,
-            &server.url(),
-            &seed,
-        )
-        .await;
-
-        assert!(
-            result.is_ok(),
-            "1500 deposits - 500 withdrawals = 1000 on-chain should balance: {:?}",
-            result
-        );
-    }
-
-    #[tokio::test]
-    async fn test_reconciliation_with_nonzero_withdrawals_mismatch_blocks() {
-        // 1500 deposits, 500 withdrawals → db_expected 1000
-        // on-chain = 1050 → mismatch 50 > threshold 10 → error
-        let mut server = mockito::Server::new_async().await;
-        let _mock = server
-            .mock("POST", "/")
-            .with_status(200)
-            .with_body(format!(
-                r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
-                token_account_balance_response(1050)
-            ))
-            .create_async()
-            .await;
-
-        let mock_storage = MockStorage::new();
-        mock_storage.set_mint_balances(vec![make_mint_balance(
-            &Pubkey::new_unique().to_string(),
-            1500,
-            500,
-        )]);
+        mock_storage.set_mint_balances(vec![make_mint_balance(&mint.to_string(), 1500, 500)]);
         let storage = Storage::Mock(mock_storage);
 
         let config = ReconciliationConfig {
             mismatch_threshold_raw: 10,
         };
         let seed = Pubkey::new_unique();
-
         let result = run_startup_reconciliation(
             &config,
             ProgramType::Escrow,
@@ -1012,19 +772,10 @@ mod tests {
             &seed,
         )
         .await;
-
-        match result {
-            Err(IndexerError::Reconciliation(ReconciliationError::MismatchExceedsThreshold {
-                count,
-                threshold,
-            })) => {
-                assert_eq!(count, 1);
-                assert_eq!(threshold, 10);
-            }
-            other => panic!(
-                "Expected MismatchExceedsThreshold for withdrawal mismatch, got: {:?}",
-                other
-            ),
-        }
+        assert!(
+            result.is_ok(),
+            "net (deposits - withdrawals) must match on-chain: {:?}",
+            result
+        );
     }
 }

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -181,11 +181,11 @@ async fn log_orphan_deposit_rows_at_startup(storage: &Storage) {
     }
 }
 
-/// Convert a per-mint net (deposits - withdrawals) into the unsigned expected
-/// balance. A negative net (withdrawals exceed deposits) is clamped to 0 with a
-/// warning. An over-u64 net is impossible for a real escrow (the ATA balance is
-/// itself a u64), so it signals a corrupt DB and aborts the startup gate rather
-/// than feeding a sentinel into the mismatch compare.
+/// Convert a per-mint net (deposits - withdrawals) into the unsigned expected balance.
+/// Negative (withdrawals > deposits) means the DB is missing deposit history (fresh or
+/// partial DB, or a withdrawal indexed before its deposit): clamp to 0 and warn, since any
+/// real on-chain balance still trips the mismatch. Over-u64 can't happen for a real escrow
+/// (the ATA balance is itself a u64), so treat it as corruption and abort startup.
 fn net_db_expected(
     net: &bigdecimal::BigDecimal,
     mint_address: &str,

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -111,7 +111,7 @@ pub async fn run_startup_reconciliation(
         .await
         .map_err(ReconciliationError::Storage)?;
 
-    let results = build_reconciliation_set(&mint_balances, &on_chain_balances);
+    let results = build_reconciliation_set(&mint_balances, &on_chain_balances)?;
 
     if results.is_empty() {
         // Reached only when both the escrow sweep and the DB are genuinely empty, i.e. a truly-first deploy.
@@ -133,7 +133,7 @@ pub async fn run_startup_reconciliation(
 fn build_reconciliation_set(
     db_balances: &[MintDbBalance],
     on_chain_balances: &HashMap<Pubkey, u64>,
-) -> Vec<MintReconciliation> {
+) -> Result<Vec<MintReconciliation>, ReconciliationError> {
     // Keyed by mint string so the DB side (String addresses) and on-chain side
     // (Pubkey) merge into one universe; BTreeMap keeps the order deterministic.
     let mut by_mint: BTreeMap<String, (u64, u64)> = BTreeMap::new();
@@ -141,19 +141,19 @@ fn build_reconciliation_set(
     for balance in db_balances {
         let net = &balance.total_deposits - &balance.total_withdrawals;
         by_mint.entry(balance.mint_address.clone()).or_default().0 =
-            net_db_expected(&net, &balance.mint_address);
+            net_db_expected(&net, &balance.mint_address)?;
     }
 
     for (mint, on_chain) in on_chain_balances {
         by_mint.entry(mint.to_string()).or_default().1 = *on_chain;
     }
 
-    by_mint
+    Ok(by_mint
         .into_iter()
         .map(|(mint, (db_expected, on_chain_actual))| {
             MintReconciliation::new(mint, db_expected, on_chain_actual)
         })
-        .collect()
+        .collect())
 }
 
 /// Log deposit rows whose mint was not allowed at the deposit's slot.
@@ -182,29 +182,28 @@ async fn log_orphan_deposit_rows_at_startup(storage: &Storage) {
 }
 
 /// Convert a per-mint net (deposits - withdrawals) into the unsigned expected
-/// balance, mirroring the operator's continuous-reconciliation seam. A negative
-/// net (withdrawals exceed deposits) is clamped to 0 with a warning; an
-/// over-u64 net is surfaced as u64::MAX so the mismatch check trips rather than
-/// the value wrapping.
-fn net_db_expected(net: &bigdecimal::BigDecimal, mint_address: &str) -> u64 {
+/// balance. A negative net (withdrawals exceed deposits) is clamped to 0 with a
+/// warning. An over-u64 net is impossible for a real escrow (the ATA balance is
+/// itself a u64), so it signals a corrupt DB and aborts the startup gate rather
+/// than feeding a sentinel into the mismatch compare.
+fn net_db_expected(
+    net: &bigdecimal::BigDecimal,
+    mint_address: &str,
+) -> Result<u64, ReconciliationError> {
     match net_to_u64(net) {
-        NetBalance::Exact(v) => v,
+        NetBalance::Exact(v) => Ok(v),
         NetBalance::Negative => {
             warn!(
                 mint = mint_address,
                 net = %net,
                 "Withdrawals exceed deposits; treating expected escrow balance as 0"
             );
-            0
+            Ok(0)
         }
-        NetBalance::Overflow => {
-            warn!(
-                mint = mint_address,
-                net = %net,
-                "Expected escrow balance exceeds u64::MAX; flagging as a reconciliation mismatch"
-            );
-            u64::MAX
-        }
+        NetBalance::Overflow => Err(ReconciliationError::DbBalanceOverflow {
+            mint: mint_address.to_string(),
+            net: net.to_string(),
+        }),
     }
 }
 
@@ -319,19 +318,24 @@ mod tests {
         // state; the net is clamped to 0 so a corrupt over-withdrawn mint reads
         // as expected balance 0 and surfaces as a mismatch, not a wrap.
         let net = bigdecimal::BigDecimal::from(-50);
-        assert_eq!(net_db_expected(&net, "mint"), 0);
+        assert_eq!(net_db_expected(&net, "mint").unwrap(), 0);
     }
 
     #[test]
     fn net_db_expected_passes_full_u64_range() {
         let net = bigdecimal::BigDecimal::from(u64::MAX);
-        assert_eq!(net_db_expected(&net, "mint"), u64::MAX);
+        assert_eq!(net_db_expected(&net, "mint").unwrap(), u64::MAX);
     }
 
     #[test]
-    fn net_db_expected_flags_over_u64_as_mismatch_sentinel() {
+    fn net_db_expected_over_u64_is_a_hard_error() {
+        // A net above u64::MAX cannot back a real escrow ATA (itself a u64), so it
+        // is a corrupt-DB signal and must fail the startup gate, not return a value.
         let net = bigdecimal::BigDecimal::from(u64::MAX) + bigdecimal::BigDecimal::from(1);
-        assert_eq!(net_db_expected(&net, "mint"), u64::MAX);
+        assert!(matches!(
+            net_db_expected(&net, "mint"),
+            Err(ReconciliationError::DbBalanceOverflow { .. })
+        ));
     }
 
     // =========================================================================
@@ -469,13 +473,16 @@ mod tests {
 
     #[test]
     fn union_empty_both_sides_is_empty() {
-        assert!(build_reconciliation_set(&[], &HashMap::new()).is_empty());
+        assert!(build_reconciliation_set(&[], &HashMap::new())
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
     fn union_db_only_mint_compares_against_zero_on_chain() {
         let results =
-            build_reconciliation_set(&[db_balance("MintAAAA", 1000, 200)], &HashMap::new());
+            build_reconciliation_set(&[db_balance("MintAAAA", 1000, 200)], &HashMap::new())
+                .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].mint, "MintAAAA");
         assert_eq!(results[0].db_expected, 800);
@@ -487,7 +494,7 @@ mod tests {
     fn union_on_chain_only_mint_compares_against_zero_db() {
         let mint = Pubkey::new_unique();
         let on_chain = HashMap::from([(mint, 1234u64)]);
-        let results = build_reconciliation_set(&[], &on_chain);
+        let results = build_reconciliation_set(&[], &on_chain).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].mint, mint.to_string());
         assert_eq!(results[0].db_expected, 0);
@@ -500,7 +507,7 @@ mod tests {
         let mint = Pubkey::new_unique();
         let on_chain = HashMap::from([(mint, 1000u64)]);
         let results =
-            build_reconciliation_set(&[db_balance(&mint.to_string(), 1000, 0)], &on_chain);
+            build_reconciliation_set(&[db_balance(&mint.to_string(), 1000, 0)], &on_chain).unwrap();
         assert_eq!(results.len(), 1, "same mint must merge to one entry");
         assert_eq!(results[0].mismatch, 0);
     }
@@ -511,8 +518,22 @@ mod tests {
         let chain_mint = Pubkey::new_unique();
         let on_chain = HashMap::from([(chain_mint, 700u64)]);
         let results =
-            build_reconciliation_set(&[db_balance(&db_mint.to_string(), 500, 0)], &on_chain);
+            build_reconciliation_set(&[db_balance(&db_mint.to_string(), 500, 0)], &on_chain)
+                .unwrap();
         assert_eq!(results.len(), 2, "union must contain both mints");
+    }
+
+    #[test]
+    fn union_db_overflow_is_a_hard_error() {
+        // A DB net above u64::MAX is corrupt accounting; building the set must fail
+        // closed rather than emit a sentinel that could compare as balanced.
+        let mut bal = db_balance("MintAAAA", 0, 0);
+        bal.total_deposits =
+            bigdecimal::BigDecimal::from(u64::MAX) + bigdecimal::BigDecimal::from(1);
+        assert!(matches!(
+            build_reconciliation_set(&[bal], &HashMap::new()),
+            Err(ReconciliationError::DbBalanceOverflow { .. })
+        ));
     }
 
     // =========================================================================

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -23,6 +23,7 @@ use crate::{
     config::{ProgramType, ReconciliationConfig},
     error::{IndexerError, ReconciliationError},
     operator::{rpc_util::RpcClientWithRetry, RetryConfig, RetryPolicy},
+    storage::common::amount::{net_to_u64, NetBalance},
     storage::Storage,
 };
 use private_channel_core::rpc::error::INVALID_PARAMS_CODE;
@@ -36,7 +37,10 @@ use tracing::{error, info, warn};
 pub struct MintReconciliation {
     pub mint: String,
     /// Expected balance according to DB: all indexed deposits − completed withdrawals.
-    pub db_expected: i64,
+    /// Unsigned because it mirrors the escrow ATA balance, itself a u64; a negative
+    /// net is clamped to 0 at the call site so this value stays lossless across the
+    /// full u64 range instead of truncating at i64::MAX.
+    pub db_expected: u64,
     /// Actual raw token balance in the escrow ATA on-chain.
     pub on_chain_actual: u64,
     /// Absolute difference: |on_chain_actual − db_expected|.  Derived from the
@@ -45,7 +49,7 @@ pub struct MintReconciliation {
 }
 
 impl MintReconciliation {
-    pub fn new(mint: String, db_expected: i64, on_chain_actual: u64) -> Self {
+    pub fn new(mint: String, db_expected: u64, on_chain_actual: u64) -> Self {
         let mismatch = compute_mismatch(db_expected, on_chain_actual);
         Self {
             mint,
@@ -134,7 +138,8 @@ pub async fn run_startup_reconciliation(
         let on_chain_actual =
             fetch_ata_balance(&rpc_client, &instance_ata, &balance.mint_address).await?;
 
-        let db_expected = balance.total_deposits - balance.total_withdrawals;
+        let net = &balance.total_deposits - &balance.total_withdrawals;
+        let db_expected = net_db_expected(&net, &balance.mint_address);
 
         results.push(MintReconciliation::new(
             balance.mint_address.clone(),
@@ -241,12 +246,37 @@ fn is_account_not_found(e: &solana_rpc_client_api::client_error::Error) -> bool 
     }
 }
 
+/// Convert a per-mint net (deposits - withdrawals) into the unsigned expected
+/// balance, mirroring the operator's continuous-reconciliation seam. A negative
+/// net (withdrawals exceed deposits) is clamped to 0 with a warning; an
+/// over-u64 net is surfaced as u64::MAX so the mismatch check trips rather than
+/// the value wrapping.
+fn net_db_expected(net: &bigdecimal::BigDecimal, mint_address: &str) -> u64 {
+    match net_to_u64(net) {
+        NetBalance::Exact(v) => v,
+        NetBalance::Negative => {
+            warn!(
+                mint = mint_address,
+                net = %net,
+                "Withdrawals exceed deposits; treating expected escrow balance as 0"
+            );
+            0
+        }
+        NetBalance::Overflow => {
+            warn!(
+                mint = mint_address,
+                net = %net,
+                "Expected escrow balance exceeds u64::MAX; flagging as a reconciliation mismatch"
+            );
+            u64::MAX
+        }
+    }
+}
+
 /// Compute the absolute difference between on-chain balance and DB expected value.
-/// Uses i128 internally to avoid overflow when subtracting.
-pub fn compute_mismatch(db_expected: i64, on_chain_actual: u64) -> u64 {
-    let diff = (on_chain_actual as i128) - (db_expected as i128);
-    // unsigned_abs() returns u128; cap at u64::MAX to keep the type consistent
-    diff.unsigned_abs().min(u64::MAX as u128) as u64
+/// Both sides are u64; the diff cannot exceed u64::MAX.
+pub fn compute_mismatch(db_expected: u64, on_chain_actual: u64) -> u64 {
+    on_chain_actual.abs_diff(db_expected)
 }
 
 /// Log results and decide whether to allow or block startup.
@@ -333,15 +363,40 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_mismatch_db_negative() {
-        // Impossible state: more completed withdrawals than deposits in DB.
-        // Mismatch is the absolute difference from 0.
-        assert_eq!(compute_mismatch(-50, 0), 50);
+    fn test_compute_mismatch_zero_both() {
+        assert_eq!(compute_mismatch(0, 0), 0);
     }
 
     #[test]
-    fn test_compute_mismatch_zero_both() {
-        assert_eq!(compute_mismatch(0, 0), 0);
+    fn test_compute_mismatch_full_u64_range() {
+        // A wiped DB (expected 0) against a u64::MAX escrow must not overflow.
+        assert_eq!(compute_mismatch(0, u64::MAX), u64::MAX);
+        assert_eq!(compute_mismatch(u64::MAX, 0), u64::MAX);
+    }
+
+    // =========================================================================
+    // net_db_expected tests
+    // =========================================================================
+
+    #[test]
+    fn net_db_expected_clamps_negative_to_zero() {
+        // Withdrawals exceeding deposits is an impossible-in-a-healthy-system
+        // state; the net is clamped to 0 so a corrupt over-withdrawn mint reads
+        // as expected balance 0 and surfaces as a mismatch, not a wrap.
+        let net = bigdecimal::BigDecimal::from(-50);
+        assert_eq!(net_db_expected(&net, "mint"), 0);
+    }
+
+    #[test]
+    fn net_db_expected_passes_full_u64_range() {
+        let net = bigdecimal::BigDecimal::from(u64::MAX);
+        assert_eq!(net_db_expected(&net, "mint"), u64::MAX);
+    }
+
+    #[test]
+    fn net_db_expected_flags_over_u64_as_mismatch_sentinel() {
+        let net = bigdecimal::BigDecimal::from(u64::MAX) + bigdecimal::BigDecimal::from(1);
+        assert_eq!(net_db_expected(&net, "mint"), u64::MAX);
     }
 
     // =========================================================================
@@ -416,7 +471,7 @@ mod tests {
     // classify_and_report tests
     // =========================================================================
 
-    fn make_result(mint: &str, db_expected: i64, on_chain_actual: u64) -> MintReconciliation {
+    fn make_result(mint: &str, db_expected: u64, on_chain_actual: u64) -> MintReconciliation {
         MintReconciliation::new(mint.to_string(), db_expected, on_chain_actual)
     }
 
@@ -600,8 +655,8 @@ mod tests {
         mock_storage.set_mint_balances(vec![crate::storage::common::models::MintDbBalance {
             mint_address: "not-a-valid-pubkey".to_string(),
             token_program: spl_token::id().to_string(),
-            total_deposits: 1000,
-            total_withdrawals: 0,
+            total_deposits: bigdecimal::BigDecimal::from(1000u64),
+            total_withdrawals: bigdecimal::BigDecimal::from(0u64),
         }]);
         let storage = Storage::Mock(mock_storage);
         let config = ReconciliationConfig {
@@ -637,8 +692,8 @@ mod tests {
         mock_storage.set_mint_balances(vec![crate::storage::common::models::MintDbBalance {
             mint_address: Pubkey::new_unique().to_string(),
             token_program: "not-a-valid-token-program".to_string(),
-            total_deposits: 500,
-            total_withdrawals: 0,
+            total_deposits: bigdecimal::BigDecimal::from(500u64),
+            total_withdrawals: bigdecimal::BigDecimal::from(0u64),
         }]);
         let storage = Storage::Mock(mock_storage);
         let config = ReconciliationConfig {
@@ -693,14 +748,14 @@ mod tests {
 
     fn make_mint_balance(
         mint_address: &str,
-        total_deposits: i64,
-        total_withdrawals: i64,
+        total_deposits: u64,
+        total_withdrawals: u64,
     ) -> crate::storage::common::models::MintDbBalance {
         crate::storage::common::models::MintDbBalance {
             mint_address: mint_address.to_string(),
             token_program: spl_token::id().to_string(),
-            total_deposits,
-            total_withdrawals,
+            total_deposits: bigdecimal::BigDecimal::from(total_deposits),
+            total_withdrawals: bigdecimal::BigDecimal::from(total_withdrawals),
         }
     }
 

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -368,6 +368,7 @@ mod tests {
         AllowMintAccounts, AllowMintData, AllowMintEvent, DepositAccounts, DepositData,
         DepositEvent, ResetSmtRootAccounts, WithdrawFundsAccounts, WithdrawFundsData,
     };
+    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::storage::mock::MockStorage;
     use solana_sdk::pubkey::Pubkey;
 
@@ -522,7 +523,7 @@ mod tests {
         assert_eq!(txn.slot, 100);
         // event.amount = 990, data.amount = 1000 (see make_deposit_instruction).
         // The DB row must carry the event-reported amount.
-        assert_eq!(txn.amount, 990);
+        assert_eq!(txn.amount, TokenAmount(990));
         assert_eq!(txn.recipient, recipient.to_string());
         assert_eq!(txn.initiator, make_pubkey(1).to_string());
         assert!(matches!(txn.transaction_type, TransactionType::Deposit));
@@ -557,7 +558,7 @@ mod tests {
         let (mint, txn) = convert_to_db_models(&ix, None);
         assert!(mint.is_none());
         let txn = txn.unwrap();
-        assert_eq!(txn.amount, 500);
+        assert_eq!(txn.amount, TokenAmount(500));
         assert_eq!(txn.recipient, make_pubkey(20).to_string());
         assert!(matches!(txn.transaction_type, TransactionType::Withdrawal));
     }

--- a/indexer/src/operator/escrow_sweep.rs
+++ b/indexer/src/operator/escrow_sweep.rs
@@ -109,8 +109,8 @@ pub async fn fetch_escrow_balances_by_mint(
                 continue;
             };
 
-            // Multiple token accounts can hold the same mint; sum them. Saturating so a
-            // pathological set of balances reports u64::MAX instead of wrapping to a small value.
+            // One mint can span several token accounts; sum them. Saturating so a corrupt
+            // over-u64 sum reports u64::MAX (and trips the mismatch) instead of wrapping.
             let acc = balances.entry(mint).or_insert(0u64);
             *acc = acc.saturating_add(amount);
         }

--- a/indexer/src/operator/escrow_sweep.rs
+++ b/indexer/src/operator/escrow_sweep.rs
@@ -1,0 +1,305 @@
+//! Shared on-chain escrow balance sweep.
+//!
+//! Both the operator's continuous reconciliation and the indexer's startup
+//! reconciliation need the authoritative custody view: the token balance the
+//! escrow instance actually holds, summed per mint across every token account
+//! it owns. Deriving the set of mints from this sweep (rather than from the DB
+//! `mints` table) is what closes the startup blind spot where a fresh or
+//! partially restored DB with real escrow balances would otherwise pass the
+//! check without ever looking on-chain.
+
+use crate::operator::utils::instruction_util::RetryPolicy;
+use crate::operator::utils::rpc_util::RpcClientWithRetry;
+use solana_account_decoder_client_types::UiAccountData;
+use solana_client::rpc_request::TokenAccountsFilter;
+use solana_sdk::pubkey::Pubkey;
+use spl_token::solana_program::program_pack::Pack;
+use spl_token::state::Account as TokenAccount;
+use std::collections::HashMap;
+use std::str::FromStr;
+use tracing::warn;
+
+/// Failure to read the escrow's on-chain token holdings. Carries a human reason
+/// so each caller can wrap it in its own error type without losing context.
+#[derive(Debug, Clone)]
+pub struct EscrowSweepError {
+    pub reason: String,
+}
+
+impl std::fmt::Display for EscrowSweepError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.reason)
+    }
+}
+
+impl std::error::Error for EscrowSweepError {}
+
+/// Sum every token account owned by the escrow instance, grouped by mint, across
+/// the SPL Token and Token-2022 programs. The returned map is the on-chain
+/// custody snapshot; a mint absent from the map holds zero on-chain.
+pub async fn fetch_escrow_balances_by_mint(
+    rpc_client: &RpcClientWithRetry,
+    escrow_instance_id: Pubkey,
+) -> Result<HashMap<Pubkey, u64>, EscrowSweepError> {
+    let mut balances = HashMap::new();
+    let token_programs = [spl_token::id(), spl_token_2022::id()];
+
+    for token_program_id in token_programs {
+        let accounts = rpc_client
+            .with_retry(
+                "get_token_accounts_by_owner",
+                RetryPolicy::Idempotent,
+                || async {
+                    rpc_client
+                        .rpc_client
+                        .get_token_accounts_by_owner(
+                            &escrow_instance_id,
+                            TokenAccountsFilter::ProgramId(token_program_id),
+                        )
+                        .await
+                },
+            )
+            .await
+            .map_err(|e| EscrowSweepError {
+                reason: format!(
+                    "Failed to fetch token accounts for program {token_program_id}: {e}"
+                ),
+            })?;
+
+        // The RPC may return accounts in binary (base64) or JSON-parsed form
+        // depending on the requested encoding; handle both.
+        for keyed_account in accounts {
+            let (mint, amount) = if let Some(decoded) = keyed_account.account.data.decode() {
+                let token_account =
+                    TokenAccount::unpack(&decoded).map_err(|e| EscrowSweepError {
+                        reason: format!(
+                            "Failed to parse token account for program {token_program_id}: {e}"
+                        ),
+                    })?;
+                (token_account.mint, token_account.amount)
+            } else if let UiAccountData::Json(parsed) = &keyed_account.account.data {
+                let info = parsed.parsed.get("info").ok_or_else(|| EscrowSweepError {
+                    reason: "Missing 'info' in parsed token account".to_string(),
+                })?;
+                let mint_str =
+                    info.get("mint")
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| EscrowSweepError {
+                            reason: "Missing 'mint' in parsed token account info".to_string(),
+                        })?;
+                let amount_str = info
+                    .get("tokenAmount")
+                    .and_then(|v| v.get("amount"))
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| EscrowSweepError {
+                        reason: "Missing 'tokenAmount.amount' in parsed token account".to_string(),
+                    })?;
+                let mint = Pubkey::from_str(mint_str).map_err(|e| EscrowSweepError {
+                    reason: format!("Invalid mint pubkey '{mint_str}': {e}"),
+                })?;
+                let amount = amount_str.parse::<u64>().map_err(|e| EscrowSweepError {
+                    reason: format!("Invalid token amount '{amount_str}': {e}"),
+                })?;
+                (mint, amount)
+            } else {
+                warn!(
+                    token_program = %token_program_id,
+                    "Skipping escrow token account with unrecognised data encoding"
+                );
+                continue;
+            };
+
+            // Multiple token accounts can hold the same mint; sum them. Saturating so a
+            // pathological set of balances reports u64::MAX instead of wrapping to a small value.
+            let acc = balances.entry(mint).or_insert(0u64);
+            *acc = acc.saturating_add(amount);
+        }
+    }
+
+    Ok(balances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operator::RetryConfig;
+    use base64::Engine as _;
+    use solana_sdk::commitment_config::CommitmentConfig;
+    use spl_token::solana_program::program_option::COption;
+    use spl_token::state::AccountState;
+
+    fn client(url: &str) -> RpcClientWithRetry {
+        RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            RetryConfig::default(),
+            CommitmentConfig::finalized(),
+        )
+    }
+
+    /// One `RpcKeyedAccount` whose `data` is the SPL Token-2022/Token binary layout,
+    /// base64-encoded, exercising the `data.decode()` + `TokenAccount::unpack` path.
+    fn base64_account(mint: Pubkey, amount: u64) -> String {
+        let account = TokenAccount {
+            mint,
+            owner: Pubkey::new_unique(),
+            amount,
+            delegate: COption::None,
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 0,
+            close_authority: COption::None,
+        };
+        let mut buf = vec![0u8; TokenAccount::LEN];
+        account.pack_into_slice(&mut buf);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&buf);
+        format!(
+            r#"{{"pubkey":"{ata}","account":{{"lamports":2039280,"owner":"{prog}","executable":false,"rentEpoch":0,"space":165,"data":["{b64}","base64"]}}}}"#,
+            ata = Pubkey::new_unique(),
+            prog = spl_token::id(),
+        )
+    }
+
+    /// One `RpcKeyedAccount` whose `data` is jsonParsed, exercising the JSON path.
+    fn json_parsed_account(mint: Pubkey, amount: u64) -> String {
+        format!(
+            r#"{{"pubkey":"{ata}","account":{{"lamports":2039280,"owner":"{prog}","executable":false,"rentEpoch":0,"space":165,"data":{{"program":"spl-token","space":165,"parsed":{{"type":"account","info":{{"mint":"{mint}","owner":"{owner}","tokenAmount":{{"amount":"{amount}","decimals":6,"uiAmount":null,"uiAmountString":"{amount}"}}}}}}}}}}}}"#,
+            ata = Pubkey::new_unique(),
+            prog = spl_token::id(),
+            owner = Pubkey::new_unique(),
+        )
+    }
+
+    /// One `RpcKeyedAccount` whose `data` carries the legacy `binary` encoding tag,
+    /// which `decode()` cannot handle and which is not jsonParsed: the unrecognised
+    /// branch the sweep skips with a warning instead of erroring.
+    fn unrecognised_encoding_account() -> String {
+        format!(
+            r#"{{"pubkey":"{ata}","account":{{"lamports":1,"owner":"{prog}","executable":false,"rentEpoch":0,"space":4,"data":["AAAA","binary"]}}}}"#,
+            ata = Pubkey::new_unique(),
+            prog = spl_token::id(),
+        )
+    }
+
+    fn result_body(values: &[String]) -> String {
+        format!(
+            r#"{{"jsonrpc":"2.0","result":{{"context":{{"slot":1}},"value":[{}]}},"id":1}}"#,
+            values.join(",")
+        )
+    }
+
+    const EMPTY_BODY: &str =
+        r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":[]},"id":1}"#;
+
+    /// The sweep calls `get_token_accounts_by_owner` once per token program. Route the
+    /// SPL Token call (matched by its program id in the request body) to `spl_accounts`
+    /// and the Token-2022 call to an empty list so the two are not double-counted.
+    async fn mock_sweep(server: &mut mockito::Server, spl_accounts: &[String]) {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(spl_token::id().to_string()))
+            .with_status(200)
+            .with_body(result_body(spl_accounts))
+            .create_async()
+            .await;
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(spl_token_2022::id().to_string()))
+            .with_status(200)
+            .with_body(EMPTY_BODY.to_string())
+            .create_async()
+            .await;
+    }
+
+    #[tokio::test]
+    async fn json_parsed_sums_multiple_accounts_per_mint() {
+        let mut server = mockito::Server::new_async().await;
+        let mint1 = Pubkey::new_unique();
+        let mint2 = Pubkey::new_unique();
+        // mint1 split across two accounts (100 + 200), mint2 in one (500).
+        mock_sweep(
+            &mut server,
+            &[
+                json_parsed_account(mint1, 100),
+                json_parsed_account(mint1, 200),
+                json_parsed_account(mint2, 500),
+            ],
+        )
+        .await;
+
+        let balances = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
+            .await
+            .unwrap();
+
+        assert_eq!(balances.len(), 2);
+        assert_eq!(balances[&mint1], 300, "same mint across accounts must sum");
+        assert_eq!(balances[&mint2], 500);
+    }
+
+    #[tokio::test]
+    async fn decodes_base64_binary_accounts() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        mock_sweep(&mut server, &[base64_account(mint, 1_234)]).await;
+
+        let balances = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
+            .await
+            .unwrap();
+
+        assert_eq!(balances[&mint], 1_234, "base64 layout must unpack and sum");
+    }
+
+    #[tokio::test]
+    async fn skips_unrecognised_encoding_without_erroring() {
+        let mut server = mockito::Server::new_async().await;
+        let mint = Pubkey::new_unique();
+        // A valid account plus one with an unrecognised encoding: the latter is skipped,
+        // not fatal, so the valid balance still lands.
+        mock_sweep(
+            &mut server,
+            &[
+                json_parsed_account(mint, 50),
+                unrecognised_encoding_account(),
+            ],
+        )
+        .await;
+
+        let balances = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
+            .await
+            .unwrap();
+
+        assert_eq!(balances.len(), 1);
+        assert_eq!(balances[&mint], 50);
+    }
+
+    #[tokio::test]
+    async fn empty_owner_returns_empty_map() {
+        let mut server = mockito::Server::new_async().await;
+        mock_sweep(&mut server, &[]).await;
+
+        let balances = fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique())
+            .await
+            .unwrap();
+
+        assert!(balances.is_empty());
+    }
+
+    #[tokio::test]
+    async fn errors_on_malformed_json_account() {
+        let mut server = mockito::Server::new_async().await;
+        // jsonParsed account missing the `tokenAmount` field: a corrupt response must
+        // surface as an error, never a silently dropped balance.
+        let malformed = format!(
+            r#"{{"pubkey":"{ata}","account":{{"lamports":1,"owner":"{prog}","executable":false,"rentEpoch":0,"space":165,"data":{{"program":"spl-token","space":165,"parsed":{{"type":"account","info":{{"mint":"{mint}","owner":"{prog}"}}}}}}}}}}"#,
+            ata = Pubkey::new_unique(),
+            prog = spl_token::id(),
+            mint = Pubkey::new_unique(),
+        );
+        mock_sweep(&mut server, &[malformed]).await;
+
+        let result =
+            fetch_escrow_balances_by_mint(&client(&server.url()), Pubkey::new_unique()).await;
+
+        let err = result.expect_err("malformed account must error").reason;
+        assert!(err.contains("tokenAmount"), "unexpected error: {err}");
+    }
+}

--- a/indexer/src/operator/fetcher.rs
+++ b/indexer/src/operator/fetcher.rs
@@ -107,6 +107,7 @@ pub async fn run_fetcher(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::models::{DbTransaction, TransactionStatus};
     use crate::storage::common::storage::mock::MockStorage;
     use chrono::Utc;
@@ -139,7 +140,7 @@ mod tests {
             initiator: "init".to_string(),
             recipient: "recv".to_string(),
             mint: "mint".to_string(),
-            amount: 1000,
+            amount: TokenAmount(1000),
             memo: None,
             transaction_type: TransactionType::Deposit,
             withdrawal_nonce: None,

--- a/indexer/src/operator/mod.rs
+++ b/indexer/src/operator/mod.rs
@@ -1,5 +1,6 @@
 pub mod constants;
 pub mod db_transaction_writer;
+pub mod escrow_sweep;
 pub mod feepayer_monitor;
 pub mod fetcher;
 #[allow(clippy::module_inception)]

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -374,14 +374,7 @@ async fn build_release_funds(
         .user(recipient)
         .transaction_nonce(nonce);
 
-    let amount = u64::try_from(transaction.amount).map_err(|_| {
-        OperatorError::Program(ProgramError::InvalidBuilder {
-            reason: format!(
-                "negative withdrawal amount {} for transaction {}",
-                transaction.amount, transaction.id
-            ),
-        })
-    })?;
+    let amount = transaction.amount.value();
     builder.amount(amount);
 
     // Remint info for recovery-on-permanent-failure.  PrivateChannel token program, not
@@ -476,14 +469,7 @@ async fn check_withdrawal_preflights(
     }
 
     if has_permanent_delegate {
-        let amount = u64::try_from(transaction.amount).map_err(|_| {
-            OperatorError::Program(ProgramError::InvalidBuilder {
-                reason: format!(
-                    "negative withdrawal amount {} for transaction {}",
-                    transaction.amount, transaction.id
-                ),
-            })
-        })?;
+        let amount = transaction.amount.value();
 
         let release_funds_state = processor_state
             .release_funds_state
@@ -688,7 +674,7 @@ pub async fn process_deposit_funds(
                 .payer(processor_state.admin_pubkey)
                 .mint_authority(processor_state.admin_pubkey)
                 .token_program(token_program)
-                .amount(transaction.amount as u64)
+                .amount(transaction.amount.value())
                 .idempotency_memo(mint_idempotency_memo(transaction.id));
 
             let proc_elapsed_ms = proc_t0.elapsed().as_millis();
@@ -753,6 +739,7 @@ mod tests {
     use super::*;
     use crate::error::{AccountError, StorageError, TransactionError};
     use crate::operator::find_allowed_mint_pda;
+    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::models::DbMint;
     use crate::storage::common::models::TransactionType;
     use crate::storage::common::storage::mock::MockStorage;
@@ -868,7 +855,7 @@ mod tests {
             initiator: "initiator".to_string(),
             recipient: recipient.to_string(),
             mint: mint.to_string(),
-            amount: 1000,
+            amount: TokenAmount(1000),
             memo: None,
             transaction_type: txn_type,
             withdrawal_nonce: nonce,
@@ -2192,7 +2179,7 @@ mod tests {
             initiator: "initiator".to_string(),
             recipient: recipient.to_string(),
             mint: mint_pubkey.to_string(),
-            amount: 1000, // > on-chain balance of 500
+            amount: TokenAmount(1000), // > on-chain balance of 500
             memo: None,
             transaction_type: crate::storage::common::models::TransactionType::Withdrawal,
             withdrawal_nonce: Some(5),
@@ -2297,7 +2284,7 @@ mod tests {
             initiator: "initiator".to_string(),
             recipient: recipient.to_string(),
             mint: mint_pubkey.to_string(),
-            amount: 1000, // < on-chain balance of 5000
+            amount: TokenAmount(1000), // < on-chain balance of 5000
             memo: None,
             transaction_type: crate::storage::common::models::TransactionType::Withdrawal,
             withdrawal_nonce: Some(5),

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -11,18 +11,13 @@
 
 use crate::config::OperatorConfig;
 use crate::error::OperatorError;
-use crate::operator::utils::instruction_util::RetryPolicy;
+use crate::operator::escrow_sweep::fetch_escrow_balances_by_mint;
 use crate::operator::RpcClientWithRetry;
 use crate::storage::common::amount::{net_to_u64, NetBalance};
 use crate::storage::Storage;
 use private_channel_core::webhook::{WebhookClient, WebhookRetryConfig};
-use solana_account_decoder_client_types::UiAccountData;
-use solana_client::rpc_request::TokenAccountsFilter;
 use solana_sdk::pubkey::Pubkey;
-use spl_token::solana_program::program_pack::Pack;
-use spl_token::state::Account as TokenAccount;
 use std::collections::{HashMap, HashSet};
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -393,101 +388,9 @@ async fn fetch_on_chain_balances(
     rpc_client: &Arc<RpcClientWithRetry>,
     escrow_instance_id: Pubkey,
 ) -> Result<HashMap<Pubkey, u64>, OperatorError> {
-    let mut balances = HashMap::new();
-    let token_programs = [spl_token::id(), spl_token_2022::id()];
-
-    for token_program_id in token_programs {
-        // Fetch all token accounts owned by the escrow for each supported token program
-        let accounts = rpc_client
-            .with_retry(
-                "get_token_accounts_by_owner",
-                RetryPolicy::Idempotent,
-                || async {
-                    rpc_client
-                        .rpc_client
-                        .get_token_accounts_by_owner(
-                            &escrow_instance_id,
-                            TokenAccountsFilter::ProgramId(token_program_id),
-                        )
-                        .await
-                },
-            )
-            .await
-            .map_err(|e| {
-                OperatorError::RpcError(format!(
-                    "Failed to fetch token accounts for program {}: {}",
-                    token_program_id, e
-                ))
-            })?;
-
-        // Parse each token account and aggregate balances by mint.
-        // The RPC may return accounts in either binary (base64) or JSON-parsed format
-        // depending on the client's requested encoding. We handle both variants.
-        for keyed_account in accounts {
-            let (mint, amount) = match &keyed_account.account.data {
-                // Binary encoding: decode base64, then unpack the SPL token layout
-                data if data.decode().is_some() => {
-                    let account_data = data.decode().unwrap();
-                    let token_account = TokenAccount::unpack(&account_data).map_err(|e| {
-                        OperatorError::RpcError(format!(
-                            "Failed to parse token account for program {}: {}",
-                            token_program_id, e
-                        ))
-                    })?;
-                    (token_account.mint, token_account.amount)
-                }
-                // JSON-parsed encoding: the RPC has already decoded the account for us;
-                // extract mint and amount from the nested `info` object.
-                UiAccountData::Json(parsed) => {
-                    let info = parsed.parsed.get("info").ok_or_else(|| {
-                        OperatorError::RpcError(
-                            "Missing 'info' in parsed token account".to_string(),
-                        )
-                    })?;
-                    let mint_str = info.get("mint").and_then(|v| v.as_str()).ok_or_else(|| {
-                        OperatorError::RpcError(
-                            "Missing 'mint' in parsed token account info".to_string(),
-                        )
-                    })?;
-                    let amount_str = info
-                        .get("tokenAmount")
-                        .and_then(|v| v.get("amount"))
-                        .and_then(|v| v.as_str())
-                        .ok_or_else(|| {
-                            OperatorError::RpcError(
-                                "Missing 'tokenAmount.amount' in parsed token account".to_string(),
-                            )
-                        })?;
-                    let mint = Pubkey::from_str(mint_str).map_err(|e| {
-                        OperatorError::RpcError(format!(
-                            "Invalid mint pubkey '{}': {}",
-                            mint_str, e
-                        ))
-                    })?;
-                    let amount = amount_str.parse::<u64>().map_err(|e| {
-                        OperatorError::RpcError(format!(
-                            "Invalid token amount '{}': {}",
-                            amount_str, e
-                        ))
-                    })?;
-                    (mint, amount)
-                }
-                // Unknown encoding variant — skip with a warning rather than hard-failing
-                _ => {
-                    warn!(
-                        "Skipping token account with unrecognised data encoding for program {}",
-                        token_program_id
-                    );
-                    continue;
-                }
-            };
-
-            // Sum balances for each mint (handles multiple token accounts for the same mint)
-            *balances.entry(mint).or_insert(0) += amount;
-        }
-    }
-
-    Ok(balances)
+    fetch_escrow_balances_by_mint(rpc_client, escrow_instance_id)
+        .await
+        .map_err(|e| OperatorError::RpcError(e.reason))
 }
 
 /// Sends webhook alerts for balance mismatches with retry logic
@@ -636,38 +539,8 @@ mod tests {
     use crate::storage::common::storage::{mock::MockStorage, Storage};
     use solana_sdk::pubkey::Pubkey;
 
-    #[test]
-    fn test_fetch_on_chain_balances_exists() {
-        // This test verifies that the fetch_on_chain_balances function exists and compiles
-        // Integration testing with a real RPC client would require a test validator
-        // and is better suited for integration tests rather than unit tests
-        let _function = fetch_on_chain_balances;
-    }
-
-    #[test]
-    fn test_pubkey_hashmap_initialization() {
-        // Test that we can create a HashMap<Pubkey, u64> as expected by the function
-        let mut balances: HashMap<Pubkey, u64> = HashMap::new();
-        let mint = Pubkey::new_unique();
-        balances.insert(mint, 1000);
-        assert_eq!(*balances.get(&mint).unwrap(), 1000);
-    }
-
-    #[test]
-    fn test_balance_aggregation_logic() {
-        // Test the aggregation logic used in fetch_on_chain_balances
-        let mut balances: HashMap<Pubkey, u64> = HashMap::new();
-        let mint1 = Pubkey::new_unique();
-        let mint2 = Pubkey::new_unique();
-
-        // Simulate multiple token accounts for the same mint
-        *balances.entry(mint1).or_insert(0) += 100;
-        *balances.entry(mint1).or_insert(0) += 200;
-        *balances.entry(mint2).or_insert(0) += 500;
-
-        assert_eq!(*balances.get(&mint1).unwrap(), 300);
-        assert_eq!(*balances.get(&mint2).unwrap(), 500);
-    }
+    // The sweep that `fetch_on_chain_balances` delegates to is tested directly in
+    // `operator::escrow_sweep` (both encodings, multi-account summing, skip/error arms).
 
     #[test]
     fn test_compare_balances_exact_match() {

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -13,6 +13,7 @@ use crate::config::OperatorConfig;
 use crate::error::OperatorError;
 use crate::operator::utils::instruction_util::RetryPolicy;
 use crate::operator::RpcClientWithRetry;
+use crate::storage::common::amount::{net_to_u64, NetBalance};
 use crate::storage::Storage;
 use private_channel_core::webhook::{WebhookClient, WebhookRetryConfig};
 use solana_account_decoder_client_types::UiAccountData;
@@ -31,6 +32,32 @@ const WEBHOOK_MAX_ATTEMPTS: u32 = 3;
 const WEBHOOK_BASE_DELAY: Duration = Duration::from_millis(500);
 const WEBHOOK_MAX_DELAY: Duration = Duration::from_secs(5);
 const WEBHOOK_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Convert a net (deposits - withdrawals) BigDecimal into the u64 the on-chain
+/// comparison uses, logging the two corruption cases. A negative net is treated
+/// as 0 (matching the prior behavior); an over-range net is surfaced as u64::MAX
+/// so the downstream compare flags a mismatch instead of silently wrapping.
+fn net_bigdecimal_to_u64(net: &bigdecimal::BigDecimal, mint_address: &str) -> u64 {
+    match net_to_u64(net) {
+        NetBalance::Exact(v) => v,
+        NetBalance::Negative => {
+            warn!(
+                mint = mint_address,
+                net = %net,
+                "Withdrawals exceed deposits; treating net escrow balance as 0 for comparison"
+            );
+            0
+        }
+        NetBalance::Overflow => {
+            warn!(
+                mint = mint_address,
+                net = %net,
+                "Net escrow balance exceeds u64::MAX; flagging as a reconciliation mismatch"
+            );
+            u64::MAX
+        }
+    }
+}
 
 /// Runs periodic escrow balance reconciliation checks
 ///
@@ -149,21 +176,8 @@ async fn perform_reconciliation_check(
             }
         })?;
 
-        // Calculate net balance (deposits - withdrawals)
-        let net_balance_i64 = if balance_result.total_deposits >= balance_result.total_withdrawals {
-            balance_result.total_deposits - balance_result.total_withdrawals
-        } else {
-            // This shouldn't happen in a properly functioning system, but handle it gracefully
-            warn!(
-                "Withdrawals exceed deposits for mint {}: deposits={}, withdrawals={}",
-                balance_result.mint_address,
-                balance_result.total_deposits,
-                balance_result.total_withdrawals
-            );
-            0 // Treat as zero balance for comparison
-        };
-
-        let net_balance = net_balance_i64 as u64;
+        let net = &balance_result.total_deposits - &balance_result.total_withdrawals;
+        let net_balance = net_bigdecimal_to_u64(&net, &balance_result.mint_address);
         db_balances.insert(mint, net_balance);
     }
 
@@ -618,6 +632,7 @@ pub async fn send_orphan_deposit_alert(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::storage::{mock::MockStorage, Storage};
     use solana_sdk::pubkey::Pubkey;
 
@@ -1662,7 +1677,7 @@ mod tests {
             initiator: "init".to_string(),
             recipient: "recip".to_string(),
             mint: mint.to_string(),
-            amount: 1,
+            amount: TokenAmount(1),
             memo: None,
             transaction_type: TransactionType::Deposit,
             withdrawal_nonce: None,

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -293,8 +293,7 @@ fn reconstruct_mint_builder_for_lookup(
     let token_program = spl_token::id();
     let recipient_ata =
         get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
-    let amount =
-        u64::try_from(row.amount).map_err(|_| format!("negative amount: {}", row.amount))?;
+    let amount = row.amount.value();
 
     let mut builder = MintToBuilder::new();
     builder
@@ -515,6 +514,7 @@ pub mod test_hooks {
 mod tests {
     use super::*;
     use crate::operator::utils::rpc_util::RetryConfig;
+    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::storage::mock::MockStorage;
     use solana_sdk::commitment_config::CommitmentConfig;
 
@@ -528,7 +528,7 @@ mod tests {
             initiator: Pubkey::new_unique().to_string(),
             recipient: Pubkey::new_unique().to_string(),
             mint: Pubkey::new_unique().to_string(),
-            amount: 1_000,
+            amount: TokenAmount(1_000),
             memo: None,
             transaction_type: TransactionType::Deposit,
             withdrawal_nonce: None,
@@ -656,7 +656,7 @@ mod tests {
                                                 "mint": mint.to_string(),
                                                 "account": recipient_ata.to_string(),
                                                 "mintAuthority": admin_pubkey.to_string(),
-                                                "amount": (row.amount as u64).to_string(),
+                                                "amount": row.amount.value().to_string(),
                                             },
                                         },
                                     },

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -512,6 +512,7 @@ mod tests {
     use crate::operator::MintCache;
     use crate::operator::RetryConfig;
     use crate::operator::RpcClientWithRetry;
+    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::storage::mock::MockStorage;
     use crate::storage::Storage;
     use solana_sdk::commitment_config::CommitmentConfig;
@@ -578,7 +579,7 @@ mod tests {
                 initiator: Pubkey::new_unique().to_string(),
                 recipient: Pubkey::new_unique().to_string(),
                 mint: Pubkey::new_unique().to_string(),
-                amount: 0,
+                amount: TokenAmount(0),
                 memo: None,
                 transaction_type: TransactionType::Withdrawal,
                 withdrawal_nonce: Some(id),

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -269,19 +269,7 @@ impl SenderState {
                 &private_channel_token_program,
             );
 
-            // u64::try_from catches negative amounts. The write path already guards
-            // against this (ba77249) but a corrupt DB row could still produce one —
-            // casting a negative i64 to u64 would produce a massive spurious remint.
-            let Some(amount) = Self::or_manual_review(
-                u64::try_from(tx.amount).map_err(|_| format!("negative amount: {}", tx.amount)),
-                storage_tx,
-                tx.id,
-                &tx.trace_id,
-            )
-            .await
-            else {
-                continue;
-            };
+            let amount = tx.amount.value();
 
             // Pair each stored signature with its last_valid_block_height. The
             // remint gate needs both to verify the withdrawal cannot still land.
@@ -389,6 +377,7 @@ impl SenderState {
 mod tests {
     use super::*;
     use crate::operator::MintCache;
+    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
     use crate::storage::common::storage::mock::MockStorage;
     use crate::storage::Storage;
@@ -449,7 +438,7 @@ mod tests {
             initiator: Pubkey::new_unique().to_string(),
             recipient: recipient.to_string(),
             mint: mint.to_string(),
-            amount: 5_000,
+            amount: TokenAmount(5_000),
             memo: None,
             transaction_type: TransactionType::Withdrawal,
             withdrawal_nonce: Some(id),
@@ -678,51 +667,8 @@ mod tests {
         assert!(storage_rx.try_recv().is_err());
     }
 
-    /// A negative amount in a PendingRemint row must never be cast to u64.
-    /// `i64` to `u64` with `as` would silently wrap: `-1_i64 as u64` produces
-    /// `18_446_744_073_709_551_615` — a remint of the entire token supply.
-    ///
-    /// The write path guards against this, but a corrupted DB row could still
-    /// produce a negative value. `u64::try_from` catches it and the operator
-    /// must escalate to ManualReview rather than execute a catastrophic remint.
-    #[tokio::test]
-    async fn recover_pending_remints_escalates_negative_amount_to_manual_review() {
-        let mock = MockStorage::new();
-        let mint = Pubkey::new_unique();
-        let recipient = Pubkey::new_unique();
-        let sig = Signature::new_unique();
-        let deadline = Utc::now() + chrono::Duration::seconds(20);
-
-        let mut bad_row = make_pending_remint_row(30, &mint, &recipient, &sig, deadline);
-        bad_row.amount = -1;
-
-        mock.pending_remint_transactions
-            .lock()
-            .unwrap()
-            .push(bad_row);
-
-        let mut state = make_sender_state(mock);
-        let (storage_tx, mut storage_rx) = mpsc::channel(10);
-
-        state.recover_pending_remints(&storage_tx).await.unwrap();
-
-        let update = storage_rx
-            .try_recv()
-            .expect("should receive ManualReview for negative amount");
-        assert_eq!(update.transaction_id, 30);
-        assert_eq!(update.status, TransactionStatus::ManualReview);
-        let err = update.error_message.as_deref().unwrap_or("");
-        assert!(
-            err.contains("negative amount"),
-            "error message should describe the negative amount: {err}"
-        );
-
-        assert!(
-            state.pending_remints.is_empty(),
-            "negative-amount row must not be queued"
-        );
-        assert!(storage_rx.try_recv().is_err());
-    }
+    // No negative-amount test here anymore: `TokenAmount(u64)` makes a negative
+    // amount unconstructable; the rejection now lives in TokenAmount's decode tests.
 
     /// An unparseable withdrawal signature in a PendingRemint row breaks the
     /// finality check: the operator cannot call `get_signature_statuses` with

--- a/indexer/src/storage/common/amount.rs
+++ b/indexer/src/storage/common/amount.rs
@@ -1,0 +1,150 @@
+use {
+    bigdecimal::{BigDecimal, ToPrimitive},
+    serde::{Deserialize, Serialize},
+    sqlx::{
+        encode::IsNull,
+        error::BoxDynError,
+        postgres::{PgArgumentBuffer, PgTypeInfo, PgValueRef},
+        Decode, Encode, Postgres, Type,
+    },
+    std::fmt,
+};
+
+/// On-chain token amounts are `u64` end to end. The database column is
+/// `NUMERIC(20,0)`, which losslessly holds the whole `u64` range (0..2^64-1).
+/// This newtype is the single signed/unsigned conversion seam: it encodes as a NUMERIC via
+/// `BigDecimal` and decodes with a checked `BigDecimal -> u64`, so a corrupt or
+/// out-of-range row surfaces as a decode error at the read site instead of a
+/// silent wrap. `#[serde(transparent)]` keeps the JSON shape a bare integer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TokenAmount(pub u64);
+
+impl TokenAmount {
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for TokenAmount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Convert a decoded NUMERIC into a `u64`, rejecting anything that cannot be the
+/// exact non-negative integer an on-chain amount must be. A negative value
+/// (e.g. a legacy wrapped `BIGINT` row), a fractional value, or a value above
+/// `u64::MAX` all fail loudly rather than wrapping.
+fn u64_from_big_decimal(value: &BigDecimal) -> Result<u64, BoxDynError> {
+    // A raw token quantity is always a whole number; a fraction means a corrupt row, not a truncation.
+    if !value.is_integer() {
+        return Err(format!("token amount {value} is not an integer").into());
+    }
+    // to_u64 yields None for negatives and for values past u64::MAX; both are corruption, never valid.
+    value
+        .to_u64()
+        .ok_or_else(|| format!("token amount {value} is out of range for u64").into())
+}
+
+/// Outcome of converting a reconciliation net (deposits - withdrawals) to a u64.
+/// A real net equals an escrow ATA balance, itself a u64, so neither a negative
+/// nor an over-u64 net can occur in a healthy system; both are corruption signals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetBalance {
+    /// The net is a valid non-negative u64.
+    Exact(u64),
+    /// Withdrawals exceeded deposits; the caller should treat the net as 0.
+    Negative,
+    /// The net exceeded u64::MAX; the caller should treat it as a mismatch signal.
+    Overflow,
+}
+
+/// Convert a net (deposits - withdrawals) BigDecimal into a checked `NetBalance`
+/// without ever wrapping. The caller decides how to log and what sentinel to use,
+/// so the per-path warning context (mint id, reason) stays at the call site.
+pub fn net_to_u64(net: &BigDecimal) -> NetBalance {
+    use bigdecimal::Zero;
+    if net < &BigDecimal::zero() {
+        return NetBalance::Negative;
+    }
+    match net.to_u64() {
+        Some(v) => NetBalance::Exact(v),
+        None => NetBalance::Overflow,
+    }
+}
+
+impl Type<Postgres> for TokenAmount {
+    fn type_info() -> PgTypeInfo {
+        <BigDecimal as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        <BigDecimal as Type<Postgres>>::compatible(ty)
+    }
+}
+
+impl Encode<'_, Postgres> for TokenAmount {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        let value = BigDecimal::from(self.0);
+        <BigDecimal as Encode<Postgres>>::encode_by_ref(&value, buf)
+    }
+}
+
+impl<'r> Decode<'r, Postgres> for TokenAmount {
+    fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
+        let decoded = <BigDecimal as Decode<Postgres>>::decode(value)?;
+        Ok(TokenAmount(u64_from_big_decimal(&decoded)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::str::FromStr};
+
+    #[test]
+    fn display_renders_bare_integer() {
+        assert_eq!(
+            TokenAmount(18_446_744_073_709_551_615).to_string(),
+            "18446744073709551615"
+        );
+    }
+
+    #[test]
+    fn serde_round_trips_as_bare_integer() {
+        let json = serde_json::to_string(&TokenAmount(u64::MAX)).unwrap();
+        assert_eq!(json, "18446744073709551615");
+        let back: TokenAmount = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, TokenAmount(u64::MAX));
+    }
+
+    #[test]
+    fn decode_helper_round_trips_full_u64_range() {
+        for v in [0u64, 1, i64::MAX as u64, i64::MAX as u64 + 1, u64::MAX] {
+            let bd = BigDecimal::from(v);
+            assert_eq!(u64_from_big_decimal(&bd).unwrap(), v);
+        }
+    }
+
+    #[test]
+    fn decode_helper_rejects_negative() {
+        let bd = BigDecimal::from(-1);
+        let err = u64_from_big_decimal(&bd).unwrap_err().to_string();
+        assert!(err.contains("out of range"), "got: {err}");
+    }
+
+    #[test]
+    fn decode_helper_rejects_non_integer() {
+        let bd = BigDecimal::from_str("1.5").unwrap();
+        let err = u64_from_big_decimal(&bd).unwrap_err().to_string();
+        assert!(err.contains("not an integer"), "got: {err}");
+    }
+
+    #[test]
+    fn decode_helper_rejects_over_u64_max() {
+        // u64::MAX + 1, which NUMERIC(20,0) can hold but u64 cannot.
+        let bd = BigDecimal::from_str("18446744073709551616").unwrap();
+        let err = u64_from_big_decimal(&bd).unwrap_err().to_string();
+        assert!(err.contains("out of range"), "got: {err}");
+    }
+}

--- a/indexer/src/storage/common/mod.rs
+++ b/indexer/src/storage/common/mod.rs
@@ -1,2 +1,3 @@
+pub mod amount;
 pub mod models;
 pub mod storage;

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -1,3 +1,5 @@
+use crate::storage::common::amount::TokenAmount;
+use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::Type;
@@ -53,7 +55,7 @@ pub struct DbTransaction {
     pub initiator: String,
     pub recipient: String,
     pub mint: String,
-    pub amount: i64,
+    pub amount: TokenAmount,
     pub memo: Option<String>,
     pub transaction_type: TransactionType,
     pub withdrawal_nonce: Option<i64>,
@@ -97,10 +99,12 @@ pub struct MintDbBalance {
     /// Sum of amounts for all indexed deposits (any status).
     /// Deposits increase the on-chain ATA balance the moment they are observed,
     /// regardless of whether the operator has completed the corresponding private_channel mint.
-    pub total_deposits: i64,
+    /// Held as `BigDecimal` because the gross sum of many near-`u64::MAX` amounts can
+    /// exceed `u64::MAX` even though the net (deposits - withdrawals) cannot.
+    pub total_deposits: BigDecimal,
     /// Sum of amounts for completed withdrawals only.
     /// Only a completed `release_funds` call actually reduces the on-chain ATA balance.
-    pub total_withdrawals: i64,
+    pub total_withdrawals: BigDecimal,
 }
 
 /// Mint metadata stored
@@ -154,7 +158,7 @@ pub struct DbTransactionBuilder {
     signature: String,
     slot: i64,
     mint: String,
-    amount: i64,
+    amount: TokenAmount,
     initiator: Option<String>,
     recipient: Option<String>,
     memo: Option<String>,
@@ -168,7 +172,7 @@ impl DbTransactionBuilder {
             signature,
             slot: slot as i64,
             mint,
-            amount: amount as i64,
+            amount: TokenAmount(amount),
             initiator: None,
             recipient: None,
             memo: None,

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -408,6 +408,8 @@ impl Storage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::common::amount::TokenAmount;
+    use bigdecimal::BigDecimal;
     use chrono::Utc;
     use mock::MockStorage;
 
@@ -428,7 +430,7 @@ mod tests {
             initiator: "initiator".to_string(),
             recipient: "recipient".to_string(),
             mint: "mint_addr".to_string(),
-            amount: 1000,
+            amount: TokenAmount(1000),
             memo: None,
             transaction_type: TransactionType::Deposit,
             withdrawal_nonce: None,
@@ -716,14 +718,14 @@ mod tests {
                 MintDbBalance {
                     mint_address: "mint_1".to_string(),
                     token_program: TOKEN_PROGRAM.to_string(),
-                    total_deposits: 1000,
-                    total_withdrawals: 300,
+                    total_deposits: BigDecimal::from(1000u64),
+                    total_withdrawals: BigDecimal::from(300u64),
                 },
                 MintDbBalance {
                     mint_address: "mint_2".to_string(),
                     token_program: TOKEN_PROGRAM.to_string(),
-                    total_deposits: 5000,
-                    total_withdrawals: 2000,
+                    total_deposits: BigDecimal::from(5000u64),
+                    total_withdrawals: BigDecimal::from(2000u64),
                 },
             ];
             mock.set_mint_balances(balances);
@@ -732,11 +734,11 @@ mod tests {
         let balances = storage.get_escrow_balances_by_mint().await.unwrap();
         assert_eq!(balances.len(), 2);
         assert_eq!(balances[0].mint_address, "mint_1");
-        assert_eq!(balances[0].total_deposits, 1000);
-        assert_eq!(balances[0].total_withdrawals, 300);
+        assert_eq!(balances[0].total_deposits, BigDecimal::from(1000u64));
+        assert_eq!(balances[0].total_withdrawals, BigDecimal::from(300u64));
         assert_eq!(balances[1].mint_address, "mint_2");
-        assert_eq!(balances[1].total_deposits, 5000);
-        assert_eq!(balances[1].total_withdrawals, 2000);
+        assert_eq!(balances[1].total_deposits, BigDecimal::from(5000u64));
+        assert_eq!(balances[1].total_withdrawals, BigDecimal::from(2000u64));
     }
 
     #[tokio::test]
@@ -748,14 +750,14 @@ mod tests {
                 MintDbBalance {
                     mint_address: "usdc".to_string(),
                     token_program: TOKEN_PROGRAM.to_string(),
-                    total_deposits: 10000,
-                    total_withdrawals: 5000,
+                    total_deposits: BigDecimal::from(10000u64),
+                    total_withdrawals: BigDecimal::from(5000u64),
                 },
                 MintDbBalance {
                     mint_address: "usdt".to_string(),
                     token_program: TOKEN_PROGRAM.to_string(),
-                    total_deposits: 8000,
-                    total_withdrawals: 3000,
+                    total_deposits: BigDecimal::from(8000u64),
+                    total_withdrawals: BigDecimal::from(3000u64),
                 },
             ];
             mock.set_mint_balances(balances);
@@ -767,11 +769,11 @@ mod tests {
             .unwrap();
         assert_eq!(balances.len(), 2);
         assert!(balances.iter().any(|b| b.mint_address == "usdc"
-            && b.total_deposits == 10000
-            && b.total_withdrawals == 5000));
+            && b.total_deposits == BigDecimal::from(10000u64)
+            && b.total_withdrawals == BigDecimal::from(5000u64)));
         assert!(balances.iter().any(|b| b.mint_address == "usdt"
-            && b.total_deposits == 8000
-            && b.total_withdrawals == 3000));
+            && b.total_deposits == BigDecimal::from(8000u64)
+            && b.total_withdrawals == BigDecimal::from(3000u64)));
     }
 
     #[tokio::test]
@@ -1151,7 +1153,7 @@ mod tests {
             initiator: "init".to_string(),
             recipient: "recip".to_string(),
             mint: mint.to_string(),
-            amount: 1,
+            amount: TokenAmount(1),
             memo: None,
             transaction_type: TransactionType::Deposit,
             withdrawal_nonce: None,

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -113,7 +113,7 @@ impl PostgresDb {
                 initiator TEXT NOT NULL,
                 recipient TEXT NOT NULL,
                 mint TEXT NOT NULL,
-                amount BIGINT NOT NULL,
+                amount NUMERIC(20,0) NOT NULL,
                 memo TEXT,
                 status transaction_status NOT NULL DEFAULT 'pending',
                 transaction_type transaction_type NOT NULL,
@@ -1507,11 +1507,11 @@ impl PostgresDb {
                 COALESCE(
                     SUM(CASE WHEN t.transaction_type = 'deposit' THEN t.amount ELSE 0 END),
                     0
-                )::BIGINT AS total_deposits,
+                )::NUMERIC AS total_deposits,
                 COALESCE(
                     SUM(CASE WHEN t.transaction_type = 'withdrawal' AND t.status = 'completed' THEN t.amount ELSE 0 END),
                     0
-                )::BIGINT AS total_withdrawals
+                )::NUMERIC AS total_withdrawals
             FROM mints m
             LEFT JOIN transactions t ON t.mint = m.mint_address
             GROUP BY m.mint_address, m.token_program
@@ -1542,11 +1542,11 @@ impl PostgresDb {
                 COALESCE(
                     SUM(CASE WHEN t.transaction_type = 'deposit' AND t.status = 'completed' THEN t.amount ELSE 0 END),
                     0
-                )::BIGINT AS total_deposits,
+                )::NUMERIC AS total_deposits,
                 COALESCE(
                     SUM(CASE WHEN t.transaction_type = 'withdrawal' AND t.status = 'completed' THEN t.amount ELSE 0 END),
                     0
-                )::BIGINT AS total_withdrawals
+                )::NUMERIC AS total_withdrawals
             FROM mints m
             LEFT JOIN transactions t ON t.mint = m.mint_address
             GROUP BY m.mint_address, m.token_program

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -271,6 +271,28 @@ impl PostgresDb {
         .await?;
         info!("landed_remint_signature migration complete");
 
+        // Widen a legacy BIGINT amount column to NUMERIC(20,0). BIGINT wraps amounts
+        // above i64::MAX negative; the cast is lossless and the guard makes it a no-op
+        // once already NUMERIC. Required because the BigDecimal decoder rejects BIGINT.
+        info!("Running amount NUMERIC widening migration if needed...");
+        sqlx::query(
+            r#"
+            DO $$ BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'transactions'
+                      AND column_name = 'amount'
+                      AND data_type = 'bigint'
+                ) THEN
+                    ALTER TABLE transactions ALTER COLUMN amount TYPE NUMERIC(20,0);
+                END IF;
+            END $$;
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        info!("amount NUMERIC widening migration complete");
+
         sqlx::query(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_trace_id ON transactions (trace_id)",
         )

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -130,6 +130,88 @@ async fn drop_tables_then_reinit() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// A database created before this change has `amount BIGINT`. init_schema must
+/// widen it to NUMERIC(20,0) in place, after which a value above i64::MAX (which
+/// BIGINT could not hold) round-trips through the TokenAmount decode path.
+#[tokio::test(flavor = "multi_thread")]
+async fn init_schema_widens_legacy_bigint_amount_column() -> Result<(), Box<dyn std::error::Error>>
+{
+    let container = Postgres::default()
+        .with_db_name("db_test")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await?;
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let db_url = format!("postgres://postgres:password@{}:{}/db_test", host, port);
+    let pool = PgPool::connect(&db_url).await?;
+
+    // Stand up the pre-change shape: the base transactions table with a BIGINT
+    // amount (newer columns are added by init_schema's ALTER migrations).
+    sqlx::query(
+        "CREATE TYPE transaction_status AS ENUM ('pending', 'processing', 'completed', 'failed')",
+    )
+    .execute(&pool)
+    .await?;
+    sqlx::query("CREATE TYPE transaction_type AS ENUM ('deposit', 'withdrawal')")
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        r#"
+        CREATE TABLE transactions (
+            id BIGSERIAL PRIMARY KEY,
+            signature TEXT NOT NULL UNIQUE,
+            slot BIGINT NOT NULL,
+            initiator TEXT NOT NULL,
+            recipient TEXT NOT NULL,
+            mint TEXT NOT NULL,
+            amount BIGINT NOT NULL,
+            memo TEXT,
+            status transaction_status NOT NULL DEFAULT 'pending',
+            transaction_type transaction_type NOT NULL,
+            withdrawal_nonce BIGINT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            processed_at TIMESTAMPTZ,
+            counterpart_signature TEXT
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    let storage = Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: db_url,
+            max_connections: 5,
+        })
+        .await?,
+    );
+    storage.init_schema().await?;
+
+    // The column type must now be numeric, not bigint.
+    let (data_type,): (String,) = sqlx::query_as(
+        "SELECT data_type::text FROM information_schema.columns
+         WHERE table_name = 'transactions' AND column_name = 'amount'",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(data_type, "numeric", "amount must be widened to NUMERIC");
+
+    // A value BIGINT could never have stored must now round-trip exactly.
+    let big = TokenAmount(i64::MAX as u64 + 1);
+    let mut txn = make_db_transaction("legacy_big", TransactionType::Deposit);
+    txn.amount = big;
+    let id = storage.insert_db_transaction(&txn).await?;
+    let (got,): (TokenAmount,) = sqlx::query_as("SELECT amount FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(got, big);
+    Ok(())
+}
+
 // ── 2. Single transaction insert ─────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread")]

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -5,9 +5,11 @@
 //!
 //! Run with: `cd indexer && cargo test --test postgres_db_test -- --test-threads=1`
 
+use bigdecimal::BigDecimal;
 use chrono::Utc;
 use private_channel_indexer::{
     storage::{
+        common::amount::TokenAmount,
         common::models::{DbMint, DbMintStatus, MintStatusAtSlot},
         DbTransaction, PostgresDb, Storage, TransactionStatus, TransactionType,
     },
@@ -55,7 +57,7 @@ fn make_db_transaction(sig: &str, txn_type: TransactionType) -> DbTransaction {
         initiator: "initiator".to_string(),
         recipient: "recipient".to_string(),
         mint: "mint_addr".to_string(),
-        amount: 1_000,
+        amount: TokenAmount(1_000),
         memo: None,
         transaction_type: txn_type,
         withdrawal_nonce: None,
@@ -138,14 +140,57 @@ async fn insert_transaction_returns_id() -> Result<(), Box<dyn std::error::Error
     let id = storage.insert_db_transaction(&txn).await?;
     assert!(id > 0);
 
-    // Readable back
-    let row: (String, i64) =
+    // Readable back; amount is NUMERIC and decodes through the TokenAmount seam.
+    let row: (String, TokenAmount) =
         sqlx::query_as("SELECT signature, amount FROM transactions WHERE id = $1")
             .bind(id)
             .fetch_one(&pool)
             .await?;
     assert_eq!(row.0, "sig_1");
-    assert_eq!(row.1, 1_000);
+    assert_eq!(row.1, TokenAmount(1_000));
+    Ok(())
+}
+
+/// A deposit and a withdrawal of `i64::MAX + 1` (a value BIGINT would have
+/// wrapped to a negative i64) must round-trip through NUMERIC bit-for-bit, both
+/// when read back as the raw column and through the DbTransaction FromRow path.
+#[tokio::test(flavor = "multi_thread")]
+async fn amount_above_i64_max_round_trips_exactly() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let big = i64::MAX as u64 + 1;
+
+    let mut deposit = make_db_transaction("big_deposit", TransactionType::Deposit);
+    deposit.amount = TokenAmount(big);
+    let mut withdrawal = make_db_transaction("big_withdrawal", TransactionType::Withdrawal);
+    withdrawal.amount = TokenAmount(big);
+
+    let deposit_id = storage.insert_db_transaction(&deposit).await?;
+    let withdrawal_id = storage.insert_db_transaction(&withdrawal).await?;
+
+    for id in [deposit_id, withdrawal_id] {
+        let row: (TokenAmount,) = sqlx::query_as("SELECT amount FROM transactions WHERE id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(
+            row.0,
+            TokenAmount(big),
+            "raw column must preserve the full u64"
+        );
+    }
+
+    let fetched = storage
+        .get_pending_db_transactions(TransactionType::Deposit, 10)
+        .await?;
+    let got = fetched
+        .iter()
+        .find(|t| t.signature == "big_deposit")
+        .expect("deposit row");
+    assert_eq!(
+        got.amount,
+        TokenAmount(big),
+        "FromRow must preserve the full u64"
+    );
     Ok(())
 }
 
@@ -480,13 +525,13 @@ async fn reconciliation_balance_counts_correctly() -> Result<(), Box<dyn std::er
     // Pending deposit (ALL deposits count for reconciliation)
     let mut d1 = make_db_transaction("recon_d1", TransactionType::Deposit);
     d1.mint = mint.to_string();
-    d1.amount = 500;
+    d1.amount = TokenAmount(500);
     storage.insert_db_transaction(&d1).await?;
 
     // Completed deposit
     let mut d2 = make_db_transaction("recon_d2", TransactionType::Deposit);
     d2.mint = mint.to_string();
-    d2.amount = 300;
+    d2.amount = TokenAmount(300);
     let d2_id = storage.insert_db_transaction(&d2).await?;
     sqlx::query("UPDATE transactions SET status = 'completed' WHERE id = $1")
         .bind(d2_id)
@@ -496,7 +541,7 @@ async fn reconciliation_balance_counts_correctly() -> Result<(), Box<dyn std::er
     // Completed withdrawal (only completed withdrawals count)
     let mut w1 = make_db_transaction("recon_w1", TransactionType::Withdrawal);
     w1.mint = mint.to_string();
-    w1.amount = 100;
+    w1.amount = TokenAmount(100);
     let w1_id = storage.insert_db_transaction(&w1).await?;
     sqlx::query("UPDATE transactions SET status = 'completed' WHERE id = $1")
         .bind(w1_id)
@@ -506,15 +551,15 @@ async fn reconciliation_balance_counts_correctly() -> Result<(), Box<dyn std::er
     // Pending withdrawal (should NOT count)
     let mut w2 = make_db_transaction("recon_w2", TransactionType::Withdrawal);
     w2.mint = mint.to_string();
-    w2.amount = 9999;
+    w2.amount = TokenAmount(9999);
     storage.insert_db_transaction(&w2).await?;
 
     let balances = storage.get_mint_balances_for_reconciliation().await?;
     assert_eq!(balances.len(), 1);
     // Deposits: 500 (pending) + 300 (completed) = 800  (all statuses)
-    assert_eq!(balances[0].total_deposits, 800);
+    assert_eq!(balances[0].total_deposits, BigDecimal::from(800u64));
     // Withdrawals: only completed = 100
-    assert_eq!(balances[0].total_withdrawals, 100);
+    assert_eq!(balances[0].total_withdrawals, BigDecimal::from(100u64));
     Ok(())
 }
 

--- a/indexer/tests/reconciliation_db_test.rs
+++ b/indexer/tests/reconciliation_db_test.rs
@@ -8,8 +8,9 @@
 //!
 //! Uses testcontainers to spin up an isolated Postgres instance for each test.
 
+use bigdecimal::BigDecimal;
 use private_channel_indexer::{
-    storage::{PostgresDb, Storage},
+    storage::{common::amount::TokenAmount, PostgresDb, Storage},
     PostgresConfig,
 };
 use solana_sdk::pubkey::Pubkey;
@@ -77,7 +78,7 @@ async fn insert_transaction(
     pool: &PgPool,
     signature: &str,
     mint: &str,
-    amount: i64,
+    amount: u64,
     transaction_type: &str,
     status: &str,
     slot: i64,
@@ -91,7 +92,7 @@ async fn insert_transaction(
     .bind(signature)
     .bind(slot)
     .bind(mint)
-    .bind(amount)
+    .bind(TokenAmount(amount))
     .bind(transaction_type)
     .bind(status)
     .execute(pool)
@@ -200,13 +201,15 @@ async fn test_only_completed_transactions_counted() -> Result<(), Box<dyn std::e
 
     // Expected: completed deposits = 1,000,000 + 500,000 = 1,500,000
     assert_eq!(
-        balance.total_deposits, 1_500_000,
+        balance.total_deposits,
+        BigDecimal::from(1_500_000u64),
         "only completed deposits should be counted"
     );
 
     // Expected: completed withdrawals = 300,000
     assert_eq!(
-        balance.total_withdrawals, 300_000,
+        balance.total_withdrawals,
+        BigDecimal::from(300_000u64),
         "only completed withdrawals should be counted"
     );
 
@@ -308,18 +311,25 @@ async fn test_multiple_mints_aggregated_independently() -> Result<(), Box<dyn st
 
     // Verify mint1
     assert_eq!(
-        balance1.total_deposits, 3_000_000,
+        balance1.total_deposits,
+        BigDecimal::from(3_000_000u64),
         "mint1: 1M + 2M deposits"
     );
     assert_eq!(
-        balance1.total_withdrawals, 500_000,
+        balance1.total_withdrawals,
+        BigDecimal::from(500_000u64),
         "mint1: 500K withdrawals"
     );
 
     // Verify mint2
-    assert_eq!(balance2.total_deposits, 5_000_000, "mint2: 5M deposits");
     assert_eq!(
-        balance2.total_withdrawals, 1_500_000,
+        balance2.total_deposits,
+        BigDecimal::from(5_000_000u64),
+        "mint2: 5M deposits"
+    );
+    assert_eq!(
+        balance2.total_withdrawals,
+        BigDecimal::from(1_500_000u64),
         "mint2: 1M + 500K withdrawals"
     );
 
@@ -346,8 +356,16 @@ async fn test_mint_with_no_transactions() -> Result<(), Box<dyn std::error::Erro
     let balance = &balances[0];
     assert_eq!(balance.mint_address, mint);
     assert_eq!(balance.token_program, token_program);
-    assert_eq!(balance.total_deposits, 0, "no deposits");
-    assert_eq!(balance.total_withdrawals, 0, "no withdrawals");
+    assert_eq!(
+        balance.total_deposits,
+        BigDecimal::from(0u64),
+        "no deposits"
+    );
+    assert_eq!(
+        balance.total_withdrawals,
+        BigDecimal::from(0u64),
+        "no withdrawals"
+    );
 
     Ok(())
 }
@@ -380,8 +398,10 @@ async fn test_large_amounts() -> Result<(), Box<dyn std::error::Error>> {
     // Insert mint
     insert_mint(&pool, &mint, 6, &token_program).await?;
 
-    // Use large amounts close to i64::MAX / 4 to test overflow protection
-    let large_amount = i64::MAX / 4;
+    // Each deposit exceeds i64::MAX, so two of them gross-sum past i64::MAX while
+    // staying within u64 - the case BIGINT could not store and the ::BIGINT SUM
+    // cast would have overflowed. NUMERIC(20,0) must round-trip both exactly.
+    let large_amount: u64 = i64::MAX as u64 + 1;
 
     insert_transaction(
         &pool,
@@ -420,14 +440,16 @@ async fn test_large_amounts() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(balances.len(), 1, "expected one mint");
 
     let balance = &balances[0];
+    // Computed in BigDecimal because the gross deposit sum exceeds i64::MAX and
+    // 2 * large_amount would overflow u64 in plain arithmetic.
+    let expected_deposits = BigDecimal::from(large_amount) * BigDecimal::from(2u64);
     assert_eq!(
-        balance.total_deposits,
-        large_amount * 2,
-        "large deposits summed correctly"
+        balance.total_deposits, expected_deposits,
+        "large deposits summed correctly past i64::MAX"
     );
     assert_eq!(
         balance.total_withdrawals,
-        large_amount / 2,
+        BigDecimal::from(large_amount / 2),
         "large withdrawal counted correctly"
     );
 
@@ -547,11 +569,13 @@ async fn test_withdrawals_exceed_deposits() -> Result<(), Box<dyn std::error::Er
 
     let balance = &balances[0];
     assert_eq!(
-        balance.total_deposits, 500_000,
+        balance.total_deposits,
+        BigDecimal::from(500_000u64),
         "deposits counted correctly"
     );
     assert_eq!(
-        balance.total_withdrawals, 700_000,
+        balance.total_withdrawals,
+        BigDecimal::from(700_000u64),
         "withdrawals counted correctly"
     );
     // Net balance would be -200_000 (deposits - withdrawals), but we just store the raw totals

--- a/indexer/tests/reconciliation_e2e_test.rs
+++ b/indexer/tests/reconciliation_e2e_test.rs
@@ -8,11 +8,12 @@
 //!
 //! Uses testcontainers for isolated Postgres instances and mockito for webhook server.
 
+use bigdecimal::{BigDecimal, ToPrimitive};
 use private_channel_core::webhook::{WebhookClient, WebhookRetryConfig};
 use private_channel_indexer::{
     config::OperatorConfig,
     operator::reconciliation::{compare_balances, send_webhook_alert, BalanceMismatch},
-    storage::{PostgresDb, Storage},
+    storage::{common::amount::TokenAmount, PostgresDb, Storage},
     PostgresConfig,
 };
 use solana_sdk::pubkey::Pubkey;
@@ -82,7 +83,7 @@ async fn insert_transaction(
     pool: &PgPool,
     signature: &str,
     mint: &str,
-    amount: i64,
+    amount: u64,
     transaction_type: &str,
     status: &str,
     slot: i64,
@@ -96,7 +97,7 @@ async fn insert_transaction(
     .bind(signature)
     .bind(slot)
     .bind(mint)
-    .bind(amount)
+    .bind(TokenAmount(amount))
     .bind(transaction_type)
     .bind(status)
     .execute(pool)
@@ -162,8 +163,8 @@ async fn test_reconciliation_success_within_tolerance() -> Result<(), Box<dyn st
 
     let balance = &balances[0];
     assert_eq!(balance.mint_address, mint);
-    assert_eq!(balance.total_deposits, 1_000_000);
-    assert_eq!(balance.total_withdrawals, 0);
+    assert_eq!(balance.total_deposits, BigDecimal::from(1_000_000u64));
+    assert_eq!(balance.total_withdrawals, BigDecimal::from(0u64));
 
     // In a real E2E test, we would:
     // 1. Mock RPC endpoint to return on-chain balance of 1,000,000
@@ -212,7 +213,9 @@ async fn test_reconciliation_detects_mismatch_and_alerts() -> Result<(), Box<dyn
             .mint_address
             .parse::<Pubkey>()
             .expect("valid mint");
-        let net_balance = (balance_result.total_deposits - balance_result.total_withdrawals) as u64;
+        let net_balance = (&balance_result.total_deposits - &balance_result.total_withdrawals)
+            .to_u64()
+            .expect("net fits u64");
         db_balances.insert(mint_key, net_balance);
     }
 
@@ -311,8 +314,8 @@ async fn test_reconciliation_multiple_mints_mixed_results() -> Result<(), Box<dy
         .find(|b| b.mint_address == mint2)
         .expect("mint2 not found");
 
-    assert_eq!(balance1.total_deposits, 1_000_000);
-    assert_eq!(balance2.total_deposits, 2_000_000);
+    assert_eq!(balance1.total_deposits, BigDecimal::from(1_000_000u64));
+    assert_eq!(balance2.total_deposits, BigDecimal::from(2_000_000u64));
 
     // In a real E2E test, we would:
     // 1. Mock RPC to return on-chain balances: mint1=1,000,000, mint2=1,800,000
@@ -430,12 +433,20 @@ async fn test_reconciliation_with_deposits_and_withdrawals(
     assert_eq!(balances.len(), 1);
 
     let balance = &balances[0];
-    assert_eq!(balance.total_deposits, 2_000_000, "total deposits");
-    assert_eq!(balance.total_withdrawals, 500_000, "total withdrawals");
+    assert_eq!(
+        balance.total_deposits,
+        BigDecimal::from(2_000_000u64),
+        "total deposits"
+    );
+    assert_eq!(
+        balance.total_withdrawals,
+        BigDecimal::from(500_000u64),
+        "total withdrawals"
+    );
 
     // Net balance should be 1,500,000 (deposits - withdrawals)
-    let net_balance = balance.total_deposits - balance.total_withdrawals;
-    assert_eq!(net_balance, 1_500_000, "net balance");
+    let net_balance = &balance.total_deposits - &balance.total_withdrawals;
+    assert_eq!(net_balance, BigDecimal::from(1_500_000u64), "net balance");
 
     // In a real E2E test, we would:
     // 1. Mock RPC to return on-chain balance of 1,500,000
@@ -507,11 +518,13 @@ async fn test_reconciliation_ignores_non_completed_transactions(
 
     let balance = &balances[0];
     assert_eq!(
-        balance.total_deposits, 1_000_000,
+        balance.total_deposits,
+        BigDecimal::from(1_000_000u64),
         "only completed deposits counted"
     );
     assert_eq!(
-        balance.total_withdrawals, 0,
+        balance.total_withdrawals,
+        BigDecimal::from(0u64),
         "only completed withdrawals counted"
     );
 
@@ -645,7 +658,9 @@ async fn test_e2e_reconciliation_with_mismatch_and_webhook_alert(
             .mint_address
             .parse::<Pubkey>()
             .expect("valid mint address");
-        let net_balance = (balance_result.total_deposits - balance_result.total_withdrawals) as u64;
+        let net_balance = (&balance_result.total_deposits - &balance_result.total_withdrawals)
+            .to_u64()
+            .expect("net fits u64");
         db_balances.insert(mint, net_balance);
     }
 
@@ -771,7 +786,9 @@ async fn test_e2e_reconciliation_success_no_alert() -> Result<(), Box<dyn std::e
             .mint_address
             .parse::<Pubkey>()
             .expect("valid mint");
-        let net_balance = (balance_result.total_deposits - balance_result.total_withdrawals) as u64;
+        let net_balance = (&balance_result.total_deposits - &balance_result.total_withdrawals)
+            .to_u64()
+            .expect("net fits u64");
         db_balances.insert(mint_key, net_balance);
     }
 

--- a/indexer/tests/remint_e2e_test.rs
+++ b/indexer/tests/remint_e2e_test.rs
@@ -8,9 +8,10 @@
 //!
 //! Uses testcontainers for isolated Postgres instances.
 
+use bigdecimal::BigDecimal;
 use chrono::Utc;
 use private_channel_indexer::{
-    storage::{PostgresDb, Storage, TransactionStatus},
+    storage::{common::amount::TokenAmount, PostgresDb, Storage, TransactionStatus},
     PostgresConfig,
 };
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
@@ -32,7 +33,7 @@ async fn insert_mint(pool: &PgPool, mint: &Pubkey) -> Result<(), sqlx::Error> {
 }
 
 /// Insert a completed deposit so escrow has a baseline balance.
-async fn insert_deposit(pool: &PgPool, mint: &Pubkey, amount: i64) -> Result<(), sqlx::Error> {
+async fn insert_deposit(pool: &PgPool, mint: &Pubkey, amount: u64) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO transactions
          (signature, slot, initiator, recipient, mint, amount,
@@ -46,7 +47,7 @@ async fn insert_deposit(pool: &PgPool, mint: &Pubkey, amount: i64) -> Result<(),
     .bind(Pubkey::new_unique().to_string())
     .bind(Pubkey::new_unique().to_string())
     .bind(mint.to_string())
-    .bind(amount)
+    .bind(TokenAmount(amount))
     .bind(uuid::Uuid::new_v4().to_string())
     .execute(pool)
     .await?;
@@ -95,7 +96,7 @@ async fn insert_withdrawal(
     pool: &PgPool,
     mint: &Pubkey,
     recipient: &Pubkey,
-    amount: i64,
+    amount: u64,
 ) -> Result<i64, sqlx::Error> {
     let row = sqlx::query_scalar::<_, i64>(
         "INSERT INTO transactions
@@ -111,7 +112,7 @@ async fn insert_withdrawal(
     .bind(Pubkey::new_unique().to_string()) // initiator
     .bind(recipient.to_string())
     .bind(mint.to_string())
-    .bind(amount)
+    .bind(TokenAmount(amount))
     .bind(uuid::Uuid::new_v4().to_string())
     .fetch_one(pool)
     .await?;
@@ -140,7 +141,7 @@ async fn test_pending_remint_persisted_and_recovered() -> Result<(), Box<dyn std
     let recipient = Pubkey::new_unique();
     let sig1 = Signature::new_unique();
     let sig2 = Signature::new_unique();
-    let amount: i64 = 10_000;
+    let amount: u64 = 10_000;
 
     // Insert the transaction in Processing status (normal pre-failure state).
     let tx_id = insert_withdrawal(&pool, &mint, &recipient, amount).await?;
@@ -169,7 +170,7 @@ async fn test_pending_remint_persisted_and_recovered() -> Result<(), Box<dyn std
 
     // Identity and amount.
     assert_eq!(row.id, tx_id);
-    assert_eq!(row.amount, amount);
+    assert_eq!(row.amount, TokenAmount(amount));
 
     // Pubkeys stored as strings and must round-trip correctly.
     assert_eq!(row.mint, mint.to_string());
@@ -355,8 +356,8 @@ async fn test_withdrawal_failure_remint_restores_balance() -> Result<(), Box<dyn
     let mint = Pubkey::new_unique();
     let recipient = Pubkey::new_unique();
     let withdrawal_sig = Signature::new_unique();
-    let deposit_amount: i64 = 10_000;
-    let withdrawal_amount: i64 = 10_000;
+    let deposit_amount: u64 = 10_000;
+    let withdrawal_amount: u64 = 10_000;
 
     // Step 1: a deposit lands — tokens enter the escrow.
     insert_mint(&pool, &mint).await?;
@@ -381,11 +382,13 @@ async fn test_withdrawal_failure_remint_restores_balance() -> Result<(), Box<dyn
         .find(|b| b.mint_address == mint.to_string())
         .expect("mint must appear in balance query");
     assert_eq!(
-        balance.total_deposits, deposit_amount,
+        balance.total_deposits,
+        BigDecimal::from(deposit_amount),
         "full deposit must be counted"
     );
     assert_eq!(
-        balance.total_withdrawals, 0,
+        balance.total_withdrawals,
+        BigDecimal::from(0u64),
         "PendingRemint withdrawal must NOT be counted — it never landed on-chain"
     );
 
@@ -411,11 +414,13 @@ async fn test_withdrawal_failure_remint_restores_balance() -> Result<(), Box<dyn
         .find(|b| b.mint_address == mint.to_string())
         .expect("mint must still appear in balance query");
     assert_eq!(
-        after_balance.total_deposits, deposit_amount,
+        after_balance.total_deposits,
+        BigDecimal::from(deposit_amount),
         "deposit must still be counted after remint"
     );
     assert_eq!(
-        after_balance.total_withdrawals, 0,
+        after_balance.total_withdrawals,
+        BigDecimal::from(0u64),
         "FailedReminted withdrawal must NOT be counted in total_withdrawals"
     );
 
@@ -435,7 +440,7 @@ async fn test_multiple_pending_remints_excluded_from_balance(
     let (pool, storage, _pg) = start_postgres().await?;
 
     let mint = Pubkey::new_unique();
-    let deposit_amount: i64 = 30_000;
+    let deposit_amount: u64 = 30_000;
 
     insert_mint(&pool, &mint).await?;
     insert_deposit(&pool, &mint, deposit_amount).await?;
@@ -443,7 +448,7 @@ async fn test_multiple_pending_remints_excluded_from_balance(
     let deadline = Utc::now() + chrono::Duration::seconds(32);
 
     // Three concurrent withdrawal failures — all in PendingRemint simultaneously.
-    for amount in [10_000i64, 8_000, 12_000] {
+    for amount in [10_000u64, 8_000, 12_000] {
         let tx_id = insert_withdrawal(&pool, &mint, &Pubkey::new_unique(), amount).await?;
         storage
             .set_pending_remint(
@@ -462,9 +467,10 @@ async fn test_multiple_pending_remints_excluded_from_balance(
         .find(|b| b.mint_address == mint.to_string())
         .expect("mint must appear in balance query");
 
-    assert_eq!(balance.total_deposits, deposit_amount);
+    assert_eq!(balance.total_deposits, BigDecimal::from(deposit_amount));
     assert_eq!(
-        balance.total_withdrawals, 0,
+        balance.total_withdrawals,
+        BigDecimal::from(0u64),
         "all three PendingRemint withdrawals must be excluded from total_withdrawals"
     );
 

--- a/integration/tests/indexer/gap_detection.rs
+++ b/integration/tests/indexer/gap_detection.rs
@@ -208,7 +208,8 @@ async fn test_gap_detection_restart_recovery() -> Result<(), Box<dyn std::error:
             tx.signature
         );
         assert_eq!(
-            db_tx.amount as u64, tx.amount,
+            db_tx.amount.value(),
+            tx.amount,
             "Amount mismatch for {}",
             tx.signature
         );
@@ -282,7 +283,8 @@ async fn test_gap_detection_restart_recovery() -> Result<(), Box<dyn std::error:
             tx.signature
         );
         assert_eq!(
-            db_tx.amount as u64, tx.amount,
+            db_tx.amount.value(),
+            tx.amount,
             "Amount mismatch for {}",
             tx.signature
         );

--- a/integration/tests/indexer/harness_sanity.rs
+++ b/integration/tests/indexer/harness_sanity.rs
@@ -30,6 +30,7 @@
 //! infrastructure and the operator did reach the HTTP boundary.
 
 use {
+    private_channel_indexer::storage::common::amount::TokenAmount,
     private_channel_indexer::storage::common::models::{
         DbMint, DbMintStatus, DbTransaction, TransactionStatus, TransactionType,
     },
@@ -55,7 +56,7 @@ fn pending_deposit_row(id: i64, mint: Pubkey, recipient: Pubkey) -> DbTransactio
         initiator: Pubkey::new_unique().to_string(),
         recipient: recipient.to_string(),
         mint: mint.to_string(),
-        amount: 1_000,
+        amount: TokenAmount(1_000),
         memo: None,
         transaction_type: TransactionType::Deposit,
         withdrawal_nonce: None,

--- a/integration/tests/indexer/helpers/db.rs
+++ b/integration/tests/indexer/helpers/db.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use private_channel_indexer::storage::common::amount::TokenAmount;
 use sqlx::PgPool;
 
 #[derive(Debug, Clone)]
@@ -9,7 +10,7 @@ pub struct DbTransaction {
     pub initiator: String,
     pub recipient: String,
     pub mint: String,
-    pub amount: i64,
+    pub amount: TokenAmount,
     pub transaction_type: String,
     pub status: String,
     pub counterpart_signature: Option<String>,
@@ -23,7 +24,7 @@ type TransactionRow = (
     String,
     String,
     String,
-    i64,
+    TokenAmount,
     String,
     String,
     Option<String>,

--- a/integration/tests/indexer/helpers/verification.rs
+++ b/integration/tests/indexer/helpers/verification.rs
@@ -11,7 +11,7 @@ pub fn validate_db_transaction(
 ) -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(db_transaction.signature, expected_transaction.signature);
     assert_eq!(db_transaction.slot, expected_transaction.slot as i64);
-    assert_eq!(db_transaction.amount, expected_transaction.amount as i64);
+    assert_eq!(db_transaction.amount.value(), expected_transaction.amount);
     assert_eq!(
         db_transaction.initiator,
         expected_transaction.user_pubkey.to_string()

--- a/integration/tests/indexer/integration.rs
+++ b/integration/tests/indexer/integration.rs
@@ -357,7 +357,7 @@ async fn verify_backfill_phase(
             idx + 1
         );
         assert_eq!(
-            db_tx.amount as u64,
+            db_tx.amount.value(),
             expected_tx.amount,
             "Amount mismatch for transaction {}",
             idx + 1

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -33,6 +33,7 @@ use private_channel_indexer::config::{
 use private_channel_indexer::operator;
 use private_channel_indexer::operator::reconciliation::run_reconciliation;
 use private_channel_indexer::operator::{RetryConfig, RpcClientWithRetry};
+use private_channel_indexer::storage::common::amount::TokenAmount;
 use private_channel_indexer::storage::common::models::{
     DbMint, DbMintStatus, DbTransaction, DbTransactionBuilder, TransactionStatus,
 };
@@ -203,7 +204,7 @@ fn make_withdrawal_transaction(
     signature: String,
     mint: String,
     recipient: String,
-    amount: i64,
+    amount: u64,
     nonce: i64,
 ) -> DbTransaction {
     let now = Utc::now();
@@ -215,7 +216,7 @@ fn make_withdrawal_transaction(
         initiator: recipient.clone(),
         recipient,
         mint,
-        amount,
+        amount: TokenAmount(amount),
         memo: None,
         transaction_type: TransactionType::Withdrawal,
         withdrawal_nonce: Some(nonce),
@@ -989,7 +990,7 @@ async fn test_sequential_withdrawals_multiple_nonces() -> Result<(), Box<dyn std
     println!("=== Operator Lifecycle: Sequential Withdrawals (Multi-Nonce) ===");
 
     const ESCROW_FUND: u64 = 200_000;
-    const WITHDRAWAL_AMOUNT: i64 = 50_000;
+    const WITHDRAWAL_AMOUNT: u64 = 50_000;
 
     let (test_validator, faucet_keypair) = start_test_validator_no_geyser().await;
     let client =
@@ -1089,7 +1090,7 @@ async fn test_sequential_withdrawals_multiple_nonces() -> Result<(), Box<dyn std
     let final_balance = get_token_balance(&client, &user_pubkey, &env.mint).await?;
     assert_eq!(
         final_balance,
-        initial_balance + (WITHDRAWAL_AMOUNT as u64) * 2,
+        initial_balance + WITHDRAWAL_AMOUNT * 2,
         "User should have received both withdrawal amounts"
     );
 

--- a/integration/tests/indexer/pausable_mint.rs
+++ b/integration/tests/indexer/pausable_mint.rs
@@ -29,6 +29,7 @@ use helpers::db;
 use private_channel_escrow_program_client::{
     instructions::AllowMintBuilder, PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
 };
+use private_channel_indexer::storage::common::amount::TokenAmount;
 use private_channel_indexer::storage::common::models::{
     DbMint, DbMintStatus, DbTransaction, TransactionStatus, TransactionType,
 };
@@ -216,7 +217,7 @@ fn make_withdrawal_transaction(
     signature: String,
     mint: String,
     recipient: String,
-    amount: i64,
+    amount: u64,
     nonce: i64,
 ) -> DbTransaction {
     let now = Utc::now();
@@ -228,7 +229,7 @@ fn make_withdrawal_transaction(
         initiator: recipient.clone(),
         recipient,
         mint,
-        amount,
+        amount: TokenAmount(amount),
         memo: None,
         transaction_type: TransactionType::Withdrawal,
         withdrawal_nonce: Some(nonce),
@@ -374,7 +375,7 @@ async fn test_withdrawal_routed_to_manual_review_when_pausable_mint_is_paused(
         withdrawal_sig.clone(),
         mint_pubkey.to_string(),
         recipient.pubkey().to_string(),
-        withdraw_amount as i64,
+        withdraw_amount,
         0,
     );
     storage.insert_db_transaction(&withdrawal_tx).await?;

--- a/integration/tests/indexer/permanent_delegate_mint.rs
+++ b/integration/tests/indexer/permanent_delegate_mint.rs
@@ -33,6 +33,7 @@ use helpers::db;
 use private_channel_escrow_program_client::{
     instructions::AllowMintBuilder, PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
 };
+use private_channel_indexer::storage::common::amount::TokenAmount;
 use private_channel_indexer::storage::common::models::{
     DbMint, DbMintStatus, DbTransaction, TransactionStatus, TransactionType,
 };
@@ -247,7 +248,7 @@ fn make_withdrawal_transaction(
     signature: String,
     mint: String,
     recipient: String,
-    amount: i64,
+    amount: u64,
     nonce: i64,
 ) -> DbTransaction {
     let now = Utc::now();
@@ -259,7 +260,7 @@ fn make_withdrawal_transaction(
         initiator: recipient.clone(),
         recipient,
         mint,
-        amount,
+        amount: TokenAmount(amount),
         memo: None,
         transaction_type: TransactionType::Withdrawal,
         withdrawal_nonce: Some(nonce),
@@ -444,7 +445,7 @@ async fn test_withdrawal_routed_to_manual_review_when_permanent_delegate_drained
         withdrawal_sig.clone(),
         mint_pubkey.to_string(),
         recipient.pubkey().to_string(),
-        withdraw_amount as i64,
+        withdraw_amount,
         0,
     );
     storage.insert_db_transaction(&withdrawal_tx).await?;
@@ -609,7 +610,7 @@ async fn test_withdrawal_routed_to_manual_review_when_escrow_ata_does_not_exist(
         withdrawal_sig.clone(),
         mint_pubkey.to_string(),
         recipient.pubkey().to_string(),
-        withdraw_amount as i64,
+        withdraw_amount,
         0,
     );
     storage.insert_db_transaction(&withdrawal_tx).await?;

--- a/integration/tests/indexer/processor_quarantine.rs
+++ b/integration/tests/indexer/processor_quarantine.rs
@@ -22,6 +22,7 @@
 
 use {
     chrono::Utc,
+    private_channel_indexer::storage::common::amount::TokenAmount,
     private_channel_indexer::storage::common::models::{
         DbTransaction, TransactionStatus, TransactionType,
     },
@@ -41,7 +42,7 @@ fn make_bad_deposit(id: i64) -> DbTransaction {
         recipient: Pubkey::new_unique().to_string(),
         // Deliberately malformed: Pubkey::from_str will reject this.
         mint: "definitely-not-base58".to_string(),
-        amount: 1_000,
+        amount: TokenAmount(1_000),
         memo: None,
         transaction_type: TransactionType::Deposit,
         withdrawal_nonce: None,

--- a/integration/tests/indexer/remint_flow.rs
+++ b/integration/tests/indexer/remint_flow.rs
@@ -100,6 +100,7 @@ async fn build_state(
 /// Defer-path tests need this; without a row the bump returns RowNotFound
 /// and the fail-closed handler escalates to ManualReview.
 fn seed_pending_remint_row(mock: &MockStorage, id: i64, attempts: i32) {
+    use private_channel_indexer::storage::common::amount::TokenAmount;
     use private_channel_indexer::storage::common::models::{
         DbTransaction, TransactionStatus, TransactionType,
     };
@@ -115,7 +116,7 @@ fn seed_pending_remint_row(mock: &MockStorage, id: i64, attempts: i32) {
             initiator: Pubkey::new_unique().to_string(),
             recipient: Pubkey::new_unique().to_string(),
             mint: Pubkey::new_unique().to_string(),
-            amount: 0,
+            amount: TokenAmount(0),
             memo: None,
             transaction_type: TransactionType::Withdrawal,
             withdrawal_nonce: Some(id),

--- a/integration/tests/indexer/remint_recovery.rs
+++ b/integration/tests/indexer/remint_recovery.rs
@@ -29,6 +29,7 @@ use {
         operator::sender::{test_hooks, TransactionStatusUpdate},
         storage::{
             common::{
+                amount::TokenAmount,
                 models::{DbTransaction, TransactionStatus, TransactionType},
                 storage::mock::MockStorage,
             },
@@ -45,7 +46,7 @@ fn make_row(
     mint: &Pubkey,
     recipient: &Pubkey,
     sig: &Signature,
-    amount: i64,
+    amount: u64,
     deadline: DateTime<Utc>,
 ) -> DbTransaction {
     let now = Utc::now();
@@ -57,7 +58,7 @@ fn make_row(
         initiator: Pubkey::new_unique().to_string(),
         recipient: recipient.to_string(),
         mint: mint.to_string(),
-        amount,
+        amount: TokenAmount(amount),
         memo: None,
         transaction_type: TransactionType::Withdrawal,
         withdrawal_nonce: Some(id),

--- a/integration/tests/indexer/state_recovery_malformed.rs
+++ b/integration/tests/indexer/state_recovery_malformed.rs
@@ -11,7 +11,10 @@
 //!     regression anchoring)
 //!   - invalid `recipient` pubkey string
 //!   - invalid withdrawal `remint_signatures[i]` string
-//!   - negative `amount` (exercises the `u64::try_from` guard)
+//!
+//! The former negative-amount shape is gone: `amount` is a `TokenAmount(u64)`,
+//! so a negative value is unconstructable and its rejection lives in the
+//! storage decode seam (`TokenAmount`'s unit tests).
 //!
 //! Plus one valid row in the same batch — it must still be recovered
 //! and enqueued into `state.pending_remints`, proving the loop
@@ -24,6 +27,7 @@ use {
         operator::sender::{test_hooks, TransactionStatusUpdate},
         storage::{
             common::{
+                amount::TokenAmount,
                 models::{DbTransaction, TransactionStatus, TransactionType},
                 storage::mock::MockStorage,
             },
@@ -40,7 +44,7 @@ fn make_row(
     mint: String,
     recipient: String,
     sig_strings: Vec<String>,
-    amount: i64,
+    amount: u64,
     deadline: DateTime<Utc>,
 ) -> DbTransaction {
     let now = Utc::now();
@@ -53,7 +57,7 @@ fn make_row(
         initiator: Pubkey::new_unique().to_string(),
         recipient,
         mint,
-        amount,
+        amount: TokenAmount(amount),
         memo: None,
         transaction_type: TransactionType::Withdrawal,
         withdrawal_nonce: Some(id),
@@ -85,9 +89,9 @@ fn make_config() -> PrivateChannelIndexerConfig {
     }
 }
 
-/// Seed four malformed rows (one per parse-error shape) plus one
+/// Seed three malformed rows (one per parse-error shape) plus one
 /// valid row. Assert:
-///   - exactly 4 ManualReview escalations emitted on the channel
+///   - exactly 3 ManualReview escalations emitted on the channel
 ///   - each escalation carries the corresponding transaction_id
 ///   - the lone valid row is rehydrated into state.pending_remints
 #[tokio::test]
@@ -129,16 +133,6 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
         deadline,
     );
 
-    // Row 13 — negative amount (u64::try_from must reject)
-    let negative_amount = make_row(
-        13,
-        Pubkey::new_unique().to_string(),
-        Pubkey::new_unique().to_string(),
-        vec![Signature::new_unique().to_string()],
-        -42,
-        deadline,
-    );
-
     // Row 14 — valid, must still be recovered
     let good = make_row(
         14,
@@ -153,7 +147,6 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
         bad_mint,
         bad_recipient,
         bad_sig,
-        negative_amount,
         good,
     ]);
 
@@ -188,7 +181,7 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
     assert_eq!(entry.signatures.len(), 1);
     assert_eq!(entry.signatures[0].signature, good_sig);
 
-    // All four bad rows must have emitted ManualReview updates.
+    // All three bad rows must have emitted ManualReview updates.
     let mut escalated_ids: Vec<i64> = Vec::new();
     while let Ok(update) = storage_rx.try_recv() {
         assert_eq!(update.status, TransactionStatus::ManualReview);
@@ -197,7 +190,7 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
     escalated_ids.sort();
     assert_eq!(
         escalated_ids,
-        vec![10, 11, 12, 13],
+        vec![10, 11, 12],
         "every malformed row must escalate exactly once; got {:?}",
         escalated_ids
     );

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -31,6 +31,7 @@ use {
     private_channel_indexer::{
         config::{OperatorConfig, PrivateChannelIndexerConfig, ProgramType, StorageType},
         operator,
+        storage::common::amount::TokenAmount,
         storage::common::models::{DbMint, DbMintStatus, DbTransaction, TransactionStatus},
         storage::{PostgresDb, Storage, TransactionType},
         PostgresConfig,
@@ -199,7 +200,7 @@ async fn null_withdrawal_nonce_is_quarantined_to_manual_review(
         initiator: recipient.to_string(),
         recipient: recipient.to_string(),
         mint: env.mint.to_string(),
-        amount: 10_000,
+        amount: TokenAmount(10_000),
         memo: None,
         transaction_type: TransactionType::Withdrawal,
         withdrawal_nonce: Some(0), // trigger will overwrite with NEXTVAL

--- a/integration/tests/private-channel/rpc/test_spl_token.rs
+++ b/integration/tests/private-channel/rpc/test_spl_token.rs
@@ -12,7 +12,7 @@ use {
         },
         PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
     },
-    private_channel_indexer::storage::TransactionType,
+    private_channel_indexer::storage::{common::amount::TokenAmount, TransactionType},
     solana_account_decoder_client_types::UiAccountData,
     solana_pubkey::Pubkey,
     solana_sdk::{
@@ -461,7 +461,7 @@ async fn solana_deposit(
                     );
                     found_deposits.push(name.to_string());
 
-                    assert_eq!(deposit_tx.amount, *amount as i64);
+                    assert_eq!(deposit_tx.amount, TokenAmount(*amount));
                     assert_eq!(deposit_tx.transaction_type, TransactionType::Deposit);
                 }
             }
@@ -784,7 +784,7 @@ async fn private_channel_burn(
 
     let withdrawal_amount = 50_000; // Same as used above
     assert_eq!(withdrawal_tx.initiator, alice.pubkey().to_string());
-    assert_eq!(withdrawal_tx.amount, withdrawal_amount as i64);
+    assert_eq!(withdrawal_tx.amount, TokenAmount(withdrawal_amount));
     assert_eq!(withdrawal_tx.transaction_type, TransactionType::Withdrawal);
 
     println!("\n✓ Withdrawal successfully recorded in PrivateChannel indexer database");

--- a/scripts/tests/update-admin-env.test.sh
+++ b/scripts/tests/update-admin-env.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for update-admin-env.sh: the private key must never land in the tracked
+# template; it must go only to the gitignored runtime env file.
+#
+# Requires `solana-keygen` on PATH. Run from the repo root:
+#   ./scripts/tests/update-admin-env.test.sh
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/scripts/update-admin-env.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+admin_keypair="$workdir/admin.json"
+solana-keygen new -o "$admin_keypair" -s --no-bip39-passphrase >/dev/null
+
+tracked_env="$workdir/.env.tracked"
+runtime_env="$workdir/.env.runtime"
+: > "$tracked_env"
+
+"$script" "$tracked_env" "$admin_keypair" "$runtime_env" >/dev/null
+
+# 1. The tracked template must carry the PUBLIC admin key and NO secret.
+grep -q '^PRIVATE_CHANNEL_ADMIN_KEYS=' "$tracked_env" \
+  || fail "tracked file missing PRIVATE_CHANNEL_ADMIN_KEYS"
+if grep -qE '^ADMIN_PRIVATE_KEY=.+' "$tracked_env"; then
+  fail "tracked file leaked the admin private key"
+fi
+
+# 2. The runtime file must carry the private key, non-empty.
+admin_priv="$(grep '^ADMIN_PRIVATE_KEY=' "$runtime_env" | tail -n1 | cut -d= -f2-)"
+[[ -n "$admin_priv" ]] || fail "ADMIN_PRIVATE_KEY is empty in runtime file"
+
+echo "PASS: the admin private key stays out of the tracked template"

--- a/scripts/update-admin-env.sh
+++ b/scripts/update-admin-env.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <env-file> <operator-keypair-path>" >&2
+# Public admin key goes to the tracked template; the private key goes only to a
+# gitignored runtime env file, so `make build-*` never puts a live key in git.
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "Usage: $0 <env-file> <admin-keypair-path> [runtime-env-file]" >&2
   exit 1
 fi
 
 env_file="$1"
-operator_keypair="$2"
+admin_keypair="$2"
+# Defaults to the gitignored `.env`, loaded last in the compose env-file chain.
+runtime_env_file="${3:-.env}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-operator_pubkey="$(solana-keygen pubkey "$operator_keypair")"
-operator_private_key="$(tr -d '\n' < "$operator_keypair")"
+admin_pubkey="$(solana-keygen pubkey "$admin_keypair")"
+admin_private_key="$(tr -d '\n' < "$admin_keypair")"
 
-"$script_dir/upsert-env.sh" "$env_file" "PRIVATE_CHANNEL_ADMIN_KEYS" "$operator_pubkey"
-"$script_dir/upsert-env.sh" "$env_file" "ADMIN_PRIVATE_KEY" "$operator_private_key"
+# Public key -> tracked template (safe to commit).
+"$script_dir/upsert-env.sh" "$env_file" "PRIVATE_CHANNEL_ADMIN_KEYS" "$admin_pubkey"
 
-echo "Updated $env_file with PRIVATE_CHANNEL_ADMIN_KEYS=$operator_pubkey"
-echo "Updated $env_file with ADMIN_PRIVATE_KEY"
+# Private key -> gitignored runtime file only.
+"$script_dir/upsert-env.sh" "$runtime_env_file" "ADMIN_PRIVATE_KEY" "$admin_private_key"
+
+echo "Updated $env_file with PRIVATE_CHANNEL_ADMIN_KEYS=$admin_pubkey"
+echo "Wrote ADMIN_PRIVATE_KEY to $runtime_env_file (gitignored)"


### PR DESCRIPTION
## Summary

SOLA2-1, SOLA2-17 (= SOLA3-2): every bridge amount was persisted as a signed `i64` / Postgres `BIGINT`
while on-chain amounts are `u64`, so a valid amount above `i64::MAX` wrapped negative in storage. On the
deposit side the operator cast the negative value back to `u64` (the user was credited) but reconciliation
read the poisoned sum and fail-closed every later restart. On the withdrawal side the burn succeeded, the
operator rejected the negative row as a poison pill, and the processor halted the entire withdrawal
pipeline. One valid large transaction was enough to trigger either outage.

SOLA3-7: startup reconciliation derived its mint universe from the `mints` table alone and returned
success when that table was empty. Only `AllowMint` populates `mints`, so a fresh or partially restored DB
against a funded escrow passed the boot-time safety gate without a single on-chain check, and the bridge
resumed blind.

SOLA3-12: `make build-localnet` / `build-devnet` wrote the generated admin private key into `.env.local` /
`.env.devnet`, which are git-tracked. A routine commit after a routine build will leak a live signing key

## What's changed

- Amounts (SOLA2-1, SOLA2-17). The `transactions.amount` column is `NUMERIC(20,0)` and a new
  `TokenAmount(u64)` newtype is the single conversion seam: it encodes through `BigDecimal` and decodes
  with a checked conversion that rejects negative, fractional, and over-`u64` values loudly. The
  `amount as i64` narrowing in the model builder is gone, and all four operator-side
  `u64::try_from` / `as u64` guard sites now read the checked `u64` directly. Reconciliation totals are
  `BigDecimal` (a gross sum of near-`u64::MAX` deposits can exceed `u64`), and the shared
  `net_to_u64` / `NetBalance` helper converts nets without wrapping in both reconciliation paths. The
  streamer reads the column as `amount::text`; its wire format (string amounts) is unchanged.
- Startup reconciliation (SOLA3-7). The operator's `get_token_accounts_by_owner` sweep moved into a shared `escrow_sweep` module, and startup reconciliation now compares the union of DB mints and on-chain escrow balances. A mint present on only one side compares against 0 on the other, so a funded escrow with an empty DB fails closed instead of passing blind; the empty-state pass remains only when both sides are genuinely empty. Recovery for a legitimately fresh DB is `indexer resync`.
- Secrets (SOLA3-12). `update-admin-env.sh` writes the public admin key to the tracked template and the
  private key only to a gitignored runtime env file (default `.env`). The compose env-file chain loads
  `.env` last so runtime secrets override the blanked templates, and the chain drops the flag when `.env`
  does not exist so a fresh clone still starts. The fail-closed secrets check validates the same chain
  compose resolves. README and DEVNET_QUICKSTART now direct secrets to `.env`.

## Tests

- `TokenAmount` unit tests: decode accepts the full `u64` range and rejects negative, fractional, and
  over-`u64` values; serde stays a bare integer. Net conversion tests cover clamp-to-zero and the
  `u64::MAX` mismatch sentinel.
- Postgres (testcontainers): a deposit and a withdrawal of `i64::MAX + 1` round-trip bit-for-bit through
  the raw column and the `FromRow` path; reconciliation sums two above-`i64::MAX` deposits correctly
  (`postgres_db_test` 44, `reconciliation_db_test` 7, `reconciliation_e2e_test` 9, `remint_e2e_test` 6).
- Reconciliation unit tests: union set construction (DB-only, chain-only, merged, disjoint), and
  startup-contract tests against a mocked RPC sweep, including the previously missing case: an empty DB
  with a funded escrow must block startup.
- Secrets: a shell test generates a keypair, runs `update-admin-env.sh`, and asserts the tracked template
  carries only the public key while the runtime file carries the private key.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 10,965 | 12,563 | 87.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27612171290) |
| Indexer | 19,674 | 22,639 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27612171290) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27612171290) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27612171290) |
| Withdraw Program | 120 | 232 | 51.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27612171254) |
| Escrow Program | 1,186 | 1,973 | 60.1% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27612171254) |
| DvP Swap Program | 247 | 1,112 | 22.2% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27612171254) |
| E2E Integration | 11,407 | 14,179 | 80.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27612171290) |
| **Total** | **45,063** | **53,581** | **84.1%** | |

> Last updated: 2026-06-16 11:20:14 UTC by E2E Integration