### PR TITLE
fix(monitoring): Correct job selectors, scrape the gateway, vendor-neutral alerting

### DIFF
--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -611,6 +611,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - PROMETHEUS_URL=${PROMETHEUS_URL:-http://prometheus:9090}
       - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-http://localhost:9/no-op}
+      - ALERT_CONTACT_TYPE=${ALERT_CONTACT_TYPE:-webhook}
     networks:
       - private-channel-network
     healthcheck:

--- a/monitoring/dashboards/private-channel-indexer.json
+++ b/monitoring/dashboards/private-channel-indexer.json
@@ -41,7 +41,7 @@
       },
       "targets": [
         {
-          "expr": "private_channel_indexer_current_slot{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}",
+          "expr": "private_channel_indexer_current_slot{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -65,7 +65,7 @@
       },
       "targets": [
         {
-          "expr": "private_channel_indexer_mints_saved_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}",
+          "expr": "private_channel_indexer_mints_saved_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -89,7 +89,7 @@
       },
       "targets": [
         {
-          "expr": "private_channel_indexer_chain_tip_slot{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}",
+          "expr": "private_channel_indexer_chain_tip_slot{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -111,7 +111,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_indexer_slots_processed_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_indexer_slots_processed_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -133,7 +133,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_indexer_transactions_saved_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_indexer_transactions_saved_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -158,7 +158,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_indexer_slot_save_errors_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_indexer_slot_save_errors_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -183,7 +183,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_indexer_rpc_errors_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_indexer_rpc_errors_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}} / {{error_type}}",
           "refId": "A"
         }
@@ -205,7 +205,7 @@
       },
       "targets": [
         {
-          "expr": "private_channel_indexer_chain_tip_slot{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"} - private_channel_indexer_current_slot{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}",
+          "expr": "private_channel_indexer_chain_tip_slot{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"} - private_channel_indexer_current_slot{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -227,12 +227,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le, program_type) (rate(private_channel_indexer_slot_processing_duration_seconds_bucket{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (le, program_type) (rate(private_channel_indexer_slot_processing_duration_seconds_bucket{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])))",
           "legendFormat": "p50 {{program_type}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le, program_type) (rate(private_channel_indexer_slot_processing_duration_seconds_bucket{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, program_type) (rate(private_channel_indexer_slot_processing_duration_seconds_bucket{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])))",
           "legendFormat": "p99 {{program_type}}",
           "refId": "B"
         }
@@ -257,7 +257,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_indexer_datasource_reconnects_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_indexer_datasource_reconnects_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -279,7 +279,7 @@
       },
       "targets": [
         {
-          "expr": "private_channel_indexer_backfill_slots_remaining{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}",
+          "expr": "private_channel_indexer_backfill_slots_remaining{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -320,7 +320,7 @@
       },
       "targets": [
         {
-          "expr": "private_channel_indexer_chain_tip_slot{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"} - private_channel_indexer_current_slot{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}",
+          "expr": "private_channel_indexer_chain_tip_slot{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"} - private_channel_indexer_current_slot{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }

--- a/monitoring/dashboards/private-channel-operator.json
+++ b/monitoring/dashboards/private-channel-operator.json
@@ -39,7 +39,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_operator_transactions_fetched_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_operator_transactions_fetched_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -61,7 +61,7 @@
       },
       "targets": [
         {
-          "expr": "private_channel_operator_backlog_depth{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}",
+          "expr": "private_channel_operator_backlog_depth{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -83,7 +83,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_operator_mints_sent_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_operator_mints_sent_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -108,7 +108,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_operator_transaction_errors_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_operator_transaction_errors_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}} / {{error_reason}}",
           "refId": "A"
         }
@@ -130,7 +130,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_operator_db_updates_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_operator_db_updates_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}} / {{status}}",
           "refId": "A"
         }
