### PR TITLE
feat: auth-admin set-role command (and actually ship the auth admin binary)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN mkdir -p private-channel-escrow-program/program/src private-channel-escrow-p
     private-channel-escrow-program/clients/rust/src private-channel-withdraw-program/clients/rust/src \
     dvp-swap-program/program/src dvp-swap-program/tests/integration-tests/src \
     dvp-swap-program/tests/transfer-hook-fixture/src dvp-swap-program/clients/rust/src \
-    core/src metrics/src auth/src bench-tps/src
+    core/src metrics/src auth/src auth/src/bin bench-tps/src
 RUN touch private-channel-escrow-program/program/src/lib.rs private-channel-escrow-program/tests/integration-tests/src/lib.rs \
     private-channel-escrow-program/clients/rust/src/lib.rs private-channel-withdraw-program/program/src/lib.rs \
     private-channel-withdraw-program/tests/integration-tests/src/lib.rs \
@@ -108,7 +108,8 @@ RUN touch private-channel-escrow-program/program/src/lib.rs private-channel-escr
     dvp-swap-program/tests/transfer-hook-fixture/src/lib.rs dvp-swap-program/clients/rust/src/lib.rs \
     core/src/lib.rs metrics/src/lib.rs auth/src/lib.rs && \
     printf 'fn main() {}\n' > bench-tps/src/main.rs && \
-    printf 'fn main() {}\n' > auth/src/main.rs
+    printf 'fn main() {}\n' > auth/src/main.rs && \
+    printf 'fn main() {}\n' > auth/src/bin/admin.rs
 
 # Build the project with the dummy files. We can cache this layer.
 # Cache mounts: target/ holds compiled artifacts; cargo registry/git hold downloaded crate sources.
@@ -167,7 +168,8 @@ RUN --mount=type=cache,target=/usr/src/private_channel/target,sharing=locked \
     && cp target/release/gateway /out/gateway \
     && cp target/release/indexer /out/indexer \
     && cp target/release/streamer /out/streamer \
-    && cp target/release/auth /out/auth
+    && cp target/release/auth /out/auth \
+    && cp target/release/auth-admin /out/auth-admin
 
 # Stage 2: Runtime
 FROM --platform=linux/amd64 debian:bookworm-slim
@@ -196,6 +198,7 @@ COPY --from=builder /out/gateway /usr/local/bin/gateway
 COPY --from=builder /out/indexer /usr/local/bin/indexer
 COPY --from=builder /out/streamer /usr/local/bin/streamer
 COPY --from=builder /out/auth /usr/local/bin/auth
+COPY --from=builder /out/auth-admin /usr/local/bin/auth-admin
 
 # Copy indexer/operator config files
 COPY indexer/config /etc/private_channel/config

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -11,6 +11,13 @@ path = "src/lib.rs"
 name = "auth"
 path = "src/main.rs"
 
+# Named explicitly (not the inferred "admin") so it doesn't collide with
+# core/src/bin/admin.rs, which also produces an "admin" binary. The collision
+# previously meant this admin tool was never the one shipped in the image.
+[[bin]]
+name = "auth-admin"
+path = "src/bin/admin.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -346,7 +346,10 @@ mod tests {
 
         set_role(
             &pool,
-            SetRoleArgs { username: "dave".into(), role: RoleArg::Operator },
+            SetRoleArgs {
+                username: "dave".into(),
+                role: RoleArg::Operator,
+            },
         )
         .await
         .expect("set role should succeed");
