### PR TITLE
chore(pre-audit): stabilize CI, build/test, docker, auth, and read-only-node startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,12 @@
+# Image tag for the private-channel-app containers (compose defaults to `latest`).
+PRIVATE_CHANNEL_VERSION=latest
+
 # Instance
 ESCROW_INSTANCE_ID=instance_pubkey
+# Escrow instance PDA the compose stack reads as COMMON_ESCROW_INSTANCE_ID.
+# Created post-deploy via `create_instance`; compose interpolation needs it set,
+# so default to the all-1s placeholder until the real PDA is written back.
+COMMON_ESCROW_INSTANCE_ID=11111111111111111111111111111111
 # Keep blank here: `make build-*` writes the live key to the gitignored `.env`.
 ADMIN_PRIVATE_KEY=
 
@@ -43,6 +50,8 @@ PRIVATE_CHANNEL_BATCH_DEADLINE_MS=10
 PRIVATE_CHANNEL_BATCH_CHANNEL_CAPACITY=16
 # Executor parallel SVM worker cap.
 PRIVATE_CHANNEL_MAX_SVM_WORKERS=8
+# Space-separated admin pubkey(s). `make build-localnet` fills this (and
+# ADMIN_PRIVATE_KEY) with a generated keypair; 
 PRIVATE_CHANNEL_ADMIN_KEYS=admin_pubkey
 
 # Gateway
@@ -50,6 +59,9 @@ GATEWAY_PORT=8899
 GATEWAY_WRITE_URL=http://write-node:8900
 GATEWAY_READ_URL=http://read-node:8901
 GATEWAY_URL=http://gateway:8899
+
+# Streamer
+STREAMER_PORT=8902
 
 # Auth Service
 # Leave JWT_SECRET blank to disable RBAC enforcement on the gateway.

--- a/.env.local
+++ b/.env.local
@@ -53,6 +53,9 @@ AUTH_DATABASE_MAX_CONNECTIONS=10
 # Grafana
 GF_ADMIN_PASSWORD=admin
 
-# Program IDs (under target/deploy/...-keypair.json)
+# Program IDs — must match each program's declare_id! and the indexer's hardcoded
+# constants, so the localnet validator deploys the .so at the address the indexer
+# watches. These are fixed (not derived from the build keypair); do not change them
+# unless you also update declare_id! and the indexer/streamer constants and rebuild.
 ESCROW_PROGRAM_ID=GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
 WITHDRAW_PROGRAM_ID=J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi

--- a/.github/actions/update-coverage-row/action.yml
+++ b/.github/actions/update-coverage-row/action.yml
@@ -14,6 +14,10 @@ inputs:
   github-token:
     description: 'GitHub token with pull-requests:write'
     required: true
+  pr-number:
+    description: 'PR number to update; defaults to the triggering pull_request event when empty'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -52,6 +56,7 @@ runs:
         INPUT_LINES_TOTAL: ${{ steps.parse.outputs.lines_total }}
         INPUT_COVERAGE: ${{ steps.parse.outputs.coverage }}
         INPUT_RUN_ID: ${{ github.run_id }}
+        INPUT_PR_NUMBER: ${{ inputs.pr-number }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -62,7 +67,10 @@ runs:
           const artifactName = process.env.INPUT_ARTIFACT_NAME;
           const runId = process.env.INPUT_RUN_ID;
           const repo = context.repo;
-          const prNumber = context.payload.pull_request?.number;
+          // Explicit pr-number wins so this action works under workflow_run, which carries no pull_request context.
+          const prNumber = process.env.INPUT_PR_NUMBER
+            ? parseInt(process.env.INPUT_PR_NUMBER, 10)
+            : context.payload.pull_request?.number;
 
           if (!prNumber) {
             console.log('Not a PR event, skipping PR body update');

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,180 @@
+name: Fork PR Coverage Table
+
+# Second stage of the coverage pipeline, for fork PRs only.
+#
+# The "Rust Checks" pull_request run builds and tests untrusted fork code with a
+# read-only token and uploads .lcov artifacts, but cannot edit the PR body (GitHub
+# downgrades the fork token to read-only). This workflow_run stage runs trusted
+# base-repo code with a write token and publishes the table. It never checks out or
+# executes fork code, so the write token is never handed to untrusted code.
+
+on:
+  workflow_run:
+    workflows: ["Rust Checks"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+# Serialize per source branch so overlapping runs do not clobber each other's PR-body edits.
+concurrency:
+  group: fork-coverage-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  publish-coverage:
+    name: Publish Fork PR Coverage Table
+    # Fork PRs only: internal PRs already get the table inline from Rust Checks.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: private-channel-runner-1
+    steps:
+      - name: Resolve and verify PR number
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const headSha = run.head_sha;
+
+            // Fork PRs leave run.pull_requests empty, so fall back to the commit association.
+            let prNumber = run.pull_requests?.[0]?.number ?? null;
+            if (!prNumber) {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+              prNumber = prs.find(p => p.state === 'open')?.number ?? null;
+            }
+            if (!prNumber) {
+              core.info('No open PR associated with the triggering commit; nothing to publish.');
+              core.setOutput('ok', 'false');
+              return;
+            }
+
+            // Anti-impersonation: the resolved PR must originate from the same head repo that
+            // produced this run, so a fork can only ever annotate its own PR, never another.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (pr.head.repo?.full_name !== run.head_repository.full_name) {
+              core.warning('Resolved PR head repo does not match the run head repo; skipping.');
+              core.setOutput('ok', 'false');
+              return;
+            }
+
+            core.setOutput('pr', String(prNumber));
+            core.setOutput('ok', 'true');
+
+      - name: Checkout base repo
+        # Default ref is the base repo's default branch (trusted code), never the fork PR head.
+        if: steps.resolve.outputs.ok == 'true'
+        uses: actions/checkout@v4
+
+      - name: Download E2E coverage artifact
+        if: steps.resolve.outputs.ok == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-coverage-reports
+          path: artifacts/e2e
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download unit coverage artifact
+        if: steps.resolve.outputs.ok == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-unit-coverage-reports
+          path: artifacts/unit
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Seed coverage skeleton if missing
+        if: steps.resolve.outputs.ok == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: prNumber });
+            if ((pr.body || '').includes('### Coverage Report')) return;
+            // Mirrors the skeleton seeded by the init-coverage-table job in rust.yml.
+            const skeleton = [
+              '',
+              '### Coverage Report',
+              '',
+              '| Component | Lines Hit | Lines Total | Coverage | Artifact |',
+              '|-----------|-----------|-------------|----------|----------|',
+              '| Core | - | - | - | - |',
+              '| Indexer | - | - | - | - |',
+              '| Gateway | - | - | - | - |',
+              '| Auth | - | - | - | - |',
+              '| Withdraw Program | - | - | - | - |',
+              '| Escrow Program | - | - | - | - |',
+              '| DvP Swap Program | - | - | - | - |',
+              '| E2E Integration | - | - | - | - |',
+              '| **Total** | **-** | **-** | **-** | |',
+              '',
+              '> Coverage runs in progress...',
+            ].join('\n');
+            await github.rest.pulls.update({ ...context.repo, pull_number: prNumber, body: (pr.body || '') + skeleton });
+
+      - name: Update PR coverage — E2E Integration
+        if: steps.resolve.outputs.ok == 'true' && hashFiles('artifacts/e2e/coverage-integration-e2e.lcov') != ''
+        uses: ./.github/actions/update-coverage-row
+        with:
+          component: E2E Integration
+          lcov-file: artifacts/e2e/coverage-integration-e2e.lcov
+          artifact-name: e2e-coverage-reports
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.resolve.outputs.pr }}
+
+      - name: Update PR coverage — Core
+        if: steps.resolve.outputs.ok == 'true' && hashFiles('artifacts/unit/coverage-core-unit.lcov') != ''
+        uses: ./.github/actions/update-coverage-row
+        with:
+          component: Core
+          lcov-file: artifacts/unit/coverage-core-unit.lcov
+          artifact-name: rust-unit-coverage-reports
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.resolve.outputs.pr }}
+
+      - name: Update PR coverage — Indexer
+        if: steps.resolve.outputs.ok == 'true' && hashFiles('artifacts/unit/coverage-indexer-unit.lcov') != ''
+        uses: ./.github/actions/update-coverage-row
+        with:
+          component: Indexer
+          lcov-file: artifacts/unit/coverage-indexer-unit.lcov
+          artifact-name: rust-unit-coverage-reports
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.resolve.outputs.pr }}
+
+      - name: Update PR coverage — Gateway
+        if: steps.resolve.outputs.ok == 'true' && hashFiles('artifacts/unit/coverage-gateway-unit.lcov') != ''
+        uses: ./.github/actions/update-coverage-row
+        with:
+          component: Gateway
+          lcov-file: artifacts/unit/coverage-gateway-unit.lcov
+          artifact-name: rust-unit-coverage-reports
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.resolve.outputs.pr }}
+
+      - name: Update PR coverage — Auth
+        if: steps.resolve.outputs.ok == 'true' && hashFiles('artifacts/unit/coverage-auth-unit.lcov') != ''
+        uses: ./.github/actions/update-coverage-row
+        with:
+          component: Auth
+          lcov-file: artifacts/unit/coverage-auth-unit.lcov
+          artifact-name: rust-unit-coverage-reports
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.resolve.outputs.pr }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,10 @@ concurrency:
 jobs:
   init-coverage-table:
     name: Initialize Coverage Table
-    if: github.event_name == 'pull_request'
+    # Skip on fork PRs: the read-only GITHUB_TOKEN can't write the PR body (403).
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: private-channel-runner-1
     steps:
       - name: Insert coverage skeleton into PR body
@@ -265,7 +268,6 @@ jobs:
       - name: Run clippy
         run: |
           cargo clippy --workspace --all-features \
-            --exclude private-channel-core \
             --exclude private-channel-integration \
             --exclude tests-private-channel-escrow-program \
             --exclude tests-private-channel-withdraw-program \
@@ -334,7 +336,11 @@ jobs:
           retention-days: 7
 
       - name: Update PR coverage — E2E Integration
-        if: github.event_name == 'pull_request'
+        # Skip on fork PRs: the read-only GITHUB_TOKEN can't write the PR body (403).
+        # Tests still run and artifacts still upload; only the PR-body table is skipped.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/update-coverage-row
         with:
           component: E2E Integration
@@ -384,7 +390,11 @@ jobs:
           retention-days: 7
 
       - name: Update PR coverage — Core
-        if: github.event_name == 'pull_request'
+        # Skip on fork PRs: the read-only GITHUB_TOKEN can't write the PR body (403).
+        # Tests still run and artifacts still upload; only the PR-body table is skipped.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/update-coverage-row
         with:
           component: Core
@@ -393,7 +403,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PR coverage — Indexer
-        if: github.event_name == 'pull_request'
+        # Skip on fork PRs: the read-only GITHUB_TOKEN can't write the PR body (403).
+        # Tests still run and artifacts still upload; only the PR-body table is skipped.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/update-coverage-row
         with:
           component: Indexer
