### PR TITLE
fix(core): unpredictable chained blockhash + config-derived blockhash validity window

### DIFF
--- a/admin-ui/Dockerfile
+++ b/admin-ui/Dockerfile
@@ -38,7 +38,6 @@ RUN --mount=type=cache,target=/pnpm-store,sharing=locked \
     pnpm install --frozen-lockfile
 
 ARG PRIVATE_CHANNEL_RPC_URL
-ARG PRIVATE_CHANNEL_WS_URL
 
 RUN npx vite build
 

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -132,7 +132,8 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
     if config.blocktime_ms == 0 {
         return Err("blocktime_ms cannot be 0".into());
     }
-    if config.max_blockhashes() == 0 && matches!(config.mode, NodeMode::Write | NodeMode::Aio) {
+    // All modes need a non-zero window: Read advertises it as last_valid_block_height, write modes size the dedup cache with it.
+    if config.max_blockhashes() == 0 {
         return Err(
             "transaction_expiration_ms must be >= blocktime_ms (max_blockhashes would be 0)".into(),
         );

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -128,8 +128,9 @@ pub struct NodeHandles {
 
 pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::error::Error>> {
     // Validate configuration
-    if config.blocktime_ms == 0 && matches!(config.mode, NodeMode::Write | NodeMode::Aio) {
-        return Err("blocktime_ms cannot be 0 for write nodes".into());
+    // max_blockhashes() divides by blocktime_ms and every mode derives it and reject a zero divisor.
+    if config.blocktime_ms == 0 {
+        return Err("blocktime_ms cannot be 0".into());
     }
     if config.max_blockhashes() == 0 && matches!(config.mode, NodeMode::Write | NodeMode::Aio) {
         return Err(
@@ -332,10 +333,12 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
             if matches!(config.mode, NodeMode::Read) {
                 repair_address_signatures(&accounts_db, Arc::clone(&config.metrics)).await?;
             }
+            let max_blockhashes = config.max_blockhashes() as u64;
             Some(ReadDeps {
                 admin_keys: config.admin_keys,
                 accounts_db,
                 live_blockhashes: live_blockhashes_arc,
+                max_blockhashes,
             })
         }
         NodeMode::Write => None,
@@ -426,7 +429,7 @@ mod tests {
         let result = run_node(config).await;
         assert!(result.is_err());
         let err = result.err().unwrap();
-        assert_eq!(err.to_string(), "blocktime_ms cannot be 0 for write nodes");
+        assert_eq!(err.to_string(), "blocktime_ms cannot be 0");
     }
 
     #[tokio::test]

--- a/core/src/rpc/get_latest_blockhash_impl.rs
+++ b/core/src/rpc/get_latest_blockhash_impl.rs
@@ -28,12 +28,10 @@ pub async fn get_latest_blockhash_impl(
             )
         })?;
 
-    // Calculate last valid block height
-    // In Solana, a blockhash is valid for approximately 150 blocks
-    // We'll use slot as the block height and add 150 for validity period
-    // TODO: We will have different expiration logic, which means it may not
-    // necessarily be 150 blocks
-    let last_valid_block_height = slot + 150;
+    // The dedup window holds max_blockhashes entries (block height == slot here),
+    // so a hash settled at this slot is evicted once the tip reaches
+    // slot + max_blockhashes.
+    let last_valid_block_height = slot.saturating_add(read_deps.max_blockhashes);
 
     Ok(Response {
         context: RpcResponseContext::new(slot),

--- a/core/src/rpc/mod.rs
+++ b/core/src/rpc/mod.rs
@@ -72,11 +72,16 @@ mod tests {
         (db, container)
     }
 
+    // A non-default window so the assertion pins the value to the threaded
+    // config field rather than to any constant baked into the endpoint.
+    const TEST_MAX_BLOCKHASHES: u64 = 200;
+
     fn make_read_deps(db: AccountsDB) -> ReadDeps {
         ReadDeps {
             accounts_db: db,
             admin_keys: vec![],
             live_blockhashes: Arc::new(RwLock::new(LinkedList::new())),
+            max_blockhashes: TEST_MAX_BLOCKHASHES,
         }
     }
 
@@ -232,7 +237,23 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.value.blockhash, blockhash.to_string());
-        assert_eq!(resp.value.last_valid_block_height, 160); // slot 10 + 150
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_valid_block_height_uses_max_blockhashes() {
+        let (mut db, _pg) = start_pg().await;
+        let slot = 10u64;
+        db.store_block(make_block_info(slot, Hash::new_unique()))
+            .await
+            .unwrap();
+        let deps = make_read_deps(db);
+        let resp = get_latest_blockhash_impl::get_latest_blockhash_impl(&deps, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.value.last_valid_block_height,
+            slot + TEST_MAX_BLOCKHASHES
+        );
     }
 
     // ── get_recent_blockhash ──────────────────────────────────────────────

--- a/core/src/rpc/rpc_impl.rs
+++ b/core/src/rpc/rpc_impl.rs
@@ -61,6 +61,7 @@ pub struct ReadDeps {
     // Used for simulating sigverify
     pub admin_keys: Vec<Pubkey>,
     pub live_blockhashes: Arc<RwLock<LinkedList<Hash>>>,
+    pub max_blockhashes: u64,
 }
 
 pub struct WriteDeps {

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -827,14 +827,15 @@ mod tests {
         assert_eq!(block1.previous_blockhash, r1.blockhash);
     }
 
+    // End-to-end: settle derives the new hash and persists it round-tripped and chained.
+    // Signature-binding is proven deterministically by compute_blockhash_depends_on_signatures;
+    // it cannot be isolated here because each settle reads its own wall-clock nanos, so this
+    // asserts the wiring and persistence instead of re-proving the content dependency.
     #[tokio::test(flavor = "multi_thread")]
-    async fn settle_blockhash_binds_transactions() {
+    async fn settle_persists_computed_blockhash() {
         let (mut db, _pg) = start_test_postgres().await;
 
-        let last = LastBlock {
-            slot: 5,
-            blockhash: Hash::new_unique(),
-        };
+        let parent_hash = Hash::new_unique();
 
         let from = Keypair::new();
         let to = Pubkey::new_unique();
@@ -846,10 +847,10 @@ mod tests {
         )]);
         let with_tx: Vec<(TransactionProcessingResult, _)> = vec![(Ok(processed), tx)];
 
-        let r_with_tx = settle_transactions(
+        let r = settle_transactions(
             Some(LastBlock {
-                slot: last.slot,
-                blockhash: last.blockhash,
+                slot: 5,
+                blockhash: parent_hash,
             }),
             &mut db,
             None,
@@ -860,18 +861,11 @@ mod tests {
         .await
         .unwrap();
 
-        let r_empty = settle_transactions(
-            Some(last),
-            &mut db,
-            None,
-            &[],
-            &(Arc::new(NoopMetrics) as SharedMetrics),
-            None,
-        )
-        .await
-        .unwrap();
-
-        assert_ne!(r_with_tx.blockhash, r_empty.blockhash);
+        assert_ne!(r.blockhash, Hash::default());
+        assert_ne!(r.blockhash, parent_hash);
+        let block = db.get_block(r.slot).await.unwrap();
+        assert_eq!(block.blockhash, r.blockhash);
+        assert_eq!(block.previous_blockhash, parent_hash);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -9,11 +9,12 @@ use {
     },
     anyhow::{anyhow, Context, Result},
     redis::AsyncCommands,
-    solana_hash::Hash,
     solana_rpc_client_types::response::RpcPerfSample,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
+        hash::{hashv, Hash},
         pubkey::Pubkey,
+        signature::Signature,
         transaction::SanitizedTransaction,
     },
     solana_svm::{
@@ -452,6 +453,26 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
     WorkerHandle::new("Settle".to_string(), handle)
 }
 
+/// Derive a block's hash by SHA-256-hashing the parent hash, the slot, a
+/// high-resolution timestamp, and every transaction signature in the block.
+/// Folding in the nanosecond timestamp and the signatures makes a future block's hash
+/// unpredictable.
+fn compute_blockhash(
+    previous: &Hash,
+    slot: u64,
+    time_nanos: u128,
+    signatures: &[Signature],
+) -> Hash {
+    let slot_bytes = slot.to_le_bytes();
+    let time_bytes = time_nanos.to_le_bytes();
+    let mut parts: Vec<&[u8]> = Vec::with_capacity(3 + signatures.len());
+    parts.push(previous.as_ref());
+    parts.push(&slot_bytes);
+    parts.push(&time_bytes);
+    parts.extend(signatures.iter().map(|s| s.as_ref()));
+    hashv(&parts)
+}
+
 /// Settle transactions: Update accounts database with changes
 async fn settle_transactions(
     last_block: Option<LastBlock>,
@@ -470,30 +491,16 @@ async fn settle_transactions(
     let mut final_accounts_actual: HashMap<Pubkey, AccountSettlement> =
         HashMap::with_capacity(n * 4);
 
-    // Determine block time
-    let block_time = SystemTime::now()
+    let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
+        .unwrap_or_default();
+    let block_time = now.as_secs() as i64;
+    let block_time_nanos = now.as_nanos();
 
-    // Generate blockhash and determine next slot
-    // TODO: Check the blockhash generation scheme
-    let (next_blockhash, next_slot, last_blockhash, last_slot) =
-        if let Some(ref last_block) = last_block {
-            let mut hash_bytes = [0u8; 32];
-            hash_bytes[0..8].copy_from_slice(&last_block.slot.to_le_bytes());
-            hash_bytes[8..16].copy_from_slice(&block_time.to_le_bytes());
-            let next_blockhash = Hash::new_from_array(hash_bytes);
-            let next_slot = last_block.slot + 1;
-            (
-                next_blockhash,
-                next_slot,
-                last_block.blockhash,
-                last_block.slot,
-            )
-        } else {
-            (Hash::default(), 0, Hash::default(), 0)
-        };
+    let (next_slot, last_blockhash, last_slot, is_genesis) = match last_block {
+        Some(ref lb) => (lb.slot + 1, lb.blockhash, lb.slot, false),
+        None => (0, Hash::default(), 0, true),
+    };
 
     // Phase 1: build account maps and transaction lists
     let t_processing_start = tokio::time::Instant::now();
@@ -562,6 +569,17 @@ async fn settle_transactions(
     }
 
     let t_processing_ms = t_processing_start.elapsed().as_secs_f64() * 1000.0;
+
+    let next_blockhash = if is_genesis {
+        Hash::default()
+    } else {
+        compute_blockhash(
+            &last_blockhash,
+            next_slot,
+            block_time_nanos,
+            &block_transaction_signatures,
+        )
+    };
 
     // Convert final_accounts to Vec for batch write
     let accounts_vec: Vec<(Pubkey, AccountSettlement)> =
@@ -658,7 +676,7 @@ mod tests {
     use solana_sdk::{
         account::AccountSharedData,
         pubkey::Pubkey,
-        signature::{Keypair, Signer},
+        signature::{Keypair, Signature, Signer},
     };
     use solana_svm::account_loader::{FeesOnlyTransaction, LoadedTransaction};
     use solana_svm::rollback_accounts::RollbackAccounts;
@@ -692,6 +710,65 @@ mod tests {
         }))
     }
 
+    fn sig(byte: u8) -> Signature {
+        Signature::from([byte; 64])
+    }
+
+    #[test]
+    fn compute_blockhash_is_deterministic_given_inputs() {
+        let parent = Hash::new_unique();
+        let sigs = vec![sig(1), sig(2)];
+        let a = compute_blockhash(&parent, 7, 123, &sigs);
+        let b = compute_blockhash(&parent, 7, 123, &sigs);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn compute_blockhash_depends_on_parent() {
+        let sigs = vec![sig(1)];
+        let a = compute_blockhash(&Hash::new_unique(), 7, 123, &sigs);
+        let b = compute_blockhash(&Hash::new_unique(), 7, 123, &sigs);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_blockhash_depends_on_slot() {
+        let parent = Hash::new_unique();
+        let sigs = vec![sig(1)];
+        let a = compute_blockhash(&parent, 7, 123, &sigs);
+        let b = compute_blockhash(&parent, 8, 123, &sigs);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_blockhash_depends_on_time() {
+        let parent = Hash::new_unique();
+        let sigs = vec![sig(1)];
+        let a = compute_blockhash(&parent, 7, 123, &sigs);
+        let b = compute_blockhash(&parent, 7, 124, &sigs);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_blockhash_depends_on_signatures() {
+        let parent = Hash::new_unique();
+        let empty = compute_blockhash(&parent, 7, 123, &[]);
+        let one = compute_blockhash(&parent, 7, 123, &[sig(1)]);
+        let other = compute_blockhash(&parent, 7, 123, &[sig(2)]);
+        assert_ne!(empty, one);
+        assert_ne!(one, other);
+    }
+
+    #[test]
+    fn compute_blockhash_is_not_predictable_packing() {
+        // A real hash spreads entropy across all 32 bytes, unlike the old slot-in-bytes[0..8], zero-tail packing.
+        let slot: u64 = 42;
+        let h = compute_blockhash(&Hash::new_unique(), slot, 123, &[sig(1)]);
+        let bytes = h.to_bytes();
+        assert!(bytes[16..32].iter().any(|&b| b != 0));
+        assert_ne!(&bytes[0..8], &slot.to_le_bytes());
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_settle_empty_results() {
         let (mut db, _pg) = start_test_postgres().await;
@@ -707,6 +784,7 @@ mod tests {
         assert!(result.is_ok());
         let r = result.unwrap();
         assert_eq!(r.slot, 0);
+        // Genesis (last_block == None) deliberately stays the default hash.
         assert_eq!(r.blockhash, Hash::default());
         assert!(r.account_settlements.is_empty());
     }
@@ -743,6 +821,57 @@ mod tests {
         .unwrap();
         assert_eq!(r2.slot, 1);
         assert_ne!(r2.blockhash, Hash::default());
+
+        // The persisted block must record r1's hash as parent, proving the chain link is written through, not just in memory.
+        let block1 = db.get_block(1).await.expect("block 1 persisted");
+        assert_eq!(block1.previous_blockhash, r1.blockhash);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_blockhash_binds_transactions() {
+        let (mut db, _pg) = start_test_postgres().await;
+
+        let last = LastBlock {
+            slot: 5,
+            blockhash: Hash::new_unique(),
+        };
+
+        let from = Keypair::new();
+        let to = Pubkey::new_unique();
+        let tx = create_test_sanitized_transaction(&from, &to, 100);
+        let account_pk = Pubkey::new_unique();
+        let processed = make_executed(vec![(
+            account_pk,
+            AccountSharedData::new(500, 0, &Pubkey::new_unique()),
+        )]);
+        let with_tx: Vec<(TransactionProcessingResult, _)> = vec![(Ok(processed), tx)];
+
+        let r_with_tx = settle_transactions(
+            Some(LastBlock {
+                slot: last.slot,
+                blockhash: last.blockhash,
+            }),
+            &mut db,
+            None,
+            &with_tx,
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let r_empty = settle_transactions(
+            Some(last),
+            &mut db,
+            None,
+            &[],
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(r_with_tx.blockhash, r_empty.blockhash);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -310,8 +310,10 @@ services:
       - STREAMER_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres-indexer:5432/${POSTGRES_INDEXER_DB}
       - STREAMER_POLL_INTERVAL_MS=200
       - STREAMER_LOG_LEVEL=info
-    ports:
-      - "${STREAMER_PORT:-8902}:${STREAMER_PORT:-8902}"
+    # Internal only: unauthenticated feed, never published to a host
+    # interface. expose is documentation; see docs/CONFIG.md for in-network access.
+    expose:
+      - "${STREAMER_PORT:-8902}"
     command: ["/usr/local/bin/streamer"]
     networks:
       - private-channel-network

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,11 +125,11 @@ flowchart TB
     PG_P[(Postgres Primary)]
     PG_R[(Postgres Replica)]
     RN[Read Node :8901]
-    ST[Streamer :8902]
+    ST["Streamer :8902 (internal only)"]
 
     Wallet -- deposit --> Escrow
     Wallet -- transact / withdraw --> GW
-    ST -. WebSocket .-> Wallet
+    ST -. "WebSocket (internal network only)" .-> Wallet
 
     Escrow -- watch --> IS
     IS -- deposit events --> PG_I
@@ -158,4 +158,4 @@ flowchart TB
 | **Transfer** | User → Gateway → Write Node → Postgres Primary |
 | **Withdrawal** | User → Gateway → Write Node → Withdraw Program (burn) → Indexer Solana Private Channels → Indexer DB → Operator Solana Private Channels → Escrow Program (release on Mainnet) |
 | **Reads** | User → Gateway → Read Node → Postgres Replica |
-| **Streaming** | Postgres Primary → Streamer → WebSocket → User |
+| **Streaming** | Postgres Primary → Streamer → WebSocket (internal network only; not publicly exposed) → in-network consumer |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -67,6 +67,18 @@ Routes `sendTransaction` to the write node; all other RPC methods go to the read
 
 Exposes `/ws` for real-time transaction streaming and `/health` for health checks.
 
+#### Accessing the streamer (internal-only)
+
+The streamer feed is unauthenticated, so it is **not published to the host**. It listens only on the
+`private-channel-network` Docker network at `ws://streamer:8902/ws` (`streamer` is the Compose service
+DNS name; container `private-channel-streamer`).
+
+To listen to the feed, attach a throwaway WebSocket client to the network:
+
+```shell
+docker run --rm --network private-channel_private-channel-network solsson/websocat ws://streamer:8902/ws
+```
+
 ## Changing Configuration
 
 Set the corresponding environment variable in your `.env.devnet` file (or equivalent) and restart the service:

--- a/docs/TECHNICAL_REQUIREMENTS.md
+++ b/docs/TECHNICAL_REQUIREMENTS.md
@@ -91,7 +91,7 @@ streams WAL to archive volumes, wire those volumes to S3 lifecycle policies.
 | Service | Port | Exposure |
 |---|---|---|
 | Gateway (RPC) | 8899 | Public, clients |
-| Streamer (WebSocket) | 8902 | Public, clients |
+| Streamer (WebSocket) | 8902 | Internal only |
 | Grafana | 37429 | Restricted, operators only |
 
 All other services bind to internal ports on the Docker network and don't
@@ -99,7 +99,7 @@ need to be exposed at the host firewall; see `docker-compose.yml` for defaults.
 
 ### Firewall
 
-- **Public ingress:** 8899 (gateway), 8902 (streamer).
+- **Public ingress:** 8899 (gateway).
 - **Outbound:** 443 to Solana mainnet RPC, 10000 to Yellowstone gRPC (if used).
 - **Internal:** allow all between stack services on the private network.
 

--- a/integration/tests/private-channel/rpc/test_simulate_transaction_guards.rs
+++ b/integration/tests/private-channel/rpc/test_simulate_transaction_guards.rs
@@ -57,6 +57,7 @@ async fn build_module(admin_keys: Vec<Pubkey>) -> (RpcModule<()>, ContainerAsync
         accounts_db: db,
         admin_keys,
         live_blockhashes: Arc::new(RwLock::new(LinkedList::new())),
+        max_blockhashes: 150,
     };
     let module = create_rpc_module(Some(read_deps), None).await;
     (module, pg)


### PR DESCRIPTION
## Summary

**A. Two in-tree blockhash TODOs (`core`).**

1. The per-block "blockhash" was `slot` and wall-clock seconds packed into the first 16 bytes of an 32 byte array - never hashed, never bound to block contents, fully predictable. An attacker could precompute a future blockhash undermining the freshness guarantee `transaction_expiration_ms` exists to provide.
2. `getLatestBlockhash` advertised `last_valid_block_height = slot + 150`, a hardcoded value. The real window is `max_blockhashes = transaction_expiration_ms / blocktime_ms`, which equals 150 only under the default config; changing either value silently made the advertised window wrong.

**B. SOLA2-6 (Medium) - public streamer WebSocket.** The streamer broadcasts every parsed transaction over an unauthenticated `/ws`, and `docker-compose.yml` published it to the host (`8902:8902`). **Nothing consumes the feed today**, so this change makes the streamer internal-only and documents in-network access. WebSocket authentication is deliberately deferred; the network change alone closes the internet-facing leak.

## What changed

**A. Blockhash.**

- Replaced the slot+seconds packing with `compute_blockhash`, a SHA-256 (`hashv`) over the parent hash, slot, a nanosecond timestamp, and the block's transaction signatures; computed once per block after the tx loop. Genesis (`last_block == None`) stays `Hash::default()`.
- `getLatestBlockhash` now returns `slot.saturating_add(max_blockhashes)` (config-derived, threaded into `ReadDeps`) instead of the hardcoded 150.
- Startup now fails closed for every mode when `blocktime_ms == 0` or `max_blockhashes() == 0`, since the Read path derives the window too.

**B. SOLA2-6 (docs + deploy only).**

- `docker-compose.yml`: dropped the `8902:8902` host publish (now `expose`), so the streamer is reachable only on `private-channel-network`.
- Docs corrected to call 8902 internal: `TECHNICAL_REQUIREMENTS.md` (port table + firewall), `ARCHITECTURE.md` (diagram + flow), and a new `CONFIG.md` in-network access section.
- `admin-ui/Dockerfile`: removed the dead `PRIVATE_CHANNEL_WS_URL` build ARG.

## Design decisions

- **Chaining + nanos + signatures.** Chaining (parent hash) is free and gives the integrity link; the nanosecond timestamp is the load-bearing unpredictability source (hashing only contents is guessable on an idle/empty block, so a sub-second input forces predicting every intermediate block); signatures add content binding.
- **Nanos is hash-only, never persisted.** Safe because nothing recomputes or decodes a stored hash (no replay engine), so a non-reproducible input is fine and is the point.
- **SOLA2-6 is network-only because nothing consumes the feed** - internal-only matches every other backend service and is the audit's own fallback recommendation.

## Tests

- Pure unit tests for `compute_blockhash`: dependence on parent/slot/time/signatures, plus a regression rejecting the old packing.
- Settle integration: persistence, the chain link, and genesis-default.
- An RPC test asserting `slot + max_blockhashes` (via a `TEST_MAX_BLOCKHASHES = 200` const distinct from 150).


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,147 | 12,760 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27758823662) |
| Indexer | 21,928 | 24,791 | 88.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27763827296) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27763827296) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27758823662) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,841 | 14,739 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27763827296) |
| **Total** | **46,627** | **54,285** | **85.9%** | |

> Last updated: 2026-06-18 14:08:42 UTC by E2E Integration