### PR TITLE
fix(core): don't persist failed transactions' account writes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, hardening/pre-release-audit]
   pull_request:
-    branches: [main, hardening/pre-release-audit]
+    branches: [main, hardening/pre-release-audit, cantina-audit]
 
 permissions:
   contents: read

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -174,31 +174,34 @@ impl BOB {
                         sanitized_transaction.signature()
                     );
 
-                    for (index, (pubkey, account_data)) in executed_transaction
-                        .loaded_transaction
-                        .accounts
-                        .iter()
-                        .enumerate()
-                    {
-                        if sanitized_transaction.is_writable(index) {
-                            if account_data.lamports() == 0 && account_data.data().is_empty() {
-                                self.accounts.insert(
-                                    *pubkey,
-                                    AccountWithMeta {
-                                        account: account_data.clone(),
-                                        deleted: true,
-                                        synced_since: None,
-                                    },
-                                );
-                            } else {
-                                self.accounts.insert(
-                                    *pubkey,
-                                    AccountWithMeta {
-                                        account: account_data.clone(),
-                                        deleted: false,
-                                        synced_since: None,
-                                    },
-                                );
+                    // A failed executed tx (status Err) holds rolled-back intermediate state; only a successful execution commits its writable accounts.
+                    if executed_transaction.was_successful() {
+                        for (index, (pubkey, account_data)) in executed_transaction
+                            .loaded_transaction
+                            .accounts
+                            .iter()
+                            .enumerate()
+                        {
+                            if sanitized_transaction.is_writable(index) {
+                                if account_data.lamports() == 0 && account_data.data().is_empty() {
+                                    self.accounts.insert(
+                                        *pubkey,
+                                        AccountWithMeta {
+                                            account: account_data.clone(),
+                                            deleted: true,
+                                            synced_since: None,
+                                        },
+                                    );
+                                } else {
+                                    self.accounts.insert(
+                                        *pubkey,
+                                        AccountWithMeta {
+                                            account: account_data.clone(),
+                                            deleted: false,
+                                            synced_since: None,
+                                        },
+                                    );
+                                }
                             }
                         }
                     }
@@ -331,7 +334,17 @@ impl TransactionProcessingCallback for BOB {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, solana_sdk::account::Account, solana_svm_callback::TransactionProcessingCallback,
+        super::*,
+        crate::test_helpers::create_test_sanitized_transaction,
+        solana_sdk::account::Account,
+        solana_sdk::signature::{Keypair, Signer},
+        solana_svm::account_loader::LoadedTransaction,
+        solana_svm::transaction_error_metrics::TransactionErrorMetrics,
+        solana_svm::transaction_execution_result::{
+            ExecutedTransaction, TransactionExecutionDetails,
+        },
+        solana_svm_callback::TransactionProcessingCallback,
+        solana_timings::ExecuteTimings,
     };
 
     fn create_test_bob() -> (BOB, mpsc::UnboundedSender<Vec<(Pubkey, AccountSettlement)>>) {
@@ -346,6 +359,132 @@ mod tests {
             executable: false,
             rent_epoch: 0,
         })
+    }
+
+    /// A token-like data account whose balance lives in its data (first 8 bytes), at the 1-lamport floor.
+    fn token_like(balance: u64) -> AccountSharedData {
+        make_account(1, &balance.to_le_bytes(), &spl_token::id())
+    }
+
+    /// Decode the `token_like` balance from an account's data.
+    fn token_balance(account: &AccountSharedData) -> u64 {
+        u64::from_le_bytes(account.data()[..8].try_into().unwrap())
+    }
+
+    /// Build a single-tx Executed processing result with the given status.
+    fn executed_with_status(
+        status: Result<(), solana_transaction_error::TransactionError>,
+        accounts: Vec<(Pubkey, AccountSharedData)>,
+    ) -> ProcessedTransaction {
+        ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                accounts,
+                ..Default::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status,
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: HashMap::new(),
+        }))
+    }
+
+    /// Wrap one processing result into a single-tx SVM output.
+    fn svm_output(result: ProcessedTransaction) -> LoadAndExecuteSanitizedTransactionsOutput {
+        LoadAndExecuteSanitizedTransactionsOutput {
+            processing_results: vec![Ok(result)],
+            error_metrics: TransactionErrorMetrics::default(),
+            execute_timings: ExecuteTimings::default(),
+            balance_collector: None,
+        }
+    }
+
+    /// A failed executed tx must not overwrite a preloaded data account X=10 with its intermediate X=6, nor create dest.
+    #[tokio::test]
+    async fn failed_executed_does_not_overwrite_existing() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let from = Keypair::new();
+        let x = from.pubkey();
+        let dest = Pubkey::new_unique();
+        bob.insert_account_for_test(x, token_like(10));
+
+        // idx 0 (x, fee payer) and idx 1 (dest) are writable in a transfer.
+        let tx = create_test_sanitized_transaction(&from, &dest, 0);
+        let output = svm_output(executed_with_status(
+            Err(solana_transaction_error::TransactionError::InstructionError(
+                1,
+                solana_sdk::instruction::InstructionError::Custom(0),
+            )),
+            vec![(x, token_like(6)), (dest, token_like(4))],
+        ));
+        bob.update_accounts(&output, std::slice::from_ref(&tx));
+
+        assert_eq!(
+            token_balance(&bob.get_account_shared_data(&x).expect("X must remain")),
+            10,
+            "failed tx must not overwrite X with its rolled-back intermediate balance"
+        );
+        assert!(
+            bob.get_account_shared_data(&dest).is_none(),
+            "dest from a failed tx must not be created"
+        );
+    }
+
+    /// Success path is unchanged: a successful executed tx still commits X=6 and dest=4 (guards against an inverted guard).
+    #[tokio::test]
+    async fn successful_executed_still_writes() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let from = Keypair::new();
+        let x = from.pubkey();
+        let dest = Pubkey::new_unique();
+        bob.insert_account_for_test(x, token_like(10));
+
+        let tx = create_test_sanitized_transaction(&from, &dest, 0);
+        let output = svm_output(executed_with_status(
+            Ok(()),
+            vec![(x, token_like(6)), (dest, token_like(4))],
+        ));
+        bob.update_accounts(&output, std::slice::from_ref(&tx));
+
+        assert_eq!(
+            token_balance(&bob.get_account_shared_data(&x).expect("X present")),
+            6,
+            "successful tx commits the new X balance"
+        );
+        assert_eq!(
+            token_balance(&bob.get_account_shared_data(&dest).expect("dest present")),
+            4,
+            "successful tx commits the new dest balance"
+        );
+    }
+
+    /// Admin-trap regression: a failed executed result with empty loaded accounts must leave a pre-existing fee payer untouched.
+    #[tokio::test]
+    async fn failed_executed_does_not_tombstone_fee_payer() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let from = Keypair::new();
+        let fee_payer = from.pubkey();
+        bob.insert_account_for_test(fee_payer, token_like(10));
+
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 0);
+        let output = svm_output(executed_with_status(
+            Err(solana_transaction_error::TransactionError::InstructionError(
+                0,
+                solana_sdk::instruction::InstructionError::Custom(0),
+            )),
+            vec![],
+        ));
+        bob.update_accounts(&output, std::slice::from_ref(&tx));
+
+        assert_eq!(
+            token_balance(&bob.get_account_shared_data(&fee_payer).expect("fee payer present")),
+            10,
+            "failed executed tx with empty accounts must not tombstone the fee payer"
+        );
     }
 
     fn now_secs() -> u64 {

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -415,10 +415,12 @@ mod tests {
         // idx 0 (x, fee payer) and idx 1 (dest) are writable in a transfer.
         let tx = create_test_sanitized_transaction(&from, &dest, 0);
         let output = svm_output(executed_with_status(
-            Err(solana_transaction_error::TransactionError::InstructionError(
-                1,
-                solana_sdk::instruction::InstructionError::Custom(0),
-            )),
+            Err(
+                solana_transaction_error::TransactionError::InstructionError(
+                    1,
+                    solana_sdk::instruction::InstructionError::Custom(0),
+                ),
+            ),
             vec![(x, token_like(6)), (dest, token_like(4))],
         ));
         bob.update_accounts(&output, std::slice::from_ref(&tx));
@@ -472,16 +474,21 @@ mod tests {
 
         let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 0);
         let output = svm_output(executed_with_status(
-            Err(solana_transaction_error::TransactionError::InstructionError(
-                0,
-                solana_sdk::instruction::InstructionError::Custom(0),
-            )),
+            Err(
+                solana_transaction_error::TransactionError::InstructionError(
+                    0,
+                    solana_sdk::instruction::InstructionError::Custom(0),
+                ),
+            ),
             vec![],
         ));
         bob.update_accounts(&output, std::slice::from_ref(&tx));
 
         assert_eq!(
-            token_balance(&bob.get_account_shared_data(&fee_payer).expect("fee payer present")),
+            token_balance(
+                &bob.get_account_shared_data(&fee_payer)
+                    .expect("fee payer present")
+            ),
             10,
             "failed executed tx with empty accounts must not tombstone the fee payer"
         );

--- a/core/src/accounts/utils.rs
+++ b/core/src/accounts/utils.rs
@@ -24,22 +24,22 @@ pub fn get_stored_transaction(
     let meta = match processed {
         ProcessedTransaction::Executed(executed) => {
             let details = &executed.execution_details;
-            // A failed executed tx commits no account changes; its loaded accounts hold rolled-back intermediate state, so report no balances rather than values that disagree with committed state.
-            let balances: Vec<u64> = if details.status.is_ok() {
-                executed
+            // Balances stay one-per-loaded-account (aligned with the account keys) for every executed result, success or failure, so callers can index balances by account.
+            TransactionStatusMeta {
+                status: details.status.clone(),
+                fee: executed.loaded_transaction.fee_details.total_fee(),
+                pre_balances: executed
                     .loaded_transaction
                     .accounts
                     .iter()
                     .map(|(_, account)| account.lamports())
-                    .collect()
-            } else {
-                Vec::new()
-            };
-            TransactionStatusMeta {
-                status: details.status.clone(),
-                fee: executed.loaded_transaction.fee_details.total_fee(),
-                pre_balances: balances.clone(),
-                post_balances: balances,
+                    .collect(),
+                post_balances: executed
+                    .loaded_transaction
+                    .accounts
+                    .iter()
+                    .map(|(_, account)| account.lamports())
+                    .collect(),
                 inner_instructions: details.inner_instructions.as_ref().map(|inner| {
                     inner
                         .iter()
@@ -195,30 +195,41 @@ mod tests {
         assert_eq!(stored.meta.post_balances, vec![7]);
     }
 
-    /// A failed executed tx commits nothing, so its stored meta must not report the rolled-back intermediate balances that would disagree with committed state.
+    /// A failed executed tx keeps its balance arrays aligned with the loaded accounts (one entry per account) so callers can still index balances by account, and its error status is recorded.
     #[test]
-    fn stored_meta_omits_balances_for_failed_executed() {
+    fn stored_meta_keeps_balances_aligned_for_failed_executed() {
         let tx = crate::test_helpers::create_test_sanitized_transaction(
             &Keypair::new(),
             &Pubkey::new_unique(),
             0,
         );
-        let intermediate = AccountSharedData::new(6, 0, &Pubkey::new_unique());
+        let accounts = vec![
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(6, 0, &Pubkey::new_unique()),
+            ),
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(4, 0, &Pubkey::new_unique()),
+            ),
+        ];
+        let n = accounts.len();
         let processed = executed_processed(
             Err(TransactionError::InstructionError(
                 1,
                 InstructionError::Custom(0),
             )),
-            vec![(Pubkey::new_unique(), intermediate)],
+            accounts,
         );
 
         let stored = get_stored_transaction(&tx, 1, 0, &processed);
 
-        assert!(
-            stored.meta.pre_balances.is_empty(),
-            "failed executed tx must not report intermediate balances"
+        assert_eq!(
+            stored.meta.pre_balances.len(),
+            n,
+            "balances must stay aligned with the account list on failure"
         );
-        assert!(stored.meta.post_balances.is_empty());
+        assert_eq!(stored.meta.post_balances.len(), n);
         assert!(
             stored.meta.err.is_some(),
             "failed executed tx must still record its error status"

--- a/core/src/accounts/utils.rs
+++ b/core/src/accounts/utils.rs
@@ -24,21 +24,22 @@ pub fn get_stored_transaction(
     let meta = match processed {
         ProcessedTransaction::Executed(executed) => {
             let details = &executed.execution_details;
+            // A failed executed tx commits no account changes; its loaded accounts hold rolled-back intermediate state, so report no balances rather than values that disagree with committed state.
+            let balances: Vec<u64> = if details.status.is_ok() {
+                executed
+                    .loaded_transaction
+                    .accounts
+                    .iter()
+                    .map(|(_, account)| account.lamports())
+                    .collect()
+            } else {
+                Vec::new()
+            };
             TransactionStatusMeta {
                 status: details.status.clone(),
                 fee: executed.loaded_transaction.fee_details.total_fee(),
-                pre_balances: executed
-                    .loaded_transaction
-                    .accounts
-                    .iter()
-                    .map(|(_, account)| account.lamports())
-                    .collect(),
-                post_balances: executed
-                    .loaded_transaction
-                    .accounts
-                    .iter()
-                    .map(|(_, account)| account.lamports())
-                    .collect(),
+                pre_balances: balances.clone(),
+                post_balances: balances,
                 inner_instructions: details.inner_instructions.as_ref().map(|inner| {
                     inner
                         .iter()
@@ -145,5 +146,82 @@ mod tests {
         let parsed = encode_transaction_data(data, UiTransactionEncoding::JsonParsed);
         let base64 = encode_transaction_data(data, UiTransactionEncoding::Base64);
         assert_eq!(parsed, base64);
+    }
+
+    use solana_sdk::{
+        account::AccountSharedData, instruction::InstructionError, pubkey::Pubkey,
+        signature::Keypair, transaction::TransactionError,
+    };
+    use solana_svm::account_loader::LoadedTransaction;
+    use solana_svm::transaction_execution_result::{
+        ExecutedTransaction, TransactionExecutionDetails,
+    };
+
+    fn executed_processed(
+        status: Result<(), TransactionError>,
+        accounts: Vec<(Pubkey, AccountSharedData)>,
+    ) -> ProcessedTransaction {
+        ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                accounts,
+                ..Default::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status,
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: std::collections::HashMap::new(),
+        }))
+    }
+
+    /// A successful executed tx records its loaded-account lamports as the stored meta balances.
+    #[test]
+    fn stored_meta_records_balances_for_successful_executed() {
+        let tx = crate::test_helpers::create_test_sanitized_transaction(
+            &Keypair::new(),
+            &Pubkey::new_unique(),
+            0,
+        );
+        let acct = AccountSharedData::new(7, 0, &Pubkey::new_unique());
+        let processed = executed_processed(Ok(()), vec![(Pubkey::new_unique(), acct)]);
+
+        let stored = get_stored_transaction(&tx, 1, 0, &processed);
+
+        assert_eq!(stored.meta.pre_balances, vec![7]);
+        assert_eq!(stored.meta.post_balances, vec![7]);
+    }
+
+    /// A failed executed tx commits nothing, so its stored meta must not report the rolled-back intermediate balances that would disagree with committed state.
+    #[test]
+    fn stored_meta_omits_balances_for_failed_executed() {
+        let tx = crate::test_helpers::create_test_sanitized_transaction(
+            &Keypair::new(),
+            &Pubkey::new_unique(),
+            0,
+        );
+        let intermediate = AccountSharedData::new(6, 0, &Pubkey::new_unique());
+        let processed = executed_processed(
+            Err(TransactionError::InstructionError(
+                1,
+                InstructionError::Custom(0),
+            )),
+            vec![(Pubkey::new_unique(), intermediate)],
+        );
+
+        let stored = get_stored_transaction(&tx, 1, 0, &processed);
+
+        assert!(
+            stored.meta.pre_balances.is_empty(),
+            "failed executed tx must not report intermediate balances"
+        );
+        assert!(stored.meta.post_balances.is_empty());
+        assert!(
+            stored.meta.err.is_some(),
+            "failed executed tx must still record its error status"
+        );
     }
 }

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -411,6 +411,10 @@ fn cap_lamports(
         let Ok(ProcessedTransaction::Executed(executed)) = result else {
             continue;
         };
+        if !executed.was_successful() {
+            // Failed executed txs commit no account writes downstream.
+            continue;
+        }
         for (index, (_, acct)) in executed.loaded_transaction.accounts.iter_mut().enumerate() {
             // Only writable accounts are persisted by the settler / BOB update.
             if !tx.is_writable(index) {
@@ -835,9 +839,11 @@ mod tests {
     // know (`transfer` → idx 0,1 writable, idx 2 system_program read-only),
     // run the cap, and read the accounts back.
 
-    /// Build a single-tx Executed output carrying `accounts` at the loaded
-    /// transaction's account positions.
-    fn executed_with(accounts: Vec<(Pubkey, AccountSharedData)>) -> TransactionProcessingResult {
+    /// Build a single-tx Executed output carrying `accounts` with the given `status`.
+    fn executed_with_status(
+        status: Result<(), solana_transaction_error::TransactionError>,
+        accounts: Vec<(Pubkey, AccountSharedData)>,
+    ) -> TransactionProcessingResult {
         use solana_svm::account_loader::LoadedTransaction;
         use solana_svm::transaction_execution_result::{
             ExecutedTransaction, TransactionExecutionDetails,
@@ -849,7 +855,7 @@ mod tests {
                     ..Default::default()
                 },
                 execution_details: TransactionExecutionDetails {
-                    status: Ok(()),
+                    status,
                     log_messages: None,
                     inner_instructions: None,
                     return_data: None,
@@ -859,6 +865,11 @@ mod tests {
                 programs_modified_by_tx: std::collections::HashMap::new(),
             },
         )))
+    }
+
+    /// A successful single-tx Executed output carrying `accounts`.
+    fn executed_with(accounts: Vec<(Pubkey, AccountSharedData)>) -> TransactionProcessingResult {
+        executed_with_status(Ok(()), accounts)
     }
 
     /// A token-like data account (program-owned, non-empty data) with `lamports`.
@@ -962,6 +973,45 @@ mod tests {
             out[2].lamports(),
             99,
             "read-only account must not be capped"
+        );
+    }
+
+    /// A failed executed tx commits no account writes downstream, so cap_lamports leaves its loaded accounts untouched.
+    #[test]
+    fn cap_skips_failed_executed() {
+        let tx = transfer(&Keypair::new(), &Pubkey::new_unique(), 0);
+        let failed = executed_with_status(
+            Err(
+                solana_transaction_error::TransactionError::InstructionError(
+                    1,
+                    solana_sdk::instruction::InstructionError::Custom(0),
+                ),
+            ),
+            vec![
+                (Pubkey::new_unique(), data_account(11)),
+                (Pubkey::new_unique(), dataless_account(10)),
+            ],
+        );
+        let mut output = LoadAndExecuteSanitizedTransactionsOutput {
+            processing_results: vec![failed],
+            error_metrics: TransactionErrorMetrics::default(),
+            execute_timings: ExecuteTimings::default(),
+            balance_collector: None,
+        };
+        cap_lamports(&mut output, std::slice::from_ref(&tx));
+        let Ok(ProcessedTransaction::Executed(executed)) = &output.processing_results[0] else {
+            panic!("expected executed");
+        };
+        let accts = &executed.loaded_transaction.accounts;
+        assert_eq!(
+            accts[0].1.lamports(),
+            11,
+            "failed-tx data account must be left untouched"
+        );
+        assert_eq!(
+            accts[1].1.lamports(),
+            10,
+            "failed-tx dataless account must be left untouched"
         );
     }
 
@@ -1118,6 +1168,64 @@ mod tests {
         // transfer still executes; nothing native persists.
         assert!(bob_balance(&deps.bob, &r).is_none_or(|l| l == 0));
         assert!(bob_balance(&deps.bob, &b.pubkey()).is_none_or(|l| l == 0));
+    }
+
+    // Real-SVM premise: a mid-tx failure is Executed{Err} and persists nothing.
+
+    /// A two-instruction system tx where ix0 succeeds and ix1 fails on
+    /// insufficient funds. The SVM returns `Executed` with `status.is_err()`,
+    /// proving the premise that a partial failure is not a top-level `Err`. The
+    /// pre-funded payer must keep its pre-execution balance in BOB: its
+    /// rolled-back intermediate state must not be committed. The data-distinguishing
+    /// assertion is carried by the bob/settle unit tests; here both system
+    /// recipients are dataless so the cap would zero them regardless.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn partial_failure_through_svm_is_executed_err_and_persists_nothing() {
+        let (accounts_db, _pg) = start_test_postgres().await;
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
+        let metrics: SharedMetrics = Arc::new(NoopMetrics);
+
+        let payer = Keypair::new();
+        fund(&mut deps.bob, &payer.pubkey(), 100);
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+
+        // ix0: payer pays A (60) and succeeds; ix1: payer pays B (60) and fails (only 40 left).
+        let ix0 = solana_system_interface::instruction::transfer(&payer.pubkey(), &a, 60);
+        let ix1 = solana_system_interface::instruction::transfer(&payer.pubkey(), &b, 60);
+        let msg = Message::new(&[ix0, ix1], Some(&payer.pubkey()));
+        let raw = Transaction::new(&[&payer], msg, Hash::default());
+        let tx = SanitizedTransaction::try_from_legacy_transaction(raw, &HashSet::new())
+            .expect("failed to build two-instruction tx");
+
+        let result = run_batch(&mut deps, &metrics, vec![tx]).await;
+
+        let r = regular_result(&result, 0);
+        assert!(
+            is_executed(r),
+            "the SVM returns Executed for a mid-tx failure"
+        );
+        let Ok(ProcessedTransaction::Executed(executed)) = r else {
+            panic!("expected executed");
+        };
+        assert!(
+            !executed.was_successful(),
+            "the partial failure surfaces as Executed with an Err status"
+        );
+        assert_eq!(
+            bob_balance(&deps.bob, &payer.pubkey()),
+            Some(100),
+            "failed tx must not clobber the pre-funded payer with its rolled-back state"
+        );
+        assert!(
+            bob_balance(&deps.bob, &a).is_none_or(|l| l == 0),
+            "intermediate credit to A must not persist"
+        );
+        assert!(
+            bob_balance(&deps.bob, &b).is_none_or(|l| l == 0),
+            "B was never credited and must be absent"
+        );
     }
 
     // ── Path parity & invariants ──

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -530,19 +530,22 @@ async fn settle_transactions(
                     sanitized_transaction.signature()
                 );
 
-                for (index, (pubkey, account_data)) in
-                    executed_tx.loaded_transaction.accounts.iter().enumerate()
-                {
-                    if sanitized_transaction.is_writable(index) {
-                        let deleted =
-                            account_data.lamports() == 0 && account_data.data().is_empty();
-                        final_accounts_actual.insert(
-                            *pubkey,
-                            AccountSettlement {
-                                account: account_data.clone(),
-                                deleted,
-                            },
-                        );
+                // A failed executed tx (status Err) holds rolled-back intermediate state; record its signature but persist no account writes.
+                if executed_tx.was_successful() {
+                    for (index, (pubkey, account_data)) in
+                        executed_tx.loaded_transaction.accounts.iter().enumerate()
+                    {
+                        if sanitized_transaction.is_writable(index) {
+                            let deleted =
+                                account_data.lamports() == 0 && account_data.data().is_empty();
+                            final_accounts_actual.insert(
+                                *pubkey,
+                                AccountSettlement {
+                                    account: account_data.clone(),
+                                    deleted,
+                                },
+                            );
+                        }
                     }
                 }
 
@@ -700,6 +703,30 @@ mod tests {
             },
             execution_details: TransactionExecutionDetails {
                 status: Ok(()),
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 100,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: std::collections::HashMap::new(),
+        }))
+    }
+
+    /// `make_executed` with an `Err` status: an executed tx that failed mid-transaction holding rolled-back accounts.
+    fn make_failed_executed(
+        accounts: Vec<(solana_sdk::pubkey::Pubkey, AccountSharedData)>,
+    ) -> ProcessedTransaction {
+        ProcessedTransaction::Executed(Box::new(ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                accounts,
+                ..Default::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status: Err(solana_transaction_error::TransactionError::InstructionError(
+                    1,
+                    solana_sdk::instruction::InstructionError::Custom(0),
+                )),
                 log_messages: None,
                 inner_instructions: None,
                 return_data: None,
@@ -1001,6 +1028,92 @@ mod tests {
         assert!(block.transaction_signatures.contains(&sig));
         // But no account settlements
         assert!(result.account_settlements.is_empty());
+    }
+
+    /// A failed executed tx must persist no account writes from its rolled-back state, yet still be recorded by signature.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failed_executed_persists_no_accounts_but_records_sig() {
+        let (mut db, _pg) = start_test_postgres().await;
+
+        let from = Keypair::new();
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 100);
+        let sig = *tx.signature();
+
+        // A token-like data account at idx 0 (writable fee payer slot).
+        let data_pk = from.pubkey();
+        let data_acct = AccountSharedData::new(500, 8, &spl_token::id());
+        let results: Vec<(TransactionProcessingResult, _)> =
+            vec![(Ok(make_failed_executed(vec![(data_pk, data_acct)])), tx)];
+
+        let result = settle_transactions(
+            None,
+            &mut db,
+            None,
+            &results,
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.account_settlements.is_empty(),
+            "a failed executed tx must persist no account writes"
+        );
+        let block = db.get_block(result.slot).await.unwrap();
+        assert!(
+            block.transaction_signatures.contains(&sig),
+            "a failed executed tx must still be recorded by signature"
+        );
+    }
+
+    /// A successful executed tx (writes A) and a failed one (would-write B): only A settles, B is absent, both sigs recorded.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mixed_success_and_failed_executed_in_batch() {
+        let (mut db, _pg) = start_test_postgres().await;
+
+        let from1 = Keypair::new();
+        let tx1 = create_test_sanitized_transaction(&from1, &Pubkey::new_unique(), 100);
+        let sig1 = *tx1.signature();
+        let a = from1.pubkey();
+        let ok = make_executed(vec![(a, AccountSharedData::new(500, 8, &spl_token::id()))]);
+
+        let from2 = Keypair::new();
+        let tx2 = create_test_sanitized_transaction(&from2, &Pubkey::new_unique(), 200);
+        let sig2 = *tx2.signature();
+        let b = from2.pubkey();
+        let failed = make_failed_executed(vec![(b, AccountSharedData::new(700, 8, &spl_token::id()))]);
+
+        let results: Vec<(TransactionProcessingResult, _)> =
+            vec![(Ok(ok), tx1), (Ok(failed), tx2)];
+
+        let result = settle_transactions(
+            None,
+            &mut db,
+            None,
+            &results,
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.account_settlements.iter().any(|(k, _)| *k == a),
+            "successful tx's account A must be settled"
+        );
+        assert!(
+            !result.account_settlements.iter().any(|(k, _)| *k == b),
+            "failed tx's account B must not be settled"
+        );
+        assert_eq!(result.account_settlements.len(), 1, "only A settles");
+
+        let block = db.get_block(result.slot).await.unwrap();
+        assert!(block.transaction_signatures.contains(&sig1));
+        assert!(
+            block.transaction_signatures.contains(&sig2),
+            "failed executed tx signature must still be recorded"
+        );
     }
 
     /// Under the lamport cap, the executor zeroes a dataless gainer (e.g. the

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -723,10 +723,12 @@ mod tests {
                 ..Default::default()
             },
             execution_details: TransactionExecutionDetails {
-                status: Err(solana_transaction_error::TransactionError::InstructionError(
-                    1,
-                    solana_sdk::instruction::InstructionError::Custom(0),
-                )),
+                status: Err(
+                    solana_transaction_error::TransactionError::InstructionError(
+                        1,
+                        solana_sdk::instruction::InstructionError::Custom(0),
+                    ),
+                ),
                 log_messages: None,
                 inner_instructions: None,
                 return_data: None,
@@ -1082,10 +1084,10 @@ mod tests {
         let tx2 = create_test_sanitized_transaction(&from2, &Pubkey::new_unique(), 200);
         let sig2 = *tx2.signature();
         let b = from2.pubkey();
-        let failed = make_failed_executed(vec![(b, AccountSharedData::new(700, 8, &spl_token::id()))]);
+        let failed =
+            make_failed_executed(vec![(b, AccountSharedData::new(700, 8, &spl_token::id()))]);
 
-        let results: Vec<(TransactionProcessingResult, _)> =
-            vec![(Ok(ok), tx1), (Ok(failed), tx2)];
+        let results: Vec<(TransactionProcessingResult, _)> = vec![(Ok(ok), tx1), (Ok(failed), tx2)];
 
         let result = settle_transactions(
             None,


### PR DESCRIPTION
## Summary

Closes issue 3. `ProcessedTransaction::Executed` only means a tx reached execution, not that it succeeded. Three consumers committed those writes unconditionally, so failed-tx state leaked into BOB and Postgres. 

The fix adds one guard to each: `cap_lamports`, `BOB::update_accounts`, and the settler now commit writable loaded accounts only when `executed.was_successful()`. A failed executed tx commits no account writes; the settler still records its signature with the `Err` status (matching Solana). 

## Design decision

- **Commit nothing on failure.** Solana commits rollback accounts (fee payer + nonce) on failure; in Private channel's gasless model those carry no committable change.

## Tests added

Seven tests written. Together they verify that a failed executed tx persists none of its rolled-back writes while a successful tx still commits normally (so the guard can neither be inverted nor break legitimate writes) and that failed txs are still recorded by signature. 


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28386862715) |
| Indexer | 22,898 | 25,994 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28386862715) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28386862715) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28386862715) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,144 | 15,129 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28386862715) |
| **Total** | **48,348** | **56,341** | **85.8%** | |

> Last updated: 2026-06-29 16:49:27 UTC by E2E Integration