@@ -402,7 +416,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PR coverage — Gateway
-        if: github.event_name == 'pull_request'
+        # Skip on fork PRs: the read-only GITHUB_TOKEN can't write the PR body (403).
+        # Tests still run and artifacts still upload; only the PR-body table is skipped.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/update-coverage-row
         with:
           component: Gateway
@@ -411,7 +429,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update PR coverage — Auth
-        if: github.event_name == 'pull_request'
+        # Skip on fork PRs: the read-only GITHUB_TOKEN can't write the PR body (403).
+        # Tests still run and artifacts still upload; only the PR-body table is skipped.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/update-coverage-row
         with:
           component: Auth

--- a/Makefile
+++ b/Makefile
@@ -79,21 +79,10 @@ check-toolchain:
 # and must work for contributors who don't have Docker installed. Gate compose/docker
 # build targets on this instead. Floor is 26.0 to match the README; the Dockerfiles use
 # BuildKit `--mount=type=cache` and the `# syntax=docker/dockerfile:1.7` frontend.
+# Shared with deployment automation via scripts/check-docker.sh so every surface
+# enforces the same Docker precondition (present + daemon reachable + >= 26).
 check-docker:
-	@if ! command -v docker >/dev/null 2>&1; then \
-	    echo "ERROR: docker not found on PATH — required for compose-based dev/test stacks (>= 26.0)"; \
-	    exit 1; \
-	fi
-	@ver="$$(docker version --format '{{.Server.Version}}' 2>/dev/null || docker version --format '{{.Client.Version}}' 2>/dev/null)"; \
-	if [ -z "$$ver" ]; then \
-	    echo "ERROR: docker present but version could not be read (daemon not running?)"; \
-	    exit 1; \
-	fi; \
-	major="$$(echo "$$ver" | cut -d. -f1)"; \
-	if [ "$$major" -lt 26 ] 2>/dev/null; then \
-	    echo "ERROR: docker is $$ver; this repo requires >= 26.0 (BuildKit cache mounts)."; \
-	    exit 1; \
-	fi
+	@./scripts/check-docker.sh
 
 install: install-toolchain ensure-geyser-plugin
 	@echo "Installing dependencies for all projects..."
@@ -545,25 +534,33 @@ COMPOSE_DEVNET   := docker-compose.devnet.yml
 # $(wildcard) drops the flag when `.env` is absent; compose errors on missing files.
 ENV_FILES_LOCAL  ?= --env-file versions.env --env-file .env.local $(if $(wildcard .env),--env-file .env)
 ENV_FILES_DEVNET ?= --env-file versions.env --env-file .env.devnet $(if $(wildcard .env),--env-file .env)
+# Optional compose profile, e.g. `make docker-up PROFILE=auth`; expands to nothing when unset.
+PROFILE_FLAG = $(if $(PROFILE),--profile $(PROFILE))
+
+# Verify .env.example documents every key any surface (env files + deploy
+# template) uses, so the env contract can't silently drift. See docs/ENV_CONTRACT.md.
+check-env-contract:
+	@./scripts/check-env-contract.sh
 
 # Fail closed before starting the stack if required secrets are blank. The
 # check script takes plain file paths, so pass the raw chain (no --env-file),
 # including the gitignored `.env` so it validates what compose actually resolves.
-check-env-local:
+# Depends on check-env-contract so a drifted key set is caught before boot.
+check-env-local: check-env-contract
 	@./scripts/check-required-env.sh versions.env .env.local $(wildcard .env)
 
-check-env-devnet:
+check-env-devnet: check-env-contract
 	@./scripts/check-required-env.sh versions.env .env.devnet $(wildcard .env)
 
 # --- Local stack (local validator) ---
 
 docker-build: check-docker check-buildkit-cache
 	@echo "Building all images ($(COMPOSE_LOCAL))..."
-	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) build
+	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) build
 
 docker-up: check-env-local check-docker check-buildkit-cache
 	@echo "Starting full stack ($(COMPOSE_LOCAL))..."
-	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) up -d
+	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) up -d
 
 # Like docker-up but preserves the local validator ledger across restarts so
 # on-chain state stays consistent with Postgres rows. Caveat: after changing
@@ -571,29 +568,29 @@ docker-up: check-env-local check-docker check-buildkit-cache
 # will keep running stale bytecode.
 docker-up-persist: check-env-local check-docker check-buildkit-cache
 	@echo "Starting full stack with validator persistence ($(COMPOSE_LOCAL))..."
-	@VALIDATOR_RESET_FLAG= docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) up -d
+	@VALIDATOR_RESET_FLAG= docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) up -d
 
 docker-rebuild: check-env-local check-docker check-buildkit-cache
 	@echo "Rebuilding and (re)starting full stack ($(COMPOSE_LOCAL))..."
-	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) up -d --build
+	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) up -d --build
 
 docker-restart: check-docker
 	@echo "Restarting full stack ($(COMPOSE_LOCAL))..."
-	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) restart
+	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) restart
 
 docker-down:
 	@echo "Stopping full stack ($(COMPOSE_LOCAL); volumes preserved)..."
-	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) down
+	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) down
 
 docker-clean:
 	@echo "Stopping full stack and removing volumes ($(COMPOSE_LOCAL))..."
-	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) down -v --remove-orphans
+	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) down -v --remove-orphans
 
 docker-logs: check-docker
-	@docker compose -f $(COMPOSE_LOCAL) logs -f --tail=200
+	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) logs -f --tail=200
 
 docker-ps: check-docker
-	@docker compose -f $(COMPOSE_LOCAL) ps
+	@docker compose -f $(COMPOSE_LOCAL) $(ENV_FILES_LOCAL) $(PROFILE_FLAG) ps
 
 # --- Devnet stack (against Solana devnet) ---
 
@@ -622,10 +619,10 @@ docker-devnet-clean:
 	@docker compose -f $(COMPOSE_DEVNET) $(ENV_FILES_DEVNET) down -v --remove-orphans
 
 docker-devnet-logs: check-docker
-	@docker compose -f $(COMPOSE_DEVNET) logs -f --tail=200
+	@docker compose -f $(COMPOSE_DEVNET) $(ENV_FILES_DEVNET) $(PROFILE_FLAG) logs -f --tail=200
 
 docker-devnet-ps: check-docker
-	@docker compose -f $(COMPOSE_DEVNET) ps
+	@docker compose -f $(COMPOSE_DEVNET) $(ENV_FILES_DEVNET) $(PROFILE_FLAG) ps
 
 help:
 	@echo "Solana Private Channels Programs - Available targets:"

--- a/README.md
+++ b/README.md
@@ -289,9 +289,14 @@ make integration-test
 
 ### Docker stack
 
-The Makefile wraps the full compose stack so you don't have to remember the `--env-file` chain. Precondition: copy the env template once (`cp .env.example .env.local`) and fill in the required secrets. No defaults are shipped: `POSTGRES_PASSWORD` and `POSTGRES_REPLICATION_PASSWORD` MUST be set (and `JWT_SECRET` if you enable auth) or the stack fails to start. Generate strong values with `openssl rand -hex 32`. Put secrets in the gitignored `.env` (loaded last, overrides the templates) rather than the tracked `.env.local`; `make build-localnet` writes `ADMIN_PRIVATE_KEY` there for you.
+The Makefile wraps the full compose stack so you don't have to remember the `--env-file` chain. Precondition: copy the env template once (`cp .env.example .env.local`) and fill in the required secrets. No defaults are shipped: `POSTGRES_PASSWORD` and `POSTGRES_REPLICATION_PASSWORD` MUST be set (and `JWT_SECRET` if you enable auth) or the stack fails to start. Generate strong values with `openssl rand -hex 32`. Put secrets in the gitignored `.env` (loaded last, overrides the templates) rather than the tracked `.env.local`.
+
+**Run `make build-localnet` once before the first `make docker-up`.** It generates an operator keypair and patches the real `PRIVATE_CHANNEL_ADMIN_KEYS` / `ADMIN_PRIVATE_KEY` and program IDs into `.env.local`, replacing the template placeholders. Skipping it leaves `PRIVATE_CHANNEL_ADMIN_KEYS=your_admin_public_key`, which the write-node rejects at startup (`Invalid admin key … Invalid Base58 string`).
 
 ```bash
+# First run only: bootstrap .env.local (admin key + program IDs)
+make build-localnet
+
 # Build all images
 make docker-build
 
@@ -305,7 +310,12 @@ make docker-rebuild
 make docker-logs
 make docker-ps
 make docker-down
+
+# Reset: wipe data volumes, then start clean
+make docker-clean && make docker-up
 ```
+
+**Resetting after a credential change.** Postgres applies `POSTGRES_PASSWORD` / `POSTGRES_REPLICATION_PASSWORD` only when it *first* initializes its data volume. If you change those values — or reuse volumes another run initialized with different credentials (e.g. `bench-tps/scripts/run.sh`, which generates its own passwords) — the server keeps the old password while the clients send the new one. Symptoms: `password authentication failed for user "private_channel"` on the nodes, and `postgres-replica` stuck at *Waiting for primary to be ready*. Fix: `make docker-clean` (drops the volumes) then `make docker-up`, so Postgres re-initializes with the current credentials.
 
 Devnet variants exist for every target (`make docker-devnet-up`, `make docker-devnet-down`, etc.) and read `.env.devnet` instead. Run `make help` for the full list.
 
@@ -325,8 +335,9 @@ cp .env.example .env.local
 # Set JWT_SECRET=<your-secret> in .env.local to enable auth
 # Generate strong values with: openssl rand -hex 32
 
-# Start full stack including auth service
-docker compose --env-file versions.env --env-file .env.local --profile auth up
+# Start full stack including the auth service (PROFILE=auth adds the auth profile;
+# omit it for the non-auth stack). Tear down with the same profile: make docker-down PROFILE=auth
+make docker-up PROFILE=auth
 ```
 
 Once running, the auth service is available at `http://localhost:${AUTH_PORT}` (default `8903`). See [auth/README.md](auth/README.md) for the full API reference, role definitions, and wallet verification flow.

--- a/bench-tps/BOTTLENECK_ANALYSIS.md
+++ b/bench-tps/BOTTLENECK_ANALYSIS.md
@@ -153,8 +153,8 @@ validator: 500–2000 TPS depending on hardware.
 ```
 bench (Solana Private Channels WithdrawFunds / burn)
   → Solana Private Channels write-node confirms (dedup → sigverify → sequencer → executor → settler)
-    → indexer-private_channel detects burn event, saves to DB
-      → operator-private_channel fetches from DB, sends Solana ReleaseFunds
+    → indexer-private-channel detects burn event, saves to DB
+      → operator-private-channel fetches from DB, sends Solana ReleaseFunds
 ```
 
 ### Dashboard: Withdraw Flow (Solana Private Channels → Solana)
@@ -171,9 +171,9 @@ Four panels in pipeline order:
 ### Signals
 
 - **Gap between Sent and Landed (panel 1)** — Solana Private Channels pipeline is dropping transactions; switch to the Pipeline Stages section to identify which Solana Private Channels stage is the bottleneck (same analysis as transfer flow above)
