### PR TITLE
fix(indexer): enforce single sender per database with advisory lock

### DIFF
--- a/indexer/src/error/operator.rs
+++ b/indexer/src/error/operator.rs
@@ -43,4 +43,7 @@ pub enum OperatorError {
         "Mint {mint} has no allowed status in mint_status_history at the deposit's slot (transaction {transaction_id}); refusing to mint"
     )]
     MintNotAllowed { transaction_id: i64, mint: String },
+
+    #[error("Another {program_type:?} sender already holds the singleton lock; refusing to start")]
+    SenderAlreadyRunning { program_type: crate::ProgramType },
 }

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -137,7 +137,11 @@ fn classify_processor_error(err: &OperatorError) -> ErrorDisposition {
         OperatorError::Program(_) => ErrorDisposition::Quarantine("program_error"),
         // MissingBuilder means the processor was constructed without the state it
         // needs — configuration bug, not a row problem.  Exit to surface it.
-        OperatorError::MissingBuilder => ErrorDisposition::Fatal,
+        // SenderAlreadyRunning is a sender-startup error and never reaches the
+        // processor, but it's Fatal in spirit, so classify it alongside.
+        OperatorError::MissingBuilder | OperatorError::SenderAlreadyRunning { .. } => {
+            ErrorDisposition::Fatal
+        }
         // A dead downstream channel means the sender or storage writer died; the
         // supervisor handles this by aborting the whole operator.
         OperatorError::ChannelSend(_)

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -166,6 +166,15 @@ use transaction::{
 };
 use types::{PollTaskResult, SenderState};
 
+/// Advisory-lock key per operator role. Distinct keys so an escrow and a
+/// withdraw sender never contend on the same lock if they share a database.
+fn sender_lock_key(program_type: ProgramType) -> i64 {
+    match program_type {
+        ProgramType::Escrow => 1,
+        ProgramType::Withdraw => 2,
+    }
+}
+
 /// Sends transactions to the blockchain and updates their status
 ///
 /// Receives TransactionBuilder (either ReleaseFunds or Mint) from processor,
@@ -198,6 +207,23 @@ pub async fn run_sender(
         confirmation_poll_interval_ms,
         source_rpc_client,
     )?;
+
+    // Refuse to start if another sender for this role already holds the lock.
+    // Held for the rest of run_sender; released on drop or process crash. Stops
+    // two overlapping senders (e.g. a rolling restart) from both reminting the
+    // same row before either confirms on-chain.
+    let _sender_lock = match state
+        .storage
+        .try_acquire_sender_lock(sender_lock_key(config.program_type))
+        .await?
+    {
+        Some(guard) => guard,
+        None => {
+            return Err(OperatorError::SenderAlreadyRunning {
+                program_type: config.program_type,
+            });
+        }
+    };
 
     // Re-hydrate the deferred remint queue from any PendingRemint rows written
     // before a crash. These will be picked up by process_pending_remints on the

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -166,12 +166,19 @@ use transaction::{
 };
 use types::{PollTaskResult, SenderState};
 
+/// Advisory-lock keys per sender role. Distinct, namespaced 64-bit values
+/// (ASCII tags, matching `TRUNCATE_ADVISORY_LOCK_ID`) so senders never collide
+/// with each other, the truncate lock, or third-party tooling that grabs
+/// small-integer advisory locks on a shared database.
+const ESCROW_SENDER_LOCK_KEY: i64 = 0x53_4E_44_5F_45_53_43_52; // "SND_ESCR"
+const WITHDRAW_SENDER_LOCK_KEY: i64 = 0x53_4E_44_5F_57_44_52_57; // "SND_WDRW"
+
 /// Advisory-lock key per operator role. Distinct keys so an escrow and a
 /// withdraw sender never contend on the same lock if they share a database.
 fn sender_lock_key(program_type: ProgramType) -> i64 {
     match program_type {
-        ProgramType::Escrow => 1,
-        ProgramType::Withdraw => 2,
+        ProgramType::Escrow => ESCROW_SENDER_LOCK_KEY,
+        ProgramType::Withdraw => WITHDRAW_SENDER_LOCK_KEY,
     }
 }
 

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -26,6 +26,7 @@ pub mod insert_mint_statuses_batch;
 pub mod insert_release_signature;
 pub mod quarantine_all_active_withdrawals;
 pub mod record_remint_result;
+pub mod sender_lock;
 pub mod set_mint_extension_flags;
 pub mod set_pending_remint;
 pub mod sync_mint_status;
@@ -305,6 +306,15 @@ impl Storage {
         &self,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         get_pending_remint_transactions::get_pending_remint_transactions(self).await
+    }
+
+    /// Try to acquire the singleton sender lock for `key`. `Ok(None)` means
+    /// another sender holds it, so the caller must refuse to start.
+    pub async fn try_acquire_sender_lock(
+        &self,
+        key: i64,
+    ) -> Result<Option<sender_lock::SenderLockGuard>, StorageError> {
+        sender_lock::try_acquire_sender_lock(self, key).await
     }
 
     /// Mark every `Pending`/`Processing` withdrawal row as `ManualReview`.

--- a/indexer/src/storage/common/storage/sender_lock.rs
+++ b/indexer/src/storage/common/storage/sender_lock.rs
@@ -1,0 +1,28 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Held for the sender's whole lifetime. Dropping it (or a crash) releases the
+/// Postgres advisory lock. The `Postgres` variant owns the pinned connection
+/// carrying the lock, so it must stay alive.
+pub enum SenderLockGuard {
+    // Boxed: the pooled connection is large and the mock variant is empty.
+    Postgres(Box<sqlx::pool::PoolConnection<sqlx::Postgres>>),
+    #[cfg(any(test, feature = "test-mock-storage"))]
+    Noop,
+}
+
+/// Try to become the singleton sender for `key`. `Ok(None)` means another
+/// sender holds the lock and the caller must refuse to start.
+pub async fn try_acquire_sender_lock(
+    storage: &Storage,
+    key: i64,
+) -> Result<Option<SenderLockGuard>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .try_acquire_sender_lock(key)
+            .await?
+            .map(|conn| SenderLockGuard::Postgres(Box::new(conn)))),
+        // Mock has no shared backing store, so nothing to contend on.
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(_) => Ok(Some(SenderLockGuard::Noop)),
+    }
+}

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -929,6 +929,21 @@ impl PostgresDb {
         .await
     }
 
