### PR TITLE
feat(indexer): index escrow/withdraw instructions invoked via CPI (EXO-121)

### DIFF
--- a/docs/INDEXER.md
+++ b/docs/INDEXER.md
@@ -40,6 +40,17 @@ Recovers missed slots on indexer restart or network issues:
 
 **Location**: [`indexer/src/indexer/backfill.rs`](../indexer/src/indexer/backfill.rs)
 
+### Transaction Identity & CPI Indexing
+
+Each indexed instruction is keyed on the triple **`(signature, instruction_index, inner_index)`**:
+
+- `instruction_index` — absolute position of the top-level instruction (or, for a CPI, of its top-level ancestor) in the transaction.
+- `inner_index` — `NULL` for a top-level instruction; otherwise the instruction's position in the **flattened inner-instruction list** of that top-level ancestor.
+
+**This works at any CPI depth, not just one level.** The validator flattens *every* CPI depth under a top-level instruction into a single inner-instruction list (`meta.innerInstructions[i].instructions`), each entry carrying a `stackHeight`. So a deposit invoked two or more hops deep (`A → B → escrow.Deposit`) is still one entry in that flat list with a unique `inner_index` — `inner_index` is a flat position, **not** a nesting level. Deposit-event scoping likewise keys on `stackHeight` (it walks the contiguous run of deeper entries after the deposit), so it resolves the correct `DepositEvent` regardless of nesting depth.
+
+**Locations**: identity column [`indexer/src/storage/common/models.rs`](../indexer/src/storage/common/models.rs); position capture [`InstructionLocation`/`InnerLocation`](../indexer/src/indexer/datasource/common/types.rs); event scoping `parse_deposit` in [`escrow.rs`](../indexer/src/indexer/datasource/common/parser/escrow.rs).
+
 
 ## Operator Components
 

--- a/indexer/src/indexer/datasource/common/parser/escrow.rs
+++ b/indexer/src/indexer/datasource/common/parser/escrow.rs
@@ -1079,6 +1079,71 @@ mod tests {
         assert_eq!(amount(deposit_b), 400, "deposit B reads its own event");
     }
 
+    /// A deposit nested two CPI hops deep (stack_height 3, beyond the one-level
+    /// case) still reads its own DepositEvent: the validator flattens every CPI
+    /// depth into one inner list, so `inner_index` stays a unique position and the
+    /// stack-height subtree scan is depth-agnostic.
+    #[test]
+    fn cpi_deposit_nested_two_levels_reads_own_event() {
+        let borsh_data = create_deposit_borsh_data();
+        let instruction = create_instruction_with_accounts(12, "dummy".to_string());
+        let account_keys = create_n_account_keys(12);
+
+        // Flattened inner set under one foreign top-level (index 4). Deposit A is
+        // two CPI hops deep (height 3); its event is a hop deeper (height 4). A
+        // deeper non-event entry sits in A's subtree before the event, proving the
+        // scan walks the whole subtree and skips non-events. Sibling deposit B
+        // (also height 3) bounds A's subtree.
+        //   [0] deposit A     height 3
+        //   [1]   nested ix   height 4   (in A's subtree, not an event)
+        //   [2]   event 700   height 4   (A's event)
+        //   [3] deposit B     height 3   (ends A's subtree)
+        //   [4]   event 800   height 4   (B's event)
+        let inner_set = vec![InnerInstructions {
+            index: 4,
+            instructions: vec![
+                deposit_ix_inner(3),
+                deposit_ix_inner(4),
+                deposit_event_inner(700, 4),
+                deposit_ix_inner(3),
+                deposit_event_inner(800, 4),
+            ],
+        }];
+
+        let parse_at = |inner_index: u32| {
+            parse_deposit(
+                &borsh_data,
+                &instruction,
+                &account_keys,
+                &inner_set,
+                InstructionLocation {
+                    top_level_index: 4,
+                    inner: Some(InnerLocation {
+                        inner_index,
+                        stack_height: Some(3),
+                    }),
+                },
+            )
+            .unwrap()
+            .unwrap()
+        };
+
+        let amount = |ix: EscrowInstruction| match ix {
+            EscrowInstruction::Deposit { event, .. } => event.amount,
+            _ => panic!("expected Deposit"),
+        };
+        assert_eq!(
+            amount(parse_at(0)),
+            700,
+            "depth-3 deposit A reads its own event past a deeper non-event entry"
+        );
+        assert_eq!(
+            amount(parse_at(3)),
+            800,
+            "sibling deposit B at the same depth reads its own event, not A's"
+        );
+    }
+
     /// A CPI deposit whose location carries no stack height can't be scoped to
     /// its own subtree, so the parser errors (drops it) rather than risk reading
     /// a neighbouring deposit's event amount.

--- a/indexer/src/indexer/datasource/common/parser/escrow.rs
+++ b/indexer/src/indexer/datasource/common/parser/escrow.rs
@@ -1,7 +1,8 @@
 use crate::{
     error::{account::AccountError, ParserError},
+    indexer::datasource::common::parser::resolve_account,
     indexer::datasource::common::types::*,
-    indexer::datasource::rpc_polling::types::InnerInstructions,
+    indexer::datasource::rpc_polling::types::{InnerInstruction, InnerInstructions},
 };
 
 use borsh::BorshDeserialize;
@@ -15,14 +16,15 @@ pub const PRIVATE_CHANNEL_ESCROW_PROGRAM_ID: &str = "GokvZqD2yP696rzNBNbQvcZ4VsL
 const CREATE_INSTANCE: u8 = 0;
 const ALLOW_MINT: u8 = 1;
 const BLOCK_MINT: u8 = 2;
-const DEPOSIT: u8 = 6;
+// pub(crate) so shared test fixtures can build valid Deposit instruction data.
+pub(crate) const DEPOSIT: u8 = 6;
 const RELEASE_FUNDS: u8 = 7;
 const RESET_SMT_ROOT: u8 = 8;
 
 // Event related constants