-- **Panel 2 `transactions_saved` grows but `mints_saved` doesn't** — indexer-private_channel indexed the slot but failed to classify the burn event; check indexer-private_channel logs
-- **Panel 3 backlog grows** — operator-private_channel is fetching but Solana RPC latency is high or ReleaseFunds transactions are failing; check operator-private_channel logs
-- **Panel 4 is zero** — operator-private_channel not running, `COMMON_SOURCE_RPC_URL` not pointing to the Solana Private Channels gateway, or the instance PDA does not match
+- **Panel 2 `transactions_saved` grows but `mints_saved` doesn't** — indexer-private-channel indexed the slot but failed to classify the burn event; check indexer-private-channel logs
+- **Panel 3 backlog grows** — operator-private-channel is fetching but Solana RPC latency is high or ReleaseFunds transactions are failing; check operator-private-channel logs
+- **Panel 4 is zero** — operator-private-channel not running, `COMMON_SOURCE_RPC_URL` not pointing to the Solana Private Channels gateway, or the instance PDA does not match
 - **`invalid instruction data` errors in operator logs** — withdrawer Solana ATAs were not created during setup; this should be handled by `setup_withdraw.rs` automatically
 
 ### Balance exhaustion

--- a/bench-tps/README.md
+++ b/bench-tps/README.md
@@ -6,7 +6,7 @@ Load testing binary for the Solana Private Channels payment channel. Supports th
 |------|-----------------|
 | \`transfer\` | Solana Private Channels SPL token transfer pipeline (dedup → sigverify → sequencer → executor → settler) |
 | `deposit` | Solana escrow deposits (Solana → Solana Private Channels, measured end-to-end via operator-solana) |
-| `withdraw` | Solana Private Channels burn + Solana release (Solana Private Channels → Solana, measured end-to-end via operator-private_channel) |
+| `withdraw` | Solana Private Channels burn + Solana release (Solana Private Channels → Solana, measured end-to-end via operator-private-channel) |
 
 ---
 
@@ -31,6 +31,16 @@ cargo build --release -p private-channel-bench-tps
 `run.sh` handles everything: generates the admin keypair, starts the full Docker
 stack, waits for services to stabilise, runs the bench, then tears down all
 containers on exit.
+
+> **Shares the `private-channel` compose stack.** `run.sh` brings up the same
+> `docker-compose.yml` (project `private-channel`) as `make docker-up`, using
+> `bench-tps/.env` and its own generated DB passwords + admin keypair. It
+> initializes the shared Postgres volumes with those credentials. So if you switch
+> back to the regular stack afterward, run `make docker-clean` first — otherwise
+> `make docker-up` (which reads `.env.local`) hits the bench-initialized volumes
+> with mismatched passwords and the nodes fail with `password authentication
+> failed` / the replica hangs at *Waiting for primary*. See the README's
+> "Resetting after a credential change" note.
 
 ---
 
@@ -133,8 +143,8 @@ exposes metrics on port 9102).
 The most complex flow — exercises the full cross-chain withdrawal path:
 
 ```
-bench → Solana Private Channels WithdrawFunds (burn) → indexer-private_channel indexes event
-      → operator-private_channel sends Solana ReleaseFunds → funds released on Solana
+bench → Solana Private Channels WithdrawFunds (burn) → indexer-private-channel indexes event
+      → operator-private-channel sends Solana ReleaseFunds → funds released on Solana
 ```
 
 Setup creates both Solana and Solana Private Channels state: an escrow instance on Solana, Solana Private Channels ATAs
@@ -158,7 +168,7 @@ funded with tokens, and Solana ATAs so that `ReleaseFunds` can transfer to them.
 | `solana_released` | `private_channel_operator_mints_sent_total{withdraw}` delta | Solana ReleaseFunds confirmed by operator |
 | `drop` | `private_channel_burned - solana_released` | Burns not yet released (indexer/operator lag) |
 
-`solana_released` requires `BENCH_WITHDRAW_OPERATOR_METRICS_URL` (operator-private_channel
+`solana_released` requires `BENCH_WITHDRAW_OPERATOR_METRICS_URL` (operator-private-channel
 on port 9103).
 
 ### Config parameters

--- a/core/src/accounts/address_index_repair.rs
+++ b/core/src/accounts/address_index_repair.rs
@@ -29,6 +29,16 @@ pub async fn repair_address_signatures(db: &AccountsDB, _metrics: SharedMetrics)
         }
     };
 
+    // The repair seeds/rewrites the address_signatures index and watermark, all
+    // of which are writes. A read-only node connects to the read replica, where
+    // any INSERT fails with "cannot execute INSERT in a read-only transaction".
+    // The writer node owns index consistency, so skip the repair here — mirrors
+    // the read-only guards in store_block / set_account / write_batch.
+    if postgres_db.read_only {
+        info!("address_signatures repair skipped (read-only mode)");
+        return Ok(());
+    }
+
     let pool = Arc::clone(&postgres_db.pool);
 
     let watermark_opt = get_address_signatures_flushed_slot(&pool)

--- a/core/src/bin/streamer.rs
+++ b/core/src/bin/streamer.rs
@@ -654,9 +654,10 @@ async fn health_handler(State(state): State<Arc<AppState>>) -> StatusCode {
     let now = now_unix();
     let accounts_fresh =
         now - state.accounts_poll_at.load(Ordering::Relaxed) < HEALTH_STALE_THRESHOLD;
-    let indexer_fresh = state.indexer_poll_at.as_ref().map_or(true, |a| {
-        now - a.load(Ordering::Relaxed) < HEALTH_STALE_THRESHOLD
-    });
+    let indexer_fresh = state
+        .indexer_poll_at
+        .as_ref()
+        .is_none_or(|a| now - a.load(Ordering::Relaxed) < HEALTH_STALE_THRESHOLD);
     if accounts_fresh && indexer_fresh {
         StatusCode::OK
     } else {

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -199,7 +199,14 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
             // Load persisted dedup state from DB before starting the stage.
             // Failure here is fatal: starting with an empty cache could allow
             // duplicate transactions to execute after a restart.
-            let db = AccountsDB::new(&config.accountsdb_connection_url, true).await?;
+            //
+            // Opened writable (read_only=false): this is the Write/Aio node, which
+            // connects to the primary and owns address_signatures index
+            // consistency. repair_address_signatures writes (seeds the watermark
+            // and re-derives rows), so it must run against a writable handle.
+            // The read-only node opens its own read_only=true handle below, where
+            // the repair is skipped.
+            let db = AccountsDB::new(&config.accountsdb_connection_url, false).await?;
             repair_address_signatures(&db, Arc::clone(&config.metrics)).await?;
             let (initial_live_blockhashes, initial_dedup_cache) = load_dedup_state(
                 &db,

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -10,8 +10,8 @@ Solana Private Channels is a private payment channel with direct access to Solan
 
 - **Escrow Program**: On-chain Solana program that holds deposited tokens (Devnet Program ID: `GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83`)
 - **Solana Private Channels Payment Channel**: Private execution environment (write node, read node, gateway)
-- **Indexer** (2 instances): `indexer-solana` watches the Escrow program on Solana for deposits; `indexer-private_channel` watches the Withdraw program on the Solana Private Channels payment channel for withdrawals
-- **Operator** (2 instances): `operator-solana` processes deposits (mints on the Solana Private Channels payment channel); `operator-private_channel` processes withdrawals (releases from escrow on Solana)
+- **Indexer** (2 instances): `indexer-solana` watches the Escrow program on Solana for deposits; `indexer-private-channel` watches the Withdraw program on the Solana Private Channels payment channel for withdrawals
+- **Operator** (2 instances): `operator-solana` processes deposits (mints on the Solana Private Channels payment channel); `operator-private-channel` processes withdrawals (releases from escrow on Solana)
 
 ## Prerequisites
 
@@ -34,6 +34,10 @@ From the project root:
 ```shell
 docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet build
 ```
+
+> **Tip:** `make docker-devnet-build` / `make docker-devnet-up` wrap these exact
+> commands and add preflight guards (Docker ≥ 26, BuildKit cache, required-secret
+> checks). The raw commands here are equivalent but skip those guards.
 
 This builds all Solana Private Channels services (gateway, nodes, indexer, operator). This will take a long time (30min to an hour or so depending on your system), so it's recommended to run this in the background while you configure the rest of the stack (or go to the gym).
 
@@ -156,7 +160,7 @@ You should see all services in a healthy/running state:
 
 ```shell
 [+] Running 21/21a The requested image's platform (linux/amd64) does not match the detected host platfo
- ✔ Network private_channel_private-channel-network Created0.0s 
+ ✔ Network private-channel_private-channel-network Created0.0s 
  ✔ Container private-channel-cadvisor Started2.4s 
  ✔ Container private-channel-postgres-primary Healthy13.1s                                
  ✔ Container private-channel-postgres-indexer Healthy14.1s                                
@@ -164,8 +168,8 @@ You should see all services in a healthy/running state:
  ✔ Container private-channel-operator-solana Started12.2s
  ✔ Container private-channel-postgres-replica Started12.7s
  ✔ Container private-channel-write-node Started2.2s   ✔ Container private-channel-read-node Started12.4s 
- ✔ Container private-channel-operator-private_channel Started11.9s 
- ✔ Container private-channel-indexer-private_channel Started12.8s 
+ ✔ Container private-channel-operator-private-channel Started11.9s 
+ ✔ Container private-channel-indexer-private-channel Started12.8s 
  ✔ Container private-channel-gateway Started12.3s 
 ```
 
@@ -250,9 +254,9 @@ You should see something like this:
 
 ```shell
 [+] Running 14/14
- ✔ Container private-channel-indexer-private_channel    Removed         10.7s 
+ ✔ Container private-channel-indexer-private-channel    Removed         10.7s 
  ✔ Container private-channel-gateway           Removed          0.7s 
- ✔ Container private-channel-operator-private_channel   Removed         10.7s 
+ ✔ Container private-channel-operator-private-channel   Removed         10.7s 
  ✔ Container private-channel-grafana           Removed          0.5s 
  ✔ Container private-channel-operator-solana   Removed         10.5s 
  ✔ Container private-channel-cadvisor          Removed          0.7s 
@@ -263,7 +267,7 @@ You should see something like this:
  ✔ Container private-channel-postgres-replica  Removed          0.9s 
  ✔ Container private-channel-write-node        Removed          0.6s 
  ✔ Container private-channel-postgres-primary  Removed          0.5s 