+    /// Try to acquire the advisory lock for `key`. The lock lives on the
+    /// returned connection; holding it keeps the connection out of the pool so
+    /// Postgres keeps the lock held. Returns `None` if another holder exists.
+    pub async fn try_acquire_sender_lock(
+        &self,
+        key: i64,
+    ) -> Result<Option<sqlx::pool::PoolConnection<sqlx::Postgres>>, sqlx::Error> {
+        let mut conn = self.pool.acquire().await?;
+        let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+            .bind(key)
+            .fetch_one(&mut *conn)
+            .await?;
+        Ok(acquired.then_some(conn))
+    }
+
     /// Get all transactions of a given type regardless of status
     pub async fn get_all_transactions_internal(
         &self,

--- a/integration/tests/indexer/reconciliation.rs
+++ b/integration/tests/indexer/reconciliation.rs
@@ -26,6 +26,11 @@ mod db_migration_race;
 #[path = "pending_remint_storage.rs"]
 mod pending_remint_storage;
 
+// run_sender singleton advisory lock: a second sender is refused while the
+// first holds the lock.
+#[path = "sender_singleton_lock.rs"]
+mod sender_singleton_lock;
+
 // End-to-end multi-instruction ledger integrity (SOLA2-13): same-signature
 // instructions must persist as distinct rows through the real processor.
 #[path = "multi_instruction_pipeline.rs"]

--- a/integration/tests/indexer/sender_singleton_lock.rs
+++ b/integration/tests/indexer/sender_singleton_lock.rs
@@ -1,0 +1,152 @@
+//! Sender singleton advisory lock.
+//!
+//! Target: `run_sender` in `indexer/src/operator/sender/mod.rs`, which acquires
+//! a per-role advisory lock before recovery and refuses to start if another
+//! sender already holds it.
+//! Binary: `reconciliation_integration` (attached via `#[path]` mod from
+//! `tests/indexer/reconciliation.rs`).
+//!
+//! Two real `run_sender` futures run against one Postgres database, each with
+//! its own connection pool, standing in for two operator processes. A spawned
+//! sender that stays pending has acquired the lock; one that resolves to `Err`
+//! was refused.
+
+use {
+    private_channel_indexer::{
+        config::{
+            PostgresConfig, PrivateChannelIndexerConfig, ProgramType, StorageType,
+            DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
+        },
+        error::OperatorError,
+        operator::{run_sender, utils::TransactionBuilder},
+        storage::{PostgresDb, Storage},
+    },
+    solana_sdk::commitment_config::CommitmentLevel,
+    std::{sync::Arc, time::Duration},
+    testcontainers::{runners::AsyncRunner, ContainerAsync},
+    testcontainers_modules::postgres::Postgres,
+    tokio::{sync::mpsc, task::JoinHandle},
+    tokio_util::sync::CancellationToken,
+};
+
+fn escrow_config() -> PrivateChannelIndexerConfig {
+    PrivateChannelIndexerConfig {
+        program_type: ProgramType::Escrow,
+        storage_type: StorageType::Postgres,
+        // No RPC traffic needed: the holder idles in its loop and the refused
+        // sender never gets past the lock check.
+        rpc_url: "http://127.0.0.1:1".to_string(),
+        source_rpc_url: None,
+        // Unused by run_sender; storage is passed in directly.
+        postgres: PostgresConfig {
+            database_url: "mock://unused".to_string(),
+            max_connections: 1,
+        },
+        escrow_instance_id: None,
+    }
+}
+
+async fn start_postgres() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_db_name("sender_lock")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("postgres container");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:password@{host}:{port}/sender_lock");
+    (url, container)
+}
+
+async fn connect(url: &str) -> Arc<Storage> {
+    let db = PostgresDb::new(&PostgresConfig {
+        database_url: url.to_string(),
+        max_connections: 5,
+    })
+    .await
+    .unwrap();
+    Arc::new(Storage::Postgres(db))
+}
+
+/// Spawn a `run_sender`. The returned handle stays pending while the sender
+/// holds the lock and resolves to `Err` if it was refused. Drop the returned
+/// processor sender to shut it down via the channel-close path. The storage
+/// `Arc` lives only inside the task, so joining the handle drops its pool and
+/// releases the lock.
+fn spawn_sender(
+    storage: Arc<Storage>,
+) -> (
+    JoinHandle<Result<(), OperatorError>>,
+    mpsc::Sender<TransactionBuilder>,
+) {
+    let (processor_tx, processor_rx) = mpsc::channel(10);
+    let handle = tokio::spawn(async move {
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+        run_sender(
+            &escrow_config(),
+            CommitmentLevel::Confirmed,
+            processor_rx,
+            storage_tx,
+            CancellationToken::new(),
+            storage,
+            3,
+            DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
+            None,
+        )
+        .await
+    });
+    (handle, processor_tx)
+}
+
+/// A second sender is refused while the first holds the lock, and a new sender
+/// can take the lock once the first exits (the rolling-restart handoff).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn second_sender_is_refused_until_the_first_exits() {
+    let (url, _container) = start_postgres().await;
+
+    // Schema must exist so the holder's startup recovery succeeds and it reaches
+    // the loop still holding the lock, rather than erroring out and releasing it.
+    connect(&url).await.init_schema().await.unwrap();
+
+    // First sender acquires the lock and idles.
+    let (first, first_tx) = spawn_sender(connect(&url).await);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert!(
+        !first.is_finished(),
+        "first sender should be running and holding the lock"
+    );
+
+    // Second sender against the same database is refused.
+    let (second, _second_tx) = spawn_sender(connect(&url).await);
+    let second_result = second.await.expect("second task panicked");
+    assert!(
+        matches!(
+            second_result,
+            Err(OperatorError::SenderAlreadyRunning {
+                program_type: ProgramType::Escrow
+            })
+        ),
+        "second sender must be refused with SenderAlreadyRunning; got {second_result:?}"
+    );
+
+    // First sender exits; its pool closes and the lock releases.
+    drop(first_tx);
+    first
+        .await
+        .expect("first task panicked")
+        .expect("first sender should exit cleanly");
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // A new sender can now acquire the lock and run.
+    let (third, third_tx) = spawn_sender(connect(&url).await);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert!(
+        !third.is_finished(),
+        "new sender should acquire the lock after the first exits"
+    );
+
+    drop(third_tx);
+    let _ = third.await;
+}


