### PR TITLE
feat(gateway): add SwapDvp accounts to RBAC ownership check

### DIFF
--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -123,6 +123,11 @@ const DELEGATE_END: usize = 108;
 // Accounts owned by this program hold a SwapDvp struct for a P2P token swap.
 // Read access is granted to either trading party (user_a, user_b) or the
 // settlement_authority, by inspecting raw bytes (no full deserialization).
+//
+// SWAP_DVP_SIZE and SWAP_DVP_OWNER_FIELDS mirror the SwapDvp layout in
+// dvp-swap-program/program/src/state/swap_dvp.rs. They are not derived from it,
+// so if a field is added or reordered there, update them here or these checks
+// will read the wrong bytes.
 // ---------------------------------------------------------------------------
 
 /// DvP swap escrow program ID.

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -118,6 +118,34 @@ const DELEGATE_OFFSET: usize = 76;
 const DELEGATE_END: usize = 108;
 
 // ---------------------------------------------------------------------------
+// DvP swap escrow program
+//
+// Accounts owned by this program hold a SwapDvp struct for a P2P token swap.
+// Read access is granted to either trading party (user_a, user_b) or the
+// settlement_authority, by inspecting raw bytes (no full deserialization).
+// ---------------------------------------------------------------------------
+
+/// DvP swap escrow program ID.
+///
+/// WARNING: the DvP swap program is NOT deployed yet. This value is the local
+/// `declare_id!` from dvp-swap-program/program/src/lib.rs and is a placeholder.
+/// Update it with the real program ID once the program is deployed, otherwise
+/// no live DvP account will match and these checks will never fire.
+const DVP_SWAP_PROGRAM: &str = "DzG1qJupt6Khm8s8jB3p93NkhPoiAg2M7vkEhkS15CtC";
+
+/// Serialized size of a SwapDvp account (SwapDvp::LEN). Smaller DvP-owned
+/// accounts (e.g. the nonce tombstone PDA) are not swaps and are denied.
+const SWAP_DVP_SIZE: usize = 394;
+
+/// Byte ranges of the SwapDvp fields whose pubkey grants read access.
+/// Layout: bump(1), user_a, user_b, mint_a, mint_b, settlement_authority, ...
+const SWAP_DVP_OWNER_FIELDS: [(usize, usize); 3] = [
+    (1, 33),    // user_a (seller)
+    (33, 65),   // user_b (buyer)
+    (129, 161), // settlement_authority
+];
+
+// ---------------------------------------------------------------------------
 // Auth decision
 // ---------------------------------------------------------------------------
 