-const EVENT_IX_TAG_LE: &[u8] = &[0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+pub(crate) const EVENT_IX_TAG_LE: &[u8] = &[0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
 const ALLOW_MINT_EVENT_DISCRIMINATOR: u8 = 1;
-const DEPOSIT_EVENT_DISCRIMINATOR: u8 = 6;
+pub(crate) const DEPOSIT_EVENT_DISCRIMINATOR: u8 = 6;
 const EVENT_DISCRIMINATOR_INDEX: usize = 8;
 // AllowMintEvent: tag(8)+disc(1)+instance_seed(32)+mint(32) = 73
 const EVENT_DECIMALS_INDEX: usize = 73;
@@ -225,6 +227,18 @@ pub struct DepositEvent {
 // ******************************************************************************************
 // Parse instructions
 // ******************************************************************************************
+/// Inner (CPI) escrow discriminators the indexer skips: operator-gated
+/// `ReleaseFunds`/`ResetSmtRoot` (already tracked as top-level) and admin
+/// `CreateInstance`/`AllowMint`/`BlockMint` (a foreign CPI of them is
+/// implausible). Only the user-initiated `Deposit` is indexed via CPI. Kept next
+/// to the discriminator constants as the one source of truth both decoders share.
+pub fn escrow_inner_discriminator_excluded(discriminator: u8) -> bool {
+    matches!(
+        discriminator,
+        CREATE_INSTANCE | ALLOW_MINT | BLOCK_MINT | RELEASE_FUNDS | RESET_SMT_ROOT
+    )
+}
+
 /// Return the `accounts.instance` carried by any escrow instruction variant.
 pub fn escrow_instance_of(ix: &EscrowInstruction) -> Pubkey {
     match ix {
@@ -242,6 +256,7 @@ pub fn parse_escrow_instruction(
     instruction: &CompiledInstruction,
     account_keys: &[Pubkey],
     inner_instructions: &[InnerInstructions],
+    location: InstructionLocation,
 ) -> Result<Option<EscrowInstruction>, ParserError> {
     // Decode base58 instruction data
     let data = bs58::decode(&instruction.data).into_vec()?;
@@ -257,10 +272,37 @@ pub fn parse_escrow_instruction(
         CREATE_INSTANCE => parse_create_instance(ix_data, instruction, account_keys),
         ALLOW_MINT => parse_allow_mint(ix_data, instruction, account_keys, inner_instructions),
         BLOCK_MINT => parse_block_mint(instruction, account_keys),
-        DEPOSIT => parse_deposit(ix_data, instruction, account_keys, inner_instructions),
+        DEPOSIT => parse_deposit(
+            ix_data,
+            instruction,
+            account_keys,
+            inner_instructions,
+            location,
+        ),
         RELEASE_FUNDS => parse_release_funds(ix_data, instruction, account_keys),
         RESET_SMT_ROOT => parse_reset_smt_root(instruction, account_keys),
         _ => Ok(None), // Unsupported instruction type
+    }
+}
+
+/// Decode an inner instruction and return its amount only if it is the escrow program's DepositEvent self-CPI; the program-id check stops a foreign instruction whose data merely starts with the event tag from being read as the event.
+fn deposit_event_amount(inner: &InnerInstruction, account_keys: &[Pubkey]) -> Option<u64> {
+    let program_id = account_keys.get(inner.instruction.program_id_index as usize)?;
+    if program_id.to_string() != PRIVATE_CHANNEL_ESCROW_PROGRAM_ID {
+        return None;
+    }
+    let event_data = bs58::decode(&inner.instruction.data).into_vec().ok()?;
+    if event_data.len() >= 145
+        && event_data.starts_with(EVENT_IX_TAG_LE)
+        && event_data[EVENT_DISCRIMINATOR_INDEX] == DEPOSIT_EVENT_DISCRIMINATOR
+    {
+        // The `>= 145` length guard guarantees this slice is exactly 8 bytes.
+        let amount_bytes: [u8; 8] = event_data[EVENT_AMOUNT_INDEX..EVENT_AMOUNT_INDEX + 8]
+            .try_into()
+            .ok()?;
+        Some(u64::from_le_bytes(amount_bytes))
+    } else {
+        None
     }
 }
 
@@ -282,13 +324,13 @@ fn parse_create_instance(
     }
 
     let accounts = CreateInstanceAccounts {
-        payer: account_keys[instruction.accounts[0] as usize],
-        admin: account_keys[instruction.accounts[1] as usize],
-        instance_seed: account_keys[instruction.accounts[2] as usize],
-        instance: account_keys[instruction.accounts[3] as usize],
-        system_program: account_keys[instruction.accounts[4] as usize],
-        event_authority: account_keys[instruction.accounts[5] as usize],
-        private_channel_escrow_program: account_keys[instruction.accounts[6] as usize],
+        payer: resolve_account(instruction, account_keys, 0)?,
+        admin: resolve_account(instruction, account_keys, 1)?,
+        instance_seed: resolve_account(instruction, account_keys, 2)?,
+        instance: resolve_account(instruction, account_keys, 3)?,
+        system_program: resolve_account(instruction, account_keys, 4)?,
+        event_authority: resolve_account(instruction, account_keys, 5)?,
+        private_channel_escrow_program: resolve_account(instruction, account_keys, 6)?,
     };
 
     Ok(Some(EscrowInstruction::CreateInstance {
@@ -316,22 +358,23 @@ fn parse_allow_mint(
     }
 
     let accounts = AllowMintAccounts {
-        payer: account_keys[instruction.accounts[0] as usize],
-        admin: account_keys[instruction.accounts[1] as usize],
-        instance: account_keys[instruction.accounts[2] as usize],
-        mint: account_keys[instruction.accounts[3] as usize],
-        allowed_mint: account_keys[instruction.accounts[4] as usize],
-        instance_ata: account_keys[instruction.accounts[5] as usize],
-        system_program: account_keys[instruction.accounts[6] as usize],
-        token_program: account_keys[instruction.accounts[7] as usize],
-        associated_token_program: account_keys[instruction.accounts[8] as usize],
-        event_authority: account_keys[instruction.accounts[9] as usize],
-        private_channel_escrow_program: account_keys[instruction.accounts[10] as usize],
+        payer: resolve_account(instruction, account_keys, 0)?,
+        admin: resolve_account(instruction, account_keys, 1)?,
+        instance: resolve_account(instruction, account_keys, 2)?,
+        mint: resolve_account(instruction, account_keys, 3)?,
+        allowed_mint: resolve_account(instruction, account_keys, 4)?,
+        instance_ata: resolve_account(instruction, account_keys, 5)?,
+        system_program: resolve_account(instruction, account_keys, 6)?,
+        token_program: resolve_account(instruction, account_keys, 7)?,
+        associated_token_program: resolve_account(instruction, account_keys, 8)?,
+        event_authority: resolve_account(instruction, account_keys, 9)?,
+        private_channel_escrow_program: resolve_account(instruction, account_keys, 10)?,
     };
 
     for inner_instruction_set in inner_instructions {
         for inner_instruction in &inner_instruction_set.instructions {
-            let Ok(event_data) = bs58::decode(&inner_instruction.data).into_vec() else {
+            let Ok(event_data) = bs58::decode(&inner_instruction.instruction.data).into_vec()
+            else {
                 continue;
             };
 
@@ -394,10 +437,12 @@ fn parse_deposit(
     instruction: &CompiledInstruction,
     account_keys: &[Pubkey],
     inner_instructions: &[InnerInstructions],
+    location: InstructionLocation,
 ) -> Result<Option<EscrowInstruction>, ParserError> {
+    // Errs when the instruction payload is truncated or not valid Deposit borsh.
     let ix_data = <DepositData as borsh::BorshDeserialize>::deserialize(&mut &data[..])?;
 
-    // Expected 12 accounts
+    // Errs when a malformed tx supplies fewer than the 12 accounts Deposit needs.
     if instruction.accounts.len() < 12 {
         return Err(AccountError::InsufficientAccounts {
             required: 12,
@@ -407,50 +452,80 @@ fn parse_deposit(
     }
 
     let accounts = DepositAccounts {
-        payer: account_keys[instruction.accounts[0] as usize],
-        user: account_keys[instruction.accounts[1] as usize],
-        instance: account_keys[instruction.accounts[2] as usize],
-        mint: account_keys[instruction.accounts[3] as usize],
-        allowed_mint: account_keys[instruction.accounts[4] as usize],
-        user_ata: account_keys[instruction.accounts[5] as usize],
-        instance_ata: account_keys[instruction.accounts[6] as usize],
-        system_program: account_keys[instruction.accounts[7] as usize],
-        token_program: account_keys[instruction.accounts[8] as usize],
-        associated_token_program: account_keys[instruction.accounts[9] as usize],
-        event_authority: account_keys[instruction.accounts[10] as usize],
-        private_channel_escrow_program: account_keys[instruction.accounts[11] as usize],
+        payer: resolve_account(instruction, account_keys, 0)?,
+        user: resolve_account(instruction, account_keys, 1)?,
+        instance: resolve_account(instruction, account_keys, 2)?,
+        mint: resolve_account(instruction, account_keys, 3)?,
+        allowed_mint: resolve_account(instruction, account_keys, 4)?,
+        user_ata: resolve_account(instruction, account_keys, 5)?,
+        instance_ata: resolve_account(instruction, account_keys, 6)?,
+        system_program: resolve_account(instruction, account_keys, 7)?,
+        token_program: resolve_account(instruction, account_keys, 8)?,
+        associated_token_program: resolve_account(instruction, account_keys, 9)?,
+        event_authority: resolve_account(instruction, account_keys, 10)?,
+        private_channel_escrow_program: resolve_account(instruction, account_keys, 11)?,
     };
 
-    for inner_instruction_set in inner_instructions {
-        for inner_instruction in &inner_instruction_set.instructions {
-            let Ok(event_data) = bs58::decode(&inner_instruction.data).into_vec() else {
-                continue;
-            };
+    // Scope the DepositEvent to this deposit's own self-CPI subtree.
+    //
+    // Stage 1: pick the inner set whose `index` equals this deposit's top-level
+    // position. That alone separates multiple top-level deposits in one tx.
+    //
+    // Stage 2: a CPI deposit may share its set with other deposits, so we can't
+    // just take the first event. Entries are listed in call order, and a
+    // deposit's own event sits among the entries right after it that are nested
+    // deeper (a higher stack height). Take that deeper run, which ends as soon as
+    // the height drops back to this deposit's level, and read the event from it.
+    //
+    // A CPI deposit with no stack height can't be scoped to its subtree, so a
+    // set holding several deposits would attribute the wrong amount. Rather than
+    // guess, error out. A top-level deposit needs no
+    // stage 2: its whole set is its own subtree.
+    let scoped_set = inner_instructions
+        .iter()
+        .find(|set| set.index as u32 == location.top_level_index);
 
-            if event_data.len() >= 145
-                && event_data.starts_with(EVENT_IX_TAG_LE)
-                && event_data[EVENT_DISCRIMINATOR_INDEX] == DEPOSIT_EVENT_DISCRIMINATOR
-            {
-                // Safety: the `>= 145` guard above guarantees this slice is
-                // always exactly 8 bytes; the unwrap cannot panic.
-                let amount_bytes: [u8; 8] = event_data[EVENT_AMOUNT_INDEX..EVENT_AMOUNT_INDEX + 8]
-                    .try_into()
-                    .unwrap();
-
-                let amount = u64::from_le_bytes(amount_bytes);
-
-                return Ok(Some(EscrowInstruction::Deposit {
-                    accounts,
-                    data: ix_data,
-                    event: DepositEvent { amount },
-                }));
-            }
+    let amount = match (scoped_set, location.inner) {
+        // CPI deposit with a known depth: read the event from its own subtree.
+        (Some(set), Some(inner_loc)) if inner_loc.stack_height.is_some() => {
+            let own_height = inner_loc.stack_height.unwrap();
+            let start = inner_loc.inner_index as usize + 1;
+            set.instructions
+                .iter()
+                .skip(start)
+                .take_while(|inner| inner.stack_height.is_some_and(|h| h > own_height))
+                .find_map(|inner| deposit_event_amount(inner, account_keys))
         }
-    }
+        // CPI deposit with no depth: can't isolate the subtree, so refuse to guess.
+        // Occurs only when the data source omits stack height (e.g. an old RPC node
+        // or a Geyser feed that doesn't emit stackHeight).
+        (Some(_), Some(_)) => {
+            return Err(ParserError::InstructionParseFailed {
+                reason: "CPI deposit without stack height: cannot scope DepositEvent".to_string(),
+            });
+        }
+        // Top-level deposit: the whole set is its subtree, so scan it directly.
+        (Some(set), None) => set
+            .instructions
+            .iter()
+            .find_map(|inner| deposit_event_amount(inner, account_keys)),
+        // No matching inner set for this deposit: no event to read.
+        (None, _) => None,
+    };
 
-    Err(ParserError::InstructionParseFailed {
-        reason: "No deposit event found".to_string(),
-    })
+    match amount {
+        Some(amount) => Ok(Some(EscrowInstruction::Deposit {
+            accounts,
+            data: ix_data,
+            event: DepositEvent { amount },
+        })),
+        // Errs when no escrow DepositEvent self-CPI exists in scope: the inner set
+        // is missing, or the scoped subtree held no event (a non-deposit tx, or an
+        // event emitted by a non-escrow program that the program-id check rejected).
+        None => Err(ParserError::InstructionParseFailed {
+            reason: "No deposit event found".to_string(),
+        }),
+    }
 }
 
 /// Parse ReleaseFunds instruction
@@ -471,18 +546,18 @@ fn parse_release_funds(
     }
 
     let accounts = ReleaseFundsAccounts {
-        payer: account_keys[instruction.accounts[0] as usize],
-        operator: account_keys[instruction.accounts[1] as usize],
-        instance: account_keys[instruction.accounts[2] as usize],
-        operator_pda: account_keys[instruction.accounts[3] as usize],
-        mint: account_keys[instruction.accounts[4] as usize],
-        allowed_mint: account_keys[instruction.accounts[5] as usize],
-        user_ata: account_keys[instruction.accounts[6] as usize],
-        instance_ata: account_keys[instruction.accounts[7] as usize],
-        token_program: account_keys[instruction.accounts[8] as usize],
-        associated_token_program: account_keys[instruction.accounts[9] as usize],
-        event_authority: account_keys[instruction.accounts[10] as usize],
-        private_channel_escrow_program: account_keys[instruction.accounts[11] as usize],
+        payer: resolve_account(instruction, account_keys, 0)?,
+        operator: resolve_account(instruction, account_keys, 1)?,
+        instance: resolve_account(instruction, account_keys, 2)?,
+        operator_pda: resolve_account(instruction, account_keys, 3)?,
+        mint: resolve_account(instruction, account_keys, 4)?,
+        allowed_mint: resolve_account(instruction, account_keys, 5)?,
+        user_ata: resolve_account(instruction, account_keys, 6)?,
+        instance_ata: resolve_account(instruction, account_keys, 7)?,
+        token_program: resolve_account(instruction, account_keys, 8)?,
+        associated_token_program: resolve_account(instruction, account_keys, 9)?,
+        event_authority: resolve_account(instruction, account_keys, 10)?,
+        private_channel_escrow_program: resolve_account(instruction, account_keys, 11)?,
     };
 
     Ok(Some(EscrowInstruction::ReleaseFunds {
@@ -506,12 +581,12 @@ fn parse_reset_smt_root(
     }
 
     let accounts = ResetSmtRootAccounts {
-        payer: account_keys[instruction.accounts[0] as usize],
-        operator: account_keys[instruction.accounts[1] as usize],
-        instance: account_keys[instruction.accounts[2] as usize],
-        operator_pda: account_keys[instruction.accounts[3] as usize],
-        event_authority: account_keys[instruction.accounts[4] as usize],
-        private_channel_escrow_program: account_keys[instruction.accounts[5] as usize],
+        payer: resolve_account(instruction, account_keys, 0)?,
+        operator: resolve_account(instruction, account_keys, 1)?,
+        instance: resolve_account(instruction, account_keys, 2)?,
+        operator_pda: resolve_account(instruction, account_keys, 3)?,
+        event_authority: resolve_account(instruction, account_keys, 4)?,
+        private_channel_escrow_program: resolve_account(instruction, account_keys, 5)?,
     };
 
     Ok(Some(EscrowInstruction::ResetSmtRoot { accounts }))
@@ -520,6 +595,7 @@ fn parse_reset_smt_root(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     // ============================================================================
     // Test Helper Functions
@@ -558,10 +634,13 @@ mod tests {
 
         vec![InnerInstructions {
             index: 0,
-            instructions: vec![CompiledInstruction {
-                program_id_index: 0,
-                accounts: vec![],
-                data: bs58::encode(&data).into_string(),
+            instructions: vec![InnerInstruction {
+                instruction: CompiledInstruction {
+                    program_id_index: ESCROW_PROGRAM_KEY_INDEX,
+                    accounts: vec![],
+                    data: bs58::encode(&data).into_string(),
+                },
+                stack_height: Some(2),
             }],
         }]
     }
@@ -569,31 +648,23 @@ mod tests {
     /// Create minimal valid Borsh-encoded data for Deposit instruction
     /// DepositIxData { amount: u64, recipient: Option<[u8; 32]> }
     fn create_deposit_borsh_data() -> Vec<u8> {
-        let mut data = vec![];
-        data.extend_from_slice(&1000u64.to_le_bytes()); // amount
-        data.push(0); // None for recipient (Option discriminator = 0)
-        data
+        crate::test_utils::escrow_fixtures::deposit_borsh(1000, None)
     }
 
-    /// Build inner instructions carrying a valid DepositEvent CPI with the
-    /// given received `amount`. Layout: tag(8) + disc(1) + instance_seed(32)
-    /// + user(32) + amount(8 LE) + recipient(32) + mint(32) = 145 bytes.
+    /// Build inner instructions carrying a valid DepositEvent CPI with the given received `amount`.
     fn create_deposit_inner_instructions(amount: u64) -> Vec<InnerInstructions> {
-        let mut data = vec![];
-        data.extend_from_slice(EVENT_IX_TAG_LE);
-        data.push(DEPOSIT_EVENT_DISCRIMINATOR);
-        data.extend_from_slice(&[0u8; 32]); // instance_seed
-        data.extend_from_slice(&[0u8; 32]); // user
-        data.extend_from_slice(&amount.to_le_bytes());
-        data.extend_from_slice(&[0u8; 32]); // recipient
-        data.extend_from_slice(&[0u8; 32]); // mint
-
         vec![InnerInstructions {
             index: 0,
-            instructions: vec![CompiledInstruction {
-                program_id_index: 0,
-                accounts: vec![],
-                data: bs58::encode(&data).into_string(),
+            instructions: vec![InnerInstruction {
+                instruction: CompiledInstruction {
+                    program_id_index: ESCROW_PROGRAM_KEY_INDEX,
+                    accounts: vec![],
+                    data: bs58::encode(crate::test_utils::escrow_fixtures::deposit_event_bytes(
+                        amount,
+                    ))
+                    .into_string(),
+                },
+                stack_height: Some(2),
             }],
         }]
     }
@@ -616,15 +687,22 @@ mod tests {
         bs58::encode(full).into_string()
     }
 
-    /// Create N account keys for testing
+    /// Account slot the inner-instruction builders point program_id at; the escrow program sits here so event inner instructions resolve to it.
+    const ESCROW_PROGRAM_KEY_INDEX: u8 = 20;
+
+    /// N test account keys with the escrow program placed at `ESCROW_PROGRAM_KEY_INDEX` (padding the list) so helper-built event CPIs resolve to it.
     fn create_n_account_keys(n: usize) -> Vec<Pubkey> {
-        (0..n)
+        let len = n.max(ESCROW_PROGRAM_KEY_INDEX as usize + 1);
+        let mut keys: Vec<Pubkey> = (0..len)
             .map(|i| {
                 let mut bytes = [0u8; 32];
                 bytes[0] = i as u8;
                 Pubkey::new_from_array(bytes)
             })
-            .collect()
+            .collect();
+        keys[ESCROW_PROGRAM_KEY_INDEX as usize] =
+            Pubkey::from_str(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID).unwrap();
+        keys
     }
 
     /// Create a CompiledInstruction with N accounts
@@ -775,6 +853,7 @@ mod tests {
             &instruction,
             &account_keys,
             &create_deposit_inner_instructions(990),
+            InstructionLocation::top_level(0),
         );
 
         let parsed = result.unwrap().expect("Some");
@@ -791,7 +870,13 @@ mod tests {
         let instruction = create_instruction_with_accounts(11, "dummy".to_string()); // Only 11 accounts (need 12)
         let account_keys = create_n_account_keys(11);
 
-        let result = parse_deposit(&borsh_data, &instruction, &account_keys, &[]);
+        let result = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &[],
+            InstructionLocation::top_level(0),
+        );
 
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -804,7 +889,13 @@ mod tests {
         let instruction = create_instruction_with_accounts(12, "dummy".to_string());
         let account_keys = create_n_account_keys(12);
 
-        let result = parse_deposit(&borsh_data, &instruction, &account_keys, &[]);
+        let result = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &[],
+            InstructionLocation::top_level(0),
+        );
 
         let err = result.unwrap_err().to_string();
         assert!(err.contains("No deposit event found"), "Error: {}", err);
@@ -866,5 +957,279 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Insufficient accounts"), "Error: {}", err);
+    }
+
+    // ============================================================================
+    // CPI hardening + event-scoping tests
+    // ============================================================================
+
+    /// A DepositEvent inner instruction on the escrow program at the given amount and stack height.
+    fn deposit_event_inner(amount: u64, stack_height: u32) -> InnerInstruction {
+        InnerInstruction {
+            instruction: CompiledInstruction {
+                program_id_index: ESCROW_PROGRAM_KEY_INDEX,
+                accounts: vec![],
+                data: bs58::encode(crate::test_utils::escrow_fixtures::deposit_event_bytes(
+                    amount,
+                ))
+                .into_string(),
+            },
+            stack_height: Some(stack_height),
+        }
+    }
+
+    /// An inner escrow Deposit instruction (the CPI'd deposit, not its event) at the given stack height.
+    fn deposit_ix_inner(stack_height: u32) -> InnerInstruction {
+        InnerInstruction {
+            instruction: CompiledInstruction {
+                program_id_index: ESCROW_PROGRAM_KEY_INDEX,
+                accounts: (0..12).collect(),
+                data: bs58::encode(crate::test_utils::escrow_fixtures::deposit_ix_bytes(
+                    1000, None,
+                ))
+                .into_string(),
+            },
+            stack_height: Some(stack_height),
+        }
+    }
+
+    /// An out-of-range account index returns an error instead of panicking the parse path.
+    #[test]
+    fn deposit_out_of_range_account_index_returns_err_not_panic() {
+        let borsh_data = create_deposit_borsh_data();
+        // 12 account entries (passes the count check) that index past the 5-key list.
+        let instruction = CompiledInstruction {
+            program_id_index: 0,
+            accounts: (50..62).collect(),
+            data: "dummy".to_string(),
+        };
+        let account_keys = create_n_account_keys(5);
+
+        let result = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &create_deposit_inner_instructions(990),
+            InstructionLocation::top_level(0),
+        );
+
+        assert!(result.is_err(), "out-of-range index must be an Err");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("out of bounds"), "Error: {}", err);
+    }
+
+    /// Two escrow deposits sharing one inner set each read their own stack-height subtree, so they get distinct amounts.
+    #[test]
+    fn two_cpi_deposits_in_one_set_get_distinct_event_amounts() {
+        let borsh_data = create_deposit_borsh_data();
+        let instruction = create_instruction_with_accounts(12, "dummy".to_string());
+        let account_keys = create_n_account_keys(12);
+
+        // Pre-order CPI walk under one foreign top-level instruction (index 4):
+        //   [0] deposit A    height 2
+        //   [1]   event 300  height 3
+        //   [2] deposit B    height 2
+        //   [3]   event 400  height 3
+        let inner_set = vec![InnerInstructions {
+            index: 4,
+            instructions: vec![
+                deposit_ix_inner(2),
+                deposit_event_inner(300, 3),
+                deposit_ix_inner(2),
+                deposit_event_inner(400, 3),
+            ],
+        }];
+
+        let deposit_a = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &inner_set,
+            InstructionLocation {
+                top_level_index: 4,
+                inner: Some(InnerLocation {
+                    inner_index: 0,
+                    stack_height: Some(2),
+                }),
+            },
+        )
+        .unwrap()
+        .unwrap();
+        let deposit_b = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &inner_set,
+            InstructionLocation {
+                top_level_index: 4,
+                inner: Some(InnerLocation {
+                    inner_index: 2,
+                    stack_height: Some(2),
+                }),
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        let amount = |ix: EscrowInstruction| match ix {
+            EscrowInstruction::Deposit { event, .. } => event.amount,
+            _ => panic!("expected Deposit"),
+        };
+        assert_eq!(amount(deposit_a), 300, "deposit A reads its own event");
+        assert_eq!(amount(deposit_b), 400, "deposit B reads its own event");
+    }
+
+    /// A CPI deposit whose location carries no stack height can't be scoped to
+    /// its own subtree, so the parser errors (drops it) rather than risk reading
+    /// a neighbouring deposit's event amount.
+    #[test]
+    fn cpi_deposit_without_stack_height_errors_rather_than_guess() {
+        let borsh_data = create_deposit_borsh_data();
+        let instruction = create_instruction_with_accounts(12, "dummy".to_string());
+        let account_keys = create_n_account_keys(12);
+
+        // Two deposits share one set, so guessing would be ambiguous.
+        let inner_set = vec![InnerInstructions {
+            index: 4,
+            instructions: vec![
+                deposit_ix_inner(2),
+                deposit_event_inner(300, 3),
+                deposit_ix_inner(2),
+                deposit_event_inner(400, 3),
+            ],
+        }];
+
+        let result = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &inner_set,
+            InstructionLocation {
+                top_level_index: 4,
+                inner: Some(InnerLocation {
+                    inner_index: 0,
+                    stack_height: None,
+                }),
+            },
+        );
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("cannot scope DepositEvent"),
+            "CPI deposit without stack height must error: {err}"
+        );
+    }
+
+    /// A CPI deposit whose own subtree holds deeper entries but no DepositEvent
+    /// errors with "No deposit event found" rather than borrowing a sibling's.
+    #[test]
+    fn cpi_deposit_with_eventless_subtree_errs() {
+        let borsh_data = create_deposit_borsh_data();
+        let instruction = create_instruction_with_accounts(12, "dummy".to_string());
+        let account_keys = create_n_account_keys(12);
+
+        // Pre-order walk: deposit A's subtree (height 3) is a nested deposit ix,
+        // not its event; deposit B at height 2 owns the only event.
+        //   [0] deposit A    height 2
+        //   [1]   deposit    height 3   (deeper, but not an event)
+        //   [2] deposit B    height 2
+        //   [3]   event 400  height 3
+        let inner_set = vec![InnerInstructions {
+            index: 4,
+            instructions: vec![
+                deposit_ix_inner(2),
+                deposit_ix_inner(3),
+                deposit_ix_inner(2),
+                deposit_event_inner(400, 3),
+            ],
+        }];
+
+        let result = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &inner_set,
+            InstructionLocation {
+                top_level_index: 4,
+                inner: Some(InnerLocation {
+                    inner_index: 0,
+                    stack_height: Some(2),
+                }),
+            },
+        );
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("No deposit event found"),
+            "eventless subtree must not borrow a sibling's event: {err}"
+        );
+    }
+
+    /// Handing the DepositEvent self-CPI instruction to the parser yields Ok(None), not a second Deposit row (double-mint guard).
+    #[test]
+    fn self_cpi_event_instruction_parses_to_none() {
+        let account_keys = create_n_account_keys(12);
+        let event = deposit_event_inner(123, 3);
+
+        let result = parse_escrow_instruction(
+            &event.instruction,
+            &account_keys,
+            &[],
+            InstructionLocation {
+                top_level_index: 0,
+                inner: Some(InnerLocation {
+                    inner_index: 1,
+                    stack_height: Some(3),
+                }),
+            },
+        );
+
+        assert!(
+            matches!(result, Ok(None)),
+            "event self-CPI must parse to Ok(None), got {result:?}"
+        );
+    }
+
+    /// An event-tag lookalike on a non-escrow program is not read as the deposit's event.
+    #[test]
+    fn foreign_program_event_lookalike_is_not_read_as_event() {
+        let borsh_data = create_deposit_borsh_data();
+        let instruction = create_instruction_with_accounts(12, "dummy".to_string());
+        let account_keys = create_n_account_keys(12);
+
+        // Same event bytes, but on a non-escrow program (key index 0).
+        let mut data = vec![];
+        data.extend_from_slice(EVENT_IX_TAG_LE);
+        data.push(DEPOSIT_EVENT_DISCRIMINATOR);
+        data.extend_from_slice(&[0u8; 32]);
+        data.extend_from_slice(&[0u8; 32]);
+        data.extend_from_slice(&999u64.to_le_bytes());
+        data.extend_from_slice(&[0u8; 32]);
+        data.extend_from_slice(&[0u8; 32]);
+        let inner_set = vec![InnerInstructions {
+            index: 0,
+            instructions: vec![InnerInstruction {
+                instruction: CompiledInstruction {
+                    program_id_index: 0, // not the escrow program
+                    accounts: vec![],
+                    data: bs58::encode(&data).into_string(),
+                },
+                stack_height: Some(2),
+            }],
+        }];
+
+        let result = parse_deposit(
+            &borsh_data,
+            &instruction,
+            &account_keys,
+            &inner_set,
+            InstructionLocation::top_level(0),
+        );
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("No deposit event found"),
+            "foreign-program event lookalike must be ignored: {err}"
+        );
     }
 }

--- a/indexer/src/indexer/datasource/common/parser/mod.rs
+++ b/indexer/src/indexer/datasource/common/parser/mod.rs
@@ -5,3 +5,62 @@ pub mod withdraw;
 pub use escrow::*;
 pub use pubkey::*;
 pub use withdraw::*;
+
+use crate::error::{account::AccountError, ParserError};
+use crate::indexer::datasource::common::types::CompiledInstruction;
+use solana_sdk::pubkey::Pubkey;
+
+/// Look up the pubkey of the instruction's `pos`-th account. Accounts are stored
+/// as positions into `account_keys`, so this bounds-checks both `pos` and that
+/// position and returns a `ParserError` (never panics) if either is out of range.
+pub(crate) fn resolve_account(
+    instruction: &CompiledInstruction,
+    account_keys: &[Pubkey],
+    pos: usize,
+) -> Result<Pubkey, ParserError> {
+    let key_index = *instruction
+        .accounts
+        .get(pos)
+        .ok_or(AccountError::AccountIndexOutOfBounds { index: pos })? as usize;
+    account_keys
+        .get(key_index)
+        .copied()
+        .ok_or_else(|| AccountError::AccountIndexOutOfBounds { index: key_index }.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::pubkey::test_pubkey;
+
+    fn ix(accounts: Vec<u8>) -> CompiledInstruction {
+        CompiledInstruction {
+            program_id_index: 0,
+            accounts,
+            data: String::new(),
+        }
+    }
+
+    #[test]
+    fn resolve_account_returns_keyed_pubkey() {
+        let keys = [test_pubkey(10), test_pubkey(11), test_pubkey(12)];
+        // accounts[1] -> account_keys[2]
+        let result = resolve_account(&ix(vec![0, 2, 1]), &keys, 1);
+        assert_eq!(result.unwrap(), test_pubkey(12));
+    }
+
+    #[test]
+    fn resolve_account_pos_past_instruction_accounts_errs() {
+        let keys = [test_pubkey(10)];
+        let result = resolve_account(&ix(vec![0]), &keys, 5);
+        assert!(result.unwrap_err().to_string().contains("out of bounds"));
+    }
+
+    #[test]
+    fn resolve_account_index_past_key_list_errs() {
+        let keys = [test_pubkey(10)];
+        // accounts[0] points at key index 7, but only one key exists.
+        let result = resolve_account(&ix(vec![7]), &keys, 0);
+        assert!(result.unwrap_err().to_string().contains("out of bounds"));
+    }
+}

--- a/indexer/src/indexer/datasource/common/parser/withdraw.rs
+++ b/indexer/src/indexer/datasource/common/parser/withdraw.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::{account::AccountError, ParserError},
-    indexer::datasource::common::types::CompiledInstruction,
+    indexer::datasource::common::parser::resolve_account,
+    indexer::datasource::common::types::{CompiledInstruction, InstructionLocation},
     indexer::datasource::rpc_polling::types::InnerInstructions,
 };
 use borsh::BorshDeserialize;
@@ -13,6 +14,11 @@ pub const PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID: &str =
 
 // Instruction discriminators
 const WITHDRAW_FUNDS: u8 = 0;
+
+/// Withdraw exposes only the user-initiated `WithdrawFunds`, so no inner (CPI) discriminator is excluded; mirrors the escrow predicate so both decoders share one per-program source of truth.
+pub fn withdraw_inner_discriminator_excluded(_discriminator: u8) -> bool {
+    false
+}
 
 // ******************************************************************************************
 // Data types for instructions
@@ -56,6 +62,8 @@ pub fn parse_withdraw_instruction(
     instruction: &CompiledInstruction,
     account_keys: &[Pubkey],
     _inner_instructions: &[InnerInstructions],
+    // WithdrawFunds emits no event; the unused location keeps a uniform parser signature across both programs.
+    _location: InstructionLocation,
 ) -> Result<Option<WithdrawInstruction>, ParserError> {
     // Decode base58 instruction data
     let data = bs58::decode(&instruction.data).into_vec()?;
@@ -90,14 +98,14 @@ fn parse_withdraw_funds(
         .into());
     }
 
-    let user = account_keys[instruction.accounts[0] as usize];
+    let user = resolve_account(instruction, account_keys, 0)?;
 
     let accounts = WithdrawFundsAccounts {
         user,
-        mint: account_keys[instruction.accounts[1] as usize],
-        token_account: account_keys[instruction.accounts[2] as usize],
-        token_program: account_keys[instruction.accounts[3] as usize],
-        associated_token_program: account_keys[instruction.accounts[4] as usize],
+        mint: resolve_account(instruction, account_keys, 1)?,
+        token_account: resolve_account(instruction, account_keys, 2)?,
+        token_program: resolve_account(instruction, account_keys, 3)?,
+        associated_token_program: resolve_account(instruction, account_keys, 4)?,
     };
 
     let destination = ix_data

--- a/indexer/src/indexer/datasource/common/types.rs
+++ b/indexer/src/indexer/datasource/common/types.rs
@@ -16,6 +16,11 @@ pub struct InstructionWithMetadata {
     /// list. Paired with `signature` it forms the durable per-instruction identity,
     /// so multiple economic events sharing one signature stay distinct.
     pub instruction_index: u32,
+    /// Position of this instruction within its parent's inner-instruction set when
+    /// it is a CPI (cross-program invocation); `None` for a top-level instruction.
+    /// Extends the identity to `(signature, instruction_index, inner_index)` so a
+    /// foreign program CPI-ing into escrow/withdraw persists as its own row.
+    pub inner_index: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -24,6 +29,34 @@ pub struct CompiledInstruction {
     pub program_id_index: u8,
     pub accounts: Vec<u8>,
     pub data: String, // base58 encoded
+}
+
+/// Where an instruction sits in its transaction, used to find the self-CPI
+/// event it emitted.
+#[derive(Debug, Clone, Copy)]
+pub struct InstructionLocation {
+    /// Position of this instruction, or of its top-level ancestor when it is a CPI.
+    pub top_level_index: u32,
+    /// Set only when this instruction is itself an inner (CPI) instruction.
+    pub inner: Option<InnerLocation>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct InnerLocation {
+    /// Position within the inner-instruction set of the top-level ancestor.
+    pub inner_index: u32,
+    /// CPI depth, used to bound the subtree of inner instructions this one owns.
+    pub stack_height: Option<u32>,
+}
+
+impl InstructionLocation {
+    /// A plain top-level instruction with no inner position.
+    pub fn top_level(top_level_index: u32) -> Self {
+        Self {
+            top_level_index,
+            inner: None,
+        }
+    }
 }
 
 /// Messages sent from datasources to transaction processor

--- a/indexer/src/indexer/datasource/rpc_polling/decoder.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/decoder.rs
@@ -15,7 +15,7 @@ use crate::indexer::datasource::common::types::CompiledInstruction;
 use crate::indexer::datasource::common::types::*;
 use crate::indexer::datasource::rpc_polling::types::{InnerInstructions, RpcBlock};
 use solana_sdk::pubkey::Pubkey;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 type ParseInstructionFn<T> = fn(
     instruction: &CompiledInstruction,
@@ -125,12 +125,21 @@ where
         // Inner (and v0 top-level) account indices reference the full key list:
         // static message keys, then loaded writable, then readonly. Append the
         // already-resolved loaded keys so those indices resolve.
-        let account_pubkeys: Vec<Pubkey> = account_keys
+        // A malformed key makes every account index untrustworthy (dropping one
+        // would shift the rest), so skip the whole transaction rather than panic.
+        let account_pubkeys: Vec<Pubkey> = match account_keys
             .iter()
             .chain(loaded_writable.iter())
             .chain(loaded_readonly.iter())
-            .map(|s| Pubkey::from_str(s).expect("Invalid pubkey"))
-            .collect();
+            .map(|s| Pubkey::from_str(s))
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!("Skipping transaction {signature}: invalid account key: {e}");
+                continue;
+            }
+        };
 
         // Filter transactions by instance ID if provided
         // Check if any account in the transaction matches the instance ID
@@ -140,7 +149,12 @@ where
             }
         }
 
-        let filter_pubkey = Pubkey::from_str(filter_program_id).ok();
+        // The filter program id is a hardcoded constant; a parse failure is a
+        // programming error, not a per-transaction condition.
+        let Ok(filter_pubkey) = Pubkey::from_str(filter_program_id) else {
+            error!("Invalid filter program id: {filter_program_id}");
+            return instructions;
+        };
 
         // Enumerate before the program-id filter so the index is the instruction's
         // absolute position in the transaction, independent of how many are relevant.
@@ -149,7 +163,7 @@ where
             let program_id = account_pubkeys.get(instruction.program_id_index as usize);
 
             // Only parse program filtered instructions
-            if program_id == filter_pubkey.as_ref() {
+            if program_id == Some(&filter_pubkey) {
                 let location = InstructionLocation::top_level(ix_index as u32);
                 match parse_instruction(
                     instruction,
@@ -175,7 +189,7 @@ where
         for inner_set in inner_instructions_list {
             for (inner_ix_index, inner) in inner_set.instructions.iter().enumerate() {
                 let program_id = account_pubkeys.get(inner.instruction.program_id_index as usize);
-                if program_id != filter_pubkey.as_ref() {
+                if program_id != Some(&filter_pubkey) {
                     continue;
                 }
                 if instruction_discriminator(&inner.instruction)

--- a/indexer/src/indexer/datasource/rpc_polling/decoder.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/decoder.rs
@@ -3,10 +3,12 @@ use std::str::FromStr;
 use crate::config::ProgramType;
 use crate::error::ParserError;
 use crate::indexer::datasource::common::parser::escrow::{
-    parse_escrow_instruction, PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
+    escrow_inner_discriminator_excluded, parse_escrow_instruction,
+    PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
 };
 use crate::indexer::datasource::common::parser::withdraw::{
-    parse_withdraw_instruction, PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID,
+    parse_withdraw_instruction, withdraw_inner_discriminator_excluded,
+    PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID,
 };
 use crate::indexer::datasource::common::parser::{EscrowInstruction, WithdrawInstruction};
 use crate::indexer::datasource::common::types::CompiledInstruction;
@@ -19,6 +21,7 @@ type ParseInstructionFn<T> = fn(
     instruction: &CompiledInstruction,
     account_keys: &[Pubkey],
     inner_instructions: &[InnerInstructions],
+    location: InstructionLocation,
 ) -> Result<Option<T>, ParserError>;
 
 /// Parse a block and extract program-specific instructions with metadata
@@ -33,48 +36,56 @@ pub fn parse_block(
             block,
             PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
             parse_escrow_instruction,
+            escrow_inner_discriminator_excluded,
             escrow_instance_id,
         )
         .into_iter()
-        .map(
-            |(signature, instruction_index, ix)| InstructionWithMetadata {
-                instruction: ProgramInstruction::Escrow(Box::new(ix)),
-                slot,
-                program_type,
-                signature: Some(signature),
-                instruction_index,
-            },
-        )
+        .map(|(signature, location, ix)| InstructionWithMetadata {
+            instruction: ProgramInstruction::Escrow(Box::new(ix)),
+            slot,
+            program_type,
+            signature: Some(signature),
+            instruction_index: location.top_level_index,
+            inner_index: location.inner.map(|i| i.inner_index),
+        })
         .collect(),
         ProgramType::Withdraw => parse_block_for_program::<WithdrawInstruction>(
             block,
             PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID,
             parse_withdraw_instruction,
+            withdraw_inner_discriminator_excluded,
             None,
         )
         .into_iter()
-        .map(
-            |(signature, instruction_index, ix)| InstructionWithMetadata {
-                instruction: ProgramInstruction::Withdraw(Box::new(ix)),
-                slot,
-                program_type,
-                signature: Some(signature),
-                instruction_index,
-            },
-        )
+        .map(|(signature, location, ix)| InstructionWithMetadata {
+            instruction: ProgramInstruction::Withdraw(Box::new(ix)),
+            slot,
+            program_type,
+            signature: Some(signature),
+            instruction_index: location.top_level_index,
+            inner_index: location.inner.map(|i| i.inner_index),
+        })
         .collect(),
     }
 }
 
-/// Parse a block and extract all instructions for a given program
-/// Returns tuples of (signature, instruction_index, instruction) for each parsed
-/// instruction, where instruction_index is the absolute position in the transaction.
+/// First byte (Anchor-style discriminator) of an instruction's base58 data, or `None` if empty/undecodable.
+fn instruction_discriminator(instruction: &CompiledInstruction) -> Option<u8> {
+    bs58::decode(&instruction.data)
+        .into_vec()
+        .ok()
+        .and_then(|d| d.first().copied())
+}
+
+/// Parse a block and return (signature, location, instruction) for every
+/// instruction of the given program.
 pub fn parse_block_for_program<T>(
     block: &RpcBlock,
     filter_program_id: &str,
     parse_instruction: ParseInstructionFn<T>,
+    inner_discriminator_excluded: fn(u8) -> bool,
     escrow_instance_id: Option<&Pubkey>,
-) -> Vec<(String, u32, T)>
+) -> Vec<(String, InstructionLocation, T)>
 where
     T: std::fmt::Debug,
 {
@@ -82,6 +93,8 @@ where
 
     for tx_with_meta in &block.transactions {
         let mut inner_instructions_list: &[InnerInstructions] = &[];
+        let mut loaded_writable: &[String] = &[];
+        let mut loaded_readonly: &[String] = &[];
 
         // Skip failed transactions
         if let Some(meta) = &tx_with_meta.meta {
@@ -91,6 +104,11 @@ where
 
             if let Some(inner_ix) = &meta.inner_instructions {
                 inner_instructions_list = inner_ix;
+            }
+
+            if let Some(loaded) = &meta.loaded_addresses {
+                loaded_writable = &loaded.writable;
+                loaded_readonly = &loaded.readonly;
             }
         }
 
@@ -104,8 +122,13 @@ where
             continue;
         };
 
+        // Inner (and v0 top-level) account indices reference the full key list:
+        // static message keys, then loaded writable, then readonly. Append the
+        // already-resolved loaded keys so those indices resolve.
         let account_pubkeys: Vec<Pubkey> = account_keys
             .iter()
+            .chain(loaded_writable.iter())
+            .chain(loaded_readonly.iter())
             .map(|s| Pubkey::from_str(s).expect("Invalid pubkey"))
             .collect();
 
@@ -117,22 +140,71 @@ where
             }
         }
 
+        let filter_pubkey = Pubkey::from_str(filter_program_id).ok();
+
         // Enumerate before the program-id filter so the index is the instruction's
         // absolute position in the transaction, independent of how many are relevant.
         for (ix_index, instruction) in tx.message.instructions.iter().enumerate() {
-            let program_id = account_keys.get(instruction.program_id_index as usize);
+            // Resolve against the full key list
+            let program_id = account_pubkeys.get(instruction.program_id_index as usize);
 
             // Only parse program filtered instructions
-            if program_id == Some(&filter_program_id.to_string()) {
-                match parse_instruction(instruction, &account_pubkeys, inner_instructions_list) {
+            if program_id == filter_pubkey.as_ref() {
+                let location = InstructionLocation::top_level(ix_index as u32);
+                match parse_instruction(
+                    instruction,
+                    &account_pubkeys,
+                    inner_instructions_list,
+                    location,
+                ) {
                     Ok(Some(ix)) => {
-                        instructions.push((signature.clone(), ix_index as u32, ix));
+                        instructions.push((signature.clone(), location, ix));
                     }
                     Ok(None) => {
                         debug!("Skipped unsupported instruction");
                     }
                     Err(e) => {
                         warn!("Failed to parse instruction: {}", e);
+                    }
+                }
+            }
+        }
+
+        // Inner (CPI) instructions: parse the filtered program's user-initiated
+        // instructions.
+        for inner_set in inner_instructions_list {
+            for (inner_ix_index, inner) in inner_set.instructions.iter().enumerate() {
+                let program_id = account_pubkeys.get(inner.instruction.program_id_index as usize);
+                if program_id != filter_pubkey.as_ref() {
+                    continue;
+                }
+                if instruction_discriminator(&inner.instruction)
+                    .is_some_and(inner_discriminator_excluded)
+                {
+                    continue;
+                }
+
+                let location = InstructionLocation {
+                    top_level_index: inner_set.index as u32,
+                    inner: Some(InnerLocation {
+                        inner_index: inner_ix_index as u32,
+                        stack_height: inner.stack_height,
+                    }),
+                };
+                match parse_instruction(
+                    &inner.instruction,
+                    &account_pubkeys,
+                    inner_instructions_list,
+                    location,
+                ) {
+                    Ok(Some(ix)) => {
+                        instructions.push((signature.clone(), location, ix));
+                    }
+                    Ok(None) => {
+                        debug!("Skipped unsupported inner instruction");
+                    }
+                    Err(e) => {
+                        warn!("Failed to parse inner instruction: {}", e);
                     }
                 }
             }
@@ -158,6 +230,7 @@ mod tests {
         instruction: &CompiledInstruction,
         _account_keys: &[Pubkey],
         _inner_instructions: &[InnerInstructions],
+        _location: InstructionLocation,
     ) -> Result<Option<String>, ParserError> {
         Ok(Some(instruction.data.clone()))
     }
@@ -167,6 +240,7 @@ mod tests {
         _instruction: &CompiledInstruction,
         _account_keys: &[Pubkey],
         _inner_instructions: &[InnerInstructions],
+        _location: InstructionLocation,
     ) -> Result<Option<String>, ParserError> {
         Ok(None)
     }
@@ -176,10 +250,35 @@ mod tests {
         _instruction: &CompiledInstruction,
         _account_keys: &[Pubkey],
         _inner_instructions: &[InnerInstructions],
+        _location: InstructionLocation,
     ) -> Result<Option<String>, ParserError> {
         Err(ParserError::InstructionParseFailed {
             reason: "Parse error".to_string(),
         })
+    }
+
+    /// Never excludes: top-level mock parser tests are unaffected by inner skips.
+    fn never_excluded(_discriminator: u8) -> bool {
+        false
+    }
+
+    /// Wrapper so mock-parser tests keep their shape over the (signature, location, value) result tuple.
+    fn parse_for_test(
+        block: &RpcBlock,
+        program_id: &str,
+        parse_instruction: ParseInstructionFn<String>,
+        escrow_instance_id: Option<&Pubkey>,
+    ) -> Vec<(String, u32, String)> {
+        parse_block_for_program(
+            block,
+            program_id,
+            parse_instruction,
+            never_excluded,
+            escrow_instance_id,
+        )
+        .into_iter()
+        .map(|(sig, location, value)| (sig, location.top_level_index, value))
+        .collect()
     }
 
     // ============================================================================
@@ -190,7 +289,7 @@ mod tests {
     fn test_empty_block() {
         let block = create_test_block();
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert!(result.is_empty());
     }
@@ -208,7 +307,7 @@ mod tests {
             vec![instruction],
         ));
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert!(result.is_empty());
     }
@@ -226,7 +325,7 @@ mod tests {
             vec![instruction],
         ));
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert!(result.is_empty());
     }
@@ -246,7 +345,7 @@ mod tests {
             vec![ix1, ix2, ix3],
         ));
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], ("sig1".to_string(), 0u32, "data1".to_string()));
@@ -270,7 +369,7 @@ mod tests {
             vec![ix0, ix1, ix2],
         ));
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], ("sig1".to_string(), 0u32, "data0".to_string()));
@@ -299,7 +398,7 @@ mod tests {
             vec![ix2],
         ));
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], ("sig1".to_string(), 0u32, "data1".to_string()));
@@ -337,7 +436,7 @@ mod tests {
             vec![ix3],
         ));
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert_eq!(result.len(), 2);
         assert_eq!(
@@ -363,7 +462,7 @@ mod tests {
 
         block.transactions.push(tx);
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         // Transaction without signature should be skipped entirely
         assert!(result.is_empty());
@@ -381,8 +480,7 @@ mod tests {
             vec![instruction],
         ));
 
-        let result =
-            parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser_returns_none, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser_returns_none, None);
 
         // Should be empty because parser returned None (unsupported instruction)
         assert!(result.is_empty());
@@ -400,8 +498,7 @@ mod tests {
             vec![instruction],
         ));
 
-        let result =
-            parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser_returns_error, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser_returns_error, None);
 
         // Should be empty because parser returned error (logged but continued)
         assert!(result.is_empty());
@@ -429,7 +526,7 @@ mod tests {
             vec![ix2],
         ));
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert_eq!(result.len(), 2);
         assert_eq!(
@@ -454,12 +551,405 @@ mod tests {
             vec![instruction],
         ));
 
-        let result = parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, None);
+        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
 
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0],
             ("sig_no_meta".to_string(), 0u32, "no_meta".to_string())
         );
