### PR TITLE
fix(indexer): retry failed slot writes, crash-to-restart instead of skipping

### DIFF
--- a/indexer/src/channel_utils.rs
+++ b/indexer/src/channel_utils.rs
@@ -9,7 +9,7 @@ use tracing::error;
 /// Once capacity is reserved, the send is guaranteed to succeed.
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// send_guaranteed(&tx, message, "committed checkpoint").await?;
 /// ```
 pub async fn send_guaranteed<T>(

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -13,6 +13,12 @@ pub enum IndexerError {
     #[error("Channel send failed during shutdown")]
     ShutdownChannelSend,
 
+    #[error("Checkpoint channel closed; cannot persist slot progress")]
+    CheckpointChannelClosed,
+
+    #[error("Transaction processor task panicked")]
+    ProcessorPanicked,
+
     #[error("Datasource error: {0}")]
     DataSource(#[from] DataSourceError),
 

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -25,6 +25,30 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
+/// Which side of the processor-vs-shutdown race fired.
+enum Supervision {
+    /// The processor task ended on its own, carrying its join result: a clean
+    /// stop, a fatal write-exhaustion error, or a panic.
+    ProcessorEnded(Result<Result<(), IndexerError>, tokio::task::JoinError>),
+    /// A shutdown signal arrived while the processor was still running.
+    ShutdownSignalled(std::io::Result<()>),
+}
+
+/// Race the running processor task against the shutdown signal. Biased to the
+/// processor so a fatal error that becomes ready at the same moment as the
+/// signal still wins, and the caller exits non-zero instead of reporting a
+/// clean shutdown.
+async fn supervise(
+    processor_handle: &mut tokio::task::JoinHandle<Result<(), IndexerError>>,
+    shutdown: impl std::future::Future<Output = std::io::Result<()>>,
+) -> Supervision {
+    tokio::select! {
+        biased;
+        res = &mut *processor_handle => Supervision::ProcessorEnded(res),
+        sig = shutdown => Supervision::ShutdownSignalled(sig),
+    }
+}
+
 pub async fn run(
     common_config: PrivateChannelIndexerConfig,
     indexer_config: IndexerConfig,
@@ -314,34 +338,108 @@ pub async fn run(
     if let Some(h) = health.clone() {
         transaction_processor = transaction_processor.with_health(h);
     }
-    let processor_handle = tokio::spawn(async move {
-        if let Err(e) = transaction_processor.start(instruction_rx).await {
-            error!("TransactionProcessor error: {}", e);
-        }
-    });
+    let mut processor_handle = tokio::spawn(transaction_processor.start(instruction_rx));
 
     info!("Indexer started, waiting for shutdown signal...");
 
-    // 9. Wait for shutdown signal
-    signal::ctrl_c()
-        .await
-        .map_err(|_| IndexerError::ShutdownChannelSend)?;
-    info!("Shutdown signal received, initiating graceful shutdown...");
+    // 9. Race the processor against the shutdown signal. The processor never
+    // returns on its own during normal operation (instruction_tx is held here
+    // and by the datasource), so the processor side only fires on a fatal write
+    // failure or a panic - both must crash the process so the supervisor
+    // restarts it and the failed slot replays from the durable checkpoint.
+    match supervise(&mut processor_handle, signal::ctrl_c()).await {
+        Supervision::ProcessorEnded(res) => {
+            // Flush batched checkpoints for already-committed slots so a restart resumes
+            // from the latest durable point; timeout-bounded since a dead DB would stall it.
+            cancellation_token.cancel();
+            drop(instruction_tx);
+            drop(checkpoint_tx);
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(5), checkpoint_handle).await;
 
-    // 10. Graceful shutdown
-    shutdown_indexer(
-        cancellation_token,
-        storage,
-        datasource,
-        datasource_handle,
-        instruction_tx,
-        checkpoint_tx,
-        checkpoint_handle,
-        processor_handle,
-    )
-    .await
-    .map_err(|_| IndexerError::ShutdownChannelSend)?;
+            match res {
+                Ok(Ok(())) => {
+                    info!("TransactionProcessor stopped cleanly");
+                }
+                Ok(Err(e)) => {
+                    error!("TransactionProcessor failed fatally: {}", e);
+                    return Err(e);
+                }
+                Err(join_err) => {
+                    error!("TransactionProcessor task panicked: {:?}", join_err);
+                    return Err(IndexerError::ProcessorPanicked);
+                }
+            }
+        }
+        Supervision::ShutdownSignalled(signal_res) => {
+            signal_res.map_err(|_| IndexerError::ShutdownChannelSend)?;
+            info!("Shutdown signal received, initiating graceful shutdown...");
+
+            // 10. Graceful shutdown
+            shutdown_indexer(
+                cancellation_token,
+                storage,
+                datasource,
+                datasource_handle,
+                instruction_tx,
+                checkpoint_tx,
+                checkpoint_handle,
+                processor_handle,
+            )
+            .await
+            .map_err(|_| IndexerError::ShutdownChannelSend)?;
+        }
+    }
 
     info!("Indexer shutdown complete");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A ready shutdown future must not steal the race from an already-finished
+    /// processor: the biased select reports the processor's fatal error so run()
+    /// exits non-zero rather than treating it as a clean shutdown.
+    #[tokio::test]
+    async fn supervise_prefers_finished_processor_over_ready_signal() {
+        let mut handle = tokio::spawn(async { Err(IndexerError::CheckpointChannelClosed) });
+        // Let the task run to completion so its future is ready when raced.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let outcome = supervise(&mut handle, std::future::ready(Ok(()))).await;
+
+        match outcome {
+            Supervision::ProcessorEnded(Ok(Err(IndexerError::CheckpointChannelClosed))) => {}
+            _ => panic!("biased select must report the finished processor's fatal error"),
+        }
+    }
+
+    /// While the processor is still running, a ready shutdown signal wins.
+    #[tokio::test]
+    async fn supervise_takes_shutdown_when_processor_running() {
+        let mut handle = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            Ok(())
+        });
+
+        let outcome = supervise(&mut handle, std::future::ready(Ok(()))).await;
+
+        assert!(matches!(outcome, Supervision::ShutdownSignalled(Ok(()))));
+        handle.abort();
+    }
+
+    /// A processor panic surfaces as a join error so run() maps it to a fatal
+    /// ProcessorPanicked exit rather than a clean shutdown.
+    #[tokio::test]
+    async fn supervise_surfaces_processor_panic() {
+        let mut handle: tokio::task::JoinHandle<Result<(), IndexerError>> =
+            tokio::spawn(async { panic!("processor boom") });
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let outcome = supervise(&mut handle, std::future::pending::<std::io::Result<()>>()).await;
+
+        assert!(matches!(outcome, Supervision::ProcessorEnded(Err(_))));
+    }
 }

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -198,6 +198,11 @@ impl TransactionProcessor {
                             "Slot {} writes failed after {} attempt(s); giving up: {}",
                             slot, attempt, e
                         );
+                        // Count the slot once, only when the retry budget is spent;
+                        // a transient failure ridden out by the retry is not an error.
+                        metrics::INDEXER_SLOT_SAVE_ERRORS
+                            .with_label_values(&[program_type.as_label()])
+                            .inc();
                         return Err(e.into());
                     }
                     let backoff = self.retry.backoff(attempt);