- ✔ Network private_channel_private-channel-network      Removed          0.2s
+ ✔ Network private-channel_private-channel-network      Removed          0.2s
 ```
 
 To also remove volumes (reset all state):
@@ -306,9 +310,9 @@ The TOML config files in `scripts/devnet/config/` allow fine-tuning:
 | File | Purpose |
 | :---- | :---- |
 | `indexer-solana.toml` | Solana chain indexer (Yellowstone) |
-| `indexer-private_channel.toml` | Solana Private Channels payment channel indexer (RPC polling) |
+| `indexer-private-channel.toml` | Solana Private Channels payment channel indexer (RPC polling) |
 | `operator-solana.toml` | Processes deposits → mints on Solana Private Channels |
-| `operator-private_channel.toml` | Processes withdrawals → releases on Solana |
+| `operator-private-channel.toml` | Processes withdrawals → releases on Solana |
 
 **Note:** The TOML files contain placeholder values. When running via Docker Compose, the environment variables from `.env.devnet` override these values at runtime. You do not need to edit the TOML files directly — configure everything through `.env.devnet`.
 

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -35,14 +35,15 @@ Before starting, ensure you have:
 
 > **One-time setup for the `make` targets.** The `make docker-devnet-*` commands below enforce a BuildKit cache cap; install it once per host with `sudo make install-buildkit-cache` (writes `/etc/docker/daemon.json`, caps build cache at ~50 GB). Skip only if you run the raw `docker compose` commands instead.
 
-## Step 0 (Optional): Build & Deploy Your Own Programs
+## Step 0 (Optional): Use a Different Program ID
 
-Only if you want to run your *own* escrow/withdraw programs instead of the canonical devnet ones (program IDs above): this compiles the programs and publishes them to devnet under your keypair.
+The images are **pinned to the canonical program IDs at compile time** (the IDs above) — `ESCROW_PROGRAM_ID` is *not* read on devnet, so an env var can't repoint them. You only need this if the escrow/withdraw program has been **redeployed to a new address**, or you're running your own. To switch:
 
-```shell
-make build-devnet                                       # build the .so files + generate an operator keypair and patch ADMIN_PRIVATE_KEY into .env
-make deploy-devnet DEPLOYER_KEY=<your-deployer-keypair>  # deploy them to devnet (prints new program IDs — set ESCROW_PROGRAM_ID/WITHDRAW_PROGRAM_ID in .env.devnet)
-```
+1. Update the program ID everywhere it's compiled in: `declare_id!` in `private-channel-{escrow,withdraw}-program/program/src/lib.rs`, the constants in `indexer/src/indexer/datasource/common/parser/{escrow,withdraw}.rs`, and `core/src/bin/streamer.rs`.
+2. Rebuild the program `.so` **and** the images: `make build-devnet && make docker-devnet-build`.
+3. Deploy your program to devnet at that address: `make deploy-devnet DEPLOYER_KEY=<your-deployer-keypair>`.
+
+Otherwise skip this — the canonical defaults work out of the box.
 
 ## Step 1: Build Docker Images
 

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -17,29 +17,49 @@ Solana Private Channels is a private payment channel with direct access to Solan
 
 Before starting, ensure you have:
 
-- **Docker** (Engine or Desktop)  
+- **Docker Engine ≥ 26** (Engine or Desktop) — required for the BuildKit cache mounts the Dockerfiles use  
   - macOS Apple Silicon: Enable "Docker VMM" in Docker settings (configurable in "Settings" \-\> "Virtual Machine Options")  
-- **Node.js** (v20+) and **pnpm**  
-- **Solana CLI** (latest)  
-- **Rust** (latest)  
+- **Node.js 24.7.0** and **pnpm 10.15.1**  
+- **Solana CLI 3.1.13** (Agave)  
+- **Rust 1.91.0** (Agave v3.1.13 requires ≥ 1.86)  
 - **Solana Wallet** that supports localhost or custom RPC (e.g., Backpack, Phantom, Solflare)  
 - **Solana Devnet RPC** endpoint  
 - **Yellowstone gRPC (Devnet)** endpoint (for real-time Solana event streaming)  
   - **Note**: You can use public Devnet RPC but need a Devnet Yellowstone gRPC node from a service provider for real-time indexing (e.g., Helius LazerStream, Triton, QuickNode).
+
+> **Pinned versions.** Match these on the host to avoid drift from the images:
+>
+> - Solana, Node, and pnpm are the values in [`versions.env`](../versions.env), used as Docker build args — the images build with exactly these.
+> - Rust is pinned in [`rust-toolchain.toml`](../rust-toolchain.toml).
+> - Docker's `≥ 26` floor is enforced by `scripts/check-docker.sh` and the deploy preflight.
+
+> **One-time setup for the `make` targets.** The `make docker-devnet-*` commands below enforce a BuildKit cache cap; install it once per host with `sudo make install-buildkit-cache` (writes `/etc/docker/daemon.json`, caps build cache at ~50 GB). Skip only if you run the raw `docker compose` commands instead.
+
+## Step 0 (Optional): Build & Deploy Your Own Programs
+
+Only if you want to run your *own* escrow/withdraw programs instead of the canonical devnet ones (program IDs above): this compiles the programs and publishes them to devnet under your keypair.
+
+```shell
+make build-devnet                                       # build the .so files + generate an operator keypair and patch ADMIN_PRIVATE_KEY into .env
+make deploy-devnet DEPLOYER_KEY=<your-deployer-keypair>  # deploy them to devnet (prints new program IDs — set ESCROW_PROGRAM_ID/WITHDRAW_PROGRAM_ID in .env.devnet)
+```
 
 ## Step 1: Build Docker Images
 
 From the project root:
 
 ```shell
-docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet build
+make docker-devnet-build
 ```
 
-> **Tip:** `make docker-devnet-build` / `make docker-devnet-up` wrap these exact
-> commands and add preflight guards (Docker ≥ 26, BuildKit cache, required-secret
-> checks). The raw commands here are equivalent but skip those guards.
+> Wraps `docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet build` with preflight guards (Docker ≥ 26, BuildKit cache, env checks). Run the raw command directly if you prefer.
 
 This builds all Solana Private Channels services (gateway, nodes, indexer, operator). This will take a long time (30min to an hour or so depending on your system), so it's recommended to run this in the background while you configure the rest of the stack (or go to the gym).
+
+> ### Deploying to a remote host?
+>
+> **This guide builds and runs the stack *locally* with Docker Compose.** For an **automated single-host remote deployment** — Ansible-driven, pulls prebuilt images from GHCR, and self-verifies in one `ansible-playbook deploy.yml` command — follow the **[Operator Runbook → `private-channel-deploy/README.md`](../private-channel-deploy/README.md)** instead.
+> The remaining steps below are for local setup only.
 
 ## Step 2: Set Up Admin UI
 
@@ -153,7 +173,7 @@ INDEXER_YELLOWSTONE_TOKEN=<your_yellowstone_auth_token>
 Once your docker build (Step 1) is complete, run:
 
 ```shell
-docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet up -d
+make docker-devnet-up
 ```
 
 You should see all services in a healthy/running state:
@@ -177,10 +197,9 @@ Check logs if needed:
 
 ```shell
 # All services
-docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet logs -f
+make docker-devnet-logs
 
-
-# Specific service
+# Specific service (no make target — use raw compose)
 docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet logs -f indexer-solana
 ```
 
@@ -247,7 +266,7 @@ The indexer detects the burn on Solana Private Channels, builds a Merkle proof, 
 ## Stopping Services
 
 ```shell
-docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet down
+make docker-devnet-down
 ```
 
 You should see something like this:
@@ -273,7 +292,7 @@ You should see something like this:
 To also remove volumes (reset all state):
 
 ```shell
-docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet down -v
+make docker-devnet-clean
 ```
 
 ## Troubleshooting
@@ -290,7 +309,7 @@ docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .
 - Verify the mint is whitelisted on the instance  
 - Try using CLI tools in `scripts/devnet/` instead of the Admin UI  
 - Check operator logs: `docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet logs operator-solana`  
-  - *Transaction failed: InstructionError(1, Custom(4))* error suggests that the admin environment variable is misconfigured. Check your ENV vars and restart your services. You may need to initialize a new instance/mint afterwards. Or, remove the volumes and start fresh `docker compose -f docker-compose.devnet.yml --env-file versions.env --env-file .env.devnet down -v`.
+  - *Transaction failed: InstructionError(1, Custom(4))* error suggests that the admin environment variable is misconfigured. Check your ENV vars and restart your services. You may need to initialize a new instance/mint afterwards. Or, remove the volumes and start fresh with `make docker-devnet-clean`.
 - If using the Admin UI, ensure your wallet is on the correct cluster for the correct task (instructions relating to instance management and deposits should use Devnet, and transfers/withdrawals should use your Solana Private Channels RPC URL (localhost:8899 in our example))
 
 ### Indexer not detecting events

--- a/docs/ENV_CONTRACT.md
+++ b/docs/ENV_CONTRACT.md
@@ -1,0 +1,73 @@
+# Environment variable contract
+
+Three surfaces start the same Docker stack — the **Makefile** (`make docker-*`),
+**raw `docker compose`** in docs/runbooks, and the **Ansible deploy**
+(`private-channel-deploy`). They legitimately source variable *values* from
+different places, but they must agree on the variable *contract*: the key set,
+their meaning, and the load order. This doc is that contract.
+
+## Canonical key list
+
+[`.env.example`](../.env.example) is the **single source of truth** for which
+variables exist. Every key any surface references must be documented there.
+`scripts/check-env-contract.sh` enforces this — it fails if `.env.local`,
+`.env.devnet`, or `private-channel-deploy/templates/env.j2` references a key
+`.env.example` doesn't document. It runs automatically before `make docker-up` /
+`docker-devnet-up` (via `check-env-local` / `check-env-devnet`) and can be run
+directly with `make check-env-contract`. It compares **names only, never values**.
+
+## Value source per surface
+
+The contract is "same keys, same precedence" — *not* "same files". Where a value
+comes from differs on purpose:
+
+| Surface | Version pins | Environment values | Secrets |
+|---|---|---|---|
+| **Makefile (local)** | `versions.env` | tracked `.env.local` | filled into gitignored `.env` (or `.env.local`) by the operator / `make build-*` |
+| **Makefile (devnet)** | `versions.env` | tracked `.env.devnet` | gitignored `.env` |
+| **Ansible deploy** | `versions.env` (copied to target) | rendered `.env` from `templates/env.j2` | templated from SOPS-backed Ansible vars into the rendered `.env` |
+
+Local dev keeps **checked-in, secret-free presets** so `git clone && make docker-up`
+works out of the box; the deploy templates **real secrets** that must never be
+committed. Same contract, different source — by design.
+
+## Precedence (load order)
+
+Every surface layers env files in the same order, later files winning on conflict:
+
+```
+versions.env  →  <environment file>  →  [optional .env override]
+```
+
+- **Makefile:** `--env-file versions.env --env-file .env.local|.env.devnet [--env-file .env]`
+- **Deploy:** `--env-file versions.env --env-file .env` (the rendered file plays the
+  role of the environment file)
+
+`versions.env` (toolchain/image pins) is **universal** — always first, on every
+surface, including doc snippets. Never start the stack without it.
+
+## Required secrets (fail-closed)
+
+`scripts/check-required-env.sh` enforces that a non-empty value resolves for the
+required secrets before the stack starts. It is shared: the Makefile's
+`check-env-*` targets and the Ansible deploy (after rendering `.env`) both run it,
+so a blank secret is caught identically on both surfaces. Currently required:
+
+- `POSTGRES_PASSWORD`
+- `POSTGRES_REPLICATION_PASSWORD`
+
+No working defaults ship for these. Generate values with `openssl rand -hex 32`.
+`JWT_SECRET` is required only when auth/RBAC is enabled (see `.env.example`).
+
+## Adding or removing a variable
+
+1. Add/remove it in **`.env.example`** first (the contract).
+2. Update the surfaces that set it: `.env.local`, `.env.devnet`, and/or
+   `templates/env.j2`.
+3. If it's a secret with no safe default, add it to `REQUIRED_VARS` in
+   `scripts/check-required-env.sh`.
+4. Run `make check-env-contract` — it must pass before the change lands.
+
+Keys with compose-side defaults (e.g. `PRIVATE_CHANNEL_VERSION`, `STREAMER_PORT`)
+are still documented in `.env.example` so the contract is complete, even though
+omitting them from an env file is harmless.

--- a/docs/PITR.md
+++ b/docs/PITR.md
@@ -50,7 +50,14 @@ This document describes how WAL archiving, base backups, and point-in-time recov
 - Identify the **target recovery time** (UTC timestamp)
 - Identify which database to restore (`primary` or `indexer`)
 
-> **Note:** The volume names below assume the Docker Compose project name is `private_channel` (the default when running from the repo root). If your project name differs, substitute `private_channel_` with your actual project name prefix. Run `docker volume ls | grep postgres` to confirm.
+> **Note:** The Compose project name is `private-channel` (set via the `name:` key
+> in `docker-compose.yml`), so volumes are prefixed `private-channel_` and containers
+> `private-channel-`. Run `docker volume ls | grep postgres` to confirm. All
+> `docker compose` commands below assume you're in the repo root (they resolve
+> `docker-compose.yml` and the `private-channel` project automatically); if compose
+> reports unset variables, prepend the standard env chain
+> `--env-file versions.env --env-file .env.local`, or use the guarded `make docker-*`
+> targets.
 
 ### Step 1: Stop the database and dependents
 
@@ -59,7 +66,7 @@ This document describes how WAL archiving, base backups, and point-in-time recov
 docker compose stop streamer write-node read-node postgres-replica postgres-primary pg-backup-primary
 
 # For postgres-indexer:
-docker compose stop indexer-solana indexer-private_channel operator-solana operator-private_channel streamer pg-backup-indexer postgres-indexer
+docker compose stop indexer-solana indexer-private-channel operator-solana operator-private-channel streamer pg-backup-indexer postgres-indexer
 ```
 
 > `streamer` depends on both `postgres-replica` (accounts DB) and `postgres-indexer` (indexer DB), so it must be stopped for either restore scenario.