+    }
+
+    // ============================================================================
+    // CPI (inner instruction) Tests
+    // ============================================================================
+
+    use crate::indexer::datasource::rpc_polling::types::{InnerInstruction, InnerInstructions};
+    use solana_transaction_status::UiLoadedAddresses;
+
+    fn inner(program_id_index: u8, data: &str, stack_height: u32) -> InnerInstruction {
+        InnerInstruction {
+            instruction: create_instruction(program_id_index, vec![], data.to_string()),
+            stack_height: Some(stack_height),
+        }
+    }
+
+    /// A program appearing only as a CPI yields a row with the parent's top-level index and the inner position.
+    #[test]
+    fn inner_only_instruction_yields_top_and_inner_index() {
+        let mut block = create_test_block();
+        // Top-level targets a foreign program (index 1); our program (key index 0) is only invoked via CPI.
+        let account_keys = create_account_keys_with_program(TEST_PROGRAM_ID, 0);
+        let foreign = create_instruction(1, vec![], "foreign".to_string());
+
+        let mut tx =
+            create_successful_transaction("sig_cpi".to_string(), account_keys, vec![foreign]);
+        tx.meta.as_mut().unwrap().inner_instructions = Some(vec![InnerInstructions {
+            index: 0,
+            instructions: vec![
+                inner(1, "skip", 2),             // foreign inner, filtered out
+                inner(0, "cpi_deposit_data", 2), // our program, indexed
+            ],
+        }]);
+        block.transactions.push(tx);
+
+        let result =
+            parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, never_excluded, None);
+
+        assert_eq!(result.len(), 1);
+        let (sig, location, data) = &result[0];
+        assert_eq!(sig, "sig_cpi");
+        assert_eq!(location.top_level_index, 0);
+        assert_eq!(location.inner.unwrap().inner_index, 1);
+        assert_eq!(data, "cpi_deposit_data");
+    }
+
+    /// Two inner sets with different `index` values each map their CPI deposit to
+    /// the correct top-level ancestor, so `top_level_index` tracks `inner_set.index`.
+    #[test]
+    fn distinct_inner_sets_map_to_their_own_top_level_index() {
+        let mut block = create_test_block();
+        // Our program at key index 0; the two top-level instructions both target
+        // a foreign program (index 1), so neither is indexed at top level.
+        let account_keys = create_account_keys_with_program(TEST_PROGRAM_ID, 0);
+        let foreign_0 = create_instruction(1, vec![], "foreign_0".to_string());
+        let foreign_1 = create_instruction(1, vec![], "foreign_1".to_string());
+
+        let mut tx = create_successful_transaction(
+            "sig_two_sets".to_string(),
+            account_keys,
+            vec![foreign_0, foreign_1],
+        );
+        tx.meta.as_mut().unwrap().inner_instructions = Some(vec![
+            InnerInstructions {
+                index: 0,
+                instructions: vec![inner(0, "deposit_a", 2)],
+            },
+            InnerInstructions {
+                index: 1,
+                instructions: vec![inner(0, "deposit_b", 2)],
+            },
+        ]);
+        block.transactions.push(tx);
+
+        let result =
+            parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, never_excluded, None);
+
+        assert_eq!(result.len(), 2);
+        // Each CPI deposit is attributed to the top-level instruction it ran under.
+        assert_eq!(result[0].1.top_level_index, 0);
+        assert_eq!(result[0].2, "deposit_a");
+        assert_eq!(result[1].1.top_level_index, 1);
+        assert_eq!(result[1].2, "deposit_b");
+    }
+
+    /// Excluded inner discriminators (operator/admin) are skipped even when they belong to our program.
+    #[test]
+    fn excluded_inner_discriminator_is_skipped() {
+        let mut block = create_test_block();
+        let account_keys = create_account_keys_with_program(TEST_PROGRAM_ID, 0);
+        let top = create_instruction(1, vec![], "foreign".to_string());
+        let mut tx = create_successful_transaction("sig_excl".to_string(), account_keys, vec![top]);
+        // Discriminator 7 (ReleaseFunds) is excluded; 6 (Deposit) is indexed.
+        let release_data = bs58::encode([7u8]).into_string();
+        let deposit_data = bs58::encode([6u8]).into_string();
+        tx.meta.as_mut().unwrap().inner_instructions = Some(vec![InnerInstructions {
+            index: 0,
+            instructions: vec![
+                InnerInstruction {
+                    instruction: create_instruction(0, vec![], release_data),
+                    stack_height: Some(2),
+                },
+                InnerInstruction {
+                    instruction: create_instruction(0, vec![], deposit_data.clone()),
+                    stack_height: Some(2),
+                },
+            ],
+        }]);
+        block.transactions.push(tx);
+
+        let result = parse_block_for_program(
+            &block,
+            TEST_PROGRAM_ID,
+            mock_parser,
+            escrow_inner_discriminator_excluded,
+            None,
+        );
+
+        assert_eq!(result.len(), 1, "only the non-excluded inner is indexed");
+        assert_eq!(result[0].2, deposit_data);
+    }
+
+    /// An inner instruction referencing a meta.loadedAddresses account resolves to the loaded key.
+    #[test]
+    fn alt_loaded_addresses_resolve_inner_accounts() {
+        // Parser that records how many account keys it was handed.
+        fn count_keys_parser(
+            instruction: &CompiledInstruction,
+            account_keys: &[Pubkey],
+            _inner: &[InnerInstructions],
+            _location: InstructionLocation,
+        ) -> Result<Option<String>, ParserError> {
+            // The account index is only valid once loaded addresses are appended.
+            let idx = instruction.accounts[0] as usize;
+            Ok(account_keys.get(idx).map(|k| k.to_string()))
+        }
+
+        let mut block = create_test_block();
+        // Static keys: [0]=foreign program (top-level target), [1]=our program (CPI-only).
+        let account_keys = vec![
+            crate::test_utils::pubkey::test_pubkey(1).to_string(),
+            TEST_PROGRAM_ID.to_string(),
+        ];
+        let loaded_writable = crate::test_utils::pubkey::test_pubkey(50).to_string();
+        let loaded_readonly = crate::test_utils::pubkey::test_pubkey(60).to_string();
+
+        // Top-level targets the foreign program at index 0; filtered out.
+        let top = create_instruction(0, vec![], "top".to_string());
+        let mut tx = create_successful_transaction("sig_alt".to_string(), account_keys, vec![top]);
+        // Inner account[0] = 3 points past the 2 static keys into the readonly loaded slot (static 0,1 + writable 2 + readonly 3).
+        tx.meta.as_mut().unwrap().inner_instructions = Some(vec![InnerInstructions {
+            index: 0,
+            instructions: vec![InnerInstruction {
+                instruction: CompiledInstruction {
+                    program_id_index: 1, // our program (CPI'd)
+                    accounts: vec![3],
+                    data: "inner".to_string(),
+                },
+                stack_height: Some(2),
+            }],
+        }]);
+        tx.meta.as_mut().unwrap().loaded_addresses = Some(UiLoadedAddresses {
+            writable: vec![loaded_writable.clone()],
+            readonly: vec![loaded_readonly.clone()],
+        });
+        block.transactions.push(tx);
+
+        let result = parse_block_for_program(
+            &block,
+            TEST_PROGRAM_ID,
+            count_keys_parser,
+            never_excluded,
+            None,
+        );
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].2, loaded_readonly,
+            "inner account index resolved into the readonly loaded addresses"
+        );
+    }
+
+    /// A CPI to our ALT-loaded program (program_id_index past the static keys) is still resolved by the inner filter.
+    #[test]
+    fn inner_filter_resolves_alt_loaded_program_id() {
+        let mut block = create_test_block();
+        // One static key: a foreign program targeted by the top-level instruction.
+        let account_keys = vec![crate::test_utils::pubkey::test_pubkey(1).to_string()];
+        let top = create_instruction(0, vec![], "foreign".to_string());
+        let mut tx =
+            create_successful_transaction("sig_alt_prog".to_string(), account_keys, vec![top]);
+
+        // Our program is ALT-loaded (writable slot), so its full-list index is 1 (static 0 + writable 1).
+        tx.meta.as_mut().unwrap().loaded_addresses = Some(UiLoadedAddresses {
+            writable: vec![TEST_PROGRAM_ID.to_string()],
+            readonly: vec![],
+        });
+        tx.meta.as_mut().unwrap().inner_instructions = Some(vec![InnerInstructions {
+            index: 0,
+            instructions: vec![InnerInstruction {
+                instruction: CompiledInstruction {
+                    program_id_index: 1, // points into loaded addresses
+                    accounts: vec![],
+                    data: "cpi".to_string(),
+                },
+                stack_height: Some(2),
+            }],
+        }]);
+        block.transactions.push(tx);
+
+        let result =
+            parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, never_excluded, None);
+
+        assert_eq!(
+            result.len(),
+            1,
+            "a CPI to our ALT-loaded program must still be indexed"
+        );
+        assert_eq!(result[0].1.inner.unwrap().inner_index, 0);
+    }
+
+    /// A top-level instruction whose program id is ALT-loaded (program_id_index
+    /// past the static keys) must still be indexed, not dropped.
+    #[test]
+    fn top_level_resolves_alt_loaded_program_id() {
+        let mut block = create_test_block();
+        // One static key: an unrelated account. Our program is not static.
+        let account_keys = vec![crate::test_utils::pubkey::test_pubkey(1).to_string()];
+        // Top-level instruction targets program_id_index 1, which lands in the
+        // loaded (writable) slot holding our program.
+        let top = create_instruction(1, vec![], "top_alt".to_string());
+        let mut tx =
+            create_successful_transaction("sig_top_alt".to_string(), account_keys, vec![top]);
+        tx.meta.as_mut().unwrap().loaded_addresses = Some(UiLoadedAddresses {
+            writable: vec![TEST_PROGRAM_ID.to_string()],
+            readonly: vec![],
+        });
+        block.transactions.push(tx);
+
+        let result =
+            parse_block_for_program(&block, TEST_PROGRAM_ID, mock_parser, never_excluded, None);
+
+        assert_eq!(
+            result.len(),
+            1,
+            "a top-level call to our ALT-loaded program must still be indexed"
+        );
+        assert_eq!(result[0].1.top_level_index, 0);
+        assert!(
+            result[0].1.inner.is_none(),
+            "must be recorded as a top-level instruction"
+        );
+    }
+
+    // ============================================================================
+    // Real escrow parser end-to-end (parse_block, not the mock parser)
+    // ============================================================================
+
+    /// Read the DepositEvent amount out of a parsed escrow Deposit row.
+    fn deposit_amount(meta: &InstructionWithMetadata) -> u64 {
+        match &meta.instruction {
+            ProgramInstruction::Escrow(ix) => match ix.as_ref() {
+                EscrowInstruction::Deposit { event, .. } => event.amount,
+                _ => panic!("expected a Deposit instruction"),
+            },
+            _ => panic!("expected an Escrow instruction"),
+        }
+    }
+
+    /// `parse_block` over the real escrow parser: two CPI deposits sharing one
+    /// transaction each resolve their *own* DepositEvent amount by stack height,
+    /// landing as two rows with distinct inner indices. The instruction (borsh)
+    /// amount is left at the default 1000 so the asserted amounts can only come
+    /// from the scoped event, proving the scoping reads the right event.
+    #[test]
+    fn real_parser_scopes_two_cpi_deposits_by_stack_height() {
+        use crate::test_utils::escrow_fixtures::{deposit_event_bytes, deposit_ix_bytes};
+
+        // Escrow program at key index 0; indices 1..12 fill the deposits' accounts.
+        let mut account_keys: Vec<String> = (0u8..12)
+            .map(|i| crate::test_utils::pubkey::test_pubkey(i).to_string())
+            .collect();
+        account_keys[0] = PRIVATE_CHANNEL_ESCROW_PROGRAM_ID.to_string();
+
+        // One foreign top-level instruction (program index 1) that CPIs two deposits.
+        let top = create_instruction(1, vec![], "foreign".to_string());
+        let mut tx =
+            create_successful_transaction("sig_cpi_real".to_string(), account_keys, vec![top]);
+
+        let deposit = || InnerInstruction {
+            instruction: CompiledInstruction {
+                program_id_index: 0, // escrow
+                accounts: (0u8..12).collect(),
+                data: bs58::encode(deposit_ix_bytes(1000, None)).into_string(),
+            },
+            stack_height: Some(2),
+        };
+        let event = |amount: u64| InnerInstruction {
+            instruction: CompiledInstruction {
+                program_id_index: 0, // escrow
+                accounts: vec![],
+                data: bs58::encode(deposit_event_bytes(amount)).into_string(),
+            },
+            stack_height: Some(3),
+        };
+
+        // Pre-order CPI walk under top-level index 0:
+        //   [0] deposit A   height 2
+        //   [1]   event 300 height 3   (A's subtree)
+        //   [2] deposit B   height 2
+        //   [3]   event 480 height 3   (B's subtree)
+        tx.meta.as_mut().unwrap().inner_instructions = Some(vec![InnerInstructions {
+            index: 0,
+            instructions: vec![deposit(), event(300), deposit(), event(480)],
+        }]);
+
+        let mut block = create_test_block();
+        block.transactions.push(tx);
+
+        let result = parse_block(&block, 7, ProgramType::Escrow, None);
+
+        assert_eq!(
+            result.len(),
+            2,
+            "two CPI deposits indexed; the event self-CPIs are not counted as rows"
+        );
+        assert_eq!(result[0].inner_index, Some(0));
+        assert_eq!(
+            deposit_amount(&result[0]),
+            300,
+            "deposit A reads its own event amount"
+        );
+        assert_eq!(result[1].inner_index, Some(2));
+        assert_eq!(
+            deposit_amount(&result[1]),
+            480,
+            "deposit B reads its own event amount, not A's"
+        );
+    }
+
+    /// `parse_block` over the real escrow parser: a top-level deposit whose escrow
+    /// program id is ALT-loaded is still parsed, resolves its event, and is
+    /// recorded with a NULL inner index.
+    #[test]
+    fn real_parser_top_level_deposit_with_alt_loaded_program() {
+        use crate::test_utils::escrow_fixtures::{deposit_event_bytes, deposit_ix_bytes};
+
+        // 12 static keys, none of which is escrow; escrow arrives via a lookup table.
+        let account_keys: Vec<String> = (0u8..12)
+            .map(|i| crate::test_utils::pubkey::test_pubkey(i).to_string())
+            .collect();
+
+        // Top-level deposit targets program index 12: the first loaded (writable) key.
+        let top = create_instruction(
+            12,
+            (0u8..12).collect(),
+            bs58::encode(deposit_ix_bytes(1000, None)).into_string(),
+        );
+        let mut tx =
+            create_successful_transaction("sig_top_lut_real".to_string(), account_keys, vec![top]);
+        tx.meta.as_mut().unwrap().loaded_addresses = Some(UiLoadedAddresses {
+            writable: vec![PRIVATE_CHANNEL_ESCROW_PROGRAM_ID.to_string()],
+            readonly: vec![],
+        });
+        // The deposit's event self-CPI, emitted by the ALT-loaded escrow program.
+        tx.meta.as_mut().unwrap().inner_instructions = Some(vec![InnerInstructions {
+            index: 0,
+            instructions: vec![InnerInstruction {
+                instruction: CompiledInstruction {
+                    program_id_index: 12, // escrow via ALT
+                    accounts: vec![],
+                    data: bs58::encode(deposit_event_bytes(555)).into_string(),
+                },
+                stack_height: Some(2),
+            }],
+        }]);
+
+        let mut block = create_test_block();
+        block.transactions.push(tx);
+
+        let result = parse_block(&block, 7, ProgramType::Escrow, None);
+
+        assert_eq!(
+            result.len(),
+            1,
+            "top-level ALT-loaded deposit must be indexed"
+        );
+        assert_eq!(result[0].instruction_index, 0);
+        assert!(
+            result[0].inner_index.is_none(),
+            "a top-level deposit has a NULL inner_index"
+        );
+        assert_eq!(deposit_amount(&result[0]), 555);
     }
 }