@@ -270,9 +275,6 @@ impl TransactionProcessor {
                 }
                 Err(e) => {
                     error!("Failed to save mints from slot {}: {}", slot, e);
-                    metrics::INDEXER_SLOT_SAVE_ERRORS
-                        .with_label_values(&[program_type.as_label()])
-                        .inc();
                     return Err(e);
                 }
             }
@@ -292,9 +294,6 @@ impl TransactionProcessor {
                         "Failed to save mint status history from slot {}: {}",
                         slot, e
                     );
-                    metrics::INDEXER_SLOT_SAVE_ERRORS
-                        .with_label_values(&[program_type.as_label()])
-                        .inc();
                     return Err(e);
                 }
             }
@@ -309,9 +308,6 @@ impl TransactionProcessor {
             touched.dedup();
             if let Err(e) = self.storage.sync_mint_status(&touched).await {
                 error!("Failed to sync mint status mirror for slot {}: {}", slot, e);
-                metrics::INDEXER_SLOT_SAVE_ERRORS
-                    .with_label_values(&[program_type.as_label()])
-                    .inc();
                 return Err(e);
             }
         }
@@ -343,9 +339,6 @@ impl TransactionProcessor {
                 }
                 Err(e) => {
                     error!("Failed to save transactions from slot {}: {}", slot, e);
-                    metrics::INDEXER_SLOT_SAVE_ERRORS
-                        .with_label_values(&[program_type.as_label()])
-                        .inc();
                     return Err(e);
                 }
             }
@@ -1614,8 +1607,8 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(
-            committed >= N,
-            "checkpoint advanced through the healed slot"
+            committed >= N2,
+            "checkpoint advanced through all slots after the healed one, not stalled at N"
         );
         // N's deposit row is present despite the transient failure.
         let inserted = mock.inserted_transactions.lock().unwrap();

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -2,7 +2,7 @@ use crate::metrics;
 use crate::{
     channel_utils::send_guaranteed,
     config::ProgramType,
-    error::IndexerError,
+    error::{IndexerError, StorageError},
     indexer::{
         checkpoint::CheckpointUpdate,
         datasource::common::{
@@ -21,8 +21,45 @@ use private_channel_metrics::{HealthState, MetricLabel};
 use solana_sdk::pubkey::Pubkey;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
+
+/// Production defaults for the per-slot DB-write retry. Sized to ride out a
+/// routine Postgres restart or failover (about 15s of cumulative backoff)
+/// before the processor gives up and exits so a restart can replay the slot.
+const DEFAULT_WRITE_MAX_ATTEMPTS: usize = 6;
+const DEFAULT_WRITE_BASE_DELAY: Duration = Duration::from_millis(500);
+const DEFAULT_WRITE_MAX_DELAY: Duration = Duration::from_secs(8);
+
+/// Bounded exponential-backoff policy for a slot's DB writes.
+#[derive(Clone, Copy, Debug)]
+pub struct WriteRetryPolicy {
+    pub max_attempts: usize,
+    pub base_delay: Duration,
+    pub max_delay: Duration,
+}
+
+impl Default for WriteRetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_WRITE_MAX_ATTEMPTS,
+            base_delay: DEFAULT_WRITE_BASE_DELAY,
+            max_delay: DEFAULT_WRITE_MAX_DELAY,
+        }
+    }
+}
+
+impl WriteRetryPolicy {
+    /// Backoff before the next attempt: `base_delay * 2^(attempt-1)`, capped at
+    /// `max_delay`. A zero base delay yields a zero wait (used by tests).
+    fn backoff(&self, attempt: usize) -> Duration {
+        let shift = attempt.saturating_sub(1).min(31) as u32;
+        self.base_delay
+            .saturating_mul(1u32 << shift)
+            .min(self.max_delay)
+    }
+}
 
 /// Transaction processor that converts instructions to transactions and saves to DB
 /// Tracks slot-level success/failure and emits committed checkpoints