@@ -363,7 +366,10 @@ mod tests {
         let (pool, _c) = start_pool().await;
         let err = set_role(
             &pool,
-            SetRoleArgs { username: "ghost".into(), role: RoleArg::Operator },
+            SetRoleArgs {
+                username: "ghost".into(),
+                role: RoleArg::Operator,
+            },
         )
         .await
         .expect_err("expected error");

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -1,7 +1,7 @@
 use {
     anyhow::{anyhow, Result},
     clap::{Parser, Subcommand},
-    private_channel_auth::{db, error::AppError},
+    private_channel_auth::{db, error::AppError, models::Role},
     solana_sdk::pubkey::Pubkey,
     sqlx::postgres::PgPoolOptions,
     std::{env, str::FromStr},
@@ -57,6 +57,13 @@ impl RoleArg {
         match self {
             RoleArg::Operator => "operator",
             RoleArg::User => "user",
+        }
+    }
+
+    fn to_model(&self) -> Role {
+        match self {
+            RoleArg::Operator => Role::Operator,
+            RoleArg::User => Role::User,
         }
     }
 }
@@ -123,7 +130,7 @@ async fn run(args: Args) -> Result<()> {
 
 async fn set_role(pool: &sqlx::PgPool, args: SetRoleArgs) -> Result<()> {
     let role = args.role.as_str();
-    let updated = db::set_user_role(pool, &args.username, role).await?;
+    let updated = db::set_user_role(pool, &args.username, args.role.to_model()).await?;
     if !updated {
         return Err(anyhow!("user not found: {}", args.username));
     }

--- a/auth/src/bin/admin.rs
+++ b/auth/src/bin/admin.rs
@@ -30,6 +30,9 @@ struct Args {
 enum Command {
     /// Attach a wallet to a user without verification — operator asserts trust
     AttachWallet(AttachWalletArgs),
+    /// Set a user's RBAC role (e.g. promote to operator so the gateway grants it
+    /// full account access + getTransaction)
+    SetRole(SetRoleArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -41,6 +44,32 @@ struct AttachWalletArgs {
     /// Base58-encoded Solana pubkey to attach to the user
     #[arg(long)]
     pubkey: String,
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+enum RoleArg {
+    Operator,
+    User,
+}
+
+impl RoleArg {
+    fn as_str(&self) -> &'static str {
+        match self {
+            RoleArg::Operator => "operator",
+            RoleArg::User => "user",
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+struct SetRoleArgs {
+    /// Username of the user whose role to change
+    #[arg(long)]
+    username: String,
+
+    /// Role to assign
+    #[arg(long)]
+    role: RoleArg,
 }
 
 #[tokio::main]
@@ -86,8 +115,20 @@ async fn run(args: Args) -> Result<()> {
 
     match args.command {
         Command::AttachWallet(args) => attach_wallet(&pool, args).await?,
+        Command::SetRole(args) => set_role(&pool, args).await?,
     }
 
+    Ok(())
+}
+
+async fn set_role(pool: &sqlx::PgPool, args: SetRoleArgs) -> Result<()> {
+    let role = args.role.as_str();
+    let updated = db::set_user_role(pool, &args.username, role).await?;
+    if !updated {
+        return Err(anyhow!("user not found: {}", args.username));
+    }
+    info!(username = %args.username, role, "set role");
+    println!("set role of {} to {}", args.username, role);
     Ok(())
 }
 
@@ -287,5 +328,38 @@ mod tests {
             .expect("list wallets");
         assert_eq!(wallets.len(), 1, "failed attach should not duplicate row");
         assert_eq!(wallets[0].pubkey, pubkey);
+    }
+
+    #[tokio::test]
+    async fn set_role_promotes_user_to_operator() {
+        let (pool, _c) = start_pool().await;
+        db::insert_user(&pool, "dave", "$argon2id$placeholder")
+            .await
+            .expect("insert user");
+
+        set_role(
+            &pool,
+            SetRoleArgs { username: "dave".into(), role: RoleArg::Operator },
+        )
+        .await
+        .expect("set role should succeed");
+
+        let user = db::find_user_by_username(&pool, "dave")
+            .await
+            .expect("find user")
+            .expect("user exists");
+        assert_eq!(user.role, private_channel_auth::models::Role::Operator);
+    }
+
+    #[tokio::test]
+    async fn set_role_rejects_unknown_user() {
+        let (pool, _c) = start_pool().await;
+        let err = set_role(
+            &pool,
+            SetRoleArgs { username: "ghost".into(), role: RoleArg::Operator },
+        )
+        .await
+        .expect_err("expected error");
+        assert!(err.to_string().contains("user not found"), "got: {err}");
     }
 }

--- a/auth/src/db.rs
+++ b/auth/src/db.rs
@@ -133,6 +133,19 @@ pub async fn insert_user(pool: &PgPool, username: &str, password_hash: &str) -> 
     })
 }
 
+/// Set a user's role by username. Returns `false` if no such user exists.
+/// `role` is cast to the enum in SQL, so callers must pass a valid variant
+/// ("operator" or "user").
+pub async fn set_user_role(pool: &PgPool, username: &str, role: &str) -> AppResult<bool> {
+    let result =
+        sqlx::query(r#"UPDATE private_channel_auth.users SET role = $2::private_channel_auth.user_role WHERE username = $1"#)
+            .bind(username)
+            .bind(role)
+            .execute(pool)
+            .await?;
+    Ok(result.rows_affected() > 0)
+}
+
 /// Insert a new challenge tied to this user. Expires in 10 minutes.
 pub async fn insert_challenge(pool: &PgPool, user_id: Uuid, nonce: Uuid) -> AppResult<Challenge> {
     let expires_at = Utc::now() + chrono::Duration::minutes(10);

--- a/auth/src/db.rs
+++ b/auth/src/db.rs
@@ -134,13 +134,17 @@ pub async fn insert_user(pool: &PgPool, username: &str, password_hash: &str) -> 
 }
 
 /// Set a user's role by username. Returns `false` if no such user exists.
-/// `role` is cast to the enum in SQL, so callers must pass a valid variant
-/// ("operator" or "user").
-pub async fn set_user_role(pool: &PgPool, username: &str, role: &str) -> AppResult<bool> {
+/// Takes the typed `Role` so the variant is compiler-enforced; the SQL casts
+/// the lowercase string to the postgres `user_role` enum.
+pub async fn set_user_role(pool: &PgPool, username: &str, role: Role) -> AppResult<bool> {
+    let role_str = match role {
+        Role::Operator => "operator",
+        Role::User => "user",
+    };
     let result =
         sqlx::query(r#"UPDATE private_channel_auth.users SET role = $2::private_channel_auth.user_role WHERE username = $1"#)
             .bind(username)
-            .bind(role)
+            .bind(role_str)
             .execute(pool)
             .await?;
     Ok(result.rows_affected() > 0)


### PR DESCRIPTION
Replaces the manual SQL UPDATE for granting operator role with a proper CLI command, and fixes a latent bug that kept the auth admin binary out of the image.

**The shadowing bug:** core/src/bin/admin.rs and auth/src/bin/admin.rs both compile to a binary named admin, so the release build collides on target/release/admin and the Dockerfile only ever copied core's. The auth admin tool (its attach-wallet command) was never actually present in the deployed image. Renamed auth's binary to auth-admin and ship it.

**The feature:** add a set-role subcommand that sets a user's role by username, reading the DB URL from the environment like attach-wallet does (so the password never lands in argv). Promoting an account is now:

    docker exec private-channel-auth auth-admin set-role --username <name> --role operator

Verified on the live devnet container: the command promotes the account, is idempotent, errors cleanly on an unknown user, and the gateway then accepts the operator token. Includes tests for the success and unknown-user paths.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,149 | 12,761 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28147710677) |
| Indexer | 22,898 | 25,994 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28147710677) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28147710677) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28147710677) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **35,867** | **40,853** | **87.8%** | |

> Last updated: 2026-06-25 05:01:49 UTC by Auth