--- a/indexer/src/indexer/datasource/rpc_polling/decoder.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/decoder.rs
@@ -985,8 +985,7 @@ mod tests {
 
         // Top-level targets the foreign router (index 1); it is not indexed.
         let top = create_instruction(1, vec![], "router".to_string());
-        let mut tx =
-            create_successful_transaction("sig_deep".to_string(), account_keys, vec![top]);
+        let mut tx = create_successful_transaction("sig_deep".to_string(), account_keys, vec![top]);
 
         let foreign = |h: u32| InnerInstruction {
             instruction: create_instruction(1, vec![], "foreign".to_string()),
@@ -1040,7 +1039,11 @@ mod tests {
         let result = parse_block(&block, 9, ProgramType::Escrow, None);
 
         // Only the three deposits surface (events parse to Ok(None); foreign skipped).
-        assert_eq!(result.len(), 3, "three escrow deposits across mixed CPI depths");
+        assert_eq!(
+            result.len(),
+            3,
+            "three escrow deposits across mixed CPI depths"
+        );
 
         // Each deposit keeps its flat position as inner_index and reads its own event.
         let got: Vec<(u32, Option<u32>, u64)> = result

--- a/indexer/src/indexer/datasource/rpc_polling/decoder.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/decoder.rs
@@ -966,4 +966,105 @@ mod tests {
         );
         assert_eq!(deposit_amount(&result[0]), 555);
     }
+
+    /// End-to-end depth guarantee: a transaction whose flattened inner list mixes
+    /// escrow deposits at 1, 2, and 4 CPI hops deep (with intermediate foreign
+    /// CPIs and self-CPI events between them) is indexed so that every deposit
+    /// gets a UNIQUE `inner_index` (its flat position) and reads its OWN event.
+    /// A one-level-only scheme or mis-scoped subtree walk would drop deposits,
+    /// collide indices, or cross amounts — all caught here.
+    #[test]
+    fn real_parser_indexes_mixed_depth_cpi_deposits_uniquely() {
+        use crate::test_utils::escrow_fixtures::{deposit_event_bytes, deposit_ix_bytes};
+
+        // escrow at key index 0; index 1 is a foreign program; 2..12 pad accounts.
+        let mut account_keys: Vec<String> = (0u8..12)
+            .map(|i| crate::test_utils::pubkey::test_pubkey(i).to_string())
+            .collect();
+        account_keys[0] = PRIVATE_CHANNEL_ESCROW_PROGRAM_ID.to_string();
+
+        // Top-level targets the foreign router (index 1); it is not indexed.
+        let top = create_instruction(1, vec![], "router".to_string());
+        let mut tx =
+            create_successful_transaction("sig_deep".to_string(), account_keys, vec![top]);
+
+        let foreign = |h: u32| InnerInstruction {
+            instruction: create_instruction(1, vec![], "foreign".to_string()),
+            stack_height: Some(h),
+        };
+        let deposit = |h: u32| InnerInstruction {
+            instruction: CompiledInstruction {
+                program_id_index: 0, // escrow
+                accounts: (0u8..12).collect(),
+                data: bs58::encode(deposit_ix_bytes(1000, None)).into_string(),
+            },
+            stack_height: Some(h),
+        };
+        let event = |amount: u64, h: u32| InnerInstruction {
+            instruction: CompiledInstruction {
+                program_id_index: 0, // escrow (its self-CPI event)
+                accounts: vec![],
+                data: bs58::encode(deposit_event_bytes(amount)).into_string(),
+            },
+            stack_height: Some(h),
+        };
+
+        // Pre-order flatten of the CPI tree under top-level 0 (height = depth):
+        //   [0] foreign A      h2
+        //   [1] deposit D1     h3   (2 hops)  -> event 111
+        //   [2]   event 111    h4
+        //   [3] foreign C      h3
+        //   [4]   foreign C2   h4
+        //   [5]   deposit D2   h5   (4 hops)  -> event 222
+        //   [6]     event 222  h6
+        //   [7] deposit D3     h2   (1 hop)   -> event 333
+        //   [8]   event 333    h3
+        tx.meta.as_mut().unwrap().inner_instructions = Some(vec![InnerInstructions {
+            index: 0,
+            instructions: vec![
+                foreign(2),
+                deposit(3),
+                event(111, 4),
+                foreign(3),
+                foreign(4),
+                deposit(5),
+                event(222, 6),
+                deposit(2),
+                event(333, 3),
+            ],
+        }]);
+
+        let mut block = create_test_block();
+        block.transactions.push(tx);
+
+        let result = parse_block(&block, 9, ProgramType::Escrow, None);
+
+        // Only the three deposits surface (events parse to Ok(None); foreign skipped).
+        assert_eq!(result.len(), 3, "three escrow deposits across mixed CPI depths");
+
+        // Each deposit keeps its flat position as inner_index and reads its own event.
+        let got: Vec<(u32, Option<u32>, u64)> = result
+            .iter()
+            .map(|m| (m.instruction_index, m.inner_index, deposit_amount(m)))
+            .collect();
+        assert_eq!(
+            got,
+            vec![(0, Some(1), 111), (0, Some(5), 222), (0, Some(7), 333)],
+            "depth 2/4/1 deposits: unique flat inner_index, each reads its own event"
+        );
+
+        // The core guarantee: (instruction_index, inner_index) is unique at every depth.
+        let mut ids: Vec<(u32, Option<u32>)> = result
+            .iter()
+            .map(|m| (m.instruction_index, m.inner_index))
+            .collect();
+        let total = ids.len();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(
+            ids.len(),
+            total,
+            "(instruction_index, inner_index) must be unique regardless of CPI depth"
+        );
+    }
 }

--- a/indexer/src/indexer/datasource/rpc_polling/types.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/types.rs
@@ -36,10 +36,22 @@ pub struct TransactionMeta {
     pub log_messages: Option<Vec<String>>,
     #[serde(rename = "innerInstructions")]
     pub inner_instructions: Option<Vec<InnerInstructions>>,
+    /// ALT keys for a v0 transaction, appended after the static keys (writable then readonly) to rebuild the full account list.
+    #[serde(rename = "loadedAddresses")]
+    pub loaded_addresses: Option<solana_transaction_status::UiLoadedAddresses>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct InnerInstructions {
     pub index: u8,
-    pub instructions: Vec<CompiledInstruction>,
+    pub instructions: Vec<InnerInstruction>,
+}
+
+/// A single inner (CPI) instruction; `stack_height` is its CPI depth, used to match a deposit to the event it emitted.
+#[derive(Debug, Deserialize, Clone)]
+pub struct InnerInstruction {
+    #[serde(flatten)]
+    pub instruction: CompiledInstruction,
+    #[serde(rename = "stackHeight")]
+    pub stack_height: Option<u32>,
 }

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -9,9 +9,7 @@ use solana_sdk::pubkey::Pubkey;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
-#[cfg(feature = "datasource-rpc")]
-use tracing::warn;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use yellowstone_grpc_client::{ClientTlsConfig, GeyserGrpcClient};
 use yellowstone_grpc_proto::geyser::{
     subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
@@ -1111,12 +1109,19 @@ async fn handle_transaction(
             .collect();
 
         // Order matters: writable then readonly, matching execution order.
-        loaded_pubkeys = meta
+        loaded_pubkeys = match meta
             .loaded_writable_addresses
             .iter()
             .chain(meta.loaded_readonly_addresses.iter())
-            .filter_map(|bytes| Pubkey::try_from(bytes.as_slice()).ok())
-            .collect();
+            .map(|bytes| Pubkey::try_from(bytes.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!("Skipping transaction at slot {slot}: invalid loaded address: {e}");
+                return Ok(());
+            }
+        };
     }
 
     // Extract signature

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -24,7 +24,7 @@ use crate::error::{DataSourceError, DataSourceRpcError};
 use crate::indexer::datasource::common::parser::escrow::parse_escrow_instruction;
 use crate::indexer::datasource::common::parser::withdraw::parse_withdraw_instruction;
 use crate::indexer::datasource::common::{datasource::DataSource, types::*};
-use crate::indexer::datasource::rpc_polling::types::InnerInstructions;
+use crate::indexer::datasource::rpc_polling::types::{InnerInstruction, InnerInstructions};
 use crate::storage::Storage;
 
 #[cfg(feature = "datasource-rpc")]
@@ -804,6 +804,270 @@ mod tests {
             err_str
         );
     }
+
+    /// A CPI-only withdraw surfaces as a row carrying the parent's top-level index and the inner position.
+    #[tokio::test]
+    async fn handle_transaction_emits_inner_cpi_withdraw() {
+        use std::str::FromStr;
+        use yellowstone_grpc_proto::prelude as proto;
+
+        let program_id = Pubkey::from_str("J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi").unwrap();
+        let signature = vec![9u8; 64];
+
+        // Top-level targets a foreign program (account index 0); the withdraw program at WITHDRAW_PROGRAM_KEY_INDEX is CPI-only.
+        let mut tx_update =
+            withdraw_tx_update_with_program_indices(signature.clone(), &program_id, &[0]);
+
+        let inner = proto::InnerInstruction {
+            program_id_index: WITHDRAW_PROGRAM_KEY_INDEX,
+            accounts: vec![0, 1, 2, 3, 4],
+            data: withdraw_funds_proto_data(),
+            stack_height: Some(2),
+        };
+        let inner_set = proto::InnerInstructions {
+            index: 0,
+            instructions: vec![inner],
+        };
+        tx_update.transaction.as_mut().unwrap().meta = Some(proto::TransactionStatusMeta {
+            inner_instructions: vec![inner_set],
+            ..Default::default()
+        });
+
+        let (tx, mut rx) = mpsc::channel(8);
+        handle_transaction(tx_update, &program_id, ProgramType::Withdraw, &tx)
+            .await
+            .unwrap();
+        drop(tx);
+
+        let mut metas = vec![];
+        while let Some(ProcessorMessage::Instruction(meta)) = rx.recv().await {
+            metas.push(meta);
+        }
+
+        assert_eq!(metas.len(), 1, "the inner CPI withdraw must surface");
+        assert_eq!(metas[0].instruction_index, 0, "parent top-level index");
+        assert_eq!(metas[0].inner_index, Some(0), "inner position");
+    }
+
+    // ============================================================================
+    // Escrow CPI deposit parsing (real parser, loaded-address resolution)
+    // ============================================================================
+
+    /// Build an escrow `SubscribeUpdateTransaction`. `account_keys` are static
+    /// message keys (raw 32-byte); instruction `data` is raw (the handler base58-
+    /// encodes); `loaded_writable`/`loaded_readonly` become the meta's ALT keys.
+    fn escrow_tx_update(
+        signature: Vec<u8>,
+        account_keys: Vec<Vec<u8>>,
+        top_level: Vec<yellowstone_grpc_proto::prelude::CompiledInstruction>,
+        inner_instructions: Vec<yellowstone_grpc_proto::prelude::InnerInstructions>,
+        loaded_writable: Vec<Vec<u8>>,
+        loaded_readonly: Vec<Vec<u8>>,
+    ) -> yellowstone_grpc_proto::geyser::SubscribeUpdateTransaction {
+        use yellowstone_grpc_proto::prelude as proto;
+        let message = proto::Message {
+            header: Some(proto::MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
+            }),
+            account_keys,
+            recent_blockhash: vec![0u8; 32],
+            instructions: top_level,
+            versioned: true,
+            address_table_lookups: vec![],
+        };
+        yellowstone_grpc_proto::geyser::SubscribeUpdateTransaction {
+            slot: 7,
+            transaction: Some(proto::SubscribeUpdateTransactionInfo {
+                signature,
+                is_vote: false,
+                transaction: Some(proto::Transaction {
+                    signatures: vec![signature_placeholder()],
+                    message: Some(message),
+                }),
+                meta: Some(proto::TransactionStatusMeta {
+                    inner_instructions,
+                    loaded_writable_addresses: loaded_writable,
+                    loaded_readonly_addresses: loaded_readonly,
+                    ..Default::default()
+                }),
+                index: 0,
+            }),
+        }
+    }
+
+    fn escrow_pubkey() -> Pubkey {
+        use std::str::FromStr;
+        Pubkey::from_str(
+            crate::indexer::datasource::common::parser::escrow::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,
+        )
+        .unwrap()
+    }
+
+    /// DepositEvent amount carried by a parsed escrow Deposit row.
+    fn escrow_deposit_amount(meta: &InstructionWithMetadata) -> u64 {
+        use crate::indexer::datasource::common::parser::EscrowInstruction;
+        match &meta.instruction {
+            ProgramInstruction::Escrow(ix) => match ix.as_ref() {
+                EscrowInstruction::Deposit { event, .. } => event.amount,
+                _ => panic!("expected a Deposit instruction"),
+            },
+            _ => panic!("expected an Escrow instruction"),
+        }
+    }
+
+    /// Two CPI escrow deposits sharing one transaction each resolve their own
+    /// DepositEvent amount by stack height (proto `stack_height` is threaded
+    /// through), landing as two rows with distinct inner indices. The borsh
+    /// amount stays at the default so the asserted amounts can only come from the
+    /// scoped event.
+    #[tokio::test]
+    async fn handle_transaction_scopes_two_cpi_escrow_deposits_by_stack_height() {
+        use crate::test_utils::escrow_fixtures::{deposit_event_bytes, deposit_ix_bytes};
+        use yellowstone_grpc_proto::prelude as proto;
+
+        let escrow = escrow_pubkey();
+        // Escrow at static key index 0; indices 1..12 fill the deposits' accounts.
+        let mut account_keys: Vec<Vec<u8>> = (0u8..12)
+            .map(|i| {
+                let mut b = [0u8; 32];
+                b[0] = i + 1;
+                b.to_vec()
+            })
+            .collect();
+        account_keys[0] = escrow.to_bytes().to_vec();
+
+        // One foreign top-level instruction (index 1) that CPIs the two deposits.
+        let top = vec![proto::CompiledInstruction {
+            program_id_index: 1,
+            accounts: vec![],
+            data: vec![],
+        }];
+
+        let deposit = || proto::InnerInstruction {
+            program_id_index: 0,
+            accounts: (0u8..12).collect(),
+            data: deposit_ix_bytes(1000, None),
+            stack_height: Some(2),
+        };
+        let event = |amount: u64| proto::InnerInstruction {
+            program_id_index: 0,
+            accounts: vec![],
+            data: deposit_event_bytes(amount),
+            stack_height: Some(3),
+        };
+        // Pre-order walk: [0] deposit A h2, [1] event 300 h3, [2] deposit B h2, [3] event 480 h3.
+        let inner_set = vec![proto::InnerInstructions {
+            index: 0,
+            instructions: vec![deposit(), event(300), deposit(), event(480)],
+        }];
+
+        let tx_update =
+            escrow_tx_update(vec![9u8; 64], account_keys, top, inner_set, vec![], vec![]);
+
+        let (tx, mut rx) = mpsc::channel(8);
+        handle_transaction(tx_update, &escrow, ProgramType::Escrow, &tx)
+            .await
+            .unwrap();
+        drop(tx);
+
+        let mut metas = vec![];
+        while let Some(ProcessorMessage::Instruction(m)) = rx.recv().await {
+            metas.push(m);
+        }
+
+        assert_eq!(
+            metas.len(),
+            2,
+            "two CPI deposits; the event self-CPIs are not counted as rows"
+        );
+        assert_eq!(metas[0].inner_index, Some(0));
+        assert_eq!(
+            escrow_deposit_amount(&metas[0]),
+            300,
+            "deposit A reads its own event"
+        );
+        assert_eq!(metas[1].inner_index, Some(2));
+        assert_eq!(
+            escrow_deposit_amount(&metas[1]),
+            480,
+            "deposit B reads its own event, not A's"
+        );
+    }
+
+    /// A top-level escrow deposit whose program id is ALT-loaded is still parsed.
+    /// Escrow is the readonly loaded key behind one writable loaded key, so it
+    /// only resolves if loaded keys are appended writable-then-readonly after the
+    /// static keys (its full-list index is 13, not 12).
+    #[tokio::test]
+    async fn handle_transaction_resolves_alt_loaded_escrow_program() {
+        use crate::test_utils::escrow_fixtures::{deposit_event_bytes, deposit_ix_bytes};
+        use yellowstone_grpc_proto::prelude as proto;
+
+        let escrow = escrow_pubkey();
+        // 12 static keys (0..11), none is escrow.
+        let account_keys: Vec<Vec<u8>> = (0u8..12)
+            .map(|i| {
+                let mut b = [0u8; 32];
+                b[0] = i + 1;
+                b.to_vec()
+            })
+            .collect();
+        let dummy_writable = {
+            let mut b = [0u8; 32];
+            b[0] = 200;
+            b.to_vec()
+        };
+
+        // Top-level deposit + its event target index 13: static 0..11, writable 12, readonly 13 (escrow).
+        let top = vec![proto::CompiledInstruction {
+            program_id_index: 13,
+            accounts: (0u8..12).collect(),
+            data: deposit_ix_bytes(1000, None),
+        }];
+        let inner_set = vec![proto::InnerInstructions {
+            index: 0,
+            instructions: vec![proto::InnerInstruction {
+                program_id_index: 13,
+                accounts: vec![],
+                data: deposit_event_bytes(555),
+                stack_height: Some(2),
+            }],
+        }];
+
+        let tx_update = escrow_tx_update(
+            vec![10u8; 64],
+            account_keys,
+            top,
+            inner_set,
+            vec![dummy_writable],
+            vec![escrow.to_bytes().to_vec()],
+        );
+
+        let (tx, mut rx) = mpsc::channel(8);
+        handle_transaction(tx_update, &escrow, ProgramType::Escrow, &tx)
+            .await
+            .unwrap();
+        drop(tx);
+
+        let mut metas = vec![];
+        while let Some(ProcessorMessage::Instruction(m)) = rx.recv().await {
+            metas.push(m);
+        }
+
+        assert_eq!(
+            metas.len(),
+            1,
+            "top-level ALT-loaded escrow deposit must be indexed"
+        );
+        assert_eq!(metas[0].instruction_index, 0);
+        assert!(
+            metas[0].inner_index.is_none(),
+            "a top-level deposit has a NULL inner_index"
+        );
+        assert_eq!(escrow_deposit_amount(&metas[0]), 555);
+    }
 }
 
 async fn handle_transaction(
@@ -821,6 +1085,9 @@ async fn handle_transaction(
         })?;
 
     let mut inner_instructions_vec: Vec<InnerInstructions> = vec![];