@@ -199,21 +227,15 @@ pub fn check_request_auth(
 // Ownership check — called by enforce_auth after fetching the raw account data
 // ---------------------------------------------------------------------------
 
-/// Checks account ownership by inspecting raw bytes without full deserialization.
+/// Checks whether `user_id` owns the account at `pubkey`, inspecting its raw
+/// `data` without full deserialization. Dispatches on `program_owner` — the
+/// account-level `owner` field from the `getAccountInfo` response, i.e. the
+/// program that owns this account:
 ///
-/// `program_owner` is the account-level `owner` field from the `getAccountInfo`
-/// response — i.e. the program that owns this account.
-///
-/// For SPL token accounts (owned by Token or Token-2022, data >= 165 bytes):
-/// - Checks the `owner` field at bytes 32-63 against `verified_wallets`.
-/// - If not matched, checks the `delegate` field at bytes 76-107 (when present).
-///
-/// For non-token-program accounts (e.g. System Program wallet accounts):
-/// - Falls back to checking `pubkey` itself against `verified_wallets`.
-///
-/// Denies if:
-/// - The account is a mint (SPL-owned but data < 165 bytes).
-/// - No ownership match is found.
+/// - SPL Token / Token-2022: `check_token_account_ownership`.
+/// - DvP swap escrow: `check_swap_dvp_ownership`.
+/// - Anything else (e.g. a System Program wallet account): falls back to
+///   checking whether the `pubkey` itself is a verified wallet.
 pub async fn check_account_data_ownership(
     data: &[u8],
     program_owner: &str,
@@ -221,20 +243,34 @@ pub async fn check_account_data_ownership(
     user_id: Uuid,
     auth_db: &PgPool,
 ) -> AuthDecision {
-    // Non-token-program account (e.g. System Program wallet, unknown PDA).
-    // The account bytes don't have a meaningful owner field to inspect, so fall
-    // back to checking whether the pubkey itself is a verified wallet.
-    if program_owner != SPL_TOKEN_PROGRAM && program_owner != SPL_TOKEN_2022_PROGRAM {
-        return match is_wallet_owned_by_user(auth_db, user_id, pubkey).await {
+    match program_owner {
+        SPL_TOKEN_PROGRAM | SPL_TOKEN_2022_PROGRAM => {
+            check_token_account_ownership(data, user_id, auth_db).await
+        }
+        DVP_SWAP_PROGRAM => check_swap_dvp_ownership(data, user_id, auth_db).await,
+        // Non-token-program account (e.g. System Program wallet, unknown PDA).
+        // The account bytes don't have a meaningful owner field to inspect, so
+        // fall back to checking whether the pubkey itself is a verified wallet.
+        _ => match is_wallet_owned_by_user(auth_db, user_id, pubkey).await {
             Ok(true) => AuthDecision::Proceed,
             Ok(false) => AuthDecision::Reject(StatusCode::FORBIDDEN, forbidden_body()),
             Err(_) => AuthDecision::Reject(StatusCode::INTERNAL_SERVER_ERROR, db_error_body()),
-        };
+        },
     }
+}
 
-    // Both SPL Token and Token-2022 use the same program for mints and token
-    // accounts. Use the data size to tell them apart: mints are 82 bytes,
-    // token accounts are 165+ bytes. Mints are not user accounts — deny them.
+/// Ownership check for SPL Token and Token-2022 accounts. Both programs share
+/// the same base layout, so this checks the `owner` field (bytes 32-63) and,
+/// if it doesn't match, the `delegate` field (bytes 76-107) when present — a
+/// delegate has spend authority and counts as ownership for read access.
+///
+/// Mints are owned by the same programs but are only 82 bytes, below
+/// `TOKEN_ACCOUNT_SIZE`; they are not user accounts and are denied.
+async fn check_token_account_ownership(
+    data: &[u8],
+    user_id: Uuid,
+    auth_db: &PgPool,
+) -> AuthDecision {
     if data.len() < TOKEN_ACCOUNT_SIZE {
         return AuthDecision::Reject(StatusCode::FORBIDDEN, forbidden_body());
     }
@@ -251,11 +287,35 @@ pub async fn check_account_data_ownership(
 
     // Check the `delegate` field if one is set.
     // Bytes 72-75 == [1, 0, 0, 0] means the Option<Pubkey> is Some.
-    // A delegate has spend authority and counts as ownership for read access.
     if data[DELEGATE_OPTION_OFFSET..DELEGATE_OPTION_OFFSET + 4] == [1, 0, 0, 0] {
         let delegate = bs58::encode(&data[DELEGATE_OFFSET..DELEGATE_END]).into_string();
 
         match is_wallet_owned_by_user(auth_db, user_id, &delegate).await {
+            Ok(true) => return AuthDecision::Proceed,
+            Ok(false) => {}
+            Err(_) => {
+                return AuthDecision::Reject(StatusCode::INTERNAL_SERVER_ERROR, db_error_body())
+            }
+        }
+    }
+
+    AuthDecision::Reject(StatusCode::FORBIDDEN, forbidden_body())
+}
+
+/// Ownership check for DvP swap escrow accounts. Grants read access if any
+/// verified wallet matches user_a, user_b, or settlement_authority, checked in
+/// that order and short-circuiting on the first match.
+///
+/// Accounts smaller than a full SwapDvp (e.g. the nonce tombstone PDA) are not
+/// swaps and are denied.
+async fn check_swap_dvp_ownership(data: &[u8], user_id: Uuid, auth_db: &PgPool) -> AuthDecision {
+    if data.len() < SWAP_DVP_SIZE {
+        return AuthDecision::Reject(StatusCode::FORBIDDEN, forbidden_body());
+    }
+
+    for (start, end) in SWAP_DVP_OWNER_FIELDS {
+        let candidate = bs58::encode(&data[start..end]).into_string();
+        match is_wallet_owned_by_user(auth_db, user_id, &candidate).await {
             Ok(true) => return AuthDecision::Proceed,
             Ok(false) => {}
             Err(_) => {
@@ -654,6 +714,26 @@ mod tests {
         let decision = check_account_data_ownership(
             &data,
             SPL_TOKEN_2022_PROGRAM,
+            "SomePubkey",
+            Uuid::new_v4(),
+            &pool,
+        )
+        .await;
+        assert!(matches!(
+            decision,
+            AuthDecision::Reject(StatusCode::FORBIDDEN, _)
+        ));
+    }
+
+    #[tokio::test]
+    async fn swap_dvp_undersized_rejected_by_size() {
+        // A DvP-owned account smaller than SWAP_DVP_SIZE (e.g. the nonce
+        // tombstone PDA) is not a swap. Rejected before touching the DB.
+        let data = vec![0u8; SWAP_DVP_SIZE - 1];
+        let pool = lazy_pool();
+        let decision = check_account_data_ownership(
+            &data,
+            DVP_SWAP_PROGRAM,
             "SomePubkey",
             Uuid::new_v4(),
             &pool,

--- a/gateway/tests/auth_integration.rs
+++ b/gateway/tests/auth_integration.rs
@@ -267,6 +267,60 @@ fn mint_account_response() -> String {
     .to_string()
 }
 
+/// DvP swap escrow program ID. Mirrors DVP_SWAP_PROGRAM in the gateway's auth
+/// module. Placeholder until the program is deployed; keep both in sync.
+const DVP_SWAP_PROGRAM: &str = "DzG1qJupt6Khm8s8jB3p93NkhPoiAg2M7vkEhkS15CtC";
+
+/// Build a getAccountInfo JSON-RPC response for a SwapDvp account (394 bytes,
+/// DvP program). user_a, user_b, and settlement_authority are written at their
+/// field offsets; all other fields are left zero.
+fn swap_dvp_response(
+    user_a: &[u8; 32],
+    user_b: &[u8; 32],
+    settlement_authority: &[u8; 32],
+) -> String {
+    let mut data = vec![0u8; 394];
+    data[1..33].copy_from_slice(user_a);
+    data[33..65].copy_from_slice(user_b);
+    data[129..161].copy_from_slice(settlement_authority);
+    let encoded = BASE64.encode(&data);
+    json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "value": {
+                "lamports": 2_282_880,
+                "owner": DVP_SWAP_PROGRAM,
+                "data": [encoded, "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        }
+    })
+    .to_string()
+}
+
+/// Build a getAccountInfo JSON-RPC response for a DvP-owned account too small
+/// to be a SwapDvp (e.g. the nonce tombstone PDA). Used to verify the gateway
+/// rejects non-swap DvP accounts for users.
+fn dvp_undersized_account_response() -> String {
+    let encoded = BASE64.encode(vec![0u8; 16]);
+    json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "value": {
+                "lamports": 1_000_000,
+                "owner": DVP_SWAP_PROGRAM,
+                "data": [encoded, "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        }
+    })
+    .to_string()
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 /// `getAccountInfo` with no Authorization header must be rejected with 401.
@@ -1144,4 +1198,198 @@ async fn test_get_signatures_for_address_operator_is_proxied() {
         .unwrap();
 
     assert_eq!(res.status(), 200);
+}
+
+// ── DvP swap escrow ──────────────────────────────────────────────────────────
+
+/// A user whose verified wallet is the SwapDvp's user_a (seller) may read it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_account_info_dvp_user_a_is_proxied() {
+    let (pool, _url, _container) = start_postgres().await;
+    db::init_schema(&pool).await.unwrap();
+
+    let wallet_bytes = [31u8; 32];
+    let user_id = insert_user(&pool, "user").await;
+    insert_wallet(&pool, user_id, &bs58::encode(wallet_bytes).into_string()).await;
+    let token = generate_token(user_id, "user");
+
+    // wallet sits in user_a; user_b and settlement_authority are unrelated.
+    let backend =
+        start_mock_backend_with_body(swap_dvp_response(&wallet_bytes, &[32u8; 32], &[33u8; 32]))
+            .await;
+    let addr = start_gateway(
+        pool,
+        "http://127.0.0.1:1".to_string(),
+        format!("http://{}", backend),
+    )
+    .await;
+
+    // The queried PDA address is arbitrary: the mock backend returns the swap
+    // account regardless, and ownership is decided from its data, not this key.
+    let dvp_pubkey = bs58::encode([99u8; 32]).into_string();
+    let res = Client::new()
+        .post(format!("http://{}", addr))
+        .bearer_auth(token)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getAccountInfo",
+            "params": [dvp_pubkey]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+}
+
+/// A user whose verified wallet is the SwapDvp's user_b (buyer) may read it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_account_info_dvp_user_b_is_proxied() {
+    let (pool, _url, _container) = start_postgres().await;
+    db::init_schema(&pool).await.unwrap();
+
+    let wallet_bytes = [34u8; 32];
+    let user_id = insert_user(&pool, "user").await;
+    insert_wallet(&pool, user_id, &bs58::encode(wallet_bytes).into_string()).await;
+    let token = generate_token(user_id, "user");
+
+    // wallet sits in user_b; user_a and settlement_authority are unrelated.
+    let backend =
+        start_mock_backend_with_body(swap_dvp_response(&[35u8; 32], &wallet_bytes, &[36u8; 32]))
+            .await;
+    let addr = start_gateway(
+        pool,
+        "http://127.0.0.1:1".to_string(),
+        format!("http://{}", backend),
+    )
+    .await;
+
+    let dvp_pubkey = bs58::encode([99u8; 32]).into_string();
+    let res = Client::new()
+        .post(format!("http://{}", addr))
+        .bearer_auth(token)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getAccountInfo",
+            "params": [dvp_pubkey]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+}
+
+/// A user whose verified wallet is the SwapDvp's settlement_authority may read it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_account_info_dvp_settlement_authority_is_proxied() {
+    let (pool, _url, _container) = start_postgres().await;
+    db::init_schema(&pool).await.unwrap();
+
+    let wallet_bytes = [37u8; 32];
+    let user_id = insert_user(&pool, "user").await;
+    insert_wallet(&pool, user_id, &bs58::encode(wallet_bytes).into_string()).await;
+    let token = generate_token(user_id, "user");
+
+    // wallet sits in settlement_authority; user_a and user_b are unrelated.
+    let backend =
+        start_mock_backend_with_body(swap_dvp_response(&[38u8; 32], &[39u8; 32], &wallet_bytes))
+            .await;
+    let addr = start_gateway(
+        pool,
+        "http://127.0.0.1:1".to_string(),
+        format!("http://{}", backend),
+    )
+    .await;
+
+    let dvp_pubkey = bs58::encode([99u8; 32]).into_string();
+    let res = Client::new()
+        .post(format!("http://{}", addr))
+        .bearer_auth(token)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getAccountInfo",
+            "params": [dvp_pubkey]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+}
+
+/// A user querying a SwapDvp whose user_a, user_b, and settlement_authority are
+/// all unrelated to their wallets must get 403.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_account_info_dvp_unowned_returns_403() {
+    let (pool, _url, _container) = start_postgres().await;
+    db::init_schema(&pool).await.unwrap();
+
+    let user_id = insert_user(&pool, "user").await;
+    insert_wallet(&pool, user_id, &bs58::encode([40u8; 32]).into_string()).await;
+    let token = generate_token(user_id, "user");
+
+    let backend =
+        start_mock_backend_with_body(swap_dvp_response(&[41u8; 32], &[42u8; 32], &[43u8; 32]))
+            .await;
+    let addr = start_gateway(
+        pool,
+        "http://127.0.0.1:1".to_string(),
+        format!("http://{}", backend),
+    )
+    .await;
+
+    let dvp_pubkey = bs58::encode([99u8; 32]).into_string();
+    let res = Client::new()
+        .post(format!("http://{}", addr))
+        .bearer_auth(token)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getAccountInfo",
+            "params": [dvp_pubkey]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 403);
+}
+
+/// A user querying a DvP-owned account too small to be a SwapDvp (e.g. the
+/// nonce tombstone PDA) must get 403, regardless of their wallets.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_account_info_dvp_undersized_returns_403() {
+    let (pool, _url, _container) = start_postgres().await;
+    db::init_schema(&pool).await.unwrap();
+
+    let user_id = insert_user(&pool, "user").await;
+    let token = generate_token(user_id, "user");
+
+    let backend = start_mock_backend_with_body(dvp_undersized_account_response()).await;
+    let addr = start_gateway(
+        pool,
+        "http://127.0.0.1:1".to_string(),
+        format!("http://{}", backend),
+    )
+    .await;
+
+    let dvp_pubkey = bs58::encode([99u8; 32]).into_string();
+    let res = Client::new()
+        .post(format!("http://{}", addr))
+        .bearer_auth(token)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getAccountInfo",
+            "params": [dvp_pubkey]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 403);
 }


### PR DESCRIPTION
Adds DvP swap escrow accounts to the gateway's RBAC ownership check. A `user` can now read a `SwapDvp` account if one of their verified wallets is `user_a`, `user_b`, or `settlement_authority`.

## Changes
  - Refactored `check_account_data_ownership` into a per-program dispatcher (`check_token_account_ownership`, `check_swap_dvp_ownership`).
  - New DvP branch: rejects non-swap DvP accounts by size, then matches the three owner fields against `verified_wallets`.
  - Integration tests: owned via each of the 3 fields → 200, unowned → 403, undersized → 403.

  ## Note

  `DVP_SWAP_PROGRAM` is a placeholder (local `declare_id!`). **Update it with the real program ID once the DvP program is deployed**, otherwise no live account will match.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,147 | 12,760 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27985709513) |
| Indexer | 22,357 | 25,288 | 88.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27985709513) |
| Gateway | 1,034 | 1,205 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27985709513) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/27985709513) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **35,255** | **40,084** | **88.0%** | |

> Last updated: 2026-06-22 21:51:21 UTC by Auth