### PR TITLE
fix(indexer): persist mint signature write-ahead and make deposit recovery signature-driven

### DIFF
--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -25,11 +25,13 @@ There are **four trigger surfaces** that can land a deposit in
    mint-init helper found the on-chain mint in a state it cannot fix by
    re-issuing `mint_to` (wrong authority on the private channel mint, or
    corrupt mint data). See **Path D** for recovery.
-3. **Recovery-worker idempotency lookup failed** — the periodic
-   stuck-row recovery worker found a stale `Processing` deposit, tried
-   the idempotency memo lookup against the PrivateChannel RPC, and the
-   RPC was unreachable. Row data is fine; no on-chain mint attempted.
-   See **Path E**.
+3. **Recovery-worker could not classify the persisted signature** - the
+   periodic stuck-row recovery worker found a stale `Processing` deposit
+   but could not determine whether its mint landed: either the
+   PrivateChannel RPC was unreachable, or a stored signature could not be
+   read or parsed (so it never reached the RPC check). Recovery quarantines
+   on uncertainty rather than risk a double-mint. The `transactions` row
+   itself is fine. See **Path E**.
 4. **Processor-side allowlist gate** — the deposit's `mint` has no row
    in the `mints` allowlist (`MintCache::assert_mint_allowlisted`). Row
    data is fine; no `MintTo` was attempted. See **Path F**.
@@ -51,7 +53,8 @@ to the right Path below.
 | `invalid_pubkey` | `mint` or `recipient` field is not a valid base58 pubkey. |
 | `invalid_builder` | Builder rejected the row's data (e.g. negative amount). |
 | `program_error` | Generic builder error not covered by the specific variants. |
-| `deposit idempotency:` | The recovery worker could not authoritatively decide whether the deposit's mint already landed. Row was quarantined on uncertainty rather than risk a double-mint. Indicates RPC health, not a row defect. See **Path E**. |
+| `could not verify mint landed` | The recovery worker could not determine whether the deposit's mint landed: the PrivateChannel RPC was uncertain, or a stored signature could not be read or parsed. Quarantined on uncertainty rather than risk a double-mint. See **Path E**. |
+| `legacy in-flight deposit, verify on-chain before re-mint` | A one-time upgrade quarantine: this deposit was already `processing` when the pre-broadcast-persist code was deployed, so it has no persisted signature and recovery cannot prove it never minted. Verify on-chain before re-arming. See **Path E** (treat as `AMBIGUOUS` until the on-chain check resolves). |
 | `recovery requeues without progress` | The recovery worker demoted this `processing` deposit 3 times (mint never landed each cycle) and quarantined rather than loop forever. Row data is fine; the mint keeps failing to land. See **Path G**. |
 
 ### Sender-side post-JIT surface (`sender/mint.rs`)
@@ -85,10 +88,15 @@ solana confirm -v <signature> --url <solana-rpc-url>
 
 ## Recovery
 
-Deposits do not need on-chain mint verification before recovery - the
-quarantine triggers on row-data validation, before any RPC call. The
-idempotency memo (`private_channel:mint-idempotency:<transaction_id>`) prevents
-double-mint on retry even if the mint somehow did land.
+Processor-side and allowlist quarantines (Paths A/B/C/F) trigger on row-data
+validation before any mint is attempted, so they do not need on-chain mint
+verification before recovery. The signature-driven recovery worker (Path E)
+is the gate against a double-mint: it re-arms (`pending`) only a deposit it
+has proven did not mint - either no signature was ever persisted (so it was
+never broadcast) or the persisted signature is provably dead. An on-chain
+mint memo (`private_channel:mint-idempotency:<transaction_id>`) is still
+emitted as a forensic marker for manual review, but recovery no longer
+depends on scanning for it.
 
 That said: **if `error_message` is `program_error`** the trigger is less
 specific and may indicate a real on-chain rejection. In that case run
@@ -138,10 +146,11 @@ deterministic error as transient could put the operator into a tight
 retry loop. The asymmetric cost favors a noisy quarantine over a silent
 retry.
 
-Re-arm to `pending` (safe - idempotency memo prevents duplicate mint),
-then [escalate](_escalation.md) (Tier 3) so the taxonomy can be
-extended to classify this error variant explicitly. Do not patch
-in-place.
+This quarantine fires on a transient error raised before the mint is
+broadcast, so no `MintTo` reached the chain and re-arming cannot
+double-mint. Re-arm to `pending`, then [escalate](_escalation.md) (Tier 3)
+so the taxonomy can be extended to classify this error variant explicitly.
+Do not patch in-place.
 
 ```sql
 UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
@@ -192,7 +201,8 @@ admin pubkey.
   ```
 
   to point the mint at the current operator admin. Then re-arm to
-  `pending` (SQL below). The idempotency memo prevents double-mint.
+  `pending` (SQL below). Safe because Step 1 already verified `NOT_LANDED`
+  on-chain - no mint exists to duplicate.
 - **Authority mismatch — current authority lost** (e.g. old admin key
   destroyed during rotation). The mint is permanently unusable.
   **Escalate (Tier 1).** Recovery is a manual coordinated mint
@@ -219,21 +229,32 @@ UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updat
  WHERE id = :transaction_id;
 ```
 
-### Path E - recovery-worker idempotency lookup failed
+### Path E - recovery-worker could not classify the persisted signature
 
-`error_message` starts with `deposit idempotency:`. The recovery worker
-quarantines rather than demote when the idempotency lookup fails on RPC
-error, because demoting would re-pick the row and risk a double-mint. This
-is the same fail-closed stance as the live mint path, which on the same RPC
-failure also stops without minting (it routes to a terminal failure via
-`send_fatal_error` rather than minting unverified). Both paths refuse to
-proceed on uncertainty; they differ only in terminal state.
+`error_message` contains `could not verify mint landed` (or, for a legacy
+upgrade row, `legacy in-flight deposit, verify on-chain before re-mint`).
+
+Deposit recovery is signature-driven: on every sweep the worker reads the
+deposit's persisted broadcast signature and asks the PrivateChannel RPC
+whether it landed. The decision is:
+
+| Persisted signature state | Recovery action |
+|---|---|
+| none recorded | demote to `pending` (provably never broadcast - the signature is persisted write-ahead, before the send) |
+| finalized success | mark `completed` |
+| dead (finalized-failed or blockhash-expired) | demote to `pending` |
+| still in flight | leave `processing`, re-check next sweep |
+| RPC uncertain / malformed signature | quarantine to `manual_review` (this Path) |
+
+The worker quarantines on uncertainty rather than demote, because demoting
+would re-pick the row and risk a double-mint. It never demotes a deposit it
+cannot prove did not mint.
 
 #### Step 1 - check RPC health
 
-Inspect the suffix of `error_message` to identify the underlying RPC
-transport failure (timeout, connection refused, HTTP 5xx, etc.).
-Confirm against the operator's current PrivateChannel RPC endpoint:
+Inspect the suffix of `error_message`. If it names an RPC transport
+failure (timeout, connection refused, HTTP 5xx, etc.), confirm against
+the operator's current PrivateChannel RPC endpoint:
 
 ```bash
 curl -s -X POST -H "Content-Type: application/json" \
@@ -241,8 +262,9 @@ curl -s -X POST -H "Content-Type: application/json" \
   <private-channel-rpc-url>
 ```
 
-If RPC is unhealthy, address that first. If RPC is healthy now,
-proceed.
+If RPC is unhealthy, address that first. If the suffix instead names an
+unparseable stored signature, RPC health is not the cause; proceed
+straight to Step 2 and treat it as an engineering escalation afterward.
 
 #### Step 2 - verify on-chain
 
@@ -259,8 +281,8 @@ Mark `completed` with the observed signature (same SQL as
 
 ##### `NOT_LANDED` — re-arm
 
-The mint did not land. Re-arm to `pending`; the idempotency memo
-prevents duplicate mint on the next attempt.
+Step 2 verified `NOT_LANDED` on-chain, so no mint exists to duplicate.
+Re-arm to `pending` for a fresh mint attempt.
 
 ```sql
 UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
@@ -385,21 +407,21 @@ SOLA2-27 attack surface, not an operations recovery.
 ### Path G - requeue cap exhausted (mint never landed)
 
 `error_message` contains `recovery requeues without progress`. Each
-recovery pass whose idempotency scan finds no existing mint (`NotLanded`)
-demotes the stuck `processing` deposit back to `pending` for a fresh
-mint. After `MAX_RECOVERY_REQUEUE_ATTEMPTS` (3) such requeues with the
-mint still never landing, recovery quarantines instead of looping. So the
-mint was retried 3 times and never landed. The lookup *succeeded* each
-time and said not-landed (distinct from Path E, where the lookup itself
-*failed* on RPC error); the row data is valid (distinct from Path A).
+recovery pass that classifies the deposit's signatures as absent or dead
+(`NotLanded`) demotes the stuck `processing` deposit back to `pending` for
+a fresh mint. After `MAX_RECOVERY_REQUEUE_ATTEMPTS` (3) such requeues with
+the mint still never landing, recovery quarantines instead of looping. So
+the mint was retried 3 times and never landed. The classification
+*succeeded* each time and said not-landed (distinct from Path E, where the
+RPC was uncertain); the row data is valid (distinct from Path A).
 
 #### Step 1 - verify on-chain
 
 Run [`_verify_onchain_mint.md`](_verify_onchain_mint.md). Expected
-verdict: `NOT_LANDED`. If `LANDED` -> the idempotency scan missed a landed
-mint; mark `completed` per **Path E** (`LANDED` branch) and
-[escalate](_escalation.md) (Tier 2) - the scan has a defect (e.g. the sig
-is past its lookback window).
+verdict: `NOT_LANDED`. If `LANDED` -> a broadcast signature landed after
+the last classification said dead; mark `completed` per **Path E**
+(`LANDED` branch) and [escalate](_escalation.md) (Tier 2) so engineering
+can review the finality timing.
 
 #### Step 2 - find why the mint never lands
 
@@ -414,8 +436,8 @@ error. A deterministic cause means re-arming will loop again ->
 
 Fix the root cause first. Then re-arm to `pending` **and reset the requeue
 counter** - re-arming without the reset re-quarantines on the next stall,
