### PR TITLE
fix: Escrow releaseFunds and auth JWT role enforcement bugs

### DIFF
--- a/auth/src/models.rs
+++ b/auth/src/models.rs
@@ -4,6 +4,11 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, sqlx::Type, Serialize, Deserialize, PartialEq)]
 #[sqlx(type_name = "user_role", rename_all = "lowercase")]
+// serde rename must match the gateway's Role enum (also lowercase): the JWT role
+// claim is serialized here and deserialized by the gateway. Without this the
+// claim would be PascalCase ("User"/"Operator") and the gateway rejects every
+// token with 401 once enforcement is on.
+#[serde(rename_all = "lowercase")]
 pub enum Role {
     Operator,
     User,

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -18,6 +18,7 @@ use chrono::Utc;
 use private_channel_escrow_program_client::instructions::{
     ReleaseFundsBuilder, ResetSmtRootBuilder,
 };
+use private_channel_escrow_program_client::programs::PRIVATE_CHANNEL_ESCROW_PROGRAM_ID;
 use private_channel_metrics::MetricLabel;
 use solana_sdk::pubkey::Pubkey;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
@@ -376,6 +377,12 @@ async fn build_release_funds(
         .instance_ata(instance_ata)
         .token_program(token_program)
         .user(recipient)
+        // The generated client's defaults for these two accounts are stale (they
+        // point at the previous escrow program and its event-authority PDA), so
+        // set them explicitly from the configured program id. Without this the
+        // release fails `verify_current_program` with IncorrectProgramId.
+        .event_authority(release_funds_state.event_authority_pda)
+        .private_channel_escrow_program(PRIVATE_CHANNEL_ESCROW_PROGRAM_ID)
         .transaction_nonce(nonce);
 
     let amount = transaction.amount.value();


### PR DESCRIPTION
Two latent bugs that only surface once you run a self deployed escrow program and turn gateway JWT enforcement on, both found while bringing up the devnet demo stack.

**Auth JWT role casing:** the gateway deserializes the JWT role claim as lowercase, but the auth service only had rename_all on the sqlx attribute, so it signed tokens with PascalCase roles. With enforcement on, the gateway rejected every token with a 401. Added serde rename_all lowercase on the auth Role enum so the claim matches the gateway. This never showed up before because enforcement was off in every existing deployment and each service's tests mint their own tokens.

**ReleaseFunds stale accounts:** the generated escrow client's default accounts for event_authority and private_channel_escrow_program point at a previously deployed escrow program. The withdraw operator relied on those defaults, so releaseFunds against a freshly deployed escrow failed verify_current_program with IncorrectProgramId and the withdrawal went to ManualReview. Now the builder passes the configured program id and the derived event authority PDA explicitly instead of trusting the codegen defaults.

Verified end to end on devnet: in channel burn to operator release to Token-2022 credit, and full per-key auth (user reads only its own account, 403 on others, getTransaction operator only).
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,149 | 12,761 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28119162765) |
| Indexer | 22,907 | 25,994 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28119162765) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28119162765) |
| Auth | 717 | 831 | 86.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28119162765) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,147 | 15,122 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28119162765) |
| **Total** | **47,955** | **55,903** | **85.8%** | |

> Last updated: 2026-06-24 18:25:39 UTC by E2E Integration