@@ -40,6 +77,10 @@ pub struct TransactionProcessor {
     health: Option<Arc<HealthState>>,
 
     configured_escrow_instance_id: Option<Pubkey>,
+
+    // Bounded-backoff policy applied to a slot's DB writes before the failure
+    // is treated as fatal.
+    retry: WriteRetryPolicy,
 }
 
 impl TransactionProcessor {
@@ -50,11 +91,17 @@ impl TransactionProcessor {
             slot_buffers: HashMap::new(),
             health: None,
             configured_escrow_instance_id: None,
+            retry: WriteRetryPolicy::default(),
         }
     }
 
     pub fn with_health(mut self, health: Arc<HealthState>) -> Self {
         self.health = Some(health);
+        self
+    }
+
+    pub fn with_write_retry(mut self, retry: WriteRetryPolicy) -> Self {
+        self.retry = retry;
         self
     }
 
@@ -80,7 +127,7 @@ impl TransactionProcessor {
                 }
                 ProcessorMessage::SlotComplete { slot, program_type } => {
                     let start = std::time::Instant::now();
-                    self.finalize_and_checkpoint(slot, program_type).await;
+                    self.finalize_and_checkpoint(slot, program_type).await?;
                     metrics::INDEXER_SLOT_PROCESSING_DURATION
                         .with_label_values(&[program_type.as_label()])
                         .observe(start.elapsed().as_secs_f64());
@@ -97,7 +144,14 @@ impl TransactionProcessor {
 
     /// Finalize and checkpoint a slot
     /// Saves any buffered transactions and always sends checkpoint (even if empty)
-    async fn finalize_and_checkpoint(&mut self, slot: u64, program_type: ProgramType) {
+    ///
+    /// Slot's write fail is a fatal error so the caller exits and restart replays
+    /// the slot from the last durable checkpoint.
+    async fn finalize_and_checkpoint(
+        &mut self,
+        slot: u64,
+        program_type: ProgramType,
+    ) -> Result<(), IndexerError> {
         let mut mints = Vec::new();
         let mut mint_statuses: Vec<DbMintStatus> = Vec::new();
         let mut transactions = Vec::new();
@@ -130,39 +184,102 @@ impl TransactionProcessor {
             }
         }
 
-        let mut send_checkpoint = true;
+        // Retry the whole write sequence on failure; every write is idempotent.
+        let mut attempt = 1;
+        loop {
+            match self
+                .write_slot(slot, program_type, &mints, &mint_statuses, &transactions)
+                .await
+            {
+                Ok(()) => break,
+                Err(e) => {
+                    if attempt >= self.retry.max_attempts {
+                        error!(
+                            "Slot {} writes failed after {} attempt(s); giving up: {}",
+                            slot, attempt, e
+                        );
+                        return Err(e.into());
+                    }
+                    let backoff = self.retry.backoff(attempt);
+                    if !backoff.is_zero() {
+                        tokio::time::sleep(backoff).await;
+                    }
+                    attempt += 1;
+                }
+            }
+        }
 
+        // Count saved mints once here rather than in write_slot, which may
+        // re-run the idempotent mints upsert across retries.
+        if !mints.is_empty() {
+            metrics::INDEXER_MINTS_SAVED
+                .with_label_values(&[program_type.as_label()])
+                .inc_by(mints.len() as f64);
+        }
+
+        // Send the checkpoint only after the writes commit. send_guaranteed
+        // reserves capacity first, so it errors only when the checkpoint writer
+        // is gone; that never recovers, so exit and let a restart rebuild the
+        // pipeline instead of retrying a closed channel.
+        match send_guaranteed(
+            &self.checkpoint_tx,
+            CheckpointUpdate { program_type, slot },
+            "checkpoint",
+        )
+        .await
+        {
+            Ok(_) => {
+                metrics::INDEXER_SLOTS_PROCESSED
+                    .with_label_values(&[program_type.as_label()])
+                    .inc();
+                metrics::INDEXER_CURRENT_SLOT
+                    .with_label_values(&[program_type.as_label()])
+                    .set(slot as f64);
+                Ok(())
+            }
+            Err(e) => {
+                error!("Checkpoint send failed for slot {}: {}", slot, e);
+                Err(IndexerError::CheckpointChannelClosed)
+            }
+        }
+    }
+
+    /// Run one attempt of a slot's DB writes in order: mints, then mint-status
+    /// history, then the status mirror, then transactions. Short-circuits on the
+    /// first failing write so a deposit is never inserted without its backing
+    /// mint-status row.
+    async fn write_slot(
+        &self,
+        slot: u64,
+        program_type: ProgramType,
+        mints: &[DbMint],
+        mint_statuses: &[DbMintStatus],
+        transactions: &[DbTransaction],
+    ) -> Result<(), StorageError> {
         // Insert mints FIRST (before transactions that might reference them)
         if !mints.is_empty() {
             info!("Finalizing slot {} with {} mint(s)", slot, mints.len());
 
-            match self.storage.upsert_mints_batch(&mints).await {
+            match self.storage.upsert_mints_batch(mints).await {
                 Ok(_) => {
                     info!(
                         "Successfully saved {} mint(s) from slot {}",
                         mints.len(),
                         slot
                     );
-                    metrics::INDEXER_MINTS_SAVED
-                        .with_label_values(&[program_type.as_label()])
-                        .inc_by(mints.len() as f64);
                 }
                 Err(e) => {
                     error!("Failed to save mints from slot {}: {}", slot, e);
                     metrics::INDEXER_SLOT_SAVE_ERRORS
                         .with_label_values(&[program_type.as_label()])
                         .inc();
-                    send_checkpoint = false;
+                    return Err(e);
                 }
             }
         }
 
         if !mint_statuses.is_empty() {
-            match self
-                .storage
-                .insert_mint_statuses_batch(&mint_statuses)
-                .await
-            {
+            match self.storage.insert_mint_statuses_batch(mint_statuses).await {
                 Ok(_) => {
                     info!(
                         "Successfully saved {} mint status row(s) from slot {}",
@@ -178,14 +295,12 @@ impl TransactionProcessor {
                     metrics::INDEXER_SLOT_SAVE_ERRORS
                         .with_label_values(&[program_type.as_label()])
                         .inc();
-                    send_checkpoint = false;
+                    return Err(e);
                 }
             }
-        }
 
-        // Derive the `mints.status` mirror for each touched mint from history.
-        // Gated on the writes above, so the mirror never leads the timeline.
-        if send_checkpoint && !mint_statuses.is_empty() {
+            // Derive the `mints.status` mirror for each touched mint from history.
+            // Gated on the writes above, so the mirror never leads the timeline.
             let mut touched: Vec<String> = mint_statuses
                 .iter()
                 .map(|s| s.mint_address.clone())
@@ -197,23 +312,13 @@ impl TransactionProcessor {
                 metrics::INDEXER_SLOT_SAVE_ERRORS
                     .with_label_values(&[program_type.as_label()])
                     .inc();
-                send_checkpoint = false;
+                return Err(e);
             }
         }
 
         if transactions.is_empty() {
             // Empty slot, just checkpoint it
             debug!("Finalizing empty slot {}", slot);
-        } else if !send_checkpoint {
-            // A prerequisite write (mints/statuses) failed; skip the deposit
-            // rows so we don't commit a deposit with no backing row. The slot
-            // isn't checkpointed, so it replays atomically.
-            warn!(
-                "Skipping transaction insert for slot {} ({} row(s)) because an earlier \
-                 write failed; slot will be reprocessed",
-                slot,
-                transactions.len()
-            );
         } else {
             info!(
                 "Finalizing slot {} with {} transactions",
@@ -223,7 +328,7 @@ impl TransactionProcessor {
 
             match self
                 .storage
-                .insert_db_transactions_batch(&transactions)
+                .insert_db_transactions_batch(transactions)
                 .await
             {
                 Ok(ids) => {
@@ -241,46 +346,12 @@ impl TransactionProcessor {
                     metrics::INDEXER_SLOT_SAVE_ERRORS
                         .with_label_values(&[program_type.as_label()])
                         .inc();
-                    send_checkpoint = false;
+                    return Err(e);
                 }
             }
         }
 
-        if send_checkpoint {
-            const MAX_ATTEMPTS: usize = 3;
-            let mut attempt = 0;
-            loop {
-                let res = send_guaranteed(
-                    &self.checkpoint_tx,
-                    CheckpointUpdate { program_type, slot },
-                    "checkpoint",
-                )
-                .await;
-
-                match res {
-                    Ok(_) => {
-                        metrics::INDEXER_SLOTS_PROCESSED
-                            .with_label_values(&[program_type.as_label()])
-                            .inc();
-                        metrics::INDEXER_CURRENT_SLOT
-                            .with_label_values(&[program_type.as_label()])
-                            .set(slot as f64);
-                        break;
-                    }
-                    Err(e) => {
-                        attempt += 1;
-                        error!(
-                            "Checkpoint send failed for slot {} (attempt {}/{}): {}",
-                            slot, attempt, MAX_ATTEMPTS, e
-                        );
-                        if attempt >= MAX_ATTEMPTS {
-                            break;
-                        }
-                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                    }
-                }
-            }
-        }
+        Ok(())
     }
 
     #[cfg(test)]
@@ -803,6 +874,16 @@ mod tests {
     // TransactionProcessor tests
     // ========================================================================
 
+    /// Fast retry policy for tests: a couple of attempts, no sleeping, so a
+    /// permanent failure exhausts immediately and a transient one self-heals.
+    fn fast_retry() -> WriteRetryPolicy {
+        WriteRetryPolicy {
+            max_attempts: 2,
+            base_delay: Duration::ZERO,
+            max_delay: Duration::ZERO,
+        }
+    }
+
     fn make_processor_and_rx(
         escrow_instance_id: Pubkey,
     ) -> (
@@ -813,7 +894,8 @@ mod tests {
         let storage = Arc::new(Storage::Mock(mock));
         let (checkpoint_tx, checkpoint_rx) = tokio::sync::mpsc::channel(100);
         let processor = TransactionProcessor::new(storage, checkpoint_tx)
-            .with_escrow_instance_id(escrow_instance_id);
+            .with_escrow_instance_id(escrow_instance_id)
+            .with_write_retry(fast_retry());
         (processor, checkpoint_rx)
     }
 
@@ -828,7 +910,8 @@ mod tests {
         let storage = Arc::new(Storage::Mock(mock.clone()));
         let (checkpoint_tx, checkpoint_rx) = tokio::sync::mpsc::channel(100);
         let processor = TransactionProcessor::new(storage, checkpoint_tx)
-            .with_escrow_instance_id(escrow_instance_id);
+            .with_escrow_instance_id(escrow_instance_id)
+            .with_write_retry(fast_retry());
         (processor, checkpoint_rx, mock)
     }
 
@@ -837,7 +920,8 @@ mod tests {
         let (mut processor, mut checkpoint_rx) = make_processor_and_rx(deposit_instance());
         processor
             .finalize_and_checkpoint(42, ProgramType::Escrow)
-            .await;
+            .await
+            .unwrap();
         let cp = checkpoint_rx.recv().await.unwrap();
         assert_eq!(cp.slot, 42);
         assert_eq!(cp.program_type, ProgramType::Escrow);
@@ -850,7 +934,8 @@ mod tests {
         processor.buffer(make_deposit_instruction(100, Some("s1".to_string()), None));
         processor
             .finalize_and_checkpoint(100, ProgramType::Escrow)
-            .await;
+            .await
+            .unwrap();
 
         {
             let inserted = mock.inserted_transactions.lock().unwrap();
@@ -869,7 +954,8 @@ mod tests {
         processor.buffer(make_allow_mint_instruction(200, Some("s2".to_string())));
         processor
             .finalize_and_checkpoint(200, ProgramType::Escrow)
-            .await;
+            .await
+            .unwrap();
 
         {
             let mints = mock.mints.lock().unwrap();
@@ -891,7 +977,8 @@ mod tests {
         ));
         processor
             .finalize_and_checkpoint(200, ProgramType::Escrow)
-            .await;
+            .await
+            .unwrap();
 
         {
             let rows = mock.mint_status_history.lock().unwrap();
@@ -921,7 +1008,8 @@ mod tests {
         ));
         processor
             .finalize_and_checkpoint(250, ProgramType::Escrow)
-            .await;
+            .await
+            .unwrap();
 
         {
             let rows = mock.mint_status_history.lock().unwrap();
@@ -945,8 +1033,37 @@ mod tests {
         assert_eq!(cp.slot, 250);
     }
 
+    /// A transient write failure is ridden out by the retry: the slot finalizes
+    /// Ok, the row lands, and exactly one checkpoint is sent.
     #[tokio::test]
-    async fn finalize_insert_mint_statuses_failure_skips_checkpoint() {
+    async fn finalize_retries_then_succeeds_transient() {
+        let (mut processor, mut checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
+        // Fail the first call, then succeed on retry (fast policy allows 2).
+        mock.set_fail_times("insert_db_transactions_batch", 1);
+        processor.buffer(make_deposit_instruction(
+            401,
+            Some("s-retry".to_string()),
+            None,
+        ));
+
+        processor
+            .finalize_and_checkpoint(401, ProgramType::Escrow)
+            .await
+            .expect("transient failure should self-heal");
+
+        {
+            let inserted = mock.inserted_transactions.lock().unwrap();
+            assert_eq!(inserted.len(), 1, "row lands once after the retry");
+            assert_eq!(inserted[0][0].slot, 401);
+        }
+        let cp = checkpoint_rx.recv().await.unwrap();
+        assert_eq!(cp.slot, 401);
+        // Exactly one checkpoint - the failed attempt did not also send one.
+        assert!(checkpoint_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn finalize_mint_status_failure_exhausts_returns_err() {
         let (mut processor, mut checkpoint_rx, mock) =
             make_processor_with_mock(allow_mint_instance());
         mock.set_should_fail("insert_mint_statuses_batch", true);
@@ -954,18 +1071,19 @@ mod tests {
             201,
             Some("sig-allow-2".to_string()),
         ));
-        processor
+        let result = processor
             .finalize_and_checkpoint(201, ProgramType::Escrow)
             .await;
 
+        assert!(result.is_err(), "permanent write failure is fatal");
         assert!(checkpoint_rx.try_recv().is_err());
     }
 
     /// AllowMint + Deposit for the same mint in one slot: if the mint-status
-    /// write fails, the deposit row must be withheld (else the gate would
-    /// quarantine it) and the slot replays.
+    /// write fails permanently, the deposit row must be withheld (else the gate
+    /// would quarantine it) and the slot fails fatally so it replays.
     #[tokio::test]
-    async fn finalize_mint_status_failure_withholds_deposit_in_same_slot() {
+    async fn finalize_mint_status_failure_withholds_deposit_then_exhausts() {
         // Both instructions must target the configured instance, or the
         // instance filter would drop one and defeat the test's intent.
         let (mut processor, mut checkpoint_rx, mock) =
@@ -981,10 +1099,11 @@ mod tests {
             None,
             allow_mint_instance(),
         ));
-        processor
+        let result = processor
             .finalize_and_checkpoint(202, ProgramType::Escrow)
             .await;
 
+        assert!(result.is_err(), "permanent write failure is fatal");
         // Checkpoint withheld so the slot replays.
         assert!(checkpoint_rx.try_recv().is_err());
         // Deposit row must not be committed without its backing status row.
@@ -995,28 +1114,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finalize_upsert_mints_failure_skips_checkpoint() {
+    async fn finalize_upsert_mints_failure_exhausts_returns_err() {
         let (mut processor, mut checkpoint_rx, mock) =
             make_processor_with_mock(allow_mint_instance());
         mock.set_should_fail("upsert_mints_batch", true);
         processor.buffer(make_allow_mint_instruction(300, Some("s3".to_string())));
-        processor
+        let result = processor
             .finalize_and_checkpoint(300, ProgramType::Escrow)
             .await;
 
-        // No checkpoint should be sent
+        assert!(result.is_err(), "permanent write failure is fatal");
         assert!(checkpoint_rx.try_recv().is_err());
     }
 
     #[tokio::test]
-    async fn finalize_insert_batch_failure_skips_checkpoint() {
+    async fn finalize_transaction_failure_exhausts_returns_err() {
         let (mut processor, mut checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
         mock.set_should_fail("insert_db_transactions_batch", true);
         processor.buffer(make_deposit_instruction(400, Some("s4".to_string()), None));
-        processor
+        let result = processor
             .finalize_and_checkpoint(400, ProgramType::Escrow)
             .await;
 
+        assert!(result.is_err(), "permanent write failure is fatal");
         assert!(checkpoint_rx.try_recv().is_err());
     }
 
@@ -1102,7 +1222,8 @@ mod tests {
     }
 
     /// A foreign SlotComplete between a same-slot AllowMint and Deposit must not split the
-    /// finalize: the later mint-status failure still withholds the deposit and the checkpoint.
+    /// finalize: the later permanent mint-status failure still withholds the deposit,
+    /// withholds SLOT_S's checkpoint, and fails the processor fatally.
     #[tokio::test]
     async fn same_slot_atomicity_survives_foreign_slotcomplete() {
         const SLOT_S: u64 = 700;
@@ -1141,7 +1262,11 @@ mod tests {
         .unwrap();
         drop(tx);
 
-        processor.start(rx).await.unwrap();
+        let result = processor.start(rx).await;
+        assert!(
+            result.is_err(),
+            "permanent same-slot write failure is fatal"
+        );
 
         let mut checkpointed = Vec::new();
         while let Ok(cp) = checkpoint_rx.try_recv() {
@@ -1166,6 +1291,126 @@ mod tests {
 
         let result = processor.start(rx).await;
         assert!(result.is_ok());
+    }
+
+    /// A permanently-failing slot write exhausts the retry and propagates out of
+    /// the start loop as a fatal Err.
+    #[tokio::test]
+    async fn start_propagates_fatal_after_exhaustion() {
+        const N: u64 = 800;
+        let (processor, _checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
+        mock.set_should_fail("insert_db_transactions_batch", true);
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
+
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            N,
+            Some("dep-n".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: N,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+
+        let result = processor.start(rx).await;
+        assert!(result.is_err());
+    }
+
+    /// The key no-leapfrog proof: when slot N's write fails permanently, start
+    /// exits Err BEFORE processing N+1, so no checkpoint is sent and N+1 is
+    /// never persisted. A restart would therefore replay from below N.
+    #[tokio::test]
+    async fn start_exhaustion_does_not_leapfrog_next_slot() {
+        const N: u64 = 900;
+        const N_NEXT: u64 = 901;
+        let (processor, mut checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
+        mock.set_should_fail("insert_db_transactions_batch", true);
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
+
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            N,
+            Some("dep-n".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: N,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            N_NEXT,
+            Some("dep-n-next".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: N_NEXT,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+
+        let result = processor.start(rx).await;
+        assert!(result.is_err(), "the failed slot is fatal");
+
+        // No checkpoint for N or N+1.
+        assert!(
+            checkpoint_rx.try_recv().is_err(),
+            "a withheld slot must not be leapfrogged"
+        );
+        // N+1's row was never written - the loop exited before processing it.
+        let inserted = mock.inserted_transactions.lock().unwrap();
+        assert!(
+            inserted.iter().flatten().all(|t| t.slot != N_NEXT as i64),
+            "N+1 must not be persisted after N fails"
+        );
+    }
+
+    /// A slot that fails within the retry budget then succeeds does not break the
+    /// happy path: N and N+1 both checkpoint in order and start ends Ok.
+    #[tokio::test]
+    async fn start_recovers_within_retries_continues() {
+        const N: u64 = 1000;
+        const N_NEXT: u64 = 1001;
+        let (processor, mut checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
+        // Fail N's write once, then succeed (fast policy allows 2 attempts).
+        mock.set_fail_times("insert_db_transactions_batch", 1);
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
+
+        for (slot, sig) in [(N, "dep-n"), (N_NEXT, "dep-n-next")] {
+            tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+                slot,
+                Some(sig.to_string()),
+                None,
+            )))
+            .await
+            .unwrap();
+            tx.send(ProcessorMessage::SlotComplete {
+                slot,
+                program_type: ProgramType::Escrow,
+            })
+            .await
+            .unwrap();
+        }
+        drop(tx);
+
+        let result = processor.start(rx).await;
+        assert!(result.is_ok(), "retry self-heal keeps the loop running");
+
+        let first = checkpoint_rx.recv().await.unwrap();
+        let second = checkpoint_rx.recv().await.unwrap();
+        assert_eq!(first.slot, N);
+        assert_eq!(second.slot, N_NEXT);
     }
 
     // ========================================================================
@@ -1196,7 +1441,8 @@ mod tests {
         let checkpoint_handle = writer.start(checkpoint_rx);
 
         let processor = TransactionProcessor::new(storage, checkpoint_tx)
-            .with_escrow_instance_id(escrow_instance_id);
+            .with_escrow_instance_id(escrow_instance_id)
+            .with_write_retry(fast_retry());
         let processor_handle = tokio::spawn(async move {
             processor.start(instruction_rx).await.unwrap();
         });
@@ -1299,5 +1545,151 @@ mod tests {
             committed < T0,
             "the unfilled tail (103..=110) is not skipped"
         );
+    }
+
+    /// Like `spawn_pipeline` but exposes the processor's Result so a fatal write
+    /// exhaustion can be observed instead of unwrapped.
+    #[allow(clippy::type_complexity)]
+    fn spawn_pipeline_result(
+        escrow_instance_id: Pubkey,
+    ) -> (
+        mpsc::Sender<ProcessorMessage>,
+        tokio::task::JoinHandle<Result<(), IndexerError>>,
+        tokio::task::JoinHandle<()>,
+        MockStorage,
+    ) {
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let (instruction_tx, instruction_rx) = mpsc::channel(64);
+        let (checkpoint_tx, checkpoint_rx) = mpsc::channel(64);
+
+        let writer = CheckpointWriter::new(storage.clone())
+            .with_batch_interval(1)
+            .with_max_batch_size(1);
+        let checkpoint_handle = writer.start(checkpoint_rx);
+
+        let processor = TransactionProcessor::new(storage, checkpoint_tx)
+            .with_escrow_instance_id(escrow_instance_id)
+            .with_write_retry(fast_retry());
+        let processor_handle = tokio::spawn(processor.start(instruction_rx));
+
+        (instruction_tx, processor_handle, checkpoint_handle, mock)
+    }
+
+    /// End-to-end self-heal: a transient write blip on slot N is ridden out by
+    /// the retry, so the durable checkpoint advances through N with no restart.
+    #[tokio::test]
+    async fn live_transient_blip_self_heals_no_gap() {
+        const N: u64 = 200;
+        const N1: u64 = 201;
+        const N2: u64 = 202;
+        let (tx, processor_handle, checkpoint_handle, mock) =
+            spawn_pipeline(deposit_instance(), None);
+        // Fail N's transaction write once, then succeed on retry.
+        mock.set_fail_times("insert_db_transactions_batch", 1);
+
+        for (slot, sig) in [(N, "dep-n"), (N1, "dep-n1"), (N2, "dep-n2")] {
+            tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+                slot,
+                Some(sig.to_string()),
+                None,
+            )))
+            .await
+            .unwrap();
+            tx.send(ProcessorMessage::SlotComplete {
+                slot,
+                program_type: ProgramType::Escrow,
+            })
+            .await
+            .unwrap();
+        }
+
+        drop(tx);
+        processor_handle.await.unwrap();
+        checkpoint_handle.await.unwrap();
+
+        let committed = mock
+            .get_committed_checkpoint("escrow")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            committed >= N,
+            "checkpoint advanced through the healed slot"
+        );
+        // N's deposit row is present despite the transient failure.
+        let inserted = mock.inserted_transactions.lock().unwrap();
+        assert!(inserted.iter().flatten().any(|t| t.slot == N as i64));
+    }
+
+    /// End-to-end exhaustion: a permanent write failure on slot N freezes the
+    /// durable checkpoint at the last good slot below N, the processor exits
+    /// Err, and N+1 is never persisted - so a restart replays from below N.
+    #[tokio::test]
+    async fn live_exhaustion_freezes_checkpoint_below_failed_slot() {
+        const M: u64 = 300;
+        const N: u64 = 301;
+        const N1: u64 = 302;
+        let (tx, processor_handle, checkpoint_handle, mock) =
+            spawn_pipeline_result(deposit_instance());
+        mock.set_should_fail("insert_db_transactions_batch", true);
+
+        // M is an empty slot that checkpoints cleanly (last good slot).
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: M,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        // N carries a deposit whose write fails permanently.
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            N,
+            Some("dep-n".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: N,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        // N+1 is queued but must never be processed.
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            N1,
+            Some("dep-n1".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: N1,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+
+        let result = processor_handle.await.unwrap();
+        assert!(
+            result.is_err(),
+            "permanent write failure exits the processor"
+        );
+        checkpoint_handle.await.unwrap();
+
+        let committed = mock
+            .get_committed_checkpoint("escrow")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            committed, M,
+            "checkpoint frozen at the last good slot below N"
+        );
+        assert!(committed < N);
+        // Neither N nor N+1 was persisted.
+        let inserted = mock.inserted_transactions.lock().unwrap();
+        assert!(inserted.iter().flatten().all(|t| t.slot != N1 as i64));
     }
 }

--- a/indexer/src/shutdown_utils.rs
+++ b/indexer/src/shutdown_utils.rs
@@ -7,6 +7,7 @@
 //! - Forced exit on timeout (configurable)
 //! - Buffer time before storage closure
 
+use crate::error::IndexerError;
 use crate::indexer::checkpoint::CheckpointUpdate;
 use crate::indexer::datasource::common::datasource::DataSource;
 use crate::indexer::datasource::common::types::ProcessorMessage;
@@ -106,7 +107,7 @@ pub async fn shutdown_indexer(
     instruction_tx: mpsc::Sender<ProcessorMessage>,
     checkpoint_tx: mpsc::Sender<CheckpointUpdate>,
     checkpoint_handle: tokio::task::JoinHandle<()>,
-    processor_handle: tokio::task::JoinHandle<()>,
+    processor_handle: tokio::task::JoinHandle<Result<(), IndexerError>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let shutdown_start = std::time::Instant::now();
 
@@ -172,7 +173,7 @@ async fn perform_indexer_shutdown_stages(
     instruction_tx: mpsc::Sender<ProcessorMessage>,
     checkpoint_tx: mpsc::Sender<CheckpointUpdate>,
     checkpoint_handle: tokio::task::JoinHandle<()>,
-    processor_handle: tokio::task::JoinHandle<()>,
+    processor_handle: tokio::task::JoinHandle<Result<(), IndexerError>>,
     config: &ShutdownConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Stage 1: Signal cancellation to datasource

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -20,6 +20,8 @@ pub type ReleaseSignatureMap = HashMap<i64, Vec<(String, i64)>>;
 pub struct MockStorage {
     pub committed_checkpoints: std::sync::Arc<Mutex<HashMap<String, u64>>>,
     pub should_fail: std::sync::Arc<Mutex<HashMap<String, bool>>>,
+    /// Per-op transient-failure counters: fail the first N calls of an op, then succeed.
+    pub fail_times: std::sync::Arc<Mutex<HashMap<String, usize>>>,
     pub mints: std::sync::Arc<Mutex<HashMap<String, DbMint>>>,
     pub mint_balances: std::sync::Arc<Mutex<Vec<MintDbBalance>>>,
     pub pending_transactions: std::sync::Arc<Mutex<Vec<DbTransaction>>>,
@@ -42,6 +44,19 @@ impl MockStorage {
     }
 
     fn check_should_fail(&self, operation: &str) -> Result<(), StorageError> {
+        // Transient injection takes precedence: fail the first N calls, then
+        // fall through to the sticky bool (and otherwise succeed).
+        {
+            let mut times = self.fail_times.lock().unwrap();
+            if let Some(remaining) = times.get_mut(operation) {
+                if *remaining > 0 {
+                    *remaining -= 1;
+                    return Err(StorageError::DatabaseError {
+                        message: format!("Simulated transient {operation} failure"),
+                    });
+                }
+            }
+        }
         if self
             .should_fail
             .lock()
@@ -69,6 +84,15 @@ impl MockStorage {
             .lock()
             .unwrap()
             .insert(program_type.to_string(), should_fail);
+    }
+
+    /// Make `operation` fail its next `times` calls, then succeed. Used to
+    /// simulate a transient storage blip that the write retry rides out.
+    pub fn set_fail_times(&self, operation: &str, times: usize) {
+        self.fail_times
+            .lock()
+            .unwrap()
+            .insert(operation.to_string(), times);
     }
 
     pub fn add_mint(&mut self, mint: DbMint) {


### PR DESCRIPTION
## Summary

Closes issue 4. In live/ungated operation the durable checkpoint tracked the highest slot seen, not the highest contiguous slot committed: when slot `N`'s writes failed its checkpoint was withheld but the processor moved on, and `N+1`'s success persisted `max(frontier, N+1)`, leapfrogging `N` so on restart a missed deposit was never minted and a missed withdrawal never released. 

The fix retries a slot's writes with bounded backoff and sends the checkpoint only after they commit; since the processor is a single sequential loop, `N+1` is never processed until `N` is persisted. On exhaustion the processor returns a fatal error that exits `run()` so the supervisor restarts and replays `N`.

Tested: transient blips self-heal, permanent failures exhaust to `Err`, deposit-withhold semantics hold, and the key proof (`start` returns `Err`, no checkpoint sent, `N+1` never persisted) plus the biased `supervise()` race are covered 

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28443932886) |
| Indexer | 23,200 | 26,282 | 88.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28443932886) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28443932886) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28443932886) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,174 | 15,167 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28443932886) |
| **Total** | **48,680** | **56,667** | **85.9%** | |

> Last updated: 2026-06-30 12:48:42 UTC by E2E Integration