+    // ALT-resolved keys live on meta, not the message; capture them here to
+    // append below so inner and v0 top-level account indices resolve (no RPC).
+    let mut loaded_pubkeys: Vec<Pubkey> = vec![];
 
     if let Some(meta) = &tx_info.meta {
         inner_instructions_vec = meta
@@ -831,13 +1098,24 @@ async fn handle_transaction(
                 instructions: ix_set
                     .instructions
                     .iter()
-                    .map(|ix| CompiledInstruction {
-                        program_id_index: ix.program_id_index as u8,
-                        accounts: ix.accounts.clone(),
-                        data: bs58::encode(&ix.data).into_string(),
+                    .map(|ix| InnerInstruction {
+                        instruction: CompiledInstruction {
+                            program_id_index: ix.program_id_index as u8,
+                            accounts: ix.accounts.clone(),
+                            data: bs58::encode(&ix.data).into_string(),
+                        },
+                        stack_height: ix.stack_height,
                     })
                     .collect(),
             })
+            .collect();
+
+        // Order matters: writable then readonly, matching execution order.
+        loaded_pubkeys = meta
+            .loaded_writable_addresses
+            .iter()
+            .chain(meta.loaded_readonly_addresses.iter())
+            .filter_map(|bytes| Pubkey::try_from(bytes.as_slice()).ok())
             .collect();
     }
 
@@ -861,13 +1139,17 @@ async fn handle_transaction(
         })?;
 
     // Get account keys and instructions