-since the counter is already at the cap. The idempotency memo still guards
-against a double-mint on retry:
+since the counter is already at the cap. Safe because Step 1 verified
+`NOT_LANDED` on-chain - no mint exists to duplicate:
 
 ```sql
 UPDATE transactions
@@ -425,6 +447,38 @@ UPDATE transactions
 
 If the mint can never land (unrecoverable), mark `failed` and
 [escalate](_escalation.md) (Tier 1) for refund coordination.
+
+## One-time upgrade step (pre-broadcast signature persistence)
+
+Deposit recovery's `none recorded -> demote` rule (Path E table) is only
+sound for rows created under the pre-broadcast-persist code. A deposit that
+was already `processing` at the moment of the upgrade may have been
+broadcast under the old combined-send path with **no persisted signature** -
+demoting it blindly would re-pick and double-mint.
+
+**Fresh deployment: N/A.** A clean install has no legacy in-flight rows.
+
+**Upgrading an environment with in-flight deposits:** the recommended cutover
+is to drain the operator (let it settle all in-flight deposits, or stop it
+with no deposits mid-`processing`) before deploying. If a drain is not
+possible, run this one-time query **once, immediately after the upgrade and
+before the recovery worker first sweeps**, to quarantine any legacy
+`processing` deposit that has no persisted signature so an operator verifies
+it on-chain (Path E) instead of risking a blind re-mint:
+
+```sql
+UPDATE transactions
+   SET status = 'manual_review',
+       error_message = 'SOLA2-12 upgrade: legacy in-flight deposit, verify on-chain before re-mint',
+       updated_at = NOW()
+ WHERE transaction_type = 'deposit'
+   AND status = 'processing'
+   AND id NOT IN (SELECT transaction_id FROM pending_release_signatures);
+```
+
+It is bounded by the in-flight-at-deploy count and never needs to run again:
+after cutover, every new deposit persists its signature before broadcast, so
+a missing signature reliably means "never sent".
 
 ## Post-incident artifacts
 

--- a/indexer/src/operator/mod.rs
+++ b/indexer/src/operator/mod.rs
@@ -17,5 +17,5 @@ pub use fetcher::run_fetcher;
 pub use operator::run;
 pub use processor::run_processor;
 pub use recovery::run_recovery_worker;
-pub use sender::{find_existing_mint_signature, run_sender, TransactionStatusUpdate};
+pub use sender::{find_existing_mint_signature_with_memo, run_sender, TransactionStatusUpdate};
 pub use utils::*;

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -3,7 +3,7 @@ use crate::error::OperatorError;
 use crate::metrics;
 use crate::operator::{
     feepayer_monitor, fetcher, processor, reconciliation, recovery, sender, DbTransactionWriter,
-    RetryConfig, RpcClientWithRetry, SignerUtil,
+    RetryConfig, RpcClientWithRetry,
 };
 use crate::shutdown_utils::shutdown_operator;
 use crate::storage::Storage;
@@ -96,12 +96,10 @@ pub async fn run(
     // signatures and this reconcile have run, and guards an unforeseen divergence.
     if program_type == crate::config::ProgramType::Withdraw {
         if let Some(preflight_instance) = instance_pda {
-            let admin_pubkey = SignerUtil::get_admin_pubkey();
             // The main rpc_client is the chain where the instance and releases live.
             let preflight = run_withdraw_preflight(
                 &storage,
                 &rpc_client,
-                admin_pubkey,
                 preflight_instance,
                 &storage_tx,
                 &cancellation_token,
@@ -238,12 +236,10 @@ pub async fn run(
         let recovery_rpc = rpc_client.clone();
         let recovery_program_type = common_config.program_type;
         let recovery_token = cancellation_token.clone();
-        let admin_pubkey = SignerUtil::get_admin_pubkey();
         tokio::spawn(async move {
             if let Err(e) = recovery::run_recovery_worker(
                 recovery_storage,
                 recovery_rpc,
-                admin_pubkey,
                 recovery_program_type,
                 recovery_storage_tx,
                 recovery_token,
@@ -358,7 +354,6 @@ pub async fn run(
 async fn run_withdraw_preflight(
     storage: &Arc<Storage>,
     rpc_client: &Arc<RpcClientWithRetry>,
-    admin_pubkey: solana_sdk::pubkey::Pubkey,
     instance_pda: solana_sdk::pubkey::Pubkey,
     storage_tx: &mpsc::Sender<sender::TransactionStatusUpdate>,
     cancellation_token: &CancellationToken,
@@ -371,7 +366,6 @@ async fn run_withdraw_preflight(
     if let Err(e) = recovery::boot_reconcile_processing(
         storage,
         rpc_client,
-        admin_pubkey,
         crate::config::ProgramType::Withdraw,
         storage_tx,
         cancellation_token,
@@ -504,15 +498,7 @@ mod tests {
         let client = Arc::new(client);
         let (storage_tx, _rx) = mpsc::channel::<sender::TransactionStatusUpdate>(8);
         let token = CancellationToken::new();
-        run_withdraw_preflight(
-            &storage,
-            &client,
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            &storage_tx,
-            &token,
-        )
-        .await
+        run_withdraw_preflight(&storage, &client, Pubkey::new_unique(), &storage_tx, &token).await
     }
 
     /// Matching local and on-chain roots: the pre-flight passes and the operator starts.

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -354,7 +354,7 @@ async fn route_outcome(
             debug!(
                 transaction_id = row.id,
                 reason = %reason,
-                "Recovery left stale Processing withdrawal untouched — release may still land"
+                "Recovery left stale Processing row untouched — broadcast may still land"
             );
         }
         RecoveryAction::Quarantine { reason } => {

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -481,6 +481,7 @@ pub mod test_hooks {
 mod tests {
     use super::*;
     use crate::operator::utils::rpc_util::RetryConfig;
+    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::storage::mock::MockStorage;
     use solana_sdk::commitment_config::CommitmentConfig;
     use solana_sdk::pubkey::Pubkey;
@@ -490,12 +491,13 @@ mod tests {
         DbTransaction {
             id,
             signature: format!("sig-{id}"),
+            instruction_index: 0,
             trace_id: format!("trace-{id}"),
             slot: 100,
             initiator: Pubkey::new_unique().to_string(),
             recipient: Pubkey::new_unique().to_string(),
             mint: Pubkey::new_unique().to_string(),
-            amount: 1_000,
+            amount: TokenAmount(1_000),
             memo: None,
             transaction_type: TransactionType::Deposit,
             withdrawal_nonce: None,
@@ -509,7 +511,6 @@ mod tests {
             pending_remint_deadline_at: None,
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
-            instruction_index: 0,
             inner_index: None,
             landed_remint_signature: None,
         }

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -5,19 +5,13 @@ use crate::config::ProgramType;
 use crate::error::OperatorError;
 use crate::metrics::OPERATOR_STALE_PROCESSING_RECOVERED;
 use crate::operator::sender::types::PendingSig;
-use crate::operator::sender::{
-    classify_release_signatures, find_existing_mint_signature, SigFinality,
-};
-use crate::operator::utils::instruction_util::{MintToBuilder, MintToBuilderWithTxnId};
-use crate::operator::utils::mint_idempotency_memo;
+use crate::operator::sender::{classify_release_signatures, SigFinality};
 use crate::operator::utils::rpc_util::RpcClientWithRetry;
 use crate::operator::TransactionStatusUpdate;
 use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
 use crate::storage::common::storage::Storage;
 use chrono::{DateTime, Utc};
-use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
-use spl_associated_token_account::get_associated_token_address_with_program_id;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,10 +31,12 @@ pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 /// Max durable Demote requeues before a stuck row is quarantined (paged).
 const MAX_RECOVERY_REQUEUE_ATTEMPTS: i32 = 3;
 
-/// Three-way outcome: uncertainty must NOT demote (double-mint risk).
+/// Deposit recovery outcome. Uncertainty must NOT demote (double-mint risk); an
+/// in-flight signature leaves the row Processing for the next sweep.
 enum DepositOutcome {
     Landed { signature: String },
     NotLanded,
+    Live { reason: String },
     Ambiguous { reason: String },
 }
 
@@ -76,7 +72,6 @@ enum RecoveryAction {
 pub async fn run_recovery_worker(
     storage: Arc<Storage>,
     rpc_client: Arc<RpcClientWithRetry>,
-    admin_pubkey: Pubkey,
     program_type: ProgramType,
     storage_tx: mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: CancellationToken,
@@ -93,7 +88,6 @@ pub async fn run_recovery_worker(
                 if let Err(e) = recover_once(
                     &storage,
                     &rpc_client,
-                    admin_pubkey,
                     program_type,
                     &storage_tx,
                     &cancellation_token,
@@ -113,7 +107,6 @@ pub async fn run_recovery_worker(
 async fn recover_once(
     storage: &Storage,
     rpc_client: &RpcClientWithRetry,
-    admin_pubkey: Pubkey,
     program_type: ProgramType,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: &CancellationToken,
@@ -147,7 +140,7 @@ async fn recover_once(
         }
         // Capture `updated_at` before the RPC so the write below CAS-checks it.
         let captured = row.updated_at;
-        let action = decide_action(&row, storage, rpc_client, admin_pubkey).await;
+        let action = decide_action(&row, storage, rpc_client).await;
         route_outcome(storage, &row, captured, action, program_type, storage_tx).await;
     }
     Ok(())
@@ -157,16 +150,14 @@ async fn decide_action(
     row: &DbTransaction,
     storage: &Storage,
     rpc_client: &RpcClientWithRetry,
-    admin_pubkey: Pubkey,
 ) -> RecoveryAction {
     let action = match row.transaction_type {
-        TransactionType::Deposit => {
-            match check_deposit_idempotency(row, rpc_client, admin_pubkey).await {
-                DepositOutcome::Landed { signature } => RecoveryAction::Complete { signature },
-                DepositOutcome::NotLanded => RecoveryAction::Demote,
-                DepositOutcome::Ambiguous { reason } => RecoveryAction::Quarantine { reason },
-            }
-        }
+        TransactionType::Deposit => match check_deposit(row, storage, rpc_client).await {
+            DepositOutcome::Landed { signature } => RecoveryAction::Complete { signature },
+            DepositOutcome::NotLanded => RecoveryAction::Demote,
+            DepositOutcome::Live { reason } => RecoveryAction::NoAction { reason },
+            DepositOutcome::Ambiguous { reason } => RecoveryAction::Quarantine { reason },
+        },
         TransactionType::Withdrawal => match check_withdrawal(row, storage, rpc_client).await {
             WithdrawalAction::Complete { signature } => RecoveryAction::Complete { signature },
             WithdrawalAction::Demote => RecoveryAction::Demote,
@@ -189,27 +180,39 @@ async fn decide_action(
     action
 }
 
-async fn check_deposit_idempotency(
+/// Decide a stuck Processing deposit's fate from its persisted broadcast signatures.
+/// Like `check_withdrawal`, but with no signatures a deposit Demotes (safe re-mint)
+/// where a withdrawal Quarantines: the pre-broadcast persist makes "no signature" mean
+/// "never broadcast", so re-minting cannot double-mint, and quarantining every such row
+/// would flood manual review at deposit volume.
+async fn check_deposit(
     row: &DbTransaction,
+    storage: &Storage,
     rpc_client: &RpcClientWithRetry,
-    admin_pubkey: Pubkey,
 ) -> DepositOutcome {
-    let builder = match reconstruct_mint_builder_for_lookup(row, admin_pubkey) {
-        Ok(b) => b,
-        Err(e) => {
+    let pending = match load_pending_sigs(storage, row.id).await {
+        Ok(p) => p,
+        Err(reason) => {
             return DepositOutcome::Ambiguous {
-                reason: format!("deposit idempotency: rebuild: {e}"),
+                reason: format!("could not verify mint landed ({reason})"),
             }
         }
     };
-    match find_existing_mint_signature(rpc_client, &builder).await {
-        Ok(Some(sig)) => DepositOutcome::Landed {
+
+    if pending.is_empty() {
+        return DepositOutcome::NotLanded;
+    }
+
+    match classify_release_signatures(rpc_client, &pending).await {
+        SigFinality::Landed(sig) => DepositOutcome::Landed {
             signature: sig.to_string(),
         },
-        Ok(None) => DepositOutcome::NotLanded,
+        SigFinality::Dead => DepositOutcome::NotLanded,
+        // Still in flight; re-check next sweep rather than demote or complete.
+        SigFinality::Live(reason) => DepositOutcome::Live { reason },
         // Never demote on uncertainty — risks a double-mint on re-pickup.
-        Err(e) => DepositOutcome::Ambiguous {
-            reason: format!("deposit idempotency: {e}"),
+        SigFinality::Uncertain(reason) => DepositOutcome::Ambiguous {
+            reason: format!("could not verify mint landed ({reason})"),
         },
     }
 }
@@ -227,39 +230,17 @@ async fn check_withdrawal(
         };
     }
 
-    let stored = match storage.get_release_signatures(row.id).await {
-        Ok(s) => s,
-        // Can't read the durable record → can't prove the release didn't land.
-        Err(e) => {
-            return WithdrawalAction::Quarantine {
-                reason: format!("release signature lookup failed: {e}"),
-            };
-        }
+    let pending = match load_pending_sigs(storage, row.id).await {
+        Ok(p) => p,
+        Err(reason) => return WithdrawalAction::Quarantine { reason },
     };
 
     // No recorded signatures → can't verify a release landed; demoting risks a
     // double-payout, so page instead.
-    if stored.is_empty() {
+    if pending.is_empty() {
         return WithdrawalAction::Quarantine {
             reason: "no broadcast signatures recorded; cannot verify release landed".to_string(),
         };
-    }
-
-    // Reconstruct PendingSigs for the classifier; a malformed stored signature
-    // is uncertainty, not "dead".
-    let mut pending = Vec::with_capacity(stored.len());
-    for (sig_str, lvbh) in &stored {
-        match Signature::from_str(sig_str) {
-            Ok(signature) => pending.push(PendingSig {
-                signature,
-                last_valid_block_height: *lvbh as u64,
-            }),
-            Err(e) => {
-                return WithdrawalAction::Quarantine {
-                    reason: format!("malformed stored release signature {sig_str}: {e}"),
-                };
-            }
-        }
     }
 
     match classify_release_signatures(rpc_client, &pending).await {
@@ -271,9 +252,9 @@ async fn check_withdrawal(
         SigFinality::Uncertain(reason) => WithdrawalAction::Quarantine {
             reason: format!(
                 "could not verify release landed ({reason}); signatures: {}",
-                stored
+                pending
                     .iter()
-                    .map(|(s, _)| s.as_str())
+                    .map(|p| p.signature.to_string())
                     .collect::<Vec<_>>()
                     .join(",")
             ),
@@ -281,36 +262,26 @@ async fn check_withdrawal(
     }
 }
 
-/// Rebuild the processor's mint builder so idempotency lookup keys match.
-fn reconstruct_mint_builder_for_lookup(
-    row: &DbTransaction,
-    admin_pubkey: Pubkey,
-) -> Result<MintToBuilderWithTxnId, String> {
-    let mint = Pubkey::from_str(&row.mint).map_err(|e| format!("invalid mint pubkey: {e}"))?;
-    let recipient =
-        Pubkey::from_str(&row.recipient).map_err(|e| format!("invalid recipient pubkey: {e}"))?;
-    // PrivateChannel is SPL-Token-only today (mirror `mint_util.rs`).
-    let token_program = spl_token::id();
-    let recipient_ata =
-        get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
-    let amount = row.amount.value();
+/// Load and parse a row's persisted broadcast signatures into `PendingSig`s for the
+/// finality classifier. Shared by deposit and withdrawal recovery. A read error or a
+/// malformed stored signature returns a quarantine reason (uncertainty, never "dead"),
+/// so callers never demote a row whose signatures could not be read or parsed.
+async fn load_pending_sigs(storage: &Storage, id: i64) -> Result<Vec<PendingSig>, String> {
+    let stored = storage
+        .get_release_signatures(id)
+        .await
+        .map_err(|e| format!("release signature lookup failed: {e}"))?;
 
-    let mut builder = MintToBuilder::new();
-    builder
-        .mint(mint)
-        .recipient(recipient)
-        .recipient_ata(recipient_ata)
-        .payer(admin_pubkey)
-        .mint_authority(admin_pubkey)
-        .token_program(token_program)
-        .amount(amount)
-        .idempotency_memo(mint_idempotency_memo(row.id));
-
-    Ok(MintToBuilderWithTxnId {
-        builder,
-        txn_id: row.id,
-        trace_id: row.trace_id.clone(),
-    })
+    let mut pending = Vec::with_capacity(stored.len());
+    for (sig_str, lvbh) in &stored {
+        let signature = Signature::from_str(sig_str)
+            .map_err(|e| format!("malformed stored release signature {sig_str}: {e}"))?;
+        pending.push(PendingSig {
+            signature,
+            last_valid_block_height: *lvbh as u64,
+        });
+    }
+    Ok(pending)
 }
 
 async fn route_outcome(
@@ -444,7 +415,6 @@ async fn route_outcome(
 pub async fn boot_reconcile_processing(
     storage: &Storage,
     rpc_client: &RpcClientWithRetry,
-    admin_pubkey: Pubkey,
     program_type: ProgramType,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: &CancellationToken,
@@ -454,7 +424,6 @@ pub async fn boot_reconcile_processing(
         recover_once(
             storage,
             rpc_client,
-            admin_pubkey,
             program_type,
             storage_tx,
             cancellation_token,
@@ -489,7 +458,6 @@ pub mod test_hooks {
     pub async fn run_recovery_once(
         storage: &Storage,
         rpc_client: &RpcClientWithRetry,
-        admin_pubkey: Pubkey,
         program_type: ProgramType,
         storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     ) -> Result<(), OperatorError> {
@@ -500,7 +468,6 @@ pub mod test_hooks {
         recover_once(
             storage,
             rpc_client,
-            admin_pubkey,
             program_type,
             storage_tx,
             &token,
@@ -514,9 +481,9 @@ pub mod test_hooks {
 mod tests {
     use super::*;
     use crate::operator::utils::rpc_util::RetryConfig;
-    use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::storage::mock::MockStorage;
     use solana_sdk::commitment_config::CommitmentConfig;
+    use solana_sdk::pubkey::Pubkey;
 
     fn make_deposit_row(id: i64) -> DbTransaction {
         let now = Utc::now();
@@ -528,7 +495,7 @@ mod tests {
             initiator: Pubkey::new_unique().to_string(),
             recipient: Pubkey::new_unique().to_string(),
             mint: Pubkey::new_unique().to_string(),
-            amount: TokenAmount(1_000),
+            amount: 1_000,
             memo: None,
             transaction_type: TransactionType::Deposit,
             withdrawal_nonce: None,
@@ -567,155 +534,156 @@ mod tests {
         )
     }
 
-    // ── check_deposit_idempotency outcome matrix ─────────────────────
+    // ── check_deposit outcome matrix (signature-driven) ──────────────
 
+    fn mock_null_status(server: &mut mockito::ServerGuard) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":1}"#,
+            )
+            .create()
+    }
+
+    fn mock_block_height(server: &mut mockito::ServerGuard, height: u64) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getBlockHeight""#.into(),
+            ))
+            .with_status(200)
+            .with_body(format!(r#"{{"jsonrpc":"2.0","result":{height},"id":1}}"#))
+            .create()
+    }
+
+    /// The keystone divergence from withdrawal: a deposit with no persisted signature is
+    /// provably never broadcast (pre-broadcast persist), so it Demotes for a safe re-mint
+    /// rather than Quarantining. No RPC is consulted.
     #[tokio::test]
-    async fn check_deposit_idempotency_landed_when_rpc_returns_match() {
-        // Scripted mock with memo-matching mint; unit equivalent of the IT fixture.
+    async fn deposit_no_sigs_demotes() {
+        let storage = Storage::Mock(MockStorage::new());
+        let client = make_rpc_client("http://localhost:1");
+        let row = make_deposit_row(1);
+        let outcome = check_deposit(&row, &storage, &client).await;
+        assert!(
+            matches!(outcome, DepositOutcome::NotLanded),
+            "empty sigs must map to NotLanded (Demote), not Ambiguous/Quarantine"
+        );
+        // Same state on the withdrawal side Quarantines; assert the difference.
+        let wrow = make_withdrawal_row(2, Some(42));
+        let waction = check_withdrawal(&wrow, &storage, &client).await;
+        assert!(
+            matches!(waction, WithdrawalAction::Quarantine { .. }),
+            "withdrawal with no sigs must Quarantine - the deliberate deposit divergence"
+        );
+    }
+
+    /// A finalized-success signature returns Landed and is never re-minted.
+    #[tokio::test]
+    async fn deposit_landed_sig_completes_without_remint() {
+        let landed_sig = Signature::new_unique();
         let mut server = mockito::Server::new_async().await;
-
-        let row = make_deposit_row(7_777);
-        let mint = Pubkey::from_str(&row.mint).unwrap();
-        let recipient = Pubkey::from_str(&row.recipient).unwrap();
-        let admin_pubkey = Pubkey::new_unique();
-        let token_program = spl_token::id();
-        let recipient_ata =
-            get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
-        let memo = mint_idempotency_memo(row.id);
-        let signature = solana_sdk::signature::Signature::new_unique();
-        let memo_program_id = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
-
-        let _sigs_mock = server
+        let _status = server
             .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "getSignaturesForAddress"
-            })))
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
             .with_status(200)
             .with_body(
-                serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": [
-                        {
-                            "signature": signature.to_string(),
-                            "slot": 100u64,
-                            "err": serde_json::Value::Null,
-                            "memo": format!("[{}] {}", memo.len(), memo),
-                            "blockTime": 1_700_000_000i64,
-                            "confirmationStatus": "finalized",
-                        }
-                    ]
-                })
-                .to_string(),
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":null,"status":{"Ok":null},"confirmationStatus":"finalized"}]},"id":1}"#,
             )
             .create();
 
-        let _tx_mock = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "getTransaction"
-            })))
-            .with_status(200)
-            .with_body(
-                serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {
-                        "slot": 100,
-                        "blockTime": 1_700_000_000i64,
-                        "meta": {
-                            "err": null,
-                            "status": { "Ok": null },
-                            "fee": 5000u64,
-                            "innerInstructions": [],
-                            "preBalances": [1_000_000u64],
-                            "postBalances": [999_995u64],
-                            "logMessages": [],
-                            "preTokenBalances": [],
-                            "postTokenBalances": [],
-                            "rewards": [],
-                            "computeUnitsConsumed": 0u64,
-                        },
-                        "transaction": {
-                            "signatures": [signature.to_string()],
-                            "message": {
-                                "accountKeys": [
-                                    {"pubkey": admin_pubkey.to_string(), "signer": true, "writable": true, "source": "transaction"},
-                                    {"pubkey": recipient_ata.to_string(), "signer": false, "writable": true, "source": "transaction"},
-                                    {"pubkey": mint.to_string(), "signer": false, "writable": true, "source": "transaction"},
-                                    {"pubkey": token_program.to_string(), "signer": false, "writable": false, "source": "transaction"},
-                                    {"pubkey": memo_program_id, "signer": false, "writable": false, "source": "transaction"},
-                                ],
-                                "recentBlockhash": "GHtXQBsoZHjzkAm2Sdm6FTyFHBCqBnLanJJhZFCFJXoe",
-                                "instructions": [
-                                    {"program": "spl-memo", "programId": memo_program_id, "parsed": memo},
-                                    {
-                                        "program": "spl-token",
-                                        "programId": token_program.to_string(),
-                                        "parsed": {
-                                            "type": "mintTo",
-                                            "info": {
-                                                "mint": mint.to_string(),
-                                                "account": recipient_ata.to_string(),
-                                                "mintAuthority": admin_pubkey.to_string(),
-                                                "amount": row.amount.value().to_string(),
-                                            },
-                                        },
-                                    },
-                                ],
-                            },
-                        },
-                    }
-                })
-                .to_string(),
-            )
-            .create();
-
+        let mock = MockStorage::new();
+        let row = make_deposit_row(1);
+        mock.insert_release_signature(row.id, landed_sig.to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
         let client = make_rpc_client(&server.url());
-        let outcome = check_deposit_idempotency(&row, &client, admin_pubkey).await;
-        match outcome {
-            DepositOutcome::Landed { signature: s } => {
-                assert_eq!(s, signature.to_string());
-            }
+
+        match check_deposit(&row, &storage, &client).await {
+            DepositOutcome::Landed { signature } => assert_eq!(signature, landed_sig.to_string()),
             _ => panic!("expected Landed"),
         }
     }
 
+    /// A null-status sig past blockhash validity is dead: NotLanded, safe to re-mint.
     #[tokio::test]
-    async fn check_deposit_idempotency_not_landed_on_empty_signatures() {
+    async fn deposit_dead_sigs_demote() {
         let mut server = mockito::Server::new_async().await;
-        let _m = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "getSignaturesForAddress"
-            })))
-            .with_status(200)
-            .with_body(serde_json::json!({"jsonrpc":"2.0","id":1,"result":[]}).to_string())
-            .create();
-        let client = make_rpc_client(&server.url());
+        let _status = mock_null_status(&mut server);
+        // current_height (1000) > lvbh (100) means expired/dead.
+        let _height = mock_block_height(&mut server, 1000);
+
+        let mock = MockStorage::new();
         let row = make_deposit_row(1);
-        let admin_pubkey = Pubkey::new_unique();
-        let outcome = check_deposit_idempotency(&row, &client, admin_pubkey).await;
-        assert!(matches!(outcome, DepositOutcome::NotLanded));
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        assert!(
+            matches!(
+                check_deposit(&row, &storage, &client).await,
+                DepositOutcome::NotLanded
+            ),
+            "dead sigs map to NotLanded (Demote)"
+        );
     }
 
+    /// A sig still within blockhash validity is Live: leave Processing this sweep.
     #[tokio::test]
-    async fn check_deposit_idempotency_ambiguous_on_transport_error() {
+    async fn deposit_live_sig_leaves_processing() {
         let mut server = mockito::Server::new_async().await;
-        // HTTP 500 → transport error → Err path → Ambiguous.
-        let _m = server
+        let _status = mock_null_status(&mut server);
+        // current_height (50) <= lvbh (1000) means still live.
+        let _height = mock_block_height(&mut server, 50);
+
+        let mock = MockStorage::new();
+        let row = make_deposit_row(1);
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 1000)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        assert!(
+            matches!(
+                check_deposit(&row, &storage, &client).await,
+                DepositOutcome::Live { .. }
+            ),
+            "a still-live sig must leave the row Processing, not demote"
+        );
+    }
+
+    /// An RPC failure during classification is uncertain: Ambiguous, never demote.
+    #[tokio::test]
+    async fn deposit_rpc_uncertain_quarantines() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = server
             .mock("POST", "/")
             .with_status(500)
             .with_body("internal server error")
             .create();
-        let client = make_rpc_client(&server.url());
+
+        let mock = MockStorage::new();
         let row = make_deposit_row(1);
-        let admin_pubkey = Pubkey::new_unique();
-        let outcome = check_deposit_idempotency(&row, &client, admin_pubkey).await;
-        match outcome {
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        match check_deposit(&row, &storage, &client).await {
             DepositOutcome::Ambiguous { reason } => {
                 assert!(
-                    reason.starts_with("deposit idempotency:"),
+                    reason.contains("could not verify mint landed"),
                     "reason: {reason}"
                 );
             }
@@ -723,33 +691,27 @@ mod tests {
         }
     }
 
+    /// A malformed stored signature (via the shared `load_pending_sigs`) is uncertainty,
+    /// never read as "dead"; it must Quarantine rather than demote.
     #[tokio::test]
-    async fn check_deposit_idempotency_ambiguous_on_method_not_found() {
-        let mut server = mockito::Server::new_async().await;
-        // -32601 must NOT collapse to NotLanded → would demote + double-mint.
-        let _m = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "getSignaturesForAddress"
-            })))
-            .with_status(200)
-            .with_body(
-                serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "error": { "code": -32601, "message": "Method not found" }
-                })
-                .to_string(),
-            )
-            .create();
-        let client = make_rpc_client(&server.url());
+    async fn deposit_malformed_stored_sig_quarantines() {
+        let mock = MockStorage::new();
         let row = make_deposit_row(1);
-        let admin_pubkey = Pubkey::new_unique();
-        let outcome = check_deposit_idempotency(&row, &client, admin_pubkey).await;
-        assert!(
-            matches!(outcome, DepositOutcome::Ambiguous { .. }),
-            "method-not-found must be Ambiguous, never NotLanded"
-        );
+        mock.insert_release_signature(row.id, "not-a-valid-base58-signature".to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client("http://localhost:1");
+
+        match check_deposit(&row, &storage, &client).await {
+            DepositOutcome::Ambiguous { reason } => {
+                assert!(
+                    reason.contains("malformed stored release signature"),
+                    "reason: {reason}"
+                );
+            }
+            _ => panic!("expected Ambiguous on malformed signature"),
+        }
     }
 
     // ── check_withdrawal outcome matrix ───────────────────────────────
@@ -814,7 +776,7 @@ mod tests {
 
         let mock = MockStorage::new();
         let row = make_withdrawal_row(1, Some(42));
-        // current_height (1000) > lvbh (100) → expired/dead.
+        // current_height (1000) > lvbh (100) means expired/dead.
         mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
             .await
             .unwrap();
@@ -886,7 +848,7 @@ mod tests {
 
         let mock = MockStorage::new();
         let row = make_withdrawal_row(1, Some(42));
-        // current_height (50) <= lvbh (1000) → still live.
+        // current_height (50) <= lvbh (1000) means still live.
         mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 1000)
             .await
             .unwrap();
@@ -1034,17 +996,7 @@ mod tests {
     /// counter increments, so the next stale sweep sees the higher count.
     #[tokio::test]
     async fn requeue_under_cap_increments_counter_and_requeues() {
-        let mut server = mockito::Server::new_async().await;
-        // Empty signatures → NotLanded → Demote.
-        let _m = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "getSignaturesForAddress"
-            })))
-            .with_status(200)
-            .with_body(serde_json::json!({"jsonrpc":"2.0","id":1,"result":[]}).to_string())
-            .create();
-
+        // No persisted signatures: NotLanded, so Demote, with no RPC consulted.
         let mock = MockStorage::new();
         let mut row = make_deposit_row(50);
         row.status = TransactionStatus::Processing;
@@ -1053,18 +1005,12 @@ mod tests {
         row.updated_at = Utc::now() - chrono::Duration::minutes(10);
         mock.pending_transactions.lock().unwrap().push(row.clone());
         let storage = Storage::Mock(mock.clone());
-        let client = make_rpc_client(&server.url());
+        let client = make_rpc_client("http://localhost:1");
         let (storage_tx, _rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(
-            &storage,
-            &client,
-            Pubkey::new_unique(),
-            ProgramType::Escrow,
-            &storage_tx,
-        )
-        .await
-        .unwrap();
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+            .await
+            .unwrap();
 
         let after = mock.pending_transactions.lock().unwrap();
         assert_eq!(
@@ -1082,16 +1028,7 @@ mod tests {
     /// ManualReview and the alert webhook is sent.
     #[tokio::test]
     async fn requeue_at_cap_quarantines_and_alerts() {
-        let mut server = mockito::Server::new_async().await;
-        let _m = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "getSignaturesForAddress"
-            })))
-            .with_status(200)
-            .with_body(serde_json::json!({"jsonrpc":"2.0","id":1,"result":[]}).to_string())
-            .create();
-
+        // No persisted signatures would Demote, but the cap converts it to Quarantine.
         let mock = MockStorage::new();
         let mut row = make_deposit_row(51);
         row.status = TransactionStatus::Processing;
@@ -1101,18 +1038,12 @@ mod tests {
         row.updated_at = Utc::now() - chrono::Duration::minutes(10);
         mock.pending_transactions.lock().unwrap().push(row.clone());
         let storage = Storage::Mock(mock.clone());
-        let client = make_rpc_client(&server.url());
+        let client = make_rpc_client("http://localhost:1");
         let (storage_tx, mut storage_rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(
-            &storage,
-            &client,
-            Pubkey::new_unique(),
-            ProgramType::Escrow,
-            &storage_tx,
-        )
-        .await
-        .unwrap();
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+            .await
+            .unwrap();
 
         let after = mock.pending_transactions.lock().unwrap();
         assert_eq!(
@@ -1135,32 +1066,24 @@ mod tests {
         );
     }
 
-    /// `decide_action` caps the Demote arm uniformly regardless of type.
+    /// `decide_action` caps the Demote arm uniformly regardless of type. Uses a deposit
+    /// row with no persisted signatures (NotLanded, so Demote, no RPC).
     #[tokio::test]
     async fn decide_action_caps_demote_at_threshold() {
-        let mut server = mockito::Server::new_async().await;
-        let _m = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "getSignaturesForAddress"
-            })))
-            .with_status(200)
-            .with_body(serde_json::json!({"jsonrpc":"2.0","id":1,"result":[]}).to_string())
-            .create();
         let storage = Storage::Mock(MockStorage::new());
-        let client = make_rpc_client(&server.url());
+        let client = make_rpc_client("http://localhost:1");
 
         let mut row = make_deposit_row(52);
         // One below the cap still demotes (requeues) - pins the off-by-one boundary.
         row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS - 1;
-        let below = decide_action(&row, &storage, &client, Pubkey::new_unique()).await;
+        let below = decide_action(&row, &storage, &client).await;
         assert!(
             matches!(below, RecoveryAction::Demote),
             "one below the cap must still Demote (requeue)"
         );
         // At the cap, the demote is converted to Quarantine.
         row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS;
-        let at_cap = decide_action(&row, &storage, &client, Pubkey::new_unique()).await;
+        let at_cap = decide_action(&row, &storage, &client).await;
         assert!(
             matches!(at_cap, RecoveryAction::Quarantine { .. }),
             "demote at the cap must become Quarantine"
@@ -1282,7 +1205,6 @@ mod tests {
         recover_once(
             &storage,
             &client,
-            Pubkey::new_unique(),
             ProgramType::Withdraw,
             &storage_tx,
             &CancellationToken::new(),
@@ -1328,7 +1250,6 @@ mod tests {
         boot_reconcile_processing(
             &storage,
             &client,
-            Pubkey::new_unique(),
             ProgramType::Withdraw,
             &storage_tx,
             &token,
@@ -1376,7 +1297,6 @@ mod tests {
         boot_reconcile_processing(
             &storage,
             &client,
-            Pubkey::new_unique(),
             ProgramType::Withdraw,
             &storage_tx,
             &token,

--- a/indexer/src/operator/sender/mint.rs
+++ b/indexer/src/operator/sender/mint.rs
@@ -1,5 +1,5 @@
 use crate::operator::utils::instruction_util::{
-    mint_idempotency_memo, InitializeMintBuilder, MintToBuilderWithTxnId, TransactionBuilder,
+    InitializeMintBuilder, MintToBuilderWithTxnId, TransactionBuilder,
 };
 use crate::operator::utils::transaction_util::{check_transaction_status, ConfirmationResult};
 use crate::operator::{
@@ -412,16 +412,6 @@ async fn mint_authority_check_with_backoff(
         }
     }
     last_check
-}
-
-/// Check recent ATA signatures for an already-confirmed mint carrying this transaction's
-/// deterministic idempotency memo.
-pub async fn find_existing_mint_signature(
-    rpc_client: &RpcClientWithRetry,
-    builder_with_txn_id: &MintToBuilderWithTxnId,
-) -> Result<Option<Signature>, String> {
-    let expected_memo = mint_idempotency_memo(builder_with_txn_id.txn_id);
-    find_existing_mint_signature_with_memo(rpc_client, builder_with_txn_id, &expected_memo).await
 }
 
 /// Check recent ATA signatures for an already-confirmed mint carrying the given memo.

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -5,7 +5,7 @@ mod state;
 mod transaction;
 pub mod types;
 
-pub use mint::{find_existing_mint_signature, find_existing_mint_signature_with_memo, JitOutcome};
+pub use mint::{find_existing_mint_signature_with_memo, JitOutcome};
 pub(crate) use remint::{classify_release_signatures, SigFinality};
 pub(crate) use state::validate_smt_root;
 pub use types::TransactionStatusUpdate;
@@ -467,6 +467,7 @@ mod tests {
             extra_error_checks_policy: ExtraErrorCheckPolicy::None,
             poll_attempts: 0,
             resend_count: 0,
+            persisted: false,
             permit: Arc::new(Semaphore::new(MAX_IN_FLIGHT))
                 .try_acquire_owned()
                 .unwrap(),

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -13,6 +13,7 @@ use crate::operator::{
     sign_and_send_transaction, ExtraErrorCheckPolicy, RetryPolicy, RpcClientWithRetry,
 };
 use crate::storage::common::models::TransactionStatus;
+use crate::storage::common::storage::Storage;
 use chrono::Utc;
 use private_channel_escrow_program_client::errors::PrivateChannelEscrowProgramError;
 use private_channel_metrics::MetricLabel;
@@ -22,9 +23,7 @@ use solana_sdk::signature::Signature;
 use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tracing::{error, info, info_span, warn, Instrument};
 
-use super::mint::{
-    cleanup_mint_builder, find_existing_mint_signature, try_jit_mint_initialization, JitOutcome,
-};
+use super::mint::{cleanup_mint_builder, try_jit_mint_initialization, JitOutcome};
 use super::proof::{cleanup_failed_transaction, rebuild_with_regenerated_proof};
 use super::types::{
     InFlightQueue, InFlightTx, InstructionWithSigners, PendingRemint, PendingSig, PollTaskResult,
@@ -174,26 +173,6 @@ pub async fn handle_transaction_submission(
     );
 
     async {
-        if let TransactionBuilder::Mint(builder_with_txn_id) = &tx_builder {
-            match find_existing_mint_signature(&state.rpc_client, builder_with_txn_id).await {
-                Ok(Some(existing_signature)) => {
-                    handle_success(state, &ctx, existing_signature, storage_tx).await;
-                    return;
-                }
-                Ok(None) => {}
-                // Deliberately fail-closed: an unverifiable lookup halts to
-                // manual review rather than risk a blind double-mint.
-                Err(e) => {
-                    error!(
-                        "Mint idempotency lookup failed for transaction_id {}: {}",
-                        builder_with_txn_id.txn_id, e
-                    );
-                    send_fatal_error(storage_tx, &ctx, &e).await;
-                    return;
-                }
-            }
-        }
-
         match state.handle_transaction_builder(tx_builder.clone()).await {
             Ok(instruction) => {
                 info!("Transaction instruction ready for submission");
@@ -203,6 +182,9 @@ pub async fn handle_transaction_submission(
                 // proof ordering requires at-most-one in-flight withdrawal at a time.
                 match &tx_builder {
                     TransactionBuilder::Mint(_) | TransactionBuilder::InitializeMint(_) => {
+                        // Only a real user-fund Mint persists write-ahead; InitializeMint
+                        // mints no balance and is on-chain idempotent, so it is excluded.
+                        let persist = matches!(tx_builder, TransactionBuilder::Mint(_));
                         spawn_fire_and_store(
                             state,
                             instruction,
@@ -211,6 +193,7 @@ pub async fn handle_transaction_submission(
                             retry_policy,
                             extra_error_checks_policy,
                             storage_tx.clone(),
+                            persist,
                         );
                     }
                     _ => {
@@ -302,6 +285,42 @@ pub(super) async fn route_builder_error(
     }
 }
 
+/// Persist a broadcast signature write-ahead (DB only), fail-closed: `Err(())` means
+/// "do not broadcast". On persist failure we count the error, log it with ids, and
+/// return early so the caller aborts before sending; the row stays Processing for the
+/// recovery worker to reconcile against the chain.
+pub(super) async fn persist_signature_or_abort(
+    storage: &Storage,
+    pt: &str,
+    transaction_id: i64,
+    signature: &Signature,
+    last_valid_block_height: u64,
+) -> Result<(), ()> {
+    if let Err(e) = storage
+        .insert_release_signature(
+            transaction_id,
+            signature.to_string(),
+            last_valid_block_height as i64,
+        )
+        .await
+    {
+        metrics::OPERATOR_TRANSACTION_ERRORS
+            .with_label_values(&[pt, "pre_send_persist_error"])
+            .inc();
+        let abort = TransactionError::PreSendPersistFailed {
+            reason: e.to_string(),
+        };
+        error!(
+            transaction_id,
+            signature = %signature,
+            "Aborting before broadcast, leaving row Processing for recovery: {}",
+            abort
+        );
+        return Err(());
+    }
+    Ok(())
+}
+
 /// Sign, send, confirm, and handle the result
 pub(super) async fn send_and_confirm(
     state: &mut SenderState,
@@ -362,29 +381,19 @@ pub(super) async fn send_and_confirm(
             }
         };
 
-    // Persist the release signature write-ahead (DB only), fail-closed. A withdrawal
-    // nonce is consumed on broadcast, so a release that lands must already have a
-    // durable signature record for crash recovery to reconcile against. On persist
-    // failure we abort before broadcasting (the nonce stays unconsumed) and leave the
-    // row Processing for the recovery worker.
+    // A withdrawal nonce is consumed on broadcast, so a release that lands must already
+    // have a durable signature record for crash recovery to reconcile against.
     if let (Some(_nonce), Some(txid)) = (ctx.withdrawal_nonce, ctx.transaction_id) {
-        if let Err(e) = state
-            .storage
-            .insert_release_signature(txid, signature.to_string(), last_valid_block_height as i64)
-            .await
+        if persist_signature_or_abort(
+            &state.storage,
+            pt,
+            txid,
+            &signature,
+            last_valid_block_height,
+        )
+        .await
+        .is_err()
         {
-            metrics::OPERATOR_TRANSACTION_ERRORS
-                .with_label_values(&[pt, "pre_send_persist_error"])
-                .inc();
-            let abort = TransactionError::PreSendPersistFailed {
-                reason: e.to_string(),
-            };
-            error!(
-                transaction_id = txid,
-                signature = %signature,
-                "Aborting release before broadcast, leaving row Processing for recovery: {}",
-                abort
-            );
             return;
         }
     }
@@ -739,6 +748,25 @@ pub(super) async fn handle_success(
 /// double-spend if the original withdrawal lands on-chain after our polling window.
 ///
 /// For non-withdrawal transactions: delegates to send_fatal_error.
+/// Leave a persisted transaction Processing after an uncertain terminal outcome.
+/// The broadcast may have landed, so a terminal Failed would strand a possibly-funded
+/// deposit and drop the signature recovery needs; recovery reconciles it next sweep.
+fn leave_processing_for_recovery(
+    pt: &str,
+    transaction_id: Option<i64>,
+    signature: &Signature,
+    reason: &str,
+) {
+    metrics::OPERATOR_TRANSACTION_ERRORS
+        .with_label_values(&[pt, "left_processing_for_recovery"])
+        .inc();
+    warn!(
+        transaction_id,
+        signature = %signature,
+        "{reason}; leaving row Processing for recovery to reconcile",
+    );
+}
+
 pub(super) async fn handle_permanent_failure(
     state: &mut SenderState,
     ctx: &TransactionContext,
@@ -907,6 +935,7 @@ pub(super) async fn fire_and_store(
                 .observe(send_start.elapsed().as_secs_f64());
             info!("Transaction sent: {}", signature);
             // push() also notifies the poll task if it is waiting on an empty queue.
+            // Only InitializeMint is resent here, and it mints no balance, so no persist.
             state.in_flight.push(InFlightTx {
                 signature,
                 ctx,
@@ -916,6 +945,7 @@ pub(super) async fn fire_and_store(
                 extra_error_checks_policy,
                 poll_attempts: 0,
                 resend_count,
+                persisted: false,
                 permit,
             });
         }
@@ -944,6 +974,7 @@ pub(super) async fn fire_and_store(
 /// Returns `false` if the semaphore is already at `MAX_IN_FLIGHT` capacity.  The DB
 /// status is left unchanged so the fetcher re-emits the transaction on the next poll
 /// cycle.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_fire_and_store(
     state: &SenderState,
     instruction: InstructionWithSigners,
@@ -952,6 +983,8 @@ pub(super) fn spawn_fire_and_store(
     retry_policy: RetryPolicy,
     extra_error_checks_policy: ExtraErrorCheckPolicy,
     storage_tx: mpsc::Sender<TransactionStatusUpdate>,
+    // True only for a real user-fund Mint
+    persist: bool,
 ) -> bool {
     let permit = match Arc::clone(&state.semaphore).try_acquire_owned() {
         Ok(p) => p,
@@ -971,42 +1004,138 @@ pub(super) fn spawn_fire_and_store(
     let rpc_client = state.rpc_client.clone();
     let in_flight = state.in_flight.clone();
     let program_type = state.program_type;
+    let storage = state.storage.clone();
 
-    tokio::spawn(async move {
-        let send_start = std::time::Instant::now();
-        match sign_and_send_transaction(rpc_client, instruction.clone(), retry_policy).await {
-            Ok((signature, _last_valid_block_height)) => {
-                metrics::OPERATOR_RPC_SEND_DURATION
-                    .with_label_values(&[program_type.as_label(), "in_flight"])
-                    .observe(send_start.elapsed().as_secs_f64());
-                info!("Transaction sent: {}", signature);
-                in_flight.push(InFlightTx {
-                    signature,
-                    ctx,
-                    instruction,
-                    compute_unit_price,
-                    retry_policy,
-                    extra_error_checks_policy,
-                    poll_attempts: 0,
-                    resend_count: 0,
-                    permit,
-                });
-            }
+    tokio::spawn(fire_and_store_task(
+        rpc_client,
+        storage,
+        in_flight,
+        program_type,
+        instruction,
+        compute_unit_price,
+        ctx,
+        retry_policy,
+        extra_error_checks_policy,
+        storage_tx,
+        persist,
+        permit,
+    ));
+
+    true
+}
+
+/// Build, sign, persist the signature when `persist` is set, then broadcast and stash
+/// the in-flight tx. A persist failure aborts before broadcast and leaves the row
+/// Processing for recovery. Split from `spawn_fire_and_store` so tests can await it
+/// directly without `tokio::spawn`.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn fire_and_store_task(
+    rpc_client: Arc<RpcClientWithRetry>,
+    storage: Arc<Storage>,
+    in_flight: Arc<InFlightQueue>,
+    program_type: ProgramType,
+    instruction: InstructionWithSigners,
+    compute_unit_price: Option<u64>,
+    ctx: TransactionContext,
+    retry_policy: RetryPolicy,
+    extra_error_checks_policy: ExtraErrorCheckPolicy,
+    storage_tx: mpsc::Sender<TransactionStatusUpdate>,
+    persist: bool,
+    permit: OwnedSemaphorePermit,
+) {
+    let pt = program_type.as_label();
+    let send_start = std::time::Instant::now();
+
+    let (transaction, signature, last_valid_block_height) =
+        match build_and_sign(&rpc_client, instruction.clone()).await {
+            Ok(signed) => signed,
             Err(e) => {
                 drop(permit);
                 metrics::OPERATOR_RPC_SEND_DURATION
-                    .with_label_values(&[program_type.as_label(), "error"])
+                    .with_label_values(&[pt, "error"])
                     .observe(send_start.elapsed().as_secs_f64());
                 metrics::OPERATOR_TRANSACTION_ERRORS
-                    .with_label_values(&[program_type.as_label(), "rpc_send_error"])
+                    .with_label_values(&[pt, "build_sign_error"])
                     .inc();
-                error!("Failed to send transaction (fire-and-forget): {}", e);
+                error!("Failed to build/sign transaction (fire-and-forget): {}", e);
+                send_fatal_error(&storage_tx, &ctx, &e.to_string()).await;
+                return;
+            }
+        };
+
+    let persisted = if persist {
+        match ctx.transaction_id {
+            Some(txid) => {
+                if persist_signature_or_abort(
+                    &storage,
+                    pt,
+                    txid,
+                    &signature,
+                    last_valid_block_height,
+                )
+                .await
+                .is_err()
+                {
+                    drop(permit);
+                    return;
+                }
+                true
+            }
+            // Persist required but no transaction_id to key on: abort before broadcasting an unrecoverable mint.
+            None => {
+                drop(permit);
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[pt, "pre_send_persist_error"])
+                    .inc();
+                error!("Persist required but transaction has no id; aborting before broadcast");
+                return;
+            }
+        }
+    } else {
+        false
+    };
+
+    match send_signed(&rpc_client, &transaction, retry_policy).await {
+        // send_signed returns the same signature we already hold; keep using it.
+        Ok(_) => {
+            metrics::OPERATOR_RPC_SEND_DURATION
+                .with_label_values(&[pt, "in_flight"])
+                .observe(send_start.elapsed().as_secs_f64());
+            info!("Transaction sent: {}", signature);
+            in_flight.push(InFlightTx {
+                signature,
+                ctx,
+                instruction,
+                compute_unit_price,
+                retry_policy,
+                extra_error_checks_policy,
+                poll_attempts: 0,
+                resend_count: 0,
+                persisted,
+                permit,
+            });
+        }
+        Err(e) => {
+            drop(permit);
+            metrics::OPERATOR_RPC_SEND_DURATION
+                .with_label_values(&[pt, "error"])
+                .observe(send_start.elapsed().as_secs_f64());
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "rpc_send_error"])
+                .inc();
+            error!("Failed to send transaction (fire-and-forget): {}", e);
+            if persisted {
+                leave_processing_for_recovery(
+                    pt,
+                    ctx.transaction_id,
+                    &signature,
+                    "send error after write-ahead persist",
+                );
+            } else {
                 send_fatal_error(&storage_tx, &ctx, &e.to_string()).await;
             }
         }
-    });
-
-    true
+    }
 }
 
 /// Route a batch of `(InFlightTx, Option<TransactionStatus>)` pairs returned by a
@@ -1068,17 +1197,26 @@ pub(super) async fn route_poll_results(
                                     "confirmation_timeout_non_idempotent",
                                 ])
                                 .inc();
-                            warn!(
-                                "Confirmation timeout for non-idempotent tx {} after {} polls — permanent failure",
-                                tx.signature, tx.poll_attempts,
-                            );
-                            handle_permanent_failure(
-                                state,
-                                &tx.ctx,
-                                storage_tx,
-                                "Confirmation failed - transaction status unknown, unsafe to retry",
-                            )
-                            .await;
+                            if tx.persisted {
+                                leave_processing_for_recovery(
+                                    state.program_type.as_label(),
+                                    tx.ctx.transaction_id,
+                                    &tx.signature,
+                                    "confirmation timeout after write-ahead persist",
+                                );
+                            } else {
+                                warn!(
+                                    "Confirmation timeout for non-idempotent tx {} after {} polls - permanent failure",
+                                    tx.signature, tx.poll_attempts,
+                                );
+                                handle_permanent_failure(
+                                    state,
+                                    &tx.ctx,
+                                    storage_tx,
+                                    "Confirmation failed - transaction status unknown, unsafe to retry",
+                                )
+                                .await;
+                            }
                         }
                         RetryPolicy::Idempotent => {
                             metrics::OPERATOR_TRANSACTION_ERRORS
@@ -1096,17 +1234,26 @@ pub(super) async fn route_poll_results(
                                         "confirmation_timeout_resend_limit",
                                     ])
                                     .inc();
-                                warn!(
-                                    "Confirmation timeout for idempotent tx {} — resend limit ({}) reached, permanent failure",
-                                    tx.signature, state.retry_max_attempts,
-                                );
-                                handle_permanent_failure(
-                                    state,
-                                    &tx.ctx,
-                                    storage_tx,
-                                    "Confirmation timeout: resend limit exceeded",
-                                )
-                                .await;
+                                if tx.persisted {
+                                    leave_processing_for_recovery(
+                                        state.program_type.as_label(),
+                                        tx.ctx.transaction_id,
+                                        &tx.signature,
+                                        "resend limit reached after write-ahead persist",
+                                    );
+                                } else {
+                                    warn!(
+                                        "Confirmation timeout for idempotent tx {} - resend limit ({}) reached, permanent failure",
+                                        tx.signature, state.retry_max_attempts,
+                                    );
+                                    handle_permanent_failure(
+                                        state,
+                                        &tx.ctx,
+                                        storage_tx,
+                                        "Confirmation timeout: resend limit exceeded",
+                                    )
+                                    .await;
+                                }
                             } else {
                                 warn!(
                                     "Confirmation timeout for idempotent tx {} after {} polls — re-sending (attempt {}/{})",
@@ -1356,7 +1503,6 @@ mod tests {
     use crate::operator::utils::smt_util::SmtState;
     use crate::operator::MintCache;
     use crate::storage::common::storage::mock::MockStorage;
-    use crate::storage::common::storage::Storage;
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine;
     use borsh::BorshSerialize;
@@ -2981,6 +3127,9 @@ mod tests {
             extra_error_checks_policy: ExtraErrorCheckPolicy::None,
             poll_attempts: 0,
             resend_count: 0,
+            // Default to not-persisted; tests that model a write-ahead-persisted
+            // deposit mint set `persisted = true` on the returned value explicitly.
+            persisted: false,
             permit: Arc::new(Semaphore::new(MAX_IN_FLIGHT))
                 .try_acquire_owned()
                 .unwrap(),
@@ -3249,10 +3398,11 @@ mod tests {
         );
     }
 
-    /// When poll_attempts reaches MAX_POLL_ATTEMPTS_CONFIRMATION for a RetryPolicy::None tx,
-    /// it must be declared a permanent failure and removed from in_flight.
+    /// When poll_attempts reaches MAX_POLL_ATTEMPTS_CONFIRMATION for a persisted
+    /// RetryPolicy::None mint, the broadcast may have landed, so it must be removed
+    /// from in_flight and left Processing for recovery (no terminal Failed write).
     #[tokio::test]
-    async fn poll_in_flight_timeout_none_policy_permanent_failure() {
+    async fn poll_in_flight_timeout_persisted_mint_left_processing() {
         let mut server = mockito::Server::new_async().await;
 
         let sig = Signature::new_unique();
@@ -3314,6 +3464,8 @@ mod tests {
                 let mut tx = make_in_flight_tx(sig, 101);
                 // Pre-fill poll_attempts to one below MAX so this poll tips it over.
                 tx.poll_attempts = MAX_POLL_ATTEMPTS_CONFIRMATION - 1;
+                // A real None-policy mint reaches in_flight only after a write-ahead persist.
+                tx.persisted = true;
                 q.push(tx);
                 q
             },
@@ -3330,20 +3482,11 @@ mod tests {
             "timed-out tx must leave in_flight"
         );
 
-        // Failed status emitted.
-        let update = storage_rx
-            .try_recv()
-            .expect("expected Failed status for non-idempotent timeout");
-        assert_eq!(update.transaction_id, 101);
-        assert_eq!(update.status, TransactionStatus::Failed);
+        // No terminal status: the row is left Processing for recovery to reconcile
+        // against the persisted signature, never written Failed here.
         assert!(
-            update
-                .error_message
-                .as_deref()
-                .unwrap_or("")
-                .contains("unknown"),
-            "error should mention unknown status: {:?}",
-            update.error_message,
+            storage_rx.try_recv().is_err(),
+            "persisted mint timeout must not write a terminal status",
         );
     }
 
@@ -3585,6 +3728,264 @@ mod tests {
         );
     }
 
+    // ── fire_and_store_task: deposit-mint pre-broadcast persist ───────
+
+    fn mint_ctx(txn_id: i64) -> TransactionContext {
+        TransactionContext {
+            transaction_id: Some(txn_id),
+            withdrawal_nonce: None,
+            trace_id: Some(format!("trace-{txn_id}")),
+        }
+    }
+
+    /// A persisting (Mint) fire-and-store run writes the signed transaction's signature
+    /// via `insert_release_signature` and then broadcasts that same signature.
+    #[tokio::test]
+    async fn mint_persists_signature_before_send() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": Signature::default().to_string()
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create();
+
+        let state = make_sender_state_with_server(&server.url());
+        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
+        let (storage_tx, _rx) = mpsc::channel(10);
+
+        fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            dummy_instruction(),
+            None,
+            mint_ctx(77),
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+            true,
+            permit,
+        )
+        .await;
+
+        send.assert();
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let stored = mock.get_release_signatures(77).await.unwrap();
+        assert_eq!(stored.len(), 1, "exactly one mint signature persisted");
+        assert_eq!(
+            stored[0].0,
+            Signature::default().to_string(),
+            "persisted signature must be the broadcast signature"
+        );
+        assert_eq!(stored[0].1, 100, "persisted lvbh must match the blockhash");
+        assert_eq!(
+            state.in_flight.len(),
+            1,
+            "successful broadcast stashes the in-flight tx"
+        );
+    }
+
+    /// A failed write-ahead persist on the mint path must NOT broadcast, must stash no
+    /// in-flight entry, and must write no terminal status (row left Processing).
+    #[tokio::test]
+    async fn mint_persist_failure_aborts_before_broadcast() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .expect(0)
+            .create();
+
+        let state = make_sender_state_with_server(&server.url());
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.set_should_fail("insert_release_signature", true);
+        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
+        let before = state.semaphore.available_permits();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            dummy_instruction(),
+            None,
+            mint_ctx(77),
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+            true,
+            permit,
+        )
+        .await;
+
+        send.assert();
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update; row stays Processing for recovery"
+        );
+        assert!(
+            state.in_flight.is_empty(),
+            "nothing stashed when persist failed"
+        );
+        assert_eq!(
+            state.semaphore.available_permits(),
+            before + 1,
+            "permit must be dropped on abort"
+        );
+    }
+
+    /// A send error AFTER the write-ahead persist must leave the row Processing for
+    /// recovery (never a terminal Failed), because the broadcast may have landed and
+    /// the persisted signature is the only durable record recovery can reconcile.
+    #[tokio::test]
+    async fn mint_send_error_after_persist_leaves_processing() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let _send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32600, "message": "Internal error"}
+                })
+                .to_string(),
+            )
+            .create();
+
+        let state = make_sender_state_with_server(&server.url());
+        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
+        let before = state.semaphore.available_permits();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            dummy_instruction(),
+            None,
+            mint_ctx(77),
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+            true,
+            permit,
+        )
+        .await;
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        assert!(
+            !mock.get_release_signatures(77).await.unwrap().is_empty(),
+            "signature must be persisted before the failing broadcast",
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "send error after persist must not write a terminal status",
+        );
+        assert!(
+            state.in_flight.is_empty(),
+            "a failed broadcast stashes no in-flight entry",
+        );
+        assert_eq!(
+            state.semaphore.available_permits(),
+            before + 1,
+            "permit must be dropped on send error",
+        );
+    }
+
+    /// A non-persisting run (persist = false) broadcasts without writing any signature
+    /// even though a transaction_id is present, proving the `persist` gate (not the
+    /// id-presence guard) is what excludes the on-chain-idempotent initialization path.
+    #[tokio::test]
+    async fn initialize_mint_does_not_persist() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let _send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": Signature::default().to_string()
+                })
+                .to_string(),
+            )
+            .create();
+
+        let state = make_sender_state_with_server(&server.url());
+        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
+        let (storage_tx, _rx) = mpsc::channel(10);
+
+        // Carry a transaction_id so the assertion exercises the `persist` gate
+        // itself rather than the inner id-presence guard short-circuiting.
+        let ctx = TransactionContext {
+            transaction_id: Some(909),
+            withdrawal_nonce: None,
+            trace_id: Some("trace-init".to_string()),
+        };
+
+        fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            dummy_instruction(),
+            None,
+            ctx,
+            RetryPolicy::Idempotent,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+            false,
+            permit,
+        )
+        .await;
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        assert!(
+            mock.get_release_signatures(909).await.unwrap().is_empty(),
+            "persist = false must not write a signature even with a transaction_id"
+        );
+        assert_eq!(
+            state.in_flight.len(),
+            1,
+            "broadcast still stashes in-flight"
+        );
+    }
+
     // ── spawn_fire_and_store: cap enforcement ─────────────────────────
 
     /// When the semaphore is exhausted (all MAX_IN_FLIGHT slots occupied),
@@ -3616,6 +4017,7 @@ mod tests {
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
             storage_tx,
+            false,
         );
 
         assert!(!result, "must return false when at capacity");
@@ -3648,6 +4050,7 @@ mod tests {
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
             storage_tx,
+            false,
         );
 
         assert!(result, "must return true when capacity is available");

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -18,6 +18,8 @@ use chrono::Utc;
 use private_channel_escrow_program_client::errors::PrivateChannelEscrowProgramError;
 use private_channel_metrics::MetricLabel;
 use solana_keychain::SolanaSigner;
+use solana_rpc_client_api::client_error::ErrorKind;
+use solana_rpc_client_api::request::RpcError;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::signature::Signature;
 use tokio::sync::{mpsc, OwnedSemaphorePermit};
@@ -754,8 +756,6 @@ pub(super) async fn handle_success(
 /// or IO error instead leaves the outcome ambiguous (the request may have reached the
 /// cluster), so a persisted mint defers to recovery rather than risk stranding a landed one.
 fn send_rejected_by_node(e: &TransactionError) -> bool {
-    use solana_rpc_client_api::client_error::ErrorKind;
-    use solana_rpc_client_api::request::RpcError;
     matches!(
         e,
         TransactionError::Rpc(err)

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1124,16 +1124,11 @@ pub(super) async fn fire_and_store_task(
                 .with_label_values(&[pt, "rpc_send_error"])
                 .inc();
             error!("Failed to send transaction (fire-and-forget): {}", e);
-            if persisted {
-                leave_processing_for_recovery(
-                    pt,
-                    ctx.transaction_id,
-                    &signature,
-                    "send error after write-ahead persist",
-                );
-            } else {
-                send_fatal_error(&storage_tx, &ctx, &e.to_string()).await;
-            }
+            // A send error means the broadcast was rejected (e.g. preflight) and did not
+            // reach the network, so this is terminal, same as the withdrawal send path.
+            // The genuinely-uncertain case (broadcast accepted, confirmation never seen)
+            // is handled in route_poll_results, which leaves a persisted mint Processing.
+            send_fatal_error(&storage_tx, &ctx, &e.to_string()).await;
         }
     }
 }
@@ -3861,11 +3856,12 @@ mod tests {
         );
     }
 
-    /// A send error AFTER the write-ahead persist must leave the row Processing for
-    /// recovery (never a terminal Failed), because the broadcast may have landed and
-    /// the persisted signature is the only durable record recovery can reconcile.
+    /// A send error (e.g. preflight rejection) means the broadcast never reached the
+    /// network, so even with the signature already persisted the mint is terminal Failed,
+    /// same as the withdrawal send path. (The broadcast-accepted-but-unconfirmed case is
+    /// the one route_poll_results leaves Processing; see the poll timeout test.)
     #[tokio::test]
-    async fn mint_send_error_after_persist_leaves_processing() {
+    async fn mint_send_error_after_persist_routes_to_failed() {
         let mut server = mockito::Server::new_async().await;
         let _hash = mock_blockhash(&mut server);
         let _send = server
@@ -3912,10 +3908,11 @@ mod tests {
             !mock.get_release_signatures(77).await.unwrap().is_empty(),
             "signature must be persisted before the failing broadcast",
         );
-        assert!(
-            storage_rx.try_recv().is_err(),
-            "send error after persist must not write a terminal status",
-        );
+        let update = storage_rx
+            .try_recv()
+            .expect("send error must emit a terminal status");
+        assert_eq!(update.transaction_id, 77);
+        assert_eq!(update.status, TransactionStatus::Failed);
         assert!(
             state.in_flight.is_empty(),
             "a failed broadcast stashes no in-flight entry",

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1219,6 +1219,12 @@ pub(super) async fn route_poll_results(
                             }
                         }
                         RetryPolicy::Idempotent => {
+                            // This resend broadcasts a fresh unpersisted signature, so a persisted
+                            // mint must never reach it (Mint is RetryPolicy::None); assert it.
+                            debug_assert!(
+                                !tx.persisted,
+                                "a write-ahead-persisted tx must not use the idempotent resend path"
+                            );
                             metrics::OPERATOR_TRANSACTION_ERRORS
                                 .with_label_values(&[
                                     state.program_type.as_label(),

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -748,6 +748,21 @@ pub(super) async fn handle_success(
 /// double-spend if the original withdrawal lands on-chain after our polling window.
 ///
 /// For non-withdrawal transactions: delegates to send_fatal_error.
+/// Whether a send failure came back as an explicit RPC rejection from the node
+/// (preflight simulation failure, blockhash errors, etc.). Such a response means the
+/// transaction was never submitted to the cluster, so failing fast is safe. A transport
+/// or IO error instead leaves the outcome ambiguous (the request may have reached the
+/// cluster), so a persisted mint defers to recovery rather than risk stranding a landed one.
+fn send_rejected_by_node(e: &TransactionError) -> bool {
+    use solana_rpc_client_api::client_error::ErrorKind;
+    use solana_rpc_client_api::request::RpcError;
+    matches!(
+        e,
+        TransactionError::Rpc(err)
+            if matches!(&err.kind, ErrorKind::RpcError(RpcError::RpcResponseError { .. }))
+    )
+}
+
 /// Leave a persisted transaction Processing after an uncertain terminal outcome.
 /// The broadcast may have landed, so a terminal Failed would strand a possibly-funded
 /// deposit and drop the signature recovery needs; recovery reconciles it next sweep.
@@ -1124,11 +1139,19 @@ pub(super) async fn fire_and_store_task(
                 .with_label_values(&[pt, "rpc_send_error"])
                 .inc();
             error!("Failed to send transaction (fire-and-forget): {}", e);
-            // A send error means the broadcast was rejected (e.g. preflight) and did not
-            // reach the network, so this is terminal, same as the withdrawal send path.
-            // The genuinely-uncertain case (broadcast accepted, confirmation never seen)
-            // is handled in route_poll_results, which leaves a persisted mint Processing.
-            send_fatal_error(&storage_tx, &ctx, &e.to_string()).await;
+            // A node rejection (e.g. preflight) means the tx never reached the cluster, so
+            // fail fast. An ambiguous transport error on a persisted mint may have landed,
+            // so leave it Processing for recovery rather than strand a possibly-funded mint.
+            if persisted && !send_rejected_by_node(&e) {
+                leave_processing_for_recovery(
+                    pt,
+                    ctx.transaction_id,
+                    &signature,
+                    "ambiguous send error after write-ahead persist",
+                );
+            } else {
+                send_fatal_error(&storage_tx, &ctx, &e.to_string()).await;
+            }
         }
     }
 }
@@ -3921,6 +3944,35 @@ mod tests {
             state.semaphore.available_permits(),
             before + 1,
             "permit must be dropped on send error",
+        );
+    }
+
+    /// A node RPC rejection (preflight, blockhash, etc.) is definitive - the tx was never
+    /// submitted - so a persisted mint fails fast; a transport/IO error is ambiguous and a
+    /// persisted mint instead defers to recovery. This classifier draws that line.
+    #[test]
+    fn send_rejected_by_node_distinguishes_rejection_from_transport_error() {
+        use solana_rpc_client_api::client_error::{Error as ClientError, ErrorKind};
+        use solana_rpc_client_api::request::{RpcError, RpcResponseErrorData};
+
+        let node_rejection = TransactionError::Rpc(Box::new(ClientError::from(
+            ErrorKind::RpcError(RpcError::RpcResponseError {
+                code: -32002,
+                message: "preflight failure".to_string(),
+                data: RpcResponseErrorData::Empty,
+            }),
+        )));
+        assert!(
+            send_rejected_by_node(&node_rejection),
+            "an RPC response error is a definitive node rejection"
+        );
+
+        let transport_error = TransactionError::Rpc(Box::new(ClientError::from(
+            ErrorKind::Custom("connection reset".to_string()),
+        )));
+        assert!(
+            !send_rejected_by_node(&transport_error),
+            "a transport error is ambiguous, not a node rejection"
         );
     }
 

--- a/indexer/src/operator/sender/types.rs
+++ b/indexer/src/operator/sender/types.rs
@@ -129,6 +129,10 @@ pub struct InFlightTx {
     /// before each re-send; once the cap is reached even an Idempotent tx is
     /// declared a permanent failure rather than looping forever.
     pub resend_count: u32,
+    /// Whether this transaction's signature was persisted write-ahead before broadcast.
+    /// When true, an uncertain terminal outcome (send error or confirmation timeout)
+    /// leaves the row Processing for recovery instead of writing Failed.
+    pub persisted: bool,
     /// Semaphore permit held for the lifetime of this entry.
     ///
     /// Acquired before spawning the send task; dropped when the entry is removed

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -1025,6 +1025,38 @@ async fn release_signature_gc_only_drops_non_processing() -> Result<(), Box<dyn 
     Ok(())
 }
 
+/// `pending_release_signatures` is keyed only by `transaction_id`, so a deposit row
+/// stores, fetches, and GCs its broadcast signature identically to a withdrawal. This
+/// proves deposits reuse the table with no schema change (the pre-broadcast persist).
+#[tokio::test(flavor = "multi_thread")]
+async fn release_signature_reuses_table_for_deposit() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let txn = make_db_transaction("rel_deposit", TransactionType::Deposit);
+    let id = storage.insert_db_transaction(&txn).await?;
+
+    storage
+        .insert_release_signature(id, "sig-deposit".to_string(), 100)
+        .await?;
+    assert_eq!(
+        storage.get_release_signatures(id).await?,
+        vec![("sig-deposit".to_string(), 100)],
+        "deposit signature round-trips like a withdrawal"
+    );
+
+    // Leaving Processing makes the row GC-eligible, same as a withdrawal.
+    sqlx::query("UPDATE transactions SET status = 'completed'::transaction_status WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await?;
+    let removed = storage.gc_stale_release_signatures().await?;
+    assert_eq!(
+        removed, 1,
+        "GC reclaims the deposit's sig once non-processing"
+    );
+    assert!(storage.get_release_signatures(id).await?.is_empty());
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn release_signature_cascade_on_transaction_delete() -> Result<(), Box<dyn std::error::Error>>
 {

--- a/integration/tests/indexer/mint_idempotency.rs
+++ b/integration/tests/indexer/mint_idempotency.rs
@@ -1,6 +1,6 @@
 //! Integration tests for operator mint idempotency.
 //!
-//! Verifies that `find_existing_mint_signature` correctly detects a previously
+//! Verifies that `find_existing_mint_signature_with_memo` correctly detects a previously
 //! confirmed mint-to transaction on-chain, preventing the operator from issuing
 //! duplicate channel tokens for the same deposit.
 //!
@@ -14,8 +14,8 @@ mod helpers;
 
 use helpers::{generate_mint, send_and_confirm_instructions, setup_wallets};
 use private_channel_indexer::operator::{
-    find_existing_mint_signature, mint_idempotency_memo, MintToBuilder, MintToBuilderWithTxnId,
-    RetryConfig, RpcClientWithRetry,
+    find_existing_mint_signature_with_memo, mint_idempotency_memo, MintToBuilder,
+    MintToBuilderWithTxnId, RetryConfig, RpcClientWithRetry,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
@@ -31,11 +31,11 @@ use std::sync::Arc;
 use test_utils::validator_helper::start_test_validator;
 
 /// Submits a real `mint_to` instruction with an idempotency memo, then confirms
-/// that `find_existing_mint_signature` can locate the transaction by matching
+/// that `find_existing_mint_signature_with_memo` can locate the transaction by matching
 /// both the memo (txn_id) and the token amount.  Also asserts that a mismatched
 /// txn_id or a different amount each independently prevent a false positive.
 #[tokio::test(flavor = "multi_thread")]
-async fn find_existing_mint_signature_detects_confirmed_mint() {
+async fn find_existing_mint_signature_with_memo_detects_confirmed_mint() {
     let (validator, faucet_keypair, _geyser_port) = start_test_validator().await;
     let rpc_url = validator.rpc_url();
     let client = RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
@@ -98,7 +98,7 @@ async fn find_existing_mint_signature_detects_confirmed_mint() {
     // after send_and_confirm_transaction returns, the address_signatures,
     // transaction_memos, and transaction_status columns may not yet be populated.
     // Poll until both getSignaturesForAddress and getTransaction succeed for
-    // our signature, guaranteeing full indexing before find_existing_mint_signature.
+    // our signature, guaranteeing full indexing before find_existing_mint_signature_with_memo.
     {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(90);
         loop {
@@ -115,7 +115,7 @@ async fn find_existing_mint_signature_detects_confirmed_mint() {
                 .await
                 .unwrap_or_default();
             if !sigs.is_empty() {
-                // Also verify getTransaction works for our sig so find_existing_mint_signature
+                // Also verify getTransaction works for our sig so find_existing_mint_signature_with_memo
                 // doesn't get a null response when it calls get_transaction internally.
                 let tx_ok = client
                     .get_transaction_with_config(
@@ -160,9 +160,13 @@ async fn find_existing_mint_signature_detects_confirmed_mint() {
         trace_id: "mint-idempotency-test".to_string(),
     };
 
-    let result = find_existing_mint_signature(&rpc_client, &builder_with_id)
-        .await
-        .unwrap();
+    let result = find_existing_mint_signature_with_memo(
+        &rpc_client,
+        &builder_with_id,
+        &mint_idempotency_memo(builder_with_id.txn_id),
+    )
+    .await
+    .unwrap();
     assert_eq!(result, Some(sig));
 
     // Different txn_id (different memo) should return None
@@ -179,9 +183,13 @@ async fn find_existing_mint_signature_detects_confirmed_mint() {
         trace_id: "mint-idempotency-test".to_string(),
     };
 
-    let result2 = find_existing_mint_signature(&rpc_client, &builder_with_wrong_id)
-        .await
-        .unwrap();
+    let result2 = find_existing_mint_signature_with_memo(
+        &rpc_client,
+        &builder_with_wrong_id,
+        &mint_idempotency_memo(builder_with_wrong_id.txn_id),
+    )
+    .await
+    .unwrap();
     assert_eq!(result2, None);
 
     // Wrong amount should return None
@@ -198,8 +206,12 @@ async fn find_existing_mint_signature_detects_confirmed_mint() {
         trace_id: "mint-idempotency-test".to_string(),
     };
 
-    let result3 = find_existing_mint_signature(&rpc_client, &builder_wrong_amount)
-        .await
-        .unwrap();
+    let result3 = find_existing_mint_signature_with_memo(
+        &rpc_client,
+        &builder_wrong_amount,
+        &mint_idempotency_memo(builder_wrong_amount.txn_id),
+    )
+    .await
+    .unwrap();
     assert_eq!(result3, None);
 }

--- a/integration/tests/indexer/mint_idempotency.rs
+++ b/integration/tests/indexer/mint_idempotency.rs
@@ -4,6 +4,10 @@
 //! confirmed mint-to transaction on-chain, preventing the operator from issuing
 //! duplicate channel tokens for the same deposit.
 //!
+//! As of the write-ahead signature-persistence change this memo scan is no longer on
+//! the live deposit-mint send path (which now persists its broadcast signature and lets
+//! recovery reconcile against it); the function is reached only from the remint path.
+//!
 //! Scenarios covered:
 //! 1. Matching txn_id + amount → existing signature returned (idempotent re-use).
 //! 2. Different txn_id (different memo)  → None (treated as a new, unseen deposit).

--- a/integration/tests/indexer/sender_mint_idempotency.rs
+++ b/integration/tests/indexer/sender_mint_idempotency.rs
@@ -9,7 +9,7 @@
 //! guarantee: a mint that landed on-chain before the operator crashed
 //! should not be re-sent.
 //!
-//! Strategy: drive the public `find_existing_mint_signature` entry
+//! Strategy: drive the public `find_existing_mint_signature_with_memo` entry
 //! point at the `MockRpcServer` wire layer. Script a
 //! `getSignaturesForAddress` reply carrying the deterministic memo
 //! `mint_idempotency_memo(txn_id)` and a matching `getTransaction`
@@ -18,7 +18,7 @@
 //! `handle_transaction_submission`) would skip the submit path.
 //!
 //! What this test validates:
-//!   - `find_existing_mint_signature` issues `getSignaturesForAddress`
+//!   - `find_existing_mint_signature_with_memo` issues `getSignaturesForAddress`
 //!     on the expected ATA
 //!   - It filters to entries that carry the memo produced by
 //!     `mint_idempotency_memo(txn_id)`
@@ -36,7 +36,7 @@
 use {
     base64::{engine::general_purpose::STANDARD, Engine as _},
     private_channel_indexer::operator::{
-        find_existing_mint_signature,
+        find_existing_mint_signature_with_memo,
         utils::{
             instruction_util::{mint_idempotency_memo, MintToBuilder, MintToBuilderWithTxnId},
             rpc_util::{RetryConfig, RpcClientWithRetry},
@@ -180,7 +180,7 @@ fn get_transaction_reply(
 }
 
 /// When a prior confirmed mint with the expected memo exists on the ATA,
-/// `find_existing_mint_signature` returns `Some(sig)` — the short-circuit
+/// `find_existing_mint_signature_with_memo` returns `Some(sig)` - the short-circuit
 /// signal the production sender uses to skip the submit path.
 #[tokio::test]
 async fn finds_prior_confirmed_mint_and_returns_short_circuit_signature() {
@@ -242,9 +242,13 @@ async fn finds_prior_confirmed_mint_and_returns_short_circuit_signature() {
         amount,
     );
 
-    let result = find_existing_mint_signature(&client, &builder_with_txn)
-        .await
-        .expect("idempotency lookup must succeed when payload matches");
+    let result = find_existing_mint_signature_with_memo(
+        &client,
+        &builder_with_txn,
+        &mint_idempotency_memo(builder_with_txn.txn_id),
+    )
+    .await
+    .expect("idempotency lookup must succeed when payload matches");
 
     let found = result.expect("matching memo + mint payload must yield Some(signature)");
     assert_eq!(
@@ -260,7 +264,7 @@ async fn finds_prior_confirmed_mint_and_returns_short_circuit_signature() {
 }
 
 /// When no prior confirmed mint matches the expected memo (empty result),
-/// `find_existing_mint_signature` returns `Ok(None)` — the production
+/// `find_existing_mint_signature_with_memo` returns `Ok(None)` - the production
 /// signal that the normal send path should proceed.
 #[tokio::test]
 async fn returns_none_when_no_prior_mint_signature_matches() {
@@ -287,9 +291,13 @@ async fn returns_none_when_no_prior_mint_signature_matches() {
         10_000,
     );
 
-    let result = find_existing_mint_signature(&client, &builder_with_txn)
-        .await
-        .expect("lookup on empty ATA must succeed");
+    let result = find_existing_mint_signature_with_memo(
+        &client,
+        &builder_with_txn,
+        &mint_idempotency_memo(builder_with_txn.txn_id),
+    )
+    .await
+    .expect("lookup on empty ATA must succeed");
 
     assert!(
         result.is_none(),

--- a/integration/tests/indexer/sender_mint_idempotency.rs
+++ b/integration/tests/indexer/sender_mint_idempotency.rs
@@ -1,21 +1,12 @@
-//! Mint idempotency short-circuit.
+//! Mint idempotency memo scan: `find_existing_mint_signature_with_memo` returns
+//! `Some(signature)` when a prior confirmed mint carries the expected memo on the
+//! recipient ATA, so the caller can skip re-minting a deposit that already landed.
 //!
-//! Covers the mint-idempotency short-circuit inside the sender's
-//! mint-build path (`indexer/src/operator/sender/transaction.rs`):
-//! when a prior confirmed mint with the expected idempotency memo is
-//! found on `getSignaturesForAddress`, the sender must short-circuit
-//! and NOT
-//! submit a duplicate mint. This is the operator-restart recovery
-//! guarantee: a mint that landed on-chain before the operator crashed
-//! should not be re-sent.
+//! No longer on the live deposit path (which now persists the signature before
+//! broadcast); only the remint path calls it. The wire behavior tested is the same.
 //!
-//! Strategy: drive the public `find_existing_mint_signature_with_memo` entry
-//! point at the `MockRpcServer` wire layer. Script a
-//! `getSignaturesForAddress` reply carrying the deterministic memo
-//! `mint_idempotency_memo(txn_id)` and a matching `getTransaction`
-//! payload, then assert the helper returns `Some(signature)` — proving
-//! the production short-circuit would fire and the caller (in
-//! `handle_transaction_submission`) would skip the submit path.
+//! Strategy: drive it against `MockRpcServer`, scripting a `getSignaturesForAddress`
+//! reply with `mint_idempotency_memo(txn_id)` and a matching `getTransaction`.
 //!
 //! What this test validates:
 //!   - `find_existing_mint_signature_with_memo` issues `getSignaturesForAddress`
@@ -24,13 +15,12 @@
 //!     `mint_idempotency_memo(txn_id)`
 //!   - It fetches the full transaction via `getTransaction` and
 //!     verifies the payload matches the expected mint parameters
-//!   - On a match, it returns `Some(signature)` so the caller can skip
+//!   - On a match, it returns `Some(signature)` so the remint caller can skip
 //!     re-sending
 //!
 //! What is intentionally NOT asserted here:
-//!   - Full `handle_transaction_submission` short-circuit (requires the
-//!     full sender state; the returned `Some(sig)` IS the production
-//!     signal that drives the caller's `return`)
+//!   - The remint caller's use of the returned `Some(sig)` (covered on the
+//!     remint path); this file pins the wire-level lookup behavior only
 //!   - Metric increments (none fire on the idempotency-hit path)
 
 use {
@@ -180,8 +170,8 @@ fn get_transaction_reply(
 }
 
 /// When a prior confirmed mint with the expected memo exists on the ATA,
-/// `find_existing_mint_signature_with_memo` returns `Some(sig)` - the short-circuit
-/// signal the production sender uses to skip the submit path.
+/// `find_existing_mint_signature_with_memo` returns `Some(sig)` - the signal the
+/// remint path uses to skip re-minting a deposit that already landed.
 #[tokio::test]
 async fn finds_prior_confirmed_mint_and_returns_short_circuit_signature() {
     let mock = MockRpcServer::start().await;
@@ -264,8 +254,8 @@ async fn finds_prior_confirmed_mint_and_returns_short_circuit_signature() {
 }
 
 /// When no prior confirmed mint matches the expected memo (empty result),
-/// `find_existing_mint_signature_with_memo` returns `Ok(None)` - the production
-/// signal that the normal send path should proceed.
+/// `find_existing_mint_signature_with_memo` returns `Ok(None)` - the signal that
+/// the remint path may proceed with the mint.
 #[tokio::test]
 async fn returns_none_when_no_prior_mint_signature_matches() {
     let mock = MockRpcServer::start().await;

--- a/integration/tests/indexer/sender_poll_rpc_error.rs
+++ b/integration/tests/indexer/sender_poll_rpc_error.rs
@@ -77,6 +77,7 @@ fn make_in_flight_tx(
         extra_error_checks_policy: ExtraErrorCheckPolicy::None,
         poll_attempts,
         resend_count,
+        persisted: false,
         permit,
     }
 }

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -7,10 +7,7 @@ use {
         metrics::OPERATOR_STALE_PROCESSING_RECOVERED,
         operator::{
             recovery::test_hooks,
-            utils::{
-                instruction_util::mint_idempotency_memo,
-                rpc_util::{RetryConfig, RpcClientWithRetry},
-            },
+            utils::rpc_util::{RetryConfig, RpcClientWithRetry},
             TransactionStatusUpdate,
         },
         storage::{common::models::DbTransactionBuilder, PostgresDb, Storage, TransactionType},
@@ -18,7 +15,6 @@ use {
     },
     serde_json::json,
     solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature},
-    spl_associated_token_account::get_associated_token_address_with_program_id,
     std::{sync::Arc, time::Duration},
     test_utils::mock_rpc::{MockRpcServer, Reply},
     tokio::sync::mpsc,
@@ -175,66 +171,8 @@ fn test_client(url: String) -> RpcClientWithRetry {
     )
 }
 
-/// Scripted `getTransaction` reply satisfying `transaction_matches_expected_mint`.
-fn get_transaction_reply(
-    signature: &Signature,
-    mint: &Pubkey,
-    recipient_ata: &Pubkey,
-    mint_authority: &Pubkey,
-    token_program: &Pubkey,
-    amount: u64,
-    memo: &str,
-) -> Reply {
-    let memo_program_id = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
-    Reply::result(json!({
-        "slot": 100,
-        "blockTime": 1_700_000_000i64,
-        "meta": {
-            "err": null,
-            "status": { "Ok": null },
-            "fee": 5000u64,
-            "innerInstructions": [],
-            "preBalances": [1_000_000u64],
-            "postBalances": [999_995u64],
-            "logMessages": [],
-            "preTokenBalances": [],
-            "postTokenBalances": [],
-            "rewards": [],
-            "computeUnitsConsumed": 0u64,
-        },
-        "transaction": {
-            "signatures": [signature.to_string()],
-            "message": {
-                "accountKeys": [
-                    {"pubkey": mint_authority.to_string(), "signer": true, "writable": true, "source": "transaction"},
-                    {"pubkey": recipient_ata.to_string(), "signer": false, "writable": true, "source": "transaction"},
-                    {"pubkey": mint.to_string(), "signer": false, "writable": true, "source": "transaction"},
-                    {"pubkey": token_program.to_string(), "signer": false, "writable": false, "source": "transaction"},
-                    {"pubkey": memo_program_id, "signer": false, "writable": false, "source": "transaction"},
-                ],
-                "recentBlockhash": "GHtXQBsoZHjzkAm2Sdm6FTyFHBCqBnLanJJhZFCFJXoe",
-                "instructions": [
-                    {"program": "spl-memo", "programId": memo_program_id, "parsed": memo},
-                    {
-                        "program": "spl-token",
-                        "programId": token_program.to_string(),
-                        "parsed": {
-                            "type": "mintTo",
-                            "info": {
-                                "mint": mint.to_string(),
-                                "account": recipient_ata.to_string(),
-                                "mintAuthority": mint_authority.to_string(),
-                                "amount": amount.to_string(),
-                            },
-                        },
-                    },
-                ],
-            },
-        },
-    }))
-}
-
-// IT-1: deposit landed → Completed (with on-chain sig).
+// IT-1 / IT-D1: deposit whose persisted broadcast signature finalized to Completed,
+// recovered from the durable signature with no double-mint (no sendTransaction).
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it1_deposit_landed_promoted_to_completed() {
@@ -243,74 +181,59 @@ async fn it1_deposit_landed_promoted_to_completed() {
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
 
-    let admin_pubkey = Pubkey::new_unique();
     let mint = Pubkey::new_unique();
     let recipient = Pubkey::new_unique();
-    let amount: u64 = 12_345;
-    let token_program = spl_token::id();
-    let recipient_ata =
-        get_associated_token_address_with_program_id(&recipient, &mint, &token_program);
-
-    let deposit_sig = Signature::new_unique();
-    let tx = make_deposit(&deposit_sig.to_string(), mint, recipient, amount);
+    let tx = make_deposit(
+        &Signature::new_unique().to_string(),
+        mint,
+        recipient,
+        12_345,
+    );
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
-    let _ = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
 
-    let memo = mint_idempotency_memo(tx_id);
-    let prior_sig = Signature::new_unique();
+    // The mint persisted this signature write-ahead before broadcast; it then landed.
+    let landed_sig = Signature::new_unique();
+    db.insert_release_signature_internal(tx_id, landed_sig.to_string(), 100)
+        .await
+        .unwrap();
 
     let mock = MockRpcServer::start().await;
     mock.enqueue(
-        "getSignaturesForAddress",
-        Reply::result(json!([{
-            "signature": prior_sig.to_string(),
-            "slot": 100u64,
-            "err": serde_json::Value::Null,
-            "memo": format!("[{}] {}", memo.len(), memo),
-            "blockTime": 1_700_000_000i64,
-            "confirmationStatus": "finalized",
-        }])),
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": {"slot": 200},
+            "value": [{
+                "slot": 100,
+                "confirmations": null,
+                "err": null,
+                "status": {"Ok": null},
+                "confirmationStatus": "finalized"
+            }]
+        })),
     );
-    mock.enqueue(
-        "getTransaction",
-        get_transaction_reply(
-            &prior_sig,
-            &mint,
-            &recipient_ata,
-            &admin_pubkey,
-            &token_program,
-            amount,
-            &memo,
-        ),
-    );
-
     let client = test_client(mock.url());
     let (storage_tx, _storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     let metric_before = snapshot_recovered("escrow", "completed", "deposit");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        admin_pubkey,
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "completed");
     assert_eq!(
         counterpart_sig_of(&pool, tx_id).await,
-        Some(prior_sig.to_string())
+        Some(landed_sig.to_string())
     );
-    // Recovery never sends transactions.
+    // Recovery never re-mints a landed deposit (no double-mint).
     assert_eq!(mock.call_count("sendTransaction"), 0);
     assert_recovered_increment("escrow", "completed", "deposit", metric_before, "IT-1");
     mock.shutdown().await;
 }
 
-// IT-2: deposit not landed → Pending (demote step).
+// IT-2 / IT-D2: deposit with no persisted signature, provably never broadcast,
+// demoted to Pending for a safe re-mint, consulting no RPC.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it2_deposit_not_landed_demoted_to_pending() {
@@ -325,27 +248,71 @@ async fn it2_deposit_not_landed_demoted_to_pending() {
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
     seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
 
+    // No persisted signature and no RPC mocks: empty-sigs demotes without any RPC call.
     let mock = MockRpcServer::start().await;
-    mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
     let client = test_client(mock.url());
     let (storage_tx, _storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     let metric_before = snapshot_recovered("escrow", "requeued", "deposit");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "pending");
+    assert_eq!(
+        mock.call_count("getSignatureStatuses"),
+        0,
+        "empty-sigs demote must not consult the RPC"
+    );
     // Live fetcher picks it up on the next tick (out of scope here).
     assert_eq!(mock.call_count("sendTransaction"), 0);
     assert_recovered_increment("escrow", "requeued", "deposit", metric_before, "IT-2");
+    mock.shutdown().await;
+}
+
+// IT-2b: deposit that WAS broadcast (persisted signature present) but whose mint is
+// provably dead (null status, blockhash expired) is demoted for a safe re-mint. Unlike
+// IT-2 (no signature, no RPC), this exercises the RPC finality classification driving
+// the re-mint decision, the case-(B)-dead double-mint boundary for deposits.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it2b_deposit_dead_signature_demoted() {
+    let (db, url, _container) = start_pg("it2b_dep_dead").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mint = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 100);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    // Persisted write-ahead before broadcast; the mint never landed and the blockhash expired.
+    db.insert_release_signature_internal(tx_id, Signature::new_unique().to_string(), 100)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    // Status null + current height (1000) > lvbh (100) → expired/dead.
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
+    );
+    mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("escrow", "requeued", "deposit");
+
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "pending");
+    // Recovery classifies the dead signature but never re-mints itself (the fetcher does).
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    assert_recovered_increment("escrow", "requeued", "deposit", metric_before, "IT-2b");
     mock.shutdown().await;
 }
 
@@ -377,15 +344,9 @@ async fn it3_withdrawal_dead_signature_demoted() {
 
     let metric_before = snapshot_recovered("withdraw", "requeued", "withdrawal");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Withdraw,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "pending");
     let fresh = updated_at_of(&pool, tx_id).await;
@@ -434,15 +395,9 @@ async fn it4_withdrawal_landed_signature_completed_no_resend() {
 
     let metric_before = snapshot_recovered("withdraw", "completed", "withdrawal");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Withdraw,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "completed");
     assert_eq!(
@@ -480,15 +435,9 @@ async fn it4b_withdrawal_live_signature_left_processing() {
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Withdraw,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(
         status_of(&pool, tx_id).await,
@@ -523,15 +472,9 @@ async fn it4c_withdrawal_no_signatures_quarantined() {
 
     let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Withdraw,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "manual_review");
     // No RPC needed — empty signature set short-circuits before classification.
@@ -586,15 +529,9 @@ async fn it4d_withdrawal_rpc_uncertain_quarantined() {
 
     let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Withdraw,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(
         status_of(&pool, tx_id).await,
@@ -656,15 +593,9 @@ async fn it4e_gc_reclaims_non_processing_release_sigs() {
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     // recover_once runs gc_stale_release_signatures at the top of the sweep.
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Withdraw,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
 
     let remaining_done: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pending_release_signatures WHERE transaction_id = $1",
@@ -685,7 +616,8 @@ async fn it4e_gc_reclaims_non_processing_release_sigs() {
     mock.shutdown().await;
 }
 
-// IT-5: deposit RPC failure → ManualReview (never silent demote).
+// IT-5 / IT-D5: deposit with a persisted signature but an RPC that cannot classify it.
+// ManualReview (never a silent demote, which would risk a double-mint).
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
@@ -699,11 +631,14 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
     let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 500);
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
     seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    db.insert_release_signature_internal(tx_id, Signature::new_unique().to_string(), 100)
+        .await
+        .unwrap();
 
     let mock = MockRpcServer::start().await;
-    // Always return a generic JSON-RPC error → transport / RPC error path.
+    // The classifier's status RPC errors every attempt, so Uncertain, so quarantine.
     mock.enqueue_sequence(
-        "getSignaturesForAddress",
+        "getSignatureStatuses",
         vec![
             Reply::error(-32000, "internal"),
             Reply::error(-32000, "internal"),
@@ -715,15 +650,9 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
 
     let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(
         status_of(&pool, tx_id).await,
@@ -736,19 +665,19 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
     assert_eq!(update.transaction_id, tx_id);
     let err = update.error_message.as_deref().unwrap_or("");
     assert!(
-        err.starts_with("deposit idempotency:"),
+        err.contains("could not verify mint landed"),
         "reason should match runbook substring: {err}"
     );
     assert_recovered_increment("escrow", "quarantined", "deposit", metric_before, "IT-5");
     mock.shutdown().await;
 }
 
-// IT-6: idempotency RPC -32601 (method not found) → Ambiguous → quarantine,
-// NOT demote. A demote would re-mint a deposit we couldn't verify (double-mint).
+// IT-6: a malformed persisted signature is uncertainty (never read as "dead"),
+// quarantine via the shared load_pending_sigs path, with no RPC consulted.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it6_method_not_found_quarantines_deposit() {
-    let (db, url, _container) = start_pg("it6_method_not_found").await;
+async fn it6_malformed_stored_sig_quarantines_deposit() {
+    let (db, url, _container) = start_pg("it6_malformed_sig").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -758,38 +687,29 @@ async fn it6_method_not_found_quarantines_deposit() {
     let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 700);
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
     seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    db.insert_release_signature_internal(tx_id, "not-a-valid-signature".to_string(), 100)
+        .await
+        .unwrap();
 
     let mock = MockRpcServer::start().await;
-    // -32601 is permanent (no retry) → strict lookup returns Err → Ambiguous.
-    mock.enqueue(
-        "getSignaturesForAddress",
-        Reply::error(-32601, "Method not found"),
-    );
     let client = test_client(mock.url());
     let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
 
-    // Proves the RPC was actually reached (not a pre-RPC bail) and not retried.
     assert_eq!(
-        mock.call_count("getSignaturesForAddress"),
-        1,
-        "the -32601 branch must be reached via exactly one RPC call"
+        mock.call_count("getSignatureStatuses"),
+        0,
+        "a malformed stored signature must quarantine before any RPC"
     );
     assert_eq!(
         status_of(&pool, tx_id).await,
         "manual_review",
-        "method-not-found is uncertainty → quarantine, never silent demote"
+        "malformed signature is uncertainty so quarantine, never silent demote"
     );
     let update = storage_rx
         .try_recv()
@@ -797,8 +717,8 @@ async fn it6_method_not_found_quarantines_deposit() {
     assert_eq!(update.transaction_id, tx_id);
     let err = update.error_message.as_deref().unwrap_or("");
     assert!(
-        err.starts_with("deposit idempotency:"),
-        "reason should match runbook substring: {err}"
+        err.contains("malformed stored release signature"),
+        "reason should name the malformed signature: {err}"
     );
     assert_recovered_increment("escrow", "quarantined", "deposit", metric_before, "IT-6");
     mock.shutdown().await;
@@ -829,15 +749,9 @@ async fn it7_fresh_processing_row_untouched() {
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(
         status_of(&pool, tx_id).await,
@@ -912,20 +826,14 @@ async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
     seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
 
+    // No persisted signature, so demote with no RPC call.
     let mock = MockRpcServer::start().await;
-    mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
     assert_eq!(status_of(&pool, tx_id).await, "pending");
 
     // Lagging in-flight write from dead operator — must no-op.
@@ -990,25 +898,16 @@ async fn it10_backlog_batched_across_ticks() {
         .await
         .unwrap();
 
+    // No persisted signatures, so demote-all path, with no RPC consulted.
     let mock = MockRpcServer::start().await;
-    // Every getSignaturesForAddress returns empty → demote-all path.
-    for _ in 0..300 {
-        mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
-    }
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     // Tick 1: should heal exactly RECOVERY_BATCH_LIMIT (100) rows.
     let t0 = std::time::Instant::now();
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
     assert!(
         t0.elapsed() < Duration::from_secs(20),
         "single tick should not starve the live path"
@@ -1021,24 +920,12 @@ async fn it10_backlog_batched_across_ticks() {
     assert_eq!(pending_count, 100, "tick 1 must heal exactly the batch cap");
 
     // Ticks 2-3: drain the rest. Healed rows are excluded (trigger bumped updated_at).
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
     let pending_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE status = 'pending'")
             .fetch_one(&pool)
@@ -1096,15 +983,9 @@ async fn it11_pending_remint_rows_untouched() {
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Withdraw,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(
         status_of(&pool, tx_id).await,
@@ -1139,15 +1020,9 @@ async fn it12_withdrawal_missing_nonce_quarantines() {
 
     let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Withdraw,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "manual_review");
     let update = storage_rx
@@ -1199,23 +1074,16 @@ async fn it13_recovery_requeue_cap_quarantines_after_max() {
         .await
         .unwrap();
 
+    // No persisted signatures means would Demote, but the requeue cap intercepts it.
     let mock = MockRpcServer::start().await;
-    // Empty signatures → NotLanded → would Demote, but the cap intercepts it.
-    mock.enqueue("getSignaturesForAddress", Reply::result(json!([])));
     let client = test_client(mock.url());
     let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
 
-    test_hooks::run_recovery_once(
-        &storage,
-        &client,
-        Pubkey::new_unique(),
-        ProgramType::Escrow,
-        &storage_tx,
-    )
-    .await
-    .unwrap();
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
 
     assert_eq!(
         status_of(&pool, tx_id).await,


### PR DESCRIPTION
## Summary

(Follow-up of #127) Extends the write-ahead release-signature pattern (shipped for withdrawals in #149) to the deposit mint path, closing the deposit half of the "ambiguous `Processing`" class. Today the mint send path persists nothing durable until **after** broadcast, so a crash between broadcast and recording leaves a `processing` row with no record of what hit the chain. Recovery resolved this with an unbounded RPC memo-scan per stuck row (`find_existing_mint_signature`, last 1000 ATA signatures) - which does not scale at deposit volume and has a moving blind spot.

This PR persists the mint signature write-ahead (a single indexed INSERT, fail-closed, before broadcast) and makes deposit recovery **signature-driven**: it reads the persisted signature and classifies its on-chain finality, exactly mirroring `check_withdrawal`. The memo-scan (live path and recovery) is deleted.

## What's changed

- **Persist the mint signature before broadcast.** The deposit mint path now signs, writes the signature to `pending_release_signatures` (fail-closed: on a write failure it does not broadcast and leaves the row `processing`), then sends. `InitializeMint` is excluded (no balance, on-chain idempotent).
- **Signature-driven deposit recovery.** Recovery reads the persisted signature and classifies its on-chain finality, mirroring withdrawals. The one divergence: with no signature a deposit re-mints (provably never broadcast) where a withdrawal pages.
- **A persisted mint is recovery-owned.** An uncertain outcome after persisting (send error or confirmation timeout) leaves the row `processing` for recovery instead of writing terminal `Failed`, which would strand a possibly-landed mint.
- **Removed the RPC memo-scan** (live path and recovery) and its now-dead helpers. The deposit double-mint guard is now the durable signature, not a per-row signature-history scan.
- **Runbook** (`deposit_manual_review.md`) updated to the signature-driven outcomes plus the one-time upgrade step.

## Tests

Written test-first; assertions target the safety-critical behavior (never double-mint, never strand a landed mint).

- **Sender (unit):** the signature is persisted before broadcast and is the same one sent; a persist failure aborts before the wire, drops the permit, stashes nothing, and writes no status; a send error or confirmation timeout after persisting leaves the row `processing` (no terminal `Failed`); `InitializeMint` does not persist.
- **Recovery (unit):** the full deposit decision matrix - landed completes (no re-mint), no-signature and dead both re-mint, in-flight waits, and RPC-uncertain or malformed-signature quarantine. The keystone test asserts the deposit-vs-withdrawal divergence on the no-signature case in one place, and the requeue cap converts a looping demote into a page.
- **Integration (`stuck_processing_recovery`, real Postgres + mock RPC):** the three deposit crash sub-cases the issue is about end-to-end - sent+landed completes with **zero** `sendTransaction`, crashed-before-send re-mints consulting no RPC, and sent+dead re-mints via the on-chain finality check - plus the RPC-uncertain and malformed-signature quarantine paths. Storage test confirms a deposit reuses the signature table and is GC'd identically.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,147 | 12,760 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27819285529) |
| Indexer | 22,168 | 25,072 | 88.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27819285529) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27819285529) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27819285529) |
| Withdraw Program | 120 | 232 | 51.7% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27540664529) |
| Escrow Program | 1,186 | 1,973 | 60.1% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27540664529) |
| DvP Swap Program | 247 | 1,112 | 22.2% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27540664529) |
| E2E Integration | 11,894 | 14,818 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27819285529) |
| **Total** | **48,226** | **56,850** | **84.8%** | |

> Last updated: 2026-06-19 10:33:17 UTC by E2E Integration