### PR DESCRIPTION
## fix(indexer): enforce single sender per database (SOLA3-18)

### Problem
`PendingRemint` recovery had no leasing or claim semantics. Two overlapping sender processes
(rolling restart, supervisor overlap, accidental second replica) would both recover the same
row and both remint it — the pre-send memo lookup can't stop this since both check the chain
before either confirms. Result: duplicate mints, inflation, solvency loss. The "one operator
per DB" assumption was never enforced.

### Fix
`run_sender` acquires a per-role Postgres advisory lock on startup, before recovery, and refuses to start (`SenderAlreadyRunning`) if another sender already holds it. The lock is held for the process lifetime and released automatically on exit or crash. Escrow and withdraw use distinct keys since they share one database, so they don't block each other.

This closes the whole class at the process level (not just remint recovery — the deposit/mint path shares the same assumption), rather than only the narrow recovery query.

### Tests
  - Integration (`sender_singleton_lock.rs`, real Postgres): a second `run_sender` is refused while the first holds the lock, and a new sender acquires it once the first exits (rolling-restart handoff).

### Notes
  - The lock pins one connection for the process lifetime; bump `max_connections` by 1 if sized tight.
  - Does not cover the rare "connection silently drops, process keeps running" case — that needs a periodic liveness re-check, deferred for now.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,147 | 12,760 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27974988151) |
| Indexer | 22,348 | 25,288 | 88.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27974988151) |
| Gateway | 994 | 1,164 | 85.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27974988151) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27974988151) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,942 | 14,886 | 80.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27974988151) |
| **Total** | **47,148** | **54,929** | **85.8%** | |

> Last updated: 2026-06-22 19:03:37 UTC by E2E Integration