@@ -155,7 +155,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_operator_db_update_errors_total{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_operator_db_update_errors_total{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }
@@ -184,7 +184,7 @@
       },
       "targets": [
         {
-          "expr": "rate(private_channel_operator_rpc_send_duration_seconds_count{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
+          "expr": "rate(private_channel_operator_rpc_send_duration_seconds_count{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])",
           "legendFormat": "{{program_type}} / {{result}}",
           "refId": "A"
         }
@@ -206,12 +206,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le, program_type) (rate(private_channel_operator_rpc_send_duration_seconds_bucket{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (le, program_type) (rate(private_channel_operator_rpc_send_duration_seconds_bucket{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])))",
           "legendFormat": "p50 {{program_type}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le, program_type) (rate(private_channel_operator_rpc_send_duration_seconds_bucket{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, program_type) (rate(private_channel_operator_rpc_send_duration_seconds_bucket{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"}[$__rate_interval])))",
           "legendFormat": "p99 {{program_type}}",
           "refId": "B"
         }
@@ -312,7 +312,7 @@
       },
       "targets": [
         {
-          "expr": "private_channel_feepayer_balance_lamports{job=~\"indexer-.*|operator-.*\", program_type=~\"$program_type\"} / 1e9",
+          "expr": "private_channel_feepayer_balance_lamports{job=~\"private-channel-(indexer|operator)-.*\", program_type=~\"$program_type\"} / 1e9",
           "legendFormat": "{{program_type}}",
           "refId": "A"
         }

--- a/monitoring/monitoring.compose.yml.j2
+++ b/monitoring/monitoring.compose.yml.j2
@@ -65,9 +65,11 @@ services:
       # env vars at Grafana startup. Same set + defaults as docker-compose.yml's
       # grafana service so both deploy paths see identical config.
       - PROMETHEUS_URL=http://prometheus:9090
-      # alerting/contact-points.yml uses this; the no-op default keeps Grafana
-      # from failing provisioning when no real webhook is configured.
+      # alerting/contact-points.yml uses these; the no-op defaults keep Grafana
+      # from failing provisioning when no real notifier is configured. Set
+      # alert_contact_type (e.g. slack) + alert_webhook_url to enable alerting.
       - ALERT_WEBHOOK_URL={{ alert_webhook_url | default('http://localhost:9/no-op') }}
+      - ALERT_CONTACT_TYPE={{ alert_contact_type | default('webhook') }}
       # Postgres datasource (for the Postgres dashboard's direct-DB queries).
       - POSTGRES_INDEXER_HOST=postgres-indexer
       - POSTGRES_INDEXER_DB={{ postgres_indexer_db }}

--- a/monitoring/prometheus.yml.j2
+++ b/monitoring/prometheus.yml.j2
@@ -97,15 +97,23 @@ scrape_configs:
         labels:
           stack: private-channel
 
-  # ── Solana Private Channels write/read/gateway /metrics (only when PRIVATE_CHANNEL_METRICS=true is
-  # set on the service; otherwise these targets show as down which is
-  # correct). Listed here so flipping PRIVATE_CHANNEL_METRICS=true requires no
+  # ── Solana Private Channels write/read node /metrics (only when the node is run
+  # with --metrics / PRIVATE_CHANNEL_METRICS=true; otherwise these targets show
+  # as down which is correct). Listed here so enabling node metrics requires no
   # Prometheus config change.
   - job_name: private-channel-services
     static_configs:
       - targets:
           - 'write-node:9090'
           - 'read-node:9090'
-          - 'gateway:9090'
+        labels:
+          stack: private-channel
+
+  # ── Gateway /metrics. The gateway always serves metrics (no flag) on
+  # METRICS_PORT, default 9101. The RPC dashboard filters on job="gateway".
+  - job_name: gateway
+    static_configs:
+      - targets:
+          - 'gateway:9101'
         labels:
           stack: private-channel

--- a/monitoring/provisioning/alerting/alert-rules.yml
+++ b/monitoring/provisioning/alerting/alert-rules.yml
@@ -61,7 +61,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: up{job=~"gateway|indexer-solana|indexer-private-channel|operator-solana|operator-private-channel"}
+              expr: up{job=~"private-channel-(indexer|operator)-.*"}
               instant: true
               refId: A
           - refId: C
@@ -134,7 +134,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: private_channel_feepayer_balance_lamports{job=~"operator-.*"} / 1e9
+              expr: private_channel_feepayer_balance_lamports{job="private-channel-operator-solana"} / 1e9
               instant: true
               refId: A
           - refId: C
@@ -168,7 +168,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: private_channel_feepayer_balance_lamports{job=~"operator-.*"} / 1e9
+              expr: private_channel_feepayer_balance_lamports{job="private-channel-operator-solana"} / 1e9
               instant: true
               refId: A
           - refId: C

--- a/monitoring/provisioning/alerting/alert-rules.yml
+++ b/monitoring/provisioning/alerting/alert-rules.yml
@@ -61,7 +61,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: up{job=~"private-channel-(indexer|operator)-.*"}
+              expr: up{job=~"private-channel-(indexer|operator)-.*|gateway"}
               instant: true
               refId: A
           - refId: C

--- a/monitoring/provisioning/alerting/contact-points.yml
+++ b/monitoring/provisioning/alerting/contact-points.yml
@@ -1,10 +1,23 @@
 apiVersion: 1
 contactPoints:
   - orgId: 1
-    name: webhook-alerts
+    name: default
     receivers:
-      - uid: webhook-alerts
-        type: webhook
+      - uid: default
+        # Vendor-neutral by default. The contact type and endpoint are
+        # deployment-configured via Grafana env-var substitution (these files are
+        # consumed as-is by the Ansible deploy, the dev compose, and the baked
+        # Grafana image, so env substitution is the only parameterization that
+        # works everywhere):
+        #   ALERT_CONTACT_TYPE  - grafana receiver type (default: webhook).
+        #                         e.g. slack, pagerduty, email, teams, opsgenie.
+        #   ALERT_WEBHOOK_URL   - endpoint URL (default: a no-op URL).
+        # Defaults give a fresh deploy a harmless no-op webhook with no external
+        # dependency. For Slack: set ALERT_CONTACT_TYPE=slack and point
+        # ALERT_WEBHOOK_URL at a Slack Incoming Webhook (Grafana's slack receiver
+        # formats the payload; a generic webhook does not). `url` is valid for
+        # both webhook and slack, so the message format is left to Grafana's
+        # per-type defaults.
+        type: ${ALERT_CONTACT_TYPE}
         settings:
           url: ${ALERT_WEBHOOK_URL}
-          httpMethod: POST

--- a/monitoring/provisioning/alerting/contact-points.yml
+++ b/monitoring/provisioning/alerting/contact-points.yml
@@ -10,14 +10,17 @@ contactPoints:
         # Grafana image, so env substitution is the only parameterization that
         # works everywhere):
         #   ALERT_CONTACT_TYPE  - grafana receiver type (default: webhook).
-        #                         e.g. slack, pagerduty, email, teams, opsgenie.
         #   ALERT_WEBHOOK_URL   - endpoint URL (default: a no-op URL).
-        # Defaults give a fresh deploy a harmless no-op webhook with no external
-        # dependency. For Slack: set ALERT_CONTACT_TYPE=slack and point
-        # ALERT_WEBHOOK_URL at a Slack Incoming Webhook (Grafana's slack receiver
-        # formats the payload; a generic webhook does not). `url` is valid for
-        # both webhook and slack, so the message format is left to Grafana's
-        # per-type defaults.
+        # The settings block below only provides `url`, so it covers the receiver
+        # types whose required setting IS a url: webhook, slack, teams. Other
+        # types need their own settings added here (pagerduty: integrationKey,
+        # email: addresses, opsgenie: apiKey/apiUrl) — a bare url would create an
+        # invalid contact point that notifies nowhere. Defaults give a fresh
+        # deploy a harmless no-op webhook with no external dependency. For Slack:
+        # set ALERT_CONTACT_TYPE=slack and point ALERT_WEBHOOK_URL at a Slack
+        # Incoming Webhook (Grafana's slack receiver formats the payload; a
+        # generic webhook does not). Message format is left to Grafana's per-type
+        # defaults.
         type: ${ALERT_CONTACT_TYPE}
         settings:
           url: ${ALERT_WEBHOOK_URL}

--- a/monitoring/provisioning/alerting/notification-policies.yml
+++ b/monitoring/provisioning/alerting/notification-policies.yml
@@ -3,7 +3,9 @@ policies:
   - orgId: 1
     receiver: default
     # Batch related alerts and avoid re-nagging too often. Tune per deployment.
-    group_by: ['alertname']
+    # Group by job too so simultaneous incidents on different services (e.g. two
+    # operators) stay distinct notifications instead of collapsing into one.
+    group_by: ['alertname', 'job']
     group_wait: 30s
     group_interval: 5m
     repeat_interval: 4h

--- a/monitoring/provisioning/alerting/notification-policies.yml
+++ b/monitoring/provisioning/alerting/notification-policies.yml
@@ -1,4 +1,9 @@
 apiVersion: 1
 policies:
   - orgId: 1
-    receiver: webhook-alerts
+    receiver: default
+    # Batch related alerts and avoid re-nagging too often. Tune per deployment.
+    group_by: ['alertname']
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/private-channel-deploy/vars/common.yml
+++ b/private-channel-deploy/vars/common.yml
@@ -72,6 +72,15 @@ validator_reset: true
 # --- Optional notification webhook posted from the report phase ---
 notify_webhook: ""
 
+# --- Grafana alerting contact point (vendor-neutral by default) ------------
+# Grafana's provisioned contact point reads these via env substitution. Leave
+# at the defaults for a no-op (alerting evaluates but notifies nowhere). To
+# enable, set both, e.g. in your env vars or secrets:
+#   alert_contact_type: slack            # any Grafana receiver type
+#   alert_webhook_url: <slack incoming webhook URL>   # treat as a secret
+alert_contact_type: "webhook"
+alert_webhook_url: "http://localhost:9/no-op"
+
 # --- Build-arg pins, mirrored from versions.env so renders stay reproducible ---
 # Shipped to the target during PHASE 3 RENDER and passed to compose via --env-file.
 versions_env_file: "{{ repo_root }}/versions.env"


### PR DESCRIPTION
A few monitoring issues that left dashboards blank and one alert silently disabled, plus a tweak so the alerting default isn't tied to any one vendor.

## Job-selector mismatch
The Indexer and Operator dashboards and two alert rules selected metrics with `job=~"indexer-.*|operator-.*"`. PromQL regex matchers are fully anchored, and the scrape jobs are actually named `private-channel-indexer-*` / `private-channel-operator-*`, so the pattern matched nothing.

Impact:
- Indexer + Operator dashboards showed no data.
- The service-down alert matched no series.
- The feepayer balance alert was silently dead (noData then OK), it would never have fired even at an empty feepayer.

Fixed the selectors to the real job names. Scoped the feepayer alert to `job="private-channel-operator-solana"` specifically: the withdraw operator and the escrow indexer also export the balance metric as 0 and would otherwise trip the critical rule.

## Gateway not scraped
The gateway always serves metrics on `METRICS_PORT` (default 9101), but Prometheus scraped `gateway:9090` under the `private-channel-services` job. Wrong port and wrong job label, and the RPC dashboard filters on `job="gateway"`. Added a dedicated `gateway` job on 9101 and removed the stale 9090 target.

## Vendor-neutral alerting
The contact point hardcoded a single receiver type. Made it configurable via `ALERT_CONTACT_TYPE` (default `webhook`) through Grafana env substitution, which is the only parameterization that works across all three ways these files are consumed (Ansible copy, dev compose bind-mount, baked Grafana image). A fresh deploy gets a harmless no-op webhook; set `alert_contact_type` (e.g. `slack`) and `alert_webhook_url` to turn on real alerting. No vendor choice baked into the repo default.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...