@@ -68,10 +75,10 @@ docker compose stop indexer-solana indexer-private_channel operator-solana opera
 
 ```bash
 # For postgres-primary:
-docker run --rm -v private_channel_postgres-primary-data:/data alpine sh -c "rm -rf /data/*"
+docker run --rm -v private-channel_postgres-primary-data:/data alpine sh -c "rm -rf /data/*"
 
 # For postgres-indexer:
-docker run --rm -v private_channel_postgres-indexer-data:/data alpine sh -c "rm -rf /data/*"
+docker run --rm -v private-channel_postgres-indexer-data:/data alpine sh -c "rm -rf /data/*"
 ```
 
 ### Step 3: Restore the base backup
@@ -80,12 +87,12 @@ Pick the most recent base backup **before** your target recovery time.
 
 ```bash
 # List available backups:
-docker run --rm -v private_channel_postgres-primary-basebackups:/backups alpine ls -la /backups/
+docker run --rm -v private-channel_postgres-primary-basebackups:/backups alpine ls -la /backups/
 
 # Restore (example with base_20260304_060000):
 docker run --rm \
-  -v private_channel_postgres-primary-basebackups:/backups:ro \
-  -v private_channel_postgres-primary-data:/data \
+  -v private-channel_postgres-primary-basebackups:/backups:ro \
+  -v private-channel_postgres-primary-data:/data \
   postgres:16-alpine sh -c "
     cd /data
     tar xzf /backups/base_20260304_060000/base.tar.gz
@@ -102,7 +109,7 @@ PostgreSQL 16 uses `postgresql.auto.conf` + `recovery.signal` (not the removed `
 
 ```bash
 docker run --rm \
-  -v private_channel_postgres-primary-data:/data \
+  -v private-channel_postgres-primary-data:/data \
   alpine sh -c "
     cat >> /data/postgresql.auto.conf << 'EOF'
 restore_command = 'cp /wal_archive/%f %p'
@@ -135,13 +142,13 @@ docker compose logs -f postgres-indexer
 docker compose up -d postgres-replica write-node read-node streamer pg-backup-primary
 
 # For postgres-indexer:
-docker compose up -d indexer-solana indexer-private_channel operator-solana operator-private_channel streamer pg-backup-indexer
+docker compose up -d indexer-solana indexer-private-channel operator-solana operator-private-channel streamer pg-backup-indexer
 ```
 
 > **Note:** The postgres-replica will need to re-sync from scratch after a primary PITR. Delete its data volume if it fails to start:
 > ```bash
 > docker compose stop postgres-replica
-> docker run --rm -v private_channel_postgres-replica-data:/data alpine sh -c "rm -rf /data/*"
+> docker run --rm -v private-channel_postgres-replica-data:/data alpine sh -c "rm -rf /data/*"
 > docker compose up -d postgres-replica
 > ```
 
@@ -160,15 +167,15 @@ Restoring `postgres-indexer` via PITR is safe:
 
 ```bash
 # Should show WAL files accumulating:
-docker run --rm -v private_channel_postgres-primary-wal-archive:/archive alpine ls -la /archive/ | tail -5
-docker run --rm -v private_channel_postgres-indexer-wal-archive:/archive alpine ls -la /archive/ | tail -5
+docker run --rm -v private-channel_postgres-primary-wal-archive:/archive alpine ls -la /archive/ | tail -5
+docker run --rm -v private-channel_postgres-indexer-wal-archive:/archive alpine ls -la /archive/ | tail -5
 ```
 
 ### Check base backups exist
 
 ```bash
-docker run --rm -v private_channel_postgres-primary-basebackups:/backups alpine ls -la /backups/
-docker run --rm -v private_channel_postgres-indexer-basebackups:/backups alpine ls -la /backups/
+docker run --rm -v private-channel_postgres-primary-basebackups:/backups alpine ls -la /backups/
+docker run --rm -v private-channel_postgres-indexer-basebackups:/backups alpine ls -la /backups/
 ```
 
 ### Check sidecar logs

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -99,7 +99,8 @@ collateral.
    triage (Step 2: oldest `updated_at` is the trigger), not in the re-arm
    query. If you have *multiple* unresolved trigger rows from different
    incidents, recover them one at a time and exclude each via `id <> :id`.
