### PR TITLE
FIx non canonical deposit withdraw tags

### DIFF
--- a/private-channel-escrow-program/program/src/processor/deposit.rs
+++ b/private-channel-escrow-program/program/src/processor/deposit.rs
@@ -154,17 +154,19 @@ fn process_instruction_data(data: &[u8]) -> Result<DepositArgs, ProgramError> {
     );
     offset += 8;
 
-    let has_recipient = data[offset] != 0;
+    let tag = data[offset];
     offset += 1;
 
-    let recipient = if has_recipient {
-        require_len!(data, offset + 32);
+    let recipient = match tag {
+        0 => None,
+        1 => {
+            require_len!(data, offset + 32);
 
-        let mut recipient_bytes = [0u8; 32];
-        recipient_bytes.copy_from_slice(&data[offset..offset + 32]);
-        Some(Address::new_from_array(recipient_bytes))
-    } else {
-        None
+            let mut recipient_bytes = [0u8; 32];
+            recipient_bytes.copy_from_slice(&data[offset..offset + 32]);
+            Some(Address::new_from_array(recipient_bytes))
+        }
+        _ => return Err(ProgramError::InvalidInstructionData),
     };
 
     Ok(DepositArgs { amount, recipient })
@@ -211,6 +213,20 @@ mod tests {
     #[test]
     fn test_process_deposit_instruction_data_insufficient_length() {
         let instruction_data = vec![1, 2, 3];
+
+        let result = process_instruction_data(&instruction_data);
+
+        assert_eq!(result.err(), Some(ProgramError::InvalidInstructionData));
+    }
+
+    #[test]
+    fn test_process_deposit_instruction_data_non_canonical_recipient_tag() {
+        // Flag byte = 2 is not a valid Option tag. The on-chain parser must reject it
+        // so it stays in sync with the Borsh-based indexer, which only accepts 0 or 1.
+        let mut instruction_data = vec![];
+        instruction_data.extend_from_slice(&1000u64.to_le_bytes());
+        instruction_data.push(2);
+        instruction_data.extend_from_slice(&[0u8; 32]);
 
         let result = process_instruction_data(&instruction_data);
 

--- a/private-channel-withdraw-program/program/src/processor/withdraw_funds.rs
+++ b/private-channel-withdraw-program/program/src/processor/withdraw_funds.rs
@@ -83,13 +83,15 @@ fn parse_instruction_data(data: &[u8]) -> Result<WithdrawFundsArgs, ProgramError
             .map_err(|_| ProgramError::InvalidInstructionData)?,
     );
 
-    let destination = if data[8] != 0 {
-        require_len!(data, 9 + 32);
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&data[9..41]);
-        Some(Address::new_from_array(bytes))
-    } else {
-        None
+    let destination = match data[8] {
+        0 => None,
+        1 => {
+            require_len!(data, 9 + 32);
+            let mut bytes = [0u8; 32];
+            bytes.copy_from_slice(&data[9..41]);
+            Some(Address::new_from_array(bytes))
+        }
+        _ => return Err(ProgramError::InvalidInstructionData),
     };
 
     Ok(WithdrawFundsArgs {
@@ -178,6 +180,20 @@ mod tests {
         instruction_data.extend_from_slice(&100u64.to_le_bytes());
         instruction_data.push(1);
         instruction_data.extend_from_slice(&[0u8; 5]);
+
+        let result = parse_instruction_data(&instruction_data);
+
+        assert_eq!(result.err(), Some(ProgramError::InvalidInstructionData));
+    }
+
+    #[test]
+    fn test_parse_instruction_data_non_canonical_option_tag() {
+        // Flag byte = 2 is not a valid Option tag. The on-chain parser must reject it
+        // so it stays in sync with the Borsh-based indexer, which only accepts 0 or 1.
+        let mut instruction_data = vec![];
+        instruction_data.extend_from_slice(&100u64.to_le_bytes());
+        instruction_data.push(2);
+        instruction_data.extend_from_slice(&[0u8; 32]);
 
         let result = parse_instruction_data(&instruction_data);
 


### PR DESCRIPTION
## SOLA2-19: Reject non-canonical Option tags in deposit/withdraw

Both `deposit` (escrow) and `withdraw_funds` parsed their optional `recipient`/`destination` with `flag != 0`, accepting any nonzero tag on-chain. The indexer deserializes the same bytes as Borsh `Option<Pubkey>`, which only accepts `0`/`1` — so an instruction with tag `2` executes on-chain (moves/burns funds) but is silently dropped by the indexer, breaking the bridge invariant in both directions.

Fix: both parsers now `match` the tag and reject anything but `0`/`1` with `InvalidInstructionData`. Added a non-canonical-tag unit test to each (TDD).
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | 129 | 241 | 53.5% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27719145847) |
| Escrow Program | 1,195 | 1,982 | 60.3% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27719145847) |
| DvP Swap Program | 270 | 1,179 | 22.9% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27719145847) |
| E2E Integration | 11,662 | 14,486 | 80.5% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27719145943) |
| **Total** | **12,986** | **16,709** | **77.7%** | |

> Last updated: 2026-06-17 21:19:41 UTC by DvP Swap Program