-    let (account_keys, instructions): (
+    let (static_keys, instructions): (
         Vec<Pubkey>,
         Vec<solana_sdk::message::compiled_instruction::CompiledInstruction>,
     ) = match &versioned_message {
         VersionedMessage::Legacy(msg) => (msg.account_keys.clone(), msg.instructions.clone()),
         VersionedMessage::V0(msg) => (msg.account_keys.clone(), msg.instructions.clone()),
     };
+
+    // Full account list (static message keys, then loaded writable, then readonly) that inner and v0 top-level account indices reference.
+    let mut account_keys = static_keys;
+    account_keys.extend(loaded_pubkeys);
 
     info!(
         "Yellowstone received transaction at slot {}, signature: {}, {} instructions",
@@ -876,7 +1158,7 @@ async fn handle_transaction(
         instructions.len()
     );
 
-    // Parse each instruction that belongs to our program
+    // Parse each top-level instruction that belongs to our program.
     for (ix_index, instruction) in instructions.into_iter().enumerate() {
         let program_id_index = instruction.program_id_index as usize;
         if program_id_index >= account_keys.len() {
@@ -887,85 +1169,161 @@ async fn handle_transaction(
             continue;
         }
 
-        let ix_program_id = account_keys[program_id_index];
-        if ix_program_id != *program_id {
+        if account_keys[program_id_index] != *program_id {
             continue; // Not our program
         }
 
-        // Convert to our CompiledInstruction type (from types.rs)
         let compiled_ix = CompiledInstruction {
             program_id_index: instruction.program_id_index,
             accounts: instruction.accounts.clone(),
             data: bs58::encode(&instruction.data).into_string(),
         };
+        let location = InstructionLocation::top_level(ix_index as u32);
 
-        // Parse instruction based on program type and handle immediately to avoid Send issues
-        let instruction_data = match program_type {
-            ProgramType::Escrow => {
-                match parse_escrow_instruction(&compiled_ix, &account_keys, &inner_instructions_vec)
-                {
-                    Ok(Some(inst)) => Some(ProgramInstruction::Escrow(Box::new(inst))),
-                    Ok(None) => {
-                        debug!(
-                            "Yellowstone: Unsupported escrow instruction at slot {}",
-                            slot
-                        );
-                        None
-                    }
-                    Err(e) => {
-                        error!("Failed to parse escrow instruction at slot {}: {}", slot, e);
-                        None
-                    }
-                }
-            }
-            ProgramType::Withdraw => {
-                match parse_withdraw_instruction(
-                    &compiled_ix,
-                    &account_keys,
-                    &inner_instructions_vec,
-                ) {
-                    Ok(Some(inst)) => Some(ProgramInstruction::Withdraw(Box::new(inst))),
-                    Ok(None) => {
-                        debug!(
-                            "Yellowstone: Unsupported withdraw instruction at slot {}",
-                            slot
-                        );
-                        None
-                    }
-                    Err(e) => {
-                        error!(
-                            "Failed to parse withdraw instruction at slot {}: {}",
-                            slot, e
-                        );
-                        None
-                    }
-                }
-            }
-        };
+        parse_and_send(
+            &compiled_ix,
+            &account_keys,
+            &inner_instructions_vec,
+            location,
+            program_type,
+            slot,
+            &signature,
+            channel,
+        )
+        .await?;
+    }
 
-        if let Some(instruction_data) = instruction_data {
-            let instruction_meta = InstructionWithMetadata {
-                instruction: instruction_data,
-                slot,
-                program_type,
-                signature: Some(signature.clone()),
-                // A Solana tx is packet-size-bounded to a few hundred instructions,
-                // far below u32/i32 max, so this cast cannot wrap.
-                instruction_index: ix_index as u32,
+    // Parse our program's inner (CPI) instructions, skipping the excluded operator/admin escrow discriminators.
+    for inner_set in &inner_instructions_vec {
+        for (inner_ix_index, inner) in inner_set.instructions.iter().enumerate() {
+            let program_id_index = inner.instruction.program_id_index as usize;
+            if account_keys.get(program_id_index) != Some(program_id) {
+                continue; // Not our program
+            }
+            if inner_discriminator_excluded(program_type, &inner.instruction) {
+                continue;
+            }
+
+            let location = InstructionLocation {
+                top_level_index: inner_set.index as u32,
+                inner: Some(InnerLocation {
+                    inner_index: inner_ix_index as u32,
+                    stack_height: inner.stack_height,
+                }),
             };
 
-            let res = send_guaranteed(
+            parse_and_send(
+                &inner.instruction,
+                &account_keys,
+                &inner_instructions_vec,
+                location,
+                program_type,
+                slot,
+                &signature,
                 channel,
-                ProcessorMessage::Instruction(instruction_meta),
-                "instruction (yellowstone)",
             )
-            .await;
-            if let Err(e) = res {
-                return Err(DataSourceRpcError::Protocol {
-                    reason: format!("Instruction send failed: {}", e),
-                });
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Whether an inner (CPI) instruction's discriminator is one the indexer skips,
+/// via the per-program predicate. Decodes the leading byte; an empty/undecodable
+/// payload is never excluded (it parses to `Ok(None)` downstream).
+fn inner_discriminator_excluded(
+    program_type: ProgramType,
+    instruction: &CompiledInstruction,
+) -> bool {
+    let Some(discriminator) = bs58::decode(&instruction.data)
+        .into_vec()
+        .ok()
+        .and_then(|d| d.first().copied())
+    else {
+        return false;
+    };
+    match program_type {
+        ProgramType::Escrow => {
+            crate::indexer::datasource::common::parser::escrow::escrow_inner_discriminator_excluded(
+                discriminator,
+            )
+        }
+        ProgramType::Withdraw => {
+            crate::indexer::datasource::common::parser::withdraw::withdraw_inner_discriminator_excluded(
+                discriminator,
+            )
+        }
+    }
+}
+
+/// Parse one compiled instruction and forward it on the processor channel; shared by the top-level and inner (CPI) paths so both produce identical rows.
+#[allow(clippy::too_many_arguments)]
+async fn parse_and_send(
+    compiled_ix: &CompiledInstruction,
+    account_keys: &[Pubkey],
+    inner_instructions: &[InnerInstructions],
+    location: InstructionLocation,
+    program_type: ProgramType,
+    slot: u64,
+    signature: &str,
+    channel: &InstructionSender,
+) -> Result<(), DataSourceRpcError> {
+    let instruction_data = match program_type {
+        ProgramType::Escrow => {
+            match parse_escrow_instruction(compiled_ix, account_keys, inner_instructions, location)
+            {
+                Ok(Some(inst)) => Some(ProgramInstruction::Escrow(Box::new(inst))),
+                Ok(None) => {
+                    debug!("Yellowstone: Unsupported escrow instruction at slot {slot}");
+                    None
+                }
+                Err(e) => {
+                    error!("Failed to parse escrow instruction at slot {slot}: {e}");
+                    None
+                }
             }
         }
+        ProgramType::Withdraw => {
+            match parse_withdraw_instruction(
+                compiled_ix,
+                account_keys,
+                inner_instructions,
+                location,
+            ) {
+                Ok(Some(inst)) => Some(ProgramInstruction::Withdraw(Box::new(inst))),
+                Ok(None) => {
+                    debug!("Yellowstone: Unsupported withdraw instruction at slot {slot}");
+                    None
+                }
+                Err(e) => {
+                    error!("Failed to parse withdraw instruction at slot {slot}: {e}");
+                    None
+                }
+            }
+        }
+    };
+
+    if let Some(instruction_data) = instruction_data {
+        let instruction_meta = InstructionWithMetadata {
+            instruction: instruction_data,
+            slot,
+            program_type,
+            signature: Some(signature.to_string()),
+            // A Solana tx holds at most a few hundred instructions, far below u32/i32 max, so this cast cannot wrap.
+            instruction_index: location.top_level_index,
+            inner_index: location.inner.map(|i| i.inner_index),
+        };
+
+        send_guaranteed(
+            channel,
+            ProcessorMessage::Instruction(instruction_meta),
+            "instruction (yellowstone)",
+        )
+        .await
+        .map_err(|e| DataSourceRpcError::Protocol {
+            reason: format!("Instruction send failed: {e}"),
+        })?;
     }
 
     Ok(())

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -370,6 +370,7 @@ fn convert_to_db_models(
                             .recipient(recipient)
                             .transaction_type(TransactionType::Deposit)
                             .instruction_index(instruction_meta.instruction_index as i32)
+                            .inner_index(instruction_meta.inner_index.map(|i| i as i32))
                             .build(),
                         ),
                     )
@@ -421,6 +422,7 @@ fn convert_to_db_models(
                         .recipient(recipient)
                         .transaction_type(TransactionType::Withdrawal)
                         .instruction_index(instruction_meta.instruction_index as i32)
+                        .inner_index(instruction_meta.inner_index.map(|i| i as i32))
                         .build(),
                     ),
                 )
@@ -509,6 +511,7 @@ mod tests {
             program_type: ProgramType::Escrow,
             signature: sig,
             instruction_index: 0,
+            inner_index: None,
         }
     }
 
@@ -535,6 +538,7 @@ mod tests {
             program_type: ProgramType::Escrow,
             signature: sig,
             instruction_index: 0,
+            inner_index: None,
         }
     }
 
@@ -558,6 +562,7 @@ mod tests {
             program_type: ProgramType::Escrow,
             signature: sig,
             instruction_index: 0,
+            inner_index: None,
         }
     }
 
@@ -582,6 +587,7 @@ mod tests {
             program_type: ProgramType::Withdraw,
             signature: sig,
             instruction_index: 0,
+            inner_index: None,
         }
     }
 
@@ -601,6 +607,7 @@ mod tests {
             program_type: ProgramType::Escrow,
             signature: sig,
             instruction_index: 0,
+            inner_index: None,
         }
     }
 
@@ -747,6 +754,7 @@ mod tests {
             program_type: ProgramType::Escrow,
             signature: Some("sig_exploit".to_string()),
             instruction_index: 0,
+            inner_index: None,
         };
 
         let (mint, status, txn) = convert_to_db_models(&ix, Some(&watched));
@@ -782,6 +790,7 @@ mod tests {
             program_type: ProgramType::Escrow,
             signature: Some("sig_exploit".to_string()),
             instruction_index: 0,
+            inner_index: None,
         };
 
         let (mint, status, txn) = convert_to_db_models(&ix, Some(&watched));

--- a/indexer/src/operator/fetcher.rs
+++ b/indexer/src/operator/fetcher.rs
@@ -155,6 +155,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         }
     }

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -871,6 +871,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         }
     }
@@ -2202,6 +2203,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         };
 