-5. **Restart the withdraw operator** (Docker: `docker compose restart
+5. **Restart the withdraw operator** (Docker, from the repo root: `docker compose
+   restart operator-private-channel`; or by container: `docker restart
    private-channel-operator-private-channel`). The fetcher picks up `pending` rows and
    processing resumes.
 6. **Confirm recovery** by watching for new `Completed` webhooks for

--- a/dvp-swap-program/Makefile
+++ b/dvp-swap-program/Makefile
@@ -60,7 +60,8 @@ fmt:
 	pnpm format
 
 # Unit tests: program crate's #[cfg(test)] modules + JS client tests.
-unit-test:
+# install + generate-clients first so the TS suites can import the gitignored src/generated.
+unit-test: install generate-clients
 	@echo "Running unit tests for swap program..."
 	pnpm test:unit
 	@cd program && cargo test

--- a/dvp-swap-program/scripts/generate-clients.ts
+++ b/dvp-swap-program/scripts/generate-clients.ts
@@ -38,6 +38,8 @@ dvpSwapCodama.accept(
 dvpSwapCodama.accept(
   renderJavaScriptVisitor(path.join(typescriptClientsDir, "src", "generated"), {
     formatCode: true,
+    // Default appends another src/generated under this path; "." writes in place to avoid double-nesting.
+    generatedFolder: ".",
     deleteFolderBeforeRendering: true,
   }),
 );

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -122,6 +122,13 @@ struct ReadyCache {
 const READY_CACHE_TTL: Duration = Duration::from_secs(2);
 const READY_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// A `JWT_SECRET` counts as "configured" only if non-empty after trimming, mirroring the
+/// auth service so a whitespace-only secret doesn't enable gateway RBAC while auth refuses
+/// to start.
+fn configured_secret(secret: Option<&str>) -> Option<&str> {
+    secret.filter(|s| !s.trim().is_empty())
+}
+
 impl Gateway {
     pub fn new(
         write_url: String,
@@ -136,12 +143,9 @@ impl Gateway {
             .enable_http1()
             .build();
         let client = Client::builder(TokioExecutor::new()).build(https);
-        // Convert the raw secret string into a DecodingKey once here.
-        // filter out empty strings so JWT_SECRET="" is treated as "not set" rather than
-        // enabling auth with a trivially forgeable empty secret (likely a misconfiguration).
-        let jwt_secret = jwt_secret
-            .as_deref()
-            .filter(|s| !s.is_empty())
+        // Treat an empty or whitespace-only JWT_SECRET as "not set"; key is built from the
+        // untrimmed bytes so it stays identical to the auth service's signing key.
+        let jwt_secret = configured_secret(jwt_secret.as_deref())
             .map(|s| DecodingKey::from_secret(s.as_bytes()));
         Self {
             write_url,
@@ -672,12 +676,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     info!("  CORS Allowed Origin: {}", args.cors_allowed_origin);
     info!(
         "  Auth enforcement: {}",
-        if args
-            .jwt_secret
-            .as_deref()
-            .filter(|s| !s.is_empty())
-            .is_some()
-        {
+        if configured_secret(args.jwt_secret.as_deref()).is_some() {
             "enabled"
         } else {
             "disabled"
@@ -693,13 +692,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     // operator who sets JWT_SECRET believes auth is active; failing here at boot
     // ensures that belief is correct rather than every request passing through
     // unguarded at runtime.
-    if args
-        .jwt_secret
-        .as_deref()
-        .filter(|s| !s.is_empty())
-        .is_some()
-        && args.auth_database_url.is_none()
-    {
+    if configured_secret(args.jwt_secret.as_deref()).is_some() && args.auth_database_url.is_none() {
         return Err(
             "JWT_SECRET is set but AUTH_DATABASE_URL is not configured. \
              Auth enforcement requires both. Either provide AUTH_DATABASE_URL \

--- a/gateway/tests/auth_integration.rs
+++ b/gateway/tests/auth_integration.rs
@@ -1011,6 +1011,70 @@ async fn test_empty_jwt_secret_disables_auth() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_whitespace_jwt_secret_disables_auth() {
+    // A whitespace-only JWT_SECRET must be treated as "not set", disabling enforcement
+    // rather than enabling RBAC with a key the auth service would reject at startup.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    let (auth_db, _, _container) = start_postgres().await;
+    db::init_schema(&auth_db)
+        .await
+        .expect("failed to init schema");
+
+    // Spin up a minimal mock backend that always returns 200.
+    let read_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let read_backend = read_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = read_listener.accept().await {
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+            let body = r#"{"jsonrpc":"2.0","id":1,"result":{"value":null}}"#;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(resp.as_bytes()).await;
+        }
+    });
+
+    let gateway = Arc::new(Gateway::new(
+        "http://127.0.0.1:1".to_string(),
+        format!("http://{}", read_backend),
+        "*".to_string(),
+        Some("   ".to_string()), // whitespace-only — must be treated as "not set"
+        Some(auth_db),
+    ));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = serve(listener, gateway).await;
+    });
+
+    // A gated method with no token should get 200 (auth disabled, proxied to backend).
+    let res = Client::new()
+        .post(format!("http://{}", addr))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getAccountInfo",
+            "params": ["SomePubkey"]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        res.status(),
+        200,
+        "whitespace-only JWT_SECRET should disable auth enforcement"
+    );
+}
+
 /// `getSignaturesForAddress` with no token must return 401.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_signatures_for_address_no_token_returns_401() {

--- a/indexer/Makefile
+++ b/indexer/Makefile
@@ -27,7 +27,10 @@ ESCROW_INSTANCE_ID ?=
 YELLOWSTONE_REPO ?= https://github.com/rpcpool/yellowstone-grpc.git
 YELLOWSTONE_DIR ?= .yellowstone-grpc
 YELLOWSTONE_BRANCH ?= fix-core-affinity-mac
-YELLOWSTONE_DYLIB_SRC = $(YELLOWSTONE_DIR)/target/release/libyellowstone_grpc_geyser.dylib
+# cargo emits the plugin as .so on Linux and .dylib on macOS; pick the right source extension.
+YELLOWSTONE_LIB_EXT := $(if $(filter Darwin,$(shell uname -s)),dylib,so)
+YELLOWSTONE_DYLIB_SRC = $(YELLOWSTONE_DIR)/target/release/libyellowstone_grpc_geyser.$(YELLOWSTONE_LIB_EXT)
+# Canonical name config.json references; dlopen loads by file format not extension, so a Linux .so copied here loads fine.
 YELLOWSTONE_DYLIB_DEST = src/indexer/datasource/common/yellowstone_grpc/libyellowstone_grpc_geyser.dylib
 
 ## Build the indexer
@@ -203,10 +206,9 @@ yellowstone-clone:
 build-yellowstone-plugin: yellowstone-clone
 	@echo "Building Yellowstone gRPC Geyser plugin..."
 	@cd $(YELLOWSTONE_DIR)/yellowstone-grpc-geyser && cargo build --release --no-default-features
-	@echo "Copying dylib to indexer..."
+	@echo "Copying plugin ($(YELLOWSTONE_LIB_EXT)) to indexer..."
 	@cp $(YELLOWSTONE_DYLIB_SRC) $(YELLOWSTONE_DYLIB_DEST)
-	@echo "✅ Plugin built and copied to: $(YELLOWSTONE_DYLIB_DEST)"
-	@echo "Note: On Linux this will be .so, on macOS .dylib, update config.json accordingly"
+	@echo "Plugin built and copied to: $(YELLOWSTONE_DYLIB_DEST)"
 
 ## Clean Yellowstone build artifacts
 clean-yellowstone:

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -1085,13 +1085,15 @@ mod tests {
 
         processor.start(rx).await.unwrap();
 
-        let batches = mock.inserted_transactions.lock().unwrap();
-        assert_eq!(batches.len(), 2, "each slot finalizes its own batch");
-        assert_eq!(batches[0][0].signature, "a");
-        assert_eq!(batches[0][0].slot, SLOT_A as i64);
-        assert_eq!(batches[1][0].signature, "b");
-        assert_eq!(batches[1][0].slot, SLOT_B as i64);
-        drop(batches);
+        // Scope the std Mutex guard so it is dropped before the awaits below.
+        {
+            let batches = mock.inserted_transactions.lock().unwrap();
+            assert_eq!(batches.len(), 2, "each slot finalizes its own batch");
+            assert_eq!(batches[0][0].signature, "a");
+            assert_eq!(batches[0][0].slot, SLOT_A as i64);
+            assert_eq!(batches[1][0].signature, "b");
+            assert_eq!(batches[1][0].slot, SLOT_B as i64);
+        }
 
         let first = checkpoint_rx.recv().await.unwrap();
         let second = checkpoint_rx.recv().await.unwrap();

--- a/indexer/src/operator/escrow_sweep.rs
+++ b/indexer/src/operator/escrow_sweep.rs
@@ -205,7 +205,7 @@ mod tests {
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex(spl_token_2022::id().to_string()))
             .with_status(200)
-            .with_body(EMPTY_BODY.to_string())
+            .with_body(EMPTY_BODY)
             .create_async()
             .await;
     }

--- a/integration/tests/indexer/multi_instruction_pipeline.rs
+++ b/integration/tests/indexer/multi_instruction_pipeline.rs
@@ -3,6 +3,7 @@
 //! Target files:
 //!   - `indexer/src/indexer/transaction_processor.rs` (buffering + convert)
 //!   - `indexer/src/storage/postgres/db.rs` (composite-key batch insert)
+//!
 //! Binary: `reconciliation_integration` (attached via `#[path]` mod from
 //! `tests/indexer/reconciliation.rs`).
 //!

--- a/monitoring/monitoring.compose.yml.j2
+++ b/monitoring/monitoring.compose.yml.j2
@@ -6,6 +6,13 @@
 # and cAdvisor sees every running container. Prometheus + Grafana run on
 # host-port-forwarded volumes for persistence across re-runs.
 
+# Explicit project name so this sibling stack has a stable, predictable identity
+# instead of inheriting the target directory basename. Kept separate from the
+# main `private-channel` project on purpose: the deploy stops/tears this stack
+# down independently, so sharing the main project name would let a main-stack
+# `down` also remove monitoring.
+name: private-channel-monitoring
+
 networks:
   private-channel:
     name: private-channel_private-channel-network

--- a/private-channel-deploy/README.md
+++ b/private-channel-deploy/README.md
@@ -12,7 +12,7 @@ Run [`scripts/install-prereqs.sh`](./scripts/install-prereqs.sh) once **on both 
 ./scripts/install-prereqs.sh        # run on control node, then again on the target host
 ```
 
-Uses `sudo` (apt + Docker repo). Run this in a terminal that can show password prompts, or `sudo -v` first to cache credentials.
+> Uses `sudo` (apt + Docker repo). Run this in a interactive terminal that can show password prompts.
 
 **Control node** (where you run `ansible-playbook`):
 
@@ -38,7 +38,7 @@ Three one-time edits per environment, done before the first deploy. They tell th
    cp secrets.yml.example secrets.yml
    ```
 
-   `secrets.yml` is plain text and gitignored. Keys: DB passwords, JWT secret, Solana keypair, GHCR creds, optional Yellowstone token + notify webhook. See the file header for required vs optional and how to generate each value.
+   `secrets.yml` is plain text and gitignored. See the file header for required vs optional and how to generate each value.
 
 Everything else is wired and shouldn't need routine changes. Cross-env defaults that you can override but rarely need to (db/user names, replication user, health-probe budgets) live in [`vars/common.yml`](./vars/common.yml); set the same key in [`vars/dev.yml`](./vars/dev.yml) to override per environment.
 

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -443,9 +443,11 @@
   #
   # WHY THIS EXISTS — DO NOT REMOVE WITHOUT UNDERSTANDING THIS:
   #
-  # The validator container boots with `--reset` (see VALIDATOR_RESET_FLAG in
-  # templates/env.j2), so every redeploy starts from genesis: empty ledger,
-  # zero ATA balances, no prior signatures. Meanwhile the indexer's startup
+  # The validator container boots with `--reset` by default (VALIDATOR_RESET_FLAG
+  # in templates/env.j2, gated by the `validator_reset` var — default true), so
+  # every redeploy starts from genesis: empty ledger, zero ATA balances, no prior
+  # signatures. (Set validator_reset=false only with persistence — see its note
+  # in vars/common.yml.) Meanwhile the indexer's startup
   # reconciliation compares its Postgres totals (deposits/withdrawals per
   # mint) against on-chain ATA balances. Stale rows from a prior run describe
   # a chain that no longer exists, the on-chain balance comes back as 0, and
@@ -621,6 +623,19 @@
         dest: "{{ host_data_dir }}/config/.env"
         mode: "0600"
       no_log: true
+
+    # Fail closed if the rendered .env is missing required secrets, using the
+    # same scripts/check-required-env.sh the Makefile's check-env-* targets run.
+    # This gives deploy and local-dev one shared env-completeness guard so both
+    # enforce the identical contract (e.g. a blank POSTGRES_PASSWORD from an
+    # undecrypted SOPS var is caught here rather than at container start).
+    - name: Validate required secrets in rendered .env
+      ansible.builtin.script:
+        cmd: >-
+          {{ repo_root }}/scripts/check-required-env.sh
+          {{ target_versions_env_file }}
+          {{ target_config_dir }}/.env
+      changed_when: false
 
     # The base compose file has bind mounts with relative `./` sources resolved
     # against the compose file's directory ({{ target_config_dir }}). When a

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -327,9 +327,11 @@
     # Mirror the template's `default(true)` so an unset flag still requires it.
     - name: Assert jwt_secret is set
       ansible.builtin.assert:
-        that: jwt_secret | default('') | length > 0
+        # `| trim` mirrors the gateway's configured_secret() trim semantics: a
+        # whitespace-only jwt_secret disables gateway auth, so it must fail here too.
+        that: jwt_secret | default('') | trim | length > 0
         fail_msg: |
-          `jwt_secret` empty in secrets.yml. Used by gateway to sign auth tokens.
+          `jwt_secret` empty (or whitespace-only) in secrets.yml. Used by gateway to sign auth tokens.
           Fix: edit secrets.yml and add `jwt_secret: <random-32+-byte-string>`  (e.g. `openssl rand -hex 32`).
       when: gateway_enforce_jwt | default(true) | bool
 

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -629,9 +629,7 @@
     - name: Validate required secrets in rendered .env
       ansible.builtin.script:
         cmd: >-
-          {{ repo_root }}/scripts/check-required-env.sh
-          {{ target_versions_env_file }}
-          {{ target_config_dir }}/.env
+          {{ repo_root }}/scripts/check-required-env.sh {{ target_versions_env_file }} {{ target_config_dir }}/.env
       changed_when: false
 
     # The base compose file has bind mounts with relative `./` sources resolved
@@ -672,6 +670,23 @@
         dest: "{{ target_config_dir }}/indexer/config/"
         mode: "0644"
         directory_mode: "0755"
+
+    # Devnet/mainnet indexer + operator TOMLs. docker-compose.devnet.yml
+    # bind-mounts ./scripts/devnet/config:/config/devnet for all four
+    # indexer/operator services; the localnet stack uses indexer/config/ above
+    # instead. Without shipping this dir, Docker auto-creates an empty one at
+    # the bind source and every service crashes looking for
+    # /config/devnet/indexer-solana.toml. The rpc_url / yellowstone endpoint
+    # inside these TOMLs are placeholders — they're overridden at runtime by the
+    # COMMON_RPC_URL / INDEXER_YELLOWSTONE_ENDPOINT env vars the devnet compose
+    # injects from the rendered .env (figment merges env over TOML).
+    - name: Copy devnet/mainnet indexer/operator TOML configs to target
+      ansible.builtin.copy:
+        src: "{{ repo_root }}/scripts/devnet/config/"
+        dest: "{{ target_config_dir }}/scripts/devnet/config/"
+        mode: "0644"
+        directory_mode: "0755"
+      when: network != 'localnet'
 
     # Validator-only assets. The validator service is included in
     # compose_services on localnet only (see vars/common.yml), but the bind

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -322,19 +322,16 @@
           `postgres_replication_password` empty in secrets.yml. postgres-replica uses it for streaming replication.
           Fix: edit secrets.yml and add `postgres_replication_password: repl_password` (literal, until init-primary.sql is parameterised).
 
+    # Only required when enforcement is on: env.j2 blanks JWT_SECRET when
+    # gateway_enforce_jwt is false, so the secret's value is unused there.
+    # Mirror the template's `default(true)` so an unset flag still requires it.
     - name: Assert jwt_secret is set
       ansible.builtin.assert:
         that: jwt_secret | default('') | length > 0
         fail_msg: |
           `jwt_secret` empty in secrets.yml. Used by gateway to sign auth tokens.
           Fix: edit secrets.yml and add `jwt_secret: <random-32+-byte-string>`  (e.g. `openssl rand -hex 32`).
-
-    - name: Assert solana_keypair is defined
-      ansible.builtin.assert:
-        that: solana_keypair is defined
-        fail_msg: |
-          `solana_keypair` missing from secrets.yml. Used by operator services to sign on-chain transactions.
-          Fix: paste the JSON byte array from `solana-keygen new` into `solana_keypair:` in secrets.yml.
+      when: gateway_enforce_jwt | default(true) | bool
 
     - name: Assert GHCR creds present
       ansible.builtin.assert:

--- a/private-channel-deploy/inventory.ini
+++ b/private-channel-deploy/inventory.ini
@@ -1,9 +1,9 @@
-# Single deployment target. Vars come from vars/dev.yml (selected by group name).
+# Single deployment target. Vars come from vars/dev.yml.
 # Add more groups (staging, prod, …) with matching vars/<group>.yml files.
 #
-# `ansible_host_key_checking=False` is set on the [dev] group only — these are
-# throwaway hosts where re-handshaking after every reset is friction without
-# security value. Staging/prod groups should leave it at the default (True)
+# `ansible_host_key_checking=False` is set on the [dev] group 
+# where re-handshaking after every reset is not needed.
+# Staging/prod groups should leave it at the default (True)
 # so the first deploy fails loud if someone hasn't pre-trusted the host key.
 # Pre-trust with: `ssh-keyscan -H <host> >> ~/.ssh/known_hosts`.
 [dev]

--- a/private-channel-deploy/secrets.yml.example
+++ b/private-channel-deploy/secrets.yml.example
@@ -4,7 +4,7 @@
 # See README "Future improvements" for the SOPS+age upgrade path.
 #
 # Required: postgres_password, postgres_replication_password, jwt_secret,
-#           grafana_admin_password, solana_keypair, ghcr_user, ghcr_token.
+#           grafana_admin_password, ghcr_user, ghcr_token.
 # Optional: yellowstone_token (devnet/mainnet only), notify_webhook.
 
 # Postgres super-user password. Used by postgres-primary and any service that
@@ -26,11 +26,6 @@ jwt_secret: ""
 # Grafana admin password. URL: http://<host>:<monitoring_grafana_port>, user: admin.
 # Forced password change on first login; rotate by editing here + redeploying.
 grafana_admin_password: ""
-
-# Solana keypair the operator services use to sign on-chain transactions.
-# Format: raw byte array as produced by `solana-keygen new --outfile <file>` (the JSON file's contents).
-# The corresponding pubkey must hold SOL on the target network.
-solana_keypair: []
 
 # GHCR credentials. Required — the deploy pulls images from GHCR.
 #   ghcr_user  = your GitHub username (or an org bot account).

--- a/private-channel-deploy/templates/env.j2
+++ b/private-channel-deploy/templates/env.j2
@@ -21,7 +21,12 @@ WITHDRAW_PROGRAM_ID={{ withdraw_program_id | default('J231K9UEpS4y4KAPwGc4gsMNCj
 # fallback kicks in) but compose's variable interpolation rejects unset vars
 # by default.
 ESCROW_INSTANCE_ID={{ escrow_instance_id | default('11111111111111111111111111111111') }}
-VALIDATOR_RESET_FLAG=--reset
+# Bundled localnet validator boot mode. Explicit, not hardcoded: `validator_reset`
+# (vars/common.yml, default true) → `--reset` boots from genesis every redeploy
+# (the indexer reconciliation rationale in deploy.yml depends on this); set false
+# to preserve the validator ledger across redeploys — the deploy analogue of
+# `make docker-up-persist`. Only safe when Postgres is NOT wiped in lockstep.
+VALIDATOR_RESET_FLAG={{ '--reset' if (validator_reset | default(true) | bool) else '' }}
 
 # --- Postgres (passwords from SOPS) ---
 POSTGRES_DB={{ postgres_db }}

--- a/private-channel-deploy/vars/common.yml
+++ b/private-channel-deploy/vars/common.yml
@@ -34,12 +34,6 @@ compose_file: "{{ 'docker-compose.devnet.yml' if network | default('localnet') i
 compose_services_base: "postgres-primary postgres-replica write-node read-node gateway postgres-indexer indexer-solana indexer-private-channel operator-solana operator-private-channel"
 compose_services: "{{ compose_services_base }}{{ ' validator' if network | default('localnet') == 'localnet' else '' }}"
 
-# Yellowstone gRPC endpoint for indexer-solana real-time streaming.
-# localnet : ignored — docker-compose.yml hardcodes http://validator:10000.
-# devnet / mainnet : your provider's URL (Helius/Triton/QuickNode); preflight
-#                    asserts non-empty. Pair with yellowstone_token in secrets.yml.
-yellowstone_endpoint: ""
-
 # --- Ports (host-side) — read by health probes ---
 gateway_port: 8899
 write_port: 8900

--- a/private-channel-deploy/vars/common.yml
+++ b/private-channel-deploy/vars/common.yml
@@ -65,6 +65,16 @@ postgres_replication_user: replicator
 # opt in explicitly. See vars/dev.yml for the rationale.
 reset_state: false
 
+# --- Validator ledger reset ---
+# Controls VALIDATOR_RESET_FLAG in the rendered .env (localnet bundled validator).
+# Default `true`: boot with `--reset` from genesis on every redeploy, which the
+# indexer's startup reconciliation depends on (see the RESET_STATE rationale in
+# deploy.yml). Set `false` to preserve the validator ledger across redeploys —
+# the deploy analogue of `make docker-up-persist`. Only safe when Postgres is
+# NOT wiped in lockstep, or the indexer will reconcile stale rows against an
+# empty chain.
+validator_reset: true
+
 # --- Optional notification webhook posted from the report phase ---
 notify_webhook: ""
 

--- a/private-channel-deploy/vars/dev.yml
+++ b/private-channel-deploy/vars/dev.yml
@@ -1,6 +1,4 @@
-# Dev environment overrides. The file most users edit.
-# Loaded by deploy.yml when invoked with `-l dev`.
-# Each option below: what it does, then how to choose.
+# Loaded by deploy.yml when invoked with `-l dev`
 
 # === What to deploy =========================================================
 
@@ -46,15 +44,10 @@ gateway_enforce_jwt: false
 # Override here if 8899 collides on this host (e.g. local Solana test-validator).
 # gateway_port: 8899
 
-# === Compose subset =========================================================
-
-# compose_services is derived in vars/common.yml (base list + `validator` on
-# localnet only). Uncomment and set explicitly here to override.
-# compose_services: "postgres-primary postgres-replica write-node read-node gateway ..."
-
-# === On-host program IDs ====================================================
-# program IDs deployed to the validator container.
-# Only relevant when network=localnet. Pinned to match the keypairs in the repo.
+# === Program IDs ===========================================================
+# Addresses the indexer/operator watch. On localnet these are also where the
+# bundled validator deploys the repo's .so files (pinned to the repo keypairs).
+# On devnet/mainnet the programs must already be deployed; set these to match.
 escrow_program_id: GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
 withdraw_program_id: J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi
 
@@ -87,7 +80,6 @@ monitoring_blackbox_port: 9115
 monitoring_cadvisor_port: 8081
 monitoring_node_exporter_port: 9101
 monitoring_postgres_exporter_port: 9187
-# Indexer postgres-exporter sits on a distinct host port so both exporters
-# (primary + indexer) can be reached without colliding. Defaults to one
-# above the primary; override only if 9188 is already taken.
+# Indexer postgres-exporter needs a distinct host port from the primary
+# exporter (9187) so both can be scraped without colliding.
 monitoring_postgres_exporter_indexer_port: 9188

--- a/private-channel-deploy/vars/dev.yml
+++ b/private-channel-deploy/vars/dev.yml
@@ -25,6 +25,14 @@ network: localnet
 #   mainnet  : your dedicated RPC (Helius, Triton, QuickNode, etc.).
 rpc_url: http://127.0.0.1:18899
 
+# yellowstone_endpoint — Yellowstone gRPC endpoint for indexer-solana real-time
+# streaming. Env-specific, so it lives here rather than in common.yml.
+#   localnet : ignored — docker-compose.yml hardcodes http://validator:10000, so "" is fine.
+#   devnet / mainnet : your provider's URL (Helius/Triton/QuickNode). Preflight
+#                      asserts non-empty when network != localnet; pair with
+#                      yellowstone_token in secrets.yml.
+yellowstone_endpoint: ""
+
 # === On-host layout ========================================================
 
 # host_data_dir — where Compose volumes, rendered config, and logs live on the host.

--- a/private-channel-escrow-program/Makefile
+++ b/private-channel-escrow-program/Makefile
@@ -55,7 +55,8 @@ generate-clients: generate-idl
 ### Tests ###
 
 # Run unit tests in program/
-unit-test:
+# install + generate-clients first so the TS suites can import the gitignored src/generated.
+unit-test: install generate-clients
 	@echo "Running unit tests for escrow program..."
 	pnpm test:unit
 	@cd program && cargo test

--- a/private-channel-escrow-program/Makefile
+++ b/private-channel-escrow-program/Makefile
@@ -92,8 +92,10 @@ all-coverage: unit-coverage coverage-html
 build-localnet:
 	$(MAKE) generate-clients
 	cd program && cargo-build-sbf
-	@echo "Updating .env.local with program IDs..."
-	@../scripts/update-program-env.sh ../.env.local $(PROGRAM_ENV_KEY) $(PROGRAM_KEYPAIR)
+	@# Do NOT patch ESCROW_PROGRAM_ID from $(PROGRAM_KEYPAIR): the program ID is fixed by
+	@# the program's declare_id! and matched by the indexer's hardcoded constant, so
+	@# .env.local carries the canonical ID statically. The build keypair differs from
+	@# declare_id, and deploying at it makes indexer-solana watch the wrong address.
 
 #############
 # Devnet

--- a/private-channel-escrow-program/scripts/generate-clients.ts
+++ b/private-channel-escrow-program/scripts/generate-clients.ts
@@ -34,14 +34,12 @@ privateChannelEscrowCodama.accept(
     }),
 );
 
-// Generate TypeScript client (renderers-js v2 signature: first arg is the
-// package root, generatedFolder option points at the codegen subdir).
-// syncPackageJson is disabled because we don't publish the generated client
-// as a standalone npm package — admin-ui consumes it via Vite path alias.
+// Emit to src/generated to match the Rust client and the @private-channel-escrow Vite/tsconfig alias; syncPackageJson off since the client isn't published.
 privateChannelEscrowCodama.accept(
-    renderJavaScriptVisitor(typescriptClientsDir, {
+    renderJavaScriptVisitor(path.join(typescriptClientsDir, 'src', 'generated'), {
         formatCode: true,
-        generatedFolder: 'src/generated',
+        // Default appends another src/generated under this path; '.' writes in place to avoid double-nesting.
+        generatedFolder: '.',
         syncPackageJson: false,
         deleteFolderBeforeRendering: true,
     }),

--- a/private-channel-withdraw-program/Makefile
+++ b/private-channel-withdraw-program/Makefile
@@ -80,8 +80,10 @@ all-coverage: unit-coverage coverage-html
 build-localnet:
 	$(MAKE) generate-clients
 	cd program && cargo-build-sbf
-	@echo "Updating .env.local with program IDs..."
-	@../scripts/update-program-env.sh ../.env.local $(PROGRAM_ENV_KEY) $(PROGRAM_KEYPAIR)
+	@# Do NOT patch WITHDRAW_PROGRAM_ID from $(PROGRAM_KEYPAIR): the program ID is fixed by
+	@# the program's declare_id! and matched by the indexer's hardcoded constant, so
+	@# .env.local carries the canonical ID statically. The build keypair differs from
+	@# declare_id, and deploying at it makes the indexer watch the wrong address.
 
 #############
 # Devnet

--- a/private-channel-withdraw-program/Makefile
+++ b/private-channel-withdraw-program/Makefile
@@ -43,7 +43,8 @@ generate-clients: generate-idl
 ### Tests ###
 
 # Run unit tests in program/
-unit-test:
+# install + generate-clients first so the TS suites can import the gitignored src/generated.
+unit-test: install generate-clients
 	@echo "Running unit tests for withdraw program..."
 	pnpm test:unit
 	@cd program && cargo test

--- a/private-channel-withdraw-program/scripts/generate-clients.ts
+++ b/private-channel-withdraw-program/scripts/generate-clients.ts
@@ -30,14 +30,12 @@ privateChannelWithdrawCodama.accept(
     }),
 );
 
-// Generate TypeScript client (renderers-js v2 signature: first arg is the
-// package root, generatedFolder option points at the codegen subdir).
-// syncPackageJson is disabled because we don't publish the generated client
-// as a standalone npm package — admin-ui consumes it via Vite path alias.
+// Emit to src/generated to match the Rust client and the @private-channel-withdraw Vite/tsconfig alias; syncPackageJson off since the client isn't published.
 privateChannelWithdrawCodama.accept(
-    renderJavaScriptVisitor(typescriptClientsDir, {
+    renderJavaScriptVisitor(path.join(typescriptClientsDir, 'src', 'generated'), {
         formatCode: true,
-        generatedFolder: 'src/generated',
+        // Default appends another src/generated under this path; '.' writes in place to avoid double-nesting.
+        generatedFolder: '.',
         syncPackageJson: false,
         deleteFolderBeforeRendering: true,
     }),

--- a/scripts/check-docker.sh
+++ b/scripts/check-docker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-docker.sh — fail closed unless a usable Docker Engine (>= 26) is present.
+# Shared guard: the Makefile's `check-docker` target runs this, and deployment
+# automation can run the same script so every surface enforces one Docker
+# precondition. >= 26 is required for the BuildKit cache mounts the compose
+# build targets rely on.
+
+MIN_MAJOR=26
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker not found on PATH — required for compose-based dev/test stacks (>= ${MIN_MAJOR}.0)" >&2
+  exit 1
+fi
+
+# Prefer the server (daemon) version; fall back to the client so a stopped
+# daemon produces the dedicated "daemon not running?" message below.
+ver="$(docker version --format '{{.Server.Version}}' 2>/dev/null \
+  || docker version --format '{{.Client.Version}}' 2>/dev/null || true)"
+if [ -z "$ver" ]; then
+  echo "ERROR: docker present but version could not be read (daemon not running?)" >&2
+  exit 1
+fi
+
+major="$(echo "$ver" | cut -d. -f1)"
+if [ "$major" -lt "$MIN_MAJOR" ] 2>/dev/null; then
+  echo "ERROR: docker is $ver; this repo requires >= ${MIN_MAJOR}.0 (BuildKit cache mounts)." >&2
+  exit 1
+fi

--- a/scripts/check-env-contract.sh
+++ b/scripts/check-env-contract.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-env-contract.sh — enforce the env-variable *contract*: `.env.example` is
+# the canonical, documented superset of every key any surface actually uses.
+#
+# The value source legitimately differs per surface (tracked presets for local
+# dev, an Ansible-rendered `.env` from env.j2 for deploy), but the *key set* must
+# not drift: if a surface references a key `.env.example` doesn't document, a
+# `git clone && make docker-up` user silently gets an unset/empty value. This
+# check fails closed on that drift. It compares key *names* only, never values.
+#
+# Usage: check-env-contract.sh   (run from repo root)
+
+cd "$(dirname "$0")/.."
+
+EXAMPLE=".env.example"
+# Surfaces whose keys must all be documented in .env.example.
+SURFACES=(
+  ".env.local"
+  ".env.devnet"
+  "private-channel-deploy/templates/env.j2"
+)
+
+# Extract the set of variable names (LHS of `KEY=`) from a file, ignoring
+# comments and blank lines. Works for both plain env files and the Jinja
+# template (whose lines are still `KEY={{ ... }}`).
+keys() {
+  grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$1" 2>/dev/null \
+    | sed -E 's/^[[:space:]]*//; s/=$//' | sort -u
+}
+
+if [[ ! -f "$EXAMPLE" ]]; then
+  echo "FATAL: $EXAMPLE not found (run from repo root)." >&2
+  exit 1
+fi
+
+example_keys="$(keys "$EXAMPLE")"
+status=0
+
+for surface in "${SURFACES[@]}"; do
+  if [[ ! -f "$surface" ]]; then
+    echo "WARN: surface not found, skipping: $surface" >&2
+    continue
+  fi
+  # Keys present in the surface but absent from .env.example.
+  undocumented="$(comm -23 <(keys "$surface") <(printf '%s\n' "$example_keys"))"
+  if [[ -n "$undocumented" ]]; then
+    echo "FAIL: $surface references keys not documented in $EXAMPLE:" >&2
+    echo "$undocumented" | sed 's/^/  - /' >&2
+    status=1
+  fi
+done
+
+if [[ $status -ne 0 ]]; then
+  echo "" >&2
+  echo "Add the missing key(s) to $EXAMPLE (the canonical contract) or remove" >&2
+  echo "them from the surface above. Values may differ per surface; keys must not." >&2
+  exit 1
+fi
+
+echo "env contract OK: every surface key is documented in $EXAMPLE."
+exit 0


### PR DESCRIPTION
## Summary

Several independent, low-risk pre-audit hardening steps. Only one touches runtime code - a read-only-node boot-path fix; the rest is CI, build/test, config/auth, repo hygiene, and dev/deploy consistency.

1. **CI: fork PRs go green and still get coverage.** Forks run with a read-only `GITHUB_TOKEN`, so the inline coverage-table writes `403` and fail the job. `rust.yml` now skips those writes for forks, and a separate least-privilege `workflow_run` job posts the fork coverage table without ever running fork code.
2. **Gateway + deploy: whitespace `JWT_SECRET`.** `JWT_SECRET="   "` turned on gateway RBAC while the auth service refused to start. The gateway (all three call sites) and the Ansible preflight now treat "empty after trimming" as unset.
3. **TS client codegen -> `src/generated/`.** All three program generators emitted the TypeScript client to the wrong path - untracked, off the Rust client's layout, and unreachable by the admin-ui alias. Fixed to emit into `clients/typescript/src/generated/`.
4. **Docker workflow consistency.** The three ways to start the stack - `make docker-*`, the docs, and the Ansible deploy - now agree on Compose project name, preflight guards, and the env-variable contract (build-vs-pull steps stay different by design).
5. **Runtime: read-only-node startup fix.** A read-only node crash-looped on boot because the address-index repair writes to its read-replica DB. It now skips the repair on read-only nodes and still runs it against the primary on the write/Aio path. Found and verified by a full `bench-tps` smoke test.
6. **Build/test hygiene.** Lint `private-channel-core` in CI (and fix the lint found), fix the test-code lints `make fmt` enforces, make `make unit-test` pass on a clean checkout, fix the Yellowstone plugin build on Linux, and add `make docker-up PROFILE=...`.
7. **Localnet program-ID consistency.** The committed program keypairs differ from each program's `declare_id!`, and `make build-localnet` patched `.env.local` from those keypairs - so localnet deployed the escrow/withdraw programs at addresses the indexer (pinned to `declare_id`) never watches, silently breaking deposit indexing. `.env.local` now carries the canonical IDs (matching `declare_id!`, the indexer constants, and the bench), and `build-localnet` no longer overwrites them.
8. **Devnet quickstart hardening (docs).** Pin prerequisite versions to `versions.env`/`rust-toolchain.toml`, route the guide through the guarded `make docker-devnet-*` targets, add a remote-deploy pointer to the Ansible runbook, correct the program-ID guidance (it's compiled-in, not an env var), and move `yellowstone_endpoint` to `vars/dev.yml` (where the preflight already says it belongs).


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,149 | 12,764 | 87.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27956167421) |
| Indexer | 22,176 | 25,071 | 88.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27956167421) |
| Gateway | 995 | 1,154 | 86.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27956167421) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27956167421) |
| Withdraw Program | 129 | 241 | 53.5% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27956167419) |
| Escrow Program | 1,195 | 1,982 | 60.3% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27956167419) |
| DvP Swap Program | 270 | 1,179 | 22.9% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27956167419) |
| E2E Integration | 11,885 | 14,822 | 80.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27956167421) |
| **Total** | **48,246** | **56,865** | **84.8%** | |

> Last updated: 2026-06-22 13:52:20 UTC by E2E Integration