### PR TITLE
fix: Route internal services' channel reads around gateway JWT auth

### DIFF
--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -357,8 +357,13 @@ services:
     environment:
       - RUST_LOG=info,private_channel_indexer=debug
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres-indexer:5432/${POSTGRES_INDEXER_DB}
-      - COMMON_RPC_URL=${GATEWAY_URL}
-      - INDEXER_BACKFILL_RPC_URL=${GATEWAY_URL}
+      # Read channel blocks straight from the read-node, not the gateway. The
+      # gateway enforces JWT auth on getBlock/getSignaturesForAddress when
+      # JWT_SECRET is set, and internal services carry no token, so routing them
+      # through the gateway would 401 and stall indexing. The read-node serves
+      # the same RPC without the auth gate.
+      - COMMON_RPC_URL=${GATEWAY_READ_URL}
+      - INDEXER_BACKFILL_RPC_URL=${GATEWAY_READ_URL}
       - METRICS_PORT=9100
       - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-http://localhost:9/no-op}
     command:
@@ -435,7 +440,10 @@ services:
       - RUST_LOG=info,private_channel_indexer=debug
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres-indexer:5432/${POSTGRES_INDEXER_DB}
       - COMMON_RPC_URL=${DEVNET_RPC_URL}
-      - COMMON_SOURCE_RPC_URL=${GATEWAY_URL}
+      # Channel-side reads go direct to the read-node, not the gateway, so they
+      # aren't blocked by gateway JWT enforcement (see indexer-private-channel).
+      # COMMON_RPC_URL above stays on devnet — that's where releases are sent.
+      - COMMON_SOURCE_RPC_URL=${GATEWAY_READ_URL}
       - COMMON_ESCROW_INSTANCE_ID=${ESCROW_INSTANCE_ID}
       - ADMIN_SIGNER=memory
       - ADMIN_PRIVATE_KEY=${ADMIN_PRIVATE_KEY}


### PR DESCRIPTION
Turning on gateway JWT enforcement (JWT_SECRET set) breaks the internal indexer and operator: they read channel blocks through the gateway with no token, so getBlock/getSignaturesForAddress start returning 401. Indexing silently stalls, burns never get indexed, and withdrawals never release. Hit this live on devnet right after enabling enforcement for per-key auth.

Fix: point the internal services' channel reads at the read-node directly (GATEWAY_READ_URL = http://read-node:8901), which serves the same RPC without the auth gate, while the gateway stays enforced for external/browser clients. This is the intended split (internal services on the private node path, gateway for outside callers).

Changed in docker-compose.devnet.yml:
- indexer-private-channel: COMMON_RPC_URL + INDEXER_BACKFILL_RPC_URL now use GATEWAY_READ_URL
- operator-private-channel: COMMON_SOURCE_RPC_URL now uses GATEWAY_READ_URL (its COMMON_RPC_URL stays on devnet, where releases are sent)

Left operator-solana on the gateway on purpose: it writes (mints) via sendTransaction, which isn't auth-gated, so it keeps working through the gateway.

Verified on the live devnet stack: after repointing, the indexer caught up, picked up a stuck burn, and the operator released it to devnet (transaction marked Completed, recipient credited).
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...