@@ -2309,6 +2311,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         };
 

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -1565,6 +1565,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         });
         id

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -543,6 +543,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         }
     }

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -594,6 +594,7 @@ mod tests {
                 finality_check_attempts: attempts,
                 recovery_requeue_attempts: 0,
                 instruction_index: 0,
+                inner_index: None,
                 landed_remint_signature: None,
             });
     }

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -453,6 +453,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         }
     }

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -88,10 +88,11 @@ pub struct DbTransaction {
     /// Paired with `signature` it is the row's durable identity, so multiple
     /// economic events in one transaction persist as distinct rows.
     pub instruction_index: i32,
-    /// Position within the parent's inner set when the source instruction is a
-    /// CPI; `None` (NULL) for a top-level instruction. Completes the durable
-    /// identity `(signature, instruction_index, inner_index)` so a CPI
-    /// deposit/withdraw does not collide with its parent's top-level row.
+    /// Position in the top-level ancestor's *flattened* inner-instruction list
+    /// for a CPI; `None` (NULL) for a top-level instruction. The validator
+    /// flattens every CPI depth into one list, so this is unique at any depth (not
+    /// a nesting level). Completes the `(signature, instruction_index, inner_index)`
+    /// identity so a CPI deposit/withdraw never collides with its parent's row.
     pub inner_index: Option<i32>,
     /// Confirmed remint signature, written in the same UPDATE that flips status
     /// to FailedReminted. A crash before the async writer runs can no longer

--- a/indexer/src/storage/common/models.rs
+++ b/indexer/src/storage/common/models.rs
@@ -88,6 +88,11 @@ pub struct DbTransaction {
     /// Paired with `signature` it is the row's durable identity, so multiple
     /// economic events in one transaction persist as distinct rows.
     pub instruction_index: i32,
+    /// Position within the parent's inner set when the source instruction is a
+    /// CPI; `None` (NULL) for a top-level instruction. Completes the durable
+    /// identity `(signature, instruction_index, inner_index)` so a CPI
+    /// deposit/withdraw does not collide with its parent's top-level row.
+    pub inner_index: Option<i32>,
     /// Confirmed remint signature, written in the same UPDATE that flips status
     /// to FailedReminted. A crash before the async writer runs can no longer
     /// leave a landed remint recorded only as PendingRemint (which would replay).
@@ -173,6 +178,7 @@ pub struct DbTransactionBuilder {
     transaction_type: Option<TransactionType>,
     trace_id: Option<String>,
     instruction_index: i32,
+    inner_index: Option<i32>,
 }
 
 impl DbTransactionBuilder {
@@ -188,6 +194,7 @@ impl DbTransactionBuilder {
             transaction_type: None,
             trace_id: None,
             instruction_index: 0,
+            inner_index: None,
         }
     }
 
@@ -221,6 +228,11 @@ impl DbTransactionBuilder {
         self
     }
 
+    pub fn inner_index(mut self, inner_index: Option<i32>) -> Self {
+        self.inner_index = inner_index;
+        self
+    }
+
     pub fn build(self) -> DbTransaction {
         let now = Utc::now();
         DbTransaction {
@@ -246,6 +258,7 @@ impl DbTransactionBuilder {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: self.instruction_index,
+            inner_index: self.inner_index,
             landed_remint_signature: None,
         }
     }

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -452,6 +452,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         }
     }
@@ -1269,6 +1270,7 @@ mod tests {
             finality_check_attempts: 0,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         });
     }

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -34,8 +34,16 @@ mod transaction_cols {
     pub const FINALITY_CHECK_ATTEMPTS: &str = "finality_check_attempts";
     pub const RECOVERY_REQUEUE_ATTEMPTS: &str = "recovery_requeue_attempts";
     pub const INSTRUCTION_INDEX: &str = "instruction_index";
+    pub const INNER_INDEX: &str = "inner_index";
     pub const LANDED_REMINT_SIGNATURE: &str = "landed_remint_signature";
 }
+
+/// ON CONFLICT target for the transactions composite uniqueness. inner_index is
+/// NULL for top-level rows and a unique index treats NULLs as distinct, so it is
+/// coalesced to -1 (an impossible position) to keep the triple `(signature,
+/// instruction_index, inner_index)` collision-detecting for them too. Inner rows
+/// carry a real >= 0 inner_index.
+const TX_CONFLICT_TARGET: &str = "(signature, instruction_index, COALESCE(inner_index, -1))";
 
 #[derive(Clone)]
 pub struct PostgresDb {
@@ -172,6 +180,32 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
         info!("instruction_index migration complete");
+
+        // Extend the unique identity to (signature, instruction_index, inner_index)
+        // so a CPI deposit/withdraw gets its own row. Build-before-drop: add the
+        // nullable column, build the new index (NULL inner_index coalesced to -1
+        // since unique indexes treat NULLs as distinct), then drop the old one.
+        info!("Running inner_index migration if needed...");
+        sqlx::query(
+            r#"
+            DO $$ BEGIN
+                ALTER TABLE transactions
+                ADD COLUMN IF NOT EXISTS inner_index INTEGER;
+            END $$;
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_signature_ix_inner \
+             ON transactions (signature, instruction_index, COALESCE(inner_index, -1))",
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query("DROP INDEX IF EXISTS idx_transactions_signature_ix")
+            .execute(&self.pool)
+            .await?;
+        info!("inner_index migration complete");
 
         // Create indexes for transactions
         sqlx::query("CREATE INDEX IF NOT EXISTS idx_transactions_status ON transactions (status)")
@@ -618,13 +652,16 @@ impl PostgresDb {
         transaction: &DbTransaction,
     ) -> Result<i64, sqlx::Error> {
         let existing: Option<(i64,)> = sqlx::query_as(&format!(
-            "SELECT {} FROM transactions WHERE {} = $1 AND {} = $2",
+            "SELECT {} FROM transactions WHERE {} = $1 AND {} = $2 \
+             AND COALESCE({}, -1) = COALESCE($3, -1)",
             transaction_cols::ID,
             transaction_cols::SIGNATURE,
-            transaction_cols::INSTRUCTION_INDEX
+            transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
         ))
         .bind(&transaction.signature)
         .bind(transaction.instruction_index)
+        .bind(transaction.inner_index)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -635,13 +672,14 @@ impl PostgresDb {
         let result: Option<(i64,)> = sqlx::query_as(&format!(
             r#"
             INSERT INTO transactions (
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            ON CONFLICT ({}, {}) DO NOTHING
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            ON CONFLICT {} DO NOTHING
             RETURNING {}
             "#,
             transaction_cols::SIGNATURE,
             transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
             transaction_cols::SLOT,
             transaction_cols::INITIATOR,
             transaction_cols::RECIPIENT,
@@ -651,12 +689,12 @@ impl PostgresDb {
             transaction_cols::TRANSACTION_TYPE,
             transaction_cols::STATUS,
             transaction_cols::TRACE_ID,
-            transaction_cols::SIGNATURE,
-            transaction_cols::INSTRUCTION_INDEX,
+            TX_CONFLICT_TARGET,
             transaction_cols::ID,
         ))
         .bind(&transaction.signature)
         .bind(transaction.instruction_index)
+        .bind(transaction.inner_index)
         .bind(transaction.slot)
         .bind(&transaction.initiator)
         .bind(&transaction.recipient)
@@ -675,13 +713,16 @@ impl PostgresDb {
 
         // Conflict occurred, fetch existing ID
         let (id,): (i64,) = sqlx::query_as(&format!(
-            "SELECT {} FROM transactions WHERE {} = $1 AND {} = $2",
+            "SELECT {} FROM transactions WHERE {} = $1 AND {} = $2 \
+             AND COALESCE({}, -1) = COALESCE($3, -1)",
             transaction_cols::ID,
             transaction_cols::SIGNATURE,
-            transaction_cols::INSTRUCTION_INDEX
+            transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
         ))
         .bind(&transaction.signature)
         .bind(transaction.instruction_index)
+        .bind(transaction.inner_index)
         .fetch_one(&self.pool)
         .await?;
 
@@ -704,13 +745,16 @@ impl PostgresDb {
         for transaction in transactions {
             // Check if already exists
             let existing: Option<(i64,)> = sqlx::query_as(&format!(
-                "SELECT {} FROM transactions WHERE {} = $1 AND {} = $2",
+                "SELECT {} FROM transactions WHERE {} = $1 AND {} = $2 \
+                 AND COALESCE({}, -1) = COALESCE($3, -1)",
                 transaction_cols::ID,
                 transaction_cols::SIGNATURE,
-                transaction_cols::INSTRUCTION_INDEX
+                transaction_cols::INSTRUCTION_INDEX,
+                transaction_cols::INNER_INDEX,
             ))
             .bind(&transaction.signature)
             .bind(transaction.instruction_index)
+            .bind(transaction.inner_index)
             .fetch_optional(&mut *tx)
             .await?;
 
@@ -723,13 +767,14 @@ impl PostgresDb {
             let result: Option<(i64,)> = sqlx::query_as(&format!(
                 r#"
                 INSERT INTO transactions (
-                    {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-                ON CONFLICT ({}, {}) DO NOTHING
+                    {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                ON CONFLICT {} DO NOTHING
                 RETURNING {}
                 "#,
                 transaction_cols::SIGNATURE,
                 transaction_cols::INSTRUCTION_INDEX,
+                transaction_cols::INNER_INDEX,
                 transaction_cols::SLOT,
                 transaction_cols::INITIATOR,
                 transaction_cols::RECIPIENT,
@@ -739,12 +784,12 @@ impl PostgresDb {
                 transaction_cols::TRANSACTION_TYPE,
                 transaction_cols::STATUS,
                 transaction_cols::TRACE_ID,
-                transaction_cols::SIGNATURE,
-                transaction_cols::INSTRUCTION_INDEX,
+                TX_CONFLICT_TARGET,
                 transaction_cols::ID,
             ))
             .bind(&transaction.signature)
             .bind(transaction.instruction_index)
+            .bind(transaction.inner_index)
             .bind(transaction.slot)
             .bind(&transaction.initiator)
             .bind(&transaction.recipient)
@@ -762,13 +807,16 @@ impl PostgresDb {
             } else {
                 // Conflict occurred, fetch existing ID
                 let (id,): (i64,) = sqlx::query_as(&format!(
-                    "SELECT {} FROM transactions WHERE {} = $1 AND {} = $2",
+                    "SELECT {} FROM transactions WHERE {} = $1 AND {} = $2 \
+                     AND COALESCE({}, -1) = COALESCE($3, -1)",
                     transaction_cols::ID,
                     transaction_cols::SIGNATURE,
-                    transaction_cols::INSTRUCTION_INDEX
+                    transaction_cols::INSTRUCTION_INDEX,
+                    transaction_cols::INNER_INDEX,
                 ))
                 .bind(&transaction.signature)
                 .bind(transaction.instruction_index)
+                .bind(transaction.inner_index)
                 .fetch_one(&mut *tx)
                 .await?;
                 ids.push(id);
@@ -788,7 +836,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -816,6 +864,7 @@ impl PostgresDb {
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
             transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filters
             transaction_cols::STATUS,
@@ -839,7 +888,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -866,6 +915,7 @@ impl PostgresDb {
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
             transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filters
             transaction_cols::STATUS,
@@ -889,7 +939,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1
             ORDER BY {} DESC
@@ -917,6 +967,7 @@ impl PostgresDb {
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
             transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filter
             transaction_cols::TRANSACTION_TYPE,
@@ -980,7 +1031,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = $1 AND {} = $2
             ORDER BY {} ASC
@@ -1009,6 +1060,7 @@ impl PostgresDb {
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
             transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filters
             transaction_cols::STATUS,
@@ -1083,7 +1135,7 @@ impl PostgresDb {
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
             WHERE {} = 'processing'
               AND {} < NOW() - make_interval(secs => $1)
@@ -1112,6 +1164,7 @@ impl PostgresDb {
             transaction_cols::FINALITY_CHECK_ATTEMPTS,
             transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
             transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
             transaction_cols::LANDED_REMINT_SIGNATURE,
             // Filters
             transaction_cols::STATUS,

--- a/indexer/src/test_utils.rs
+++ b/indexer/src/test_utils.rs
@@ -41,12 +41,14 @@ pub mod rpc_blocks {
                 err: Some(serde_json::json!({"InstructionError": [0, "Custom(1)"]})),
                 log_messages: None,
                 inner_instructions: None,
+                loaded_addresses: None,
             })
         } else {
             Some(TransactionMeta {
                 err: None,
                 log_messages: None,
                 inner_instructions: None,
+                loaded_addresses: None,
             })
         };
 
@@ -116,6 +118,53 @@ pub mod rpc_blocks {
             .map(|i| pubkey::test_pubkey(i as u8).to_string())
             .chain(std::iter::once(program_id.to_string()))
             .collect()
+    }
+}
+
+/// Byte-layout builders for escrow Deposit instructions and their DepositEvent
+/// self-CPI. Centralised here so the escrow parser tests and the decoder tests
+/// build the exact same bytes against one source of truth (the `pub(crate)`
+/// escrow constants), rather than each re-encoding the layout.
+#[cfg(test)]
+pub mod escrow_fixtures {
+    use crate::indexer::datasource::common::parser::escrow::{
+        DEPOSIT, DEPOSIT_EVENT_DISCRIMINATOR, EVENT_IX_TAG_LE,
+    };
+    use solana_sdk::pubkey::Pubkey;
+
+    /// Borsh body of a Deposit instruction (after the discriminator):
+    /// amount (u64 LE) + `Option<recipient>`.
+    pub fn deposit_borsh(amount: u64, recipient: Option<Pubkey>) -> Vec<u8> {
+        let mut data = amount.to_le_bytes().to_vec();
+        match recipient {
+            Some(r) => {
+                data.push(1);
+                data.extend_from_slice(r.as_ref());
+            }
+            None => data.push(0),
+        }
+        data
+    }
+
+    /// Full Deposit *instruction* bytes: discriminator + borsh body. Pre-base58.
+    pub fn deposit_ix_bytes(amount: u64, recipient: Option<Pubkey>) -> Vec<u8> {
+        let mut data = vec![DEPOSIT];
+        data.extend(deposit_borsh(amount, recipient));
+        data
+    }
+
+    /// DepositEvent self-CPI bytes (145B): tag(8) + disc(1) + instance_seed(32)
+    /// + user(32) + amount(8 LE) + recipient(32) + mint(32).
+    pub fn deposit_event_bytes(amount: u64) -> Vec<u8> {
+        let mut data = Vec::with_capacity(145);
+        data.extend_from_slice(EVENT_IX_TAG_LE);
+        data.push(DEPOSIT_EVENT_DISCRIMINATOR);
+        data.extend_from_slice(&[0u8; 32]); // instance_seed
+        data.extend_from_slice(&[0u8; 32]); // user
+        data.extend_from_slice(&amount.to_le_bytes());
+        data.extend_from_slice(&[0u8; 32]); // recipient
+        data.extend_from_slice(&[0u8; 32]); // mint
+        data
     }
 }
 

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -72,6 +72,7 @@ fn make_db_transaction(sig: &str, txn_type: TransactionType) -> DbTransaction {
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     }
 }

--- a/integration/tests/indexer/db_migration_race.rs
+++ b/integration/tests/indexer/db_migration_race.rs
@@ -76,14 +76,29 @@ async fn test_init_schema_is_idempotent_across_runs() {
     assert_eq!(count, 0, "no rows yet; table exists and is reachable");
 
     // The single-signature uniqueness must have been swapped for the composite
-    // index across both runs; the old index and constraint must be gone.
-    let composite_index: i64 = sqlx::query_scalar(
+    // triple index across both runs; the old single-signature and
+    // (signature, instruction_index) indexes must be gone.
+    let triple_index: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_transactions_signature_ix_inner'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        triple_index, 1,
+        "composite triple signature index must exist"
+    );
+
+    let prev_composite_index: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_transactions_signature_ix'",
     )
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(composite_index, 1, "composite signature index must exist");
+    assert_eq!(
+        prev_composite_index, 0,
+        "the (signature, instruction_index) index must be dropped after the inner_index migration"
+    );
 
     let old_index: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_transactions_signature'",
@@ -117,10 +132,18 @@ async fn test_init_schema_upgrades_legacy_signature_only_schema() {
     let pool = sqlx::PgPool::connect(&url).await.expect("sqlx connect");
 
     // Seed the current schema, then rewind it to the legacy shape: drop the
-    // composite index and the instruction_index column, and restore the old
-    // single-signature unique constraint plus its standalone index.
+    // triple index, the inner_index and instruction_index columns, and restore
+    // the old single-signature unique constraint plus its standalone index.
     storage.init_schema().await.expect("seed current schema");
+    sqlx::query("DROP INDEX IF EXISTS idx_transactions_signature_ix_inner")
+        .execute(&pool)
+        .await
+        .unwrap();
     sqlx::query("DROP INDEX IF EXISTS idx_transactions_signature_ix")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE transactions DROP COLUMN IF EXISTS inner_index")
         .execute(&pool)
         .await
         .unwrap();
@@ -155,15 +178,15 @@ async fn test_init_schema_upgrades_legacy_signature_only_schema() {
     .unwrap();
     assert_eq!(has_column, 1, "instruction_index column must be added");
 
-    let composite_index: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_transactions_signature_ix'",
+    let triple_index: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_transactions_signature_ix_inner'",
     )
     .fetch_one(&pool)
     .await
     .unwrap();
     assert_eq!(
-        composite_index, 1,
-        "composite signature index must exist after upgrade"
+        triple_index, 1,
+        "composite triple signature index must exist after upgrade"
     );
 
     let old_constraint: i64 = sqlx::query_scalar(
@@ -184,6 +207,137 @@ async fn test_init_schema_upgrades_legacy_signature_only_schema() {
     .await
     .unwrap();
     assert_eq!(old_index, 0, "old single-signature index must be dropped");
+}
+
+// ── 1c. Upgrade from a (signature, instruction_index) schema to the triple ──
+// A database that predates inner_index carries the
+// idx_transactions_signature_ix composite but no inner_index column. init_schema
+// must add the column, build the triple unique index, and drop the old one
+// without failing on the not-yet-present column.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_init_schema_upgrades_instruction_index_schema_to_triple() {
+    let (db, url, _container) = start_postgres("c1_triple_upgrade").await;
+    let storage = Storage::Postgres(db);
+    let pool = sqlx::PgPool::connect(&url).await.expect("sqlx connect");
+
+    // Seed the current schema, then rewind to the pre-inner_index shape: drop the
+    // triple index and inner_index column and restore the (signature,
+    // instruction_index) composite index.
+    storage.init_schema().await.expect("seed current schema");
+    sqlx::query("DROP INDEX IF EXISTS idx_transactions_signature_ix_inner")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE transactions DROP COLUMN inner_index")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE UNIQUE INDEX idx_transactions_signature_ix \
+         ON transactions (signature, instruction_index)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // The upgrade run must not crash on the missing column and must converge.
+    storage
+        .init_schema()
+        .await
+        .expect("init_schema must upgrade a (signature, instruction_index) schema");
+
+    let has_column: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.columns \
+         WHERE table_name = 'transactions' AND column_name = 'inner_index'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(has_column, 1, "inner_index column must be added");
+
+    let triple_index: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pg_indexes \
+         WHERE indexname = 'idx_transactions_signature_ix_inner'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        triple_index, 1,
+        "triple unique index must exist after upgrade"
+    );
+
+    let old_index: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_transactions_signature_ix'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        old_index, 0,
+        "old (signature, instruction_index) index must be dropped"
+    );
+}
+
+// ── 1d. Top-level + inner rows under one signature persist distinctly ───────
+// A top-level deposit (inner_index NULL) and an inner CPI deposit (inner_index 0)
+// at the SAME (signature, instruction_index) must persist as two rows, and the
+// COALESCE(-1) sentinel must still collapse a duplicate top-level row.
+#[tokio::test(flavor = "multi_thread")]
+async fn cpi_inner_and_top_level_persist_as_distinct_rows() {
+    let (db, url, _container) = start_postgres("c1_cpi_identity").await;
+    let storage = Storage::Postgres(db.clone());
+    storage.init_schema().await.unwrap();
+
+    let signature = Signature::new_unique().to_string();
+    let mint = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+    let recipient = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+
+    let build = |inner_index: Option<i32>, amount: u64| {
+        DbTransactionBuilder::new(signature.clone(), 1, mint.clone(), amount)
+            .initiator(recipient.clone())
+            .recipient(recipient.clone())
+            .transaction_type(TransactionType::Deposit)
+            .instruction_index(0)
+            .inner_index(inner_index)
+            .build()
+    };
+
+    // Top-level (NULL) and inner (0) sharing (signature, instruction_index=0).
+    let batch = vec![build(None, 100), build(Some(0), 200)];
+    let ids = storage
+        .insert_db_transactions_batch(&batch)
+        .await
+        .expect("batch insert ok");
+    assert_eq!(ids.len(), 2);
+    assert_ne!(ids[0], ids[1], "top-level and inner rows are distinct");
+
+    let pool = sqlx::PgPool::connect(&url).await.expect("sqlx connect");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE signature = $1")
+        .bind(&signature)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 2, "two distinct rows persist; got {count}");
+
+    // Re-inserting both is idempotent, including the NULL-inner_index top-level
+    // row (COALESCE(-1) sentinel keeps it collision-detecting).
+    let ids_again = storage
+        .insert_db_transactions_batch(&batch)
+        .await
+        .expect("re-insert ok");
+    assert_eq!(ids_again, ids, "re-insert returns the same ids");
+
+    let count_after: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE signature = $1")
+            .bind(&signature)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        count_after, 2,
+        "re-insert creates no new rows; got {count_after}"
+    );
 }
 
 // ── 2. Duplicate-key race in insert_transaction ────────────────────────────

--- a/integration/tests/indexer/harness_sanity.rs
+++ b/integration/tests/indexer/harness_sanity.rs
@@ -71,6 +71,7 @@ fn pending_deposit_row(id: i64, mint: Pubkey, recipient: Pubkey) -> DbTransactio
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     }
 }

--- a/integration/tests/indexer/multi_instruction_pipeline.rs
+++ b/integration/tests/indexer/multi_instruction_pipeline.rs
@@ -107,6 +107,7 @@ fn deposit_meta(
         program_type: ProgramType::Escrow,
         signature: Some(signature.to_string()),
         instruction_index,
+        inner_index: None,
     }
 }
 
@@ -141,6 +142,7 @@ fn withdraw_meta(
         program_type: ProgramType::Withdraw,
         signature: Some(signature.to_string()),
         instruction_index,
+        inner_index: None,
     }
 }
 
@@ -239,6 +241,72 @@ async fn two_same_signature_deposits_persist_as_distinct_rows() {
     );
     assert_eq!(rows[0].2, recipient_a.to_string());
     assert_eq!(rows[1].2, recipient_b.to_string());
+}
+
+/// A top-level deposit and a CPI deposit sharing one (signature,
+/// instruction_index) must persist as two distinct rows: the top-level row with
+/// NULL inner_index, the inner row with inner_index 0. Re-driving the slot is
+/// idempotent on the composite triple, so no duplicate rows appear.
+#[tokio::test(flavor = "multi_thread")]
+async fn top_level_and_cpi_deposit_persist_as_distinct_rows() {
+    let (db, url, _pg) = start_postgres("c1_cpi_pipeline").await;
+    db.init_schema().await.unwrap();
+    let storage = Arc::new(Storage::Postgres(db));
+
+    let instance = Pubkey::new_unique();
+    let signature = Signature::new_unique().to_string();
+    let recipient_top = Pubkey::new_unique();
+    let recipient_cpi = Pubkey::new_unique();
+
+    // Both at instruction_index 0; the CPI one carries inner_index 0.
+    let mut top = deposit_meta(7, &signature, instance, 0, recipient_top, 990);
+    top.inner_index = None;
+    let mut cpi = deposit_meta(7, &signature, instance, 0, recipient_cpi, 480);
+    cpi.inner_index = Some(0);
+
+    let messages = || {
+        vec![
+            ProcessorMessage::Instruction(top.clone()),
+            ProcessorMessage::Instruction(cpi.clone()),
+            ProcessorMessage::SlotComplete {
+                slot: 7,
+                program_type: ProgramType::Escrow,
+            },
+        ]
+    };
+
+    run_slot(storage.clone(), instance, messages()).await;
+    // Re-drive the same slot: must be idempotent on the triple.
+    run_slot(storage, instance, messages()).await;
+
+    let pool = sqlx::PgPool::connect(&url).await.expect("sqlx connect");
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE signature = $1")
+        .bind(&signature)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        count, 2,
+        "top-level + CPI deposit persist as two rows, idempotent on replay; got {count}"
+    );
+
+    let rows: Vec<(i32, Option<i32>, i64, String)> = sqlx::query_as(
+        "SELECT instruction_index, inner_index, amount::bigint, recipient FROM transactions \
+         WHERE signature = $1 ORDER BY COALESCE(inner_index, -1)",
+    )
+    .bind(&signature)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 2);
+    // Ordered by COALESCE(inner_index, -1): the top-level NULL coalesces to -1 and sorts first.
+    assert_eq!(rows[0].1, None, "top-level row has NULL inner_index");
+    assert_eq!(rows[0].2, 990);
+    assert_eq!(rows[0].3, recipient_top.to_string());
+    assert_eq!(rows[1].1, Some(0), "CPI row has inner_index 0");
+    assert_eq!(rows[1].2, 480);
+    assert_eq!(rows[1].3, recipient_cpi.to_string());
 }
 
 /// Two `WithdrawFunds` instructions sharing one signature must both persist as distinct rows, each getting its own withdrawal_nonce from the per-row trigger.

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -231,6 +231,7 @@ fn make_withdrawal_transaction(
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     }
 }

--- a/integration/tests/indexer/parser_malformation.rs
+++ b/integration/tests/indexer/parser_malformation.rs
@@ -21,7 +21,9 @@
 //!   6. Truncated borsh payload for CreateInstance  → `Err` from borsh
 
 use private_channel_indexer::indexer::datasource::common::parser::escrow::parse_escrow_instruction;
-use private_channel_indexer::indexer::datasource::common::types::CompiledInstruction;
+use private_channel_indexer::indexer::datasource::common::types::{
+    CompiledInstruction, InstructionLocation,
+};
 use solana_sdk::pubkey::Pubkey;
 
 fn account_keys(n: usize) -> Vec<Pubkey> {
@@ -41,7 +43,9 @@ fn ix(program_id_index: u8, accounts: Vec<u8>, data_b58: &str) -> CompiledInstru
 fn test_parse_escrow_empty_data_returns_none() {
     let keys = account_keys(8);
     let instruction = ix(0, vec![0, 1, 2, 3, 4, 5, 6], "");
-    let result = parse_escrow_instruction(&instruction, &keys, &[]).unwrap();
+    let result =
+        parse_escrow_instruction(&instruction, &keys, &[], InstructionLocation::top_level(0))
+            .unwrap();
     assert!(
         result.is_none(),
         "empty instruction data must produce Ok(None)"
@@ -56,7 +60,9 @@ fn test_parse_escrow_unknown_discriminator_returns_none() {
     // to `_ => Ok(None)` without erroring.
     let ff = bs58::encode(&[0xFFu8]).into_string();
     let instruction = ix(0, vec![0, 1, 2, 3, 4, 5, 6], &ff);
-    let result = parse_escrow_instruction(&instruction, &keys, &[]).unwrap();
+    let result =
+        parse_escrow_instruction(&instruction, &keys, &[], InstructionLocation::top_level(0))
+            .unwrap();
     assert!(
         result.is_none(),
         "unknown discriminator must be Ok(None), got {result:?}"
@@ -75,7 +81,7 @@ fn test_parse_escrow_create_instance_insufficient_accounts_errs() {
     let data_b58 = bs58::encode(&data_bytes).into_string();
     let instruction = ix(0, vec![0, 1, 2], &data_b58); // only 3 accounts
 
-    let err = parse_escrow_instruction(&instruction, &keys, &[])
+    let err = parse_escrow_instruction(&instruction, &keys, &[], InstructionLocation::top_level(0))
         .expect_err("CREATE_INSTANCE with < 7 accounts must error");
     let msg = format!("{err:?}").to_lowercase();
     assert!(
@@ -90,7 +96,7 @@ fn test_parse_escrow_invalid_base58_errs() {
     let keys = account_keys(8);
     // Lowercase 'l' is invalid in base58's alphabet.
     let instruction = ix(0, vec![0, 1, 2, 3, 4, 5, 6], "lllll");
-    let err = parse_escrow_instruction(&instruction, &keys, &[])
+    let err = parse_escrow_instruction(&instruction, &keys, &[], InstructionLocation::top_level(0))
         .expect_err("invalid base58 must surface the decode error");
     let msg = format!("{err:?}").to_lowercase();
     assert!(
@@ -112,7 +118,7 @@ fn test_parse_escrow_truncated_borsh_errs() {
     let keys = account_keys(8);
     let truncated = bs58::encode(&[6u8, 0u8]).into_string(); // DEPOSIT + 1 payload byte
     let instruction = ix(0, vec![0, 1, 2, 3, 4], &truncated); // 5 accounts — enough to pass the count check
-    let err = parse_escrow_instruction(&instruction, &keys, &[])
+    let err = parse_escrow_instruction(&instruction, &keys, &[], InstructionLocation::top_level(0))
         .expect_err("truncated borsh payload must error");
     let msg = format!("{err:?}").to_lowercase();
     assert!(
@@ -134,7 +140,7 @@ fn test_parse_escrow_deposit_insufficient_accounts_errs() {
     let data_b58 = bs58::encode(&data_bytes).into_string();
     let instruction = ix(0, vec![0u8], &data_b58); // 1 account only
 
-    let err = parse_escrow_instruction(&instruction, &keys, &[])
+    let err = parse_escrow_instruction(&instruction, &keys, &[], InstructionLocation::top_level(0))
         .expect_err("DEPOSIT with 1 account must error");
     let msg = format!("{err:?}").to_lowercase();
     assert!(

--- a/integration/tests/indexer/pausable_mint.rs
+++ b/integration/tests/indexer/pausable_mint.rs
@@ -244,6 +244,7 @@ fn make_withdrawal_transaction(
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     }
 }

--- a/integration/tests/indexer/permanent_delegate_mint.rs
+++ b/integration/tests/indexer/permanent_delegate_mint.rs
@@ -275,6 +275,7 @@ fn make_withdrawal_transaction(
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     }
 }

--- a/integration/tests/indexer/processor_quarantine.rs
+++ b/integration/tests/indexer/processor_quarantine.rs
@@ -57,6 +57,7 @@ fn make_bad_deposit(id: i64) -> DbTransaction {
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     }
 }

--- a/integration/tests/indexer/remint_flow.rs
+++ b/integration/tests/indexer/remint_flow.rs
@@ -131,6 +131,7 @@ fn seed_pending_remint_row(mock: &MockStorage, id: i64, attempts: i32) {
             finality_check_attempts: attempts,
             recovery_requeue_attempts: 0,
             instruction_index: 0,
+            inner_index: None,
             landed_remint_signature: None,
         });
 }

--- a/integration/tests/indexer/remint_recovery.rs
+++ b/integration/tests/indexer/remint_recovery.rs
@@ -73,6 +73,7 @@ fn make_row(
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     }
 }

--- a/integration/tests/indexer/state_recovery_malformed.rs
+++ b/integration/tests/indexer/state_recovery_malformed.rs
@@ -72,6 +72,7 @@ fn make_row(
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     }
 }

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -215,6 +215,7 @@ async fn null_withdrawal_nonce_is_quarantined_to_manual_review(
         finality_check_attempts: 0,
         recovery_requeue_attempts: 0,
         instruction_index: 0,
+        inner_index: None,
         landed_remint_signature: None,
     };
     storage.insert_db_transaction(&withdrawal).await?;


### PR DESCRIPTION
## Summary

Closes EXO-121 (follow-up to SOLA2-13 #148). The indexer only ever turned **top-level** escrow/withdraw instructions into rows; when a foreign program CPIs into the escrow (`Deposit`) or withdraw (`WithdrawFunds`) program, that inner instruction was never indexed. For deposits that surfaces later as reconciliation drift; for withdraws it is a direct loss of funds (tokens burned, no nonce assigned, no release scheduled).

This PR indexes the inner (CPI) **user-initiated** instructions, extends the durable identity one nesting level deeper, and closes a v0/lookup-table crash-loop in the parse path along the way. Operator (`ReleaseFunds`/`ResetSmtRoot`) and admin (`CreateInstance`/`AllowMint`) inner instructions are deliberately skipped.

## What changed

- **Inner (CPI) instruction indexing in both datasources.** The RPC and Yellowstone decoders now walk each transaction's inner-instruction sets, keep the ones invoking the escrow/withdraw program, so user-initiated `Deposit`/`WithdrawFunds` made via CPI become rows.
- **Row identity extended to `(signature, instruction_index, inner_index)`.** `inner_index` is `NULL` for top-level rows and the inner position for CPI rows. The DB migration builds the new unique index over `(signature, instruction_index, COALESCE(inner_index, -1))` before dropping the old one, and INSERT / `ON CONFLICT` / SELECT-by-key all key on that triple, so a top-level and a CPI instruction in one tx persist as distinct rows.
- **Deposit-event scoping.** `parse_deposit` resolves its `DepositEvent` by top-level index and, for CPI deposits, the stack-height subtree, so multiple deposits in one transaction can't read each other's amount; an unscopeable CPI deposit errors rather than guess.
- **Full account-key reconstruction at the datasource** Keys are rebuilt as `static ++ ALT loaded_writable ++ ALT  loaded_readonly` from existing transaction meta, so account indices in v0 transactions resolve correctly.
- **Parser hardening.** Account lookups go through a bounds-checked `resolve_account` that returns a `ParserError` instead of panicking, closing a v0-transaction crash-loop.

## Tests

- **Unit:** inner-instruction indexing + ALT-key resolution (both decoders); deposit-event scoping (two CPI deposits get distinct amounts, no-stack-height CPI errors, foreign/self-CPI lookalikes ignored); `resolve_account` errs instead of panicking; Yellowstone inner CPI withdraw.
- **Integration (Postgres testcontainers):** migration idempotency + legacy-schema upgrade to the triple; top-level + CPI deposit persist as two rows; CPI-deposit pipeline.

## Scope

- Indexed: inner escrow `Deposit` and withdraw `WithdrawFunds`.
- Not indexed: operator (`ReleaseFunds`/`ResetSmtRoot`) and admin (`CreateInstance`/`AllowMint`) inner instructions.

## Review guide

~1.6k of the ~2k added lines are tests (inline + integration); ~400 are production. Main files: `parser/escrow.rs` (two-stage deposit-event scoping + checked account access), `rpc_polling/decoder.rs` (inner iteration + ALT key resolution), `yellowstone/source.rs` (same, gRPC path, via shared `parse_and_send`), `storage/postgres/db.rs` (migration + `ON CONFLICT`/SELECT-by-key).

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,036 | 12,647 | 87.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27712955669) |
| Indexer | 21,937 | 24,791 | 88.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27712955669) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27712955669) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27712955669) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,825 | 14,725 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27712955669) |
| **Total** | **46,509** | **54,158** | **85.9%** | |

> Last updated: 2026-06-17 19:35:16 UTC by E2E Integration