### PR TITLE
fix(indexer): fail closed when a getBlock response is missing transaction metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,12 @@ ADMIN_PRIVATE_KEY=
 DEVNET_RPC_URL=solana_rpc_url
 DEVNET_YELLOWSTONE_ENDPOINT=yellowstone_url
 INDEXER_YELLOWSTONE_TOKEN=yellowstone_x_token
+# Optional fallback RPC for the indexer's live RPC-polling loop only. Consulted
+# once when the primary returns a slot with missing transaction metadata
+# (meta: null). MUST be an archival/full-history endpoint, or failover is a no-op.
+# Backfill and resync do not use it - they fail closed; point the backfill RPC at
+# a full-history endpoint instead. Leave unset to fail closed and retry the slot.
+# INDEXER_RPC_POLLING_FALLBACK_RPC_URL=https://your-archival-endpoint
 # Local validator RPC (Only if running docker locally)
 LOCAL_VALIDATOR_RPC_URL=http://validator:8899
 # Controls whether the local validator wipes its ledger on container start.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,8 +3340,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot 0.12.4",
  "pear",
  "serde",
+ "tempfile",
  "toml 0.8.23",
  "uncased",
  "version_check",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -81,6 +81,7 @@ solana-keychain = { version = "0.1.0", features = ["all"] }
 
 [dev-dependencies]
 bigdecimal = "0.3"
+figment = { workspace = true, features = ["test"] }
 tokio = { workspace = true, features = ["test-util"] }
 spl-associated-token-account = { workspace = true }
 

--- a/indexer/config/example-indexer.toml
+++ b/indexer/config/example-indexer.toml
@@ -41,6 +41,14 @@ error_retry_interval_ms = 5000
 # Batch size for processing blocks
 batch_size = 50
 
+# Optional fallback for the live RPC-polling loop only, consulted once (and
+# re-validated) when the primary returns a slot with missing metadata
+# (meta: null). It MUST be archival/full-history; a load-balanced peer can
+# return the same meta: null. Backfill and resync ignore it and fail closed,
+# so point indexer.backfill.rpc_url at a full-history endpoint for those paths.
+# Omit to fail closed. Env override: INDEXER_RPC_POLLING_FALLBACK_RPC_URL
+# fallback_rpc_url = "https://your-archival-endpoint"
+
 # === Yellowstone gRPC Configuration ===
 [indexer.yellowstone]
 # Yellowstone gRPC endpoint URL

--- a/indexer/config/local/indexer-private-channel.toml
+++ b/indexer/config/local/indexer-private-channel.toml
@@ -19,6 +19,9 @@ start_slot = 0
 poll_interval_ms = 1000
 error_retry_interval_ms = 5000
 batch_size = 50
+# Optional archival fallback for missing-meta slots (live polling only; backfill
+# fails closed). Omit to fail closed. Env: INDEXER_RPC_POLLING_FALLBACK_RPC_URL
+# fallback_rpc_url = "https://your-archival-endpoint"
 
 [indexer.backfill]
 enabled = true

--- a/indexer/config/local/indexer-solana.toml
+++ b/indexer/config/local/indexer-solana.toml
@@ -28,6 +28,9 @@ commitment = "finalized"
 poll_interval_ms = 1000
 error_retry_interval_ms = 5000
 batch_size = 50
+# Optional archival fallback for missing-meta slots (live polling only; backfill
+# fails closed). Omit to fail closed. Env: INDEXER_RPC_POLLING_FALLBACK_RPC_URL
+# fallback_rpc_url = "https://your-archival-endpoint"
 
 [indexer.backfill]
 enabled = true

--- a/indexer/src/bin/indexer.rs
+++ b/indexer/src/bin/indexer.rs
@@ -61,6 +61,8 @@ struct RpcPollingSection {
     encoding: Option<UiTransactionEncoding>,
     #[serde(default)]
     commitment: Option<CommitmentLevel>,
+    #[serde(default)]
+    fallback_rpc_url: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -249,6 +251,7 @@ async fn run_indexer(figment: Figment, verbose: bool) -> Result<(), Box<dyn std:
                 from_slot: rpc.start_slot,
                 encoding: rpc.encoding.unwrap_or(UiTransactionEncoding::Json),
                 commitment: rpc.commitment.unwrap_or(CommitmentLevel::Finalized),
+                fallback_rpc_url: rpc.fallback_rpc_url,
             };
             (Some(config), None)
         }
@@ -279,6 +282,7 @@ async fn run_indexer(figment: Figment, verbose: bool) -> Result<(), Box<dyn std:
                 from_slot: rpc.start_slot,
                 encoding: rpc.encoding.unwrap_or(UiTransactionEncoding::Json),
                 commitment: rpc.commitment.unwrap_or(CommitmentLevel::Finalized),
+                fallback_rpc_url: rpc.fallback_rpc_url,
             });
 
             (rpc_config, Some(config))

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -83,6 +83,10 @@ pub struct RpcPollingConfig {
     pub encoding: UiTransactionEncoding,
     /// RPC commitment level for getSlot calls
     pub commitment: CommitmentLevel,
+    /// Optional archival/full-history RPC consulted once by the live polling loop
+    /// when the primary returns a slot with missing transaction metadata.
+    #[serde(default)]
+    pub fallback_rpc_url: Option<String>,
 }
 
 /// Yellowstone gRPC specific configuration
@@ -345,6 +349,7 @@ mod tests {
                 batch_size: 10,
                 encoding: UiTransactionEncoding::Json,
                 commitment: CommitmentLevel::Finalized,
+                fallback_rpc_url: None,
             }),
             yellowstone: None,
             backfill: BackfillConfig {

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -83,6 +83,9 @@ pub enum BackfillError {
         source: DataSourceRpcError,
     },
 
+    #[error("Slot {slot} transaction {signature} is missing metadata; block is incomplete")]
+    MissingMeta { slot: u64, signature: String },
+
     // Channel errors
     #[error("Channel send failed: {0}")]
     ChannelSend(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -133,6 +133,19 @@ pub async fn fill_slot_range(
         for (slot, block_result) in blocks {
             match block_result {
                 Ok(Some(block)) => {
+                    // A missing-meta block is unverifiable: abort before the SlotComplete send so the
+                    // checkpoint never advances past it; the caller surfaces the error and retries.
+                    if let Some(signature) = decoder::first_missing_meta(&block) {
+                        error!(
+                            "Backfill slot {} has transaction {} missing meta; aborting before checkpoint",
+                            slot, signature
+                        );
+                        metrics::INDEXER_RPC_ERRORS
+                            .with_label_values(&[program_type.as_label(), "missing_meta"])
+                            .inc();
+                        return Err(BackfillError::MissingMeta { slot, signature }.into());
+                    }
+
                     let instructions_with_meta = decoder::parse_block(
                         &block,
                         slot,
@@ -500,6 +513,37 @@ mod tests {
                 .create()
         }
 
+        /// getBlock returns a well-formed block carrying one transaction with
+        /// `meta: null`, which the guard must reject as incomplete.
+        fn mock_get_block_missing_meta(server: &mut Server, slot: u64) -> mockito::Mock {
+            server
+                .mock("POST", "/")
+                .match_body(mockito::Matcher::PartialJson(json!({
+                    "method": "getBlock",
+                    "params": [slot]
+                })))
+                .with_status(200)
+                .with_body(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "result": {
+                            "blockhash": "TestBlockHash11111111111111111111111111111",
+                            "parentSlot": slot - 1,
+                            "transactions": [{
+                                "transaction": {
+                                    "signatures": ["sig_missing_meta"],
+                                    "message": { "accountKeys": [], "instructions": [] }
+                                },
+                                "meta": null
+                            }]
+                        },
+                        "id": 1
+                    })
+                    .to_string(),
+                )
+                .create()
+        }
+
         #[tokio::test]
         async fn fill_slot_range_empty_blocks() {
             let mut server = Server::new_async().await;
@@ -587,6 +631,44 @@ mod tests {
                 fill_slot_range(&poller, 100, 101, 10, ProgramType::Escrow, None, &tx).await;
 
             assert!(result.is_err());
+        }
+
+        /// A batch where slot N's block has a `meta: null` transaction must
+        /// abort with `MissingMeta { slot: N }` before sending SlotComplete{N} (and
+        /// before any SlotComplete for slots after N), so the checkpoint never
+        /// advances past the incomplete slot.
+        #[tokio::test]
+        async fn fill_slot_range_missing_meta_aborts_before_slot_complete() {
+            let mut server = Server::new_async().await;
+
+            // Batch over (100, 102] = [101, 102]; slot 101 is incomplete.
+            let _m1 = mock_get_block_missing_meta(&mut server, 101);
+            let _m2 = mock_get_block_success(&mut server, 102);
+
+            let poller = RpcPoller::new(
+                server.url(),
+                UiTransactionEncoding::Json,
+                CommitmentLevel::Finalized,
+            );
+
+            let (tx, mut rx) = mpsc::channel(64);
+            let result =
+                fill_slot_range(&poller, 100, 102, 10, ProgramType::Escrow, None, &tx).await;
+
+            let err = result.unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("missing metadata"), "unexpected error: {msg}");
+            assert!(msg.contains("101"), "error should name the slot: {msg}");
+
+            drop(tx);
+            let messages: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+            let advanced = messages
+                .iter()
+                .any(|m| matches!(m, ProcessorMessage::SlotComplete { slot, .. } if *slot >= 101));
+            assert!(
+                !advanced,
+                "no SlotComplete must be sent for slot 101 or beyond on an incomplete block"
+            );
         }
 
         #[tokio::test]

--- a/indexer/src/indexer/datasource/rpc_polling/decoder.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/decoder.rs
@@ -24,7 +24,28 @@ type ParseInstructionFn<T> = fn(
     location: InstructionLocation,
 ) -> Result<Option<T>, ParserError>;
 
-/// Parse a block and extract program-specific instructions with metadata
+/// Returns a label for the first `meta`-less
+/// transaction in `block`, or `None` if all carry metadata; a single `meta: null`
+/// tx makes the slot unverifiable, so callers MUST fail closed on `Some(_)`.
+pub fn first_missing_meta(block: &RpcBlock) -> Option<String> {
+    for (index, tx_with_meta) in block.transactions.iter().enumerate() {
+        if tx_with_meta.meta.is_none() {
+            return Some(
+                tx_with_meta
+                    .transaction
+                    .signatures
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| format!("tx#{index}")),
+            );
+        }
+    }
+    None
+}
+
+/// Parse a block and extract program-specific instructions with metadata.
+///
+/// Precondition: every transaction in `block` must carry `meta`.
 pub fn parse_block(
     block: &RpcBlock,
     slot: u64,
@@ -553,25 +574,95 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_transaction_no_meta_treated_as_successful() {
-        let mut block = create_test_block();
-        let account_keys = create_account_keys_with_program(TEST_PROGRAM_ID, 0);
-        let instruction = create_instruction(0, vec![], "no_meta".to_string());
+    // ============================================================================
+    // first_missing_meta guard Tests
+    // ============================================================================
 
-        block.transactions.push(create_transaction_no_meta(
-            "sig_no_meta".to_string(),
-            account_keys,
-            vec![instruction],
+    /// Every transaction carries meta, so the block is complete.
+    #[test]
+    fn first_missing_meta_all_present_returns_none() {
+        let mut block = create_test_block();
+        let keys = create_account_keys_with_program(TEST_PROGRAM_ID, 0);
+        let ix = create_instruction(0, vec![], "data".to_string());
+        block.transactions.push(create_successful_transaction(
+            "sig_ok".to_string(),
+            keys.clone(),
+            vec![ix.clone()],
+        ));
+        block.transactions.push(create_failed_transaction(
+            "sig_failed".to_string(),
+            keys,
+            vec![ix],
         ));
 
-        let result = parse_for_test(&block, TEST_PROGRAM_ID, mock_parser, None);
+        assert_eq!(first_missing_meta(&block), None);
+    }
 
-        assert_eq!(result.len(), 1);
-        assert_eq!(
-            result[0],
-            ("sig_no_meta".to_string(), 0u32, "no_meta".to_string())
-        );
+    /// One meta-less transaction among successful ones is reported by its signature.
+    #[test]
+    fn first_missing_meta_reports_signature_of_missing_tx() {
+        let mut block = create_test_block();
+        let keys = create_account_keys_with_program(TEST_PROGRAM_ID, 0);
+        let ix = create_instruction(0, vec![], "data".to_string());
+        block.transactions.push(create_successful_transaction(
+            "sig_ok".to_string(),
+            keys.clone(),
+            vec![ix.clone()],
+        ));
+        block.transactions.push(create_transaction_no_meta(
+            "sig_no_meta".to_string(),
+            keys,
+            vec![ix],
+        ));
+
+        assert_eq!(first_missing_meta(&block), Some("sig_no_meta".to_string()));
+    }
+
+    /// A meta-less transaction with no signature falls back to `tx#<index>` (no panic).
+    #[test]
+    fn first_missing_meta_no_signature_falls_back_to_index() {
+        let mut block = create_test_block();
+        let keys = create_account_keys_with_program(TEST_PROGRAM_ID, 0);
+        let ix = create_instruction(0, vec![], "data".to_string());
+        // First a normal tx so the missing-meta tx lands at index 1.
+        block.transactions.push(create_successful_transaction(
+            "sig_ok".to_string(),
+            keys.clone(),
+            vec![ix.clone()],
+        ));
+        let mut no_meta = create_transaction_no_meta("dummy".to_string(), keys, vec![ix]);
+        no_meta.transaction.signatures = vec![];
+        block.transactions.push(no_meta);
+
+        assert_eq!(first_missing_meta(&block), Some("tx#1".to_string()));
+    }
+
+    /// An empty block carries no missing-meta transaction.
+    #[test]
+    fn first_missing_meta_empty_block_returns_none() {
+        let block = create_test_block();
+        assert_eq!(first_missing_meta(&block), None);
+    }
+
+    /// A failed transaction (meta present, `err = Some`) is not missing meta;
+    /// the meta-less transaction is the one reported.
+    #[test]
+    fn first_missing_meta_failed_tx_is_not_missing_meta() {
+        let mut block = create_test_block();
+        let keys = create_account_keys_with_program(TEST_PROGRAM_ID, 0);
+        let ix = create_instruction(0, vec![], "data".to_string());
+        block.transactions.push(create_failed_transaction(
+            "sig_failed".to_string(),
+            keys.clone(),
+            vec![ix.clone()],
+        ));
+        block.transactions.push(create_transaction_no_meta(
+            "sig_no_meta".to_string(),
+            keys,
+            vec![ix],
+        ));
+
+        assert_eq!(first_missing_meta(&block), Some("sig_no_meta".to_string()));
     }
 
     // ============================================================================

--- a/indexer/src/indexer/datasource/rpc_polling/source.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/source.rs
@@ -1,4 +1,5 @@
 use super::rpc::RpcPoller;
+use super::types::RpcBlock;
 use crate::channel_utils::send_guaranteed;
 use crate::config::ProgramType;
 use crate::error::DataSourceError;
@@ -24,6 +25,11 @@ pub struct RpcPollingSource {
     commitment: CommitmentLevel,
     program_type: ProgramType,
     escrow_instance_id: Option<solana_sdk::pubkey::Pubkey>,
+    // Optional archival/full-history RPC consulted once when the primary returns
+    // a slot with missing meta. Must be an archival endpoint; a load-balanced
+    // peer can return the same `meta: null` for an archived slot, making failover
+    // a no-op.
+    fallback_rpc_url: Option<String>,
     health: Option<Arc<HealthState>>,
 }
 
@@ -39,6 +45,7 @@ impl RpcPollingSource {
         commitment: CommitmentLevel,
         program_type: ProgramType,
         escrow_instance_id: Option<solana_sdk::pubkey::Pubkey>,
+        fallback_rpc_url: Option<String>,
     ) -> Self {
         Self {
             rpc_url,
@@ -50,6 +57,7 @@ impl RpcPollingSource {
             commitment,
             program_type,
             escrow_instance_id,
+            fallback_rpc_url,
             health: None,
         }
     }
@@ -57,6 +65,16 @@ impl RpcPollingSource {
     pub fn with_health(mut self, health: Arc<HealthState>) -> Self {
         self.health = Some(health);
         self
+    }
+}
+
+/// Re-fetches `slot` once from the fallback RPC, returning the block only if it now
+/// passes the missing-meta guard; any error, absent slot, or still-missing meta yields None.
+async fn refetch_missing_meta_via_fallback(fallback: &RpcPoller, slot: u64) -> Option<RpcBlock> {
+    let (_slot, result) = fallback.get_blocks_batch(vec![slot]).await.pop()?;
+    match result {
+        Ok(Some(block)) if decoder::first_missing_meta(&block).is_none() => Some(block),
+        _ => None,
     }
 }
 
@@ -72,6 +90,12 @@ impl DataSource for RpcPollingSource {
             self.encoding,
             self.commitment,
         ));
+
+        // Built once; consulted only on the rare missing-meta path
+        let fallback_poller = self
+            .fallback_rpc_url
+            .clone()
+            .map(|url| Arc::new(RpcPoller::new(url, self.encoding, self.commitment)));
 
         // Current slot is either the from slot or the latest slot
         let mut current_slot = if let Some(slot) = self.from_slot {
@@ -138,6 +162,46 @@ impl DataSource for RpcPollingSource {
                 for (slot, block_result) in blocks {
                     match block_result {
                         Ok(Some(block)) => {
+                            // A missing-meta block is unverifiable: try one fallback re-fetch, and if that
+                            // is unavailable or also incomplete, fail closed (no SlotComplete, no advance).
+                            let block = match decoder::first_missing_meta(&block) {
+                                None => block,
+                                Some(signature) => {
+                                    let recovered = match &fallback_poller {
+                                        Some(fb) => {
+                                            refetch_missing_meta_via_fallback(fb, slot).await
+                                        }
+                                        None => None,
+                                    };
+                                    match recovered {
+                                        Some(clean) => {
+                                            info!(
+                                                "Slot {} recovered from fallback RPC after primary returned transaction {} missing meta",
+                                                slot, signature
+                                            );
+                                            clean
+                                        }
+                                        None => {
+                                            error!(
+                                                "Slot {} has transaction {} missing meta; refusing to checkpoint past an incomplete block",
+                                                slot, signature
+                                            );
+                                            metrics::INDEXER_RPC_ERRORS
+                                                .with_label_values(&[
+                                                    program_type.as_label(),
+                                                    "missing_meta",
+                                                ])
+                                                .inc();
+                                            tokio::time::sleep(Duration::from_millis(
+                                                error_retry_interval_ms,
+                                            ))
+                                            .await;
+                                            break;
+                                        }
+                                    }
+                                }
+                            };
+
                             // Parse program-specific instructions from block with metadata
                             let instructions_with_meta = decoder::parse_block(
                                 &block,
@@ -300,6 +364,102 @@ mod tests {
             .create()
     }
 
+    /// Program id and account keys for a top-level WithdrawFunds transaction, so a
+    /// block built from these would yield exactly one indexed instruction if it
+    /// were treated as a success.
+    fn withdraw_block_transaction(meta: serde_json::Value) -> serde_json::Value {
+        use crate::indexer::datasource::common::parser::withdraw::PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID;
+        // WithdrawFunds: discriminator 0, then borsh amount (u64 LE) + None destination.
+        let mut data = vec![0u8];
+        data.extend_from_slice(&1000u64.to_le_bytes());
+        data.push(0);
+        let ix_data = bs58::encode(data).into_string();
+        let mut account_keys = vec![PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID.to_string()];
+        for seed in 1u8..=5 {
+            account_keys.push(crate::test_utils::pubkey::test_pubkey(seed).to_string());
+        }
+        json!({
+            "transaction": {
+                "signatures": ["sig_missing_meta"],
+                "message": {
+                    "accountKeys": account_keys,
+                    "instructions": [{
+                        "programIdIndex": 0,
+                        "accounts": [1, 2, 3, 4, 5],
+                        "data": ix_data
+                    }]
+                }
+            },
+            "meta": meta
+        })
+    }
+
+    /// getBlock returns a block carrying one in-scope transaction with `meta: null`.
+    /// The block is well-formed JSON but incomplete; the guard must reject it.
+    fn mock_get_block_missing_meta(
+        server: &mut Server,
+        slot: u64,
+        expect_at_least: usize,
+    ) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [slot]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "blockhash": "TestBlockHash11111111111111111111111111111",
+                        "parentSlot": slot - 1,
+                        "transactions": [withdraw_block_transaction(serde_json::Value::Null)]
+                    },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .expect_at_least(expect_at_least)
+            .create()
+    }
+
+    /// getBlock returns the same in-scope transaction but with complete (successful)
+    /// meta, so the guard passes and the WithdrawFunds is indexed.
+    fn mock_get_block_complete_withdraw(
+        server: &mut Server,
+        slot: u64,
+        expect_at_least: usize,
+    ) -> mockito::Mock {
+        let meta = json!({
+            "err": null,
+            "logMessages": null,
+            "innerInstructions": null,
+            "loadedAddresses": null
+        });
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [slot]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "blockhash": "TestBlockHash11111111111111111111111111111",
+                        "parentSlot": slot - 1,
+                        "transactions": [withdraw_block_transaction(meta)]
+                    },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .expect_at_least(expect_at_least)
+            .create()
+    }
+
     /// getBlock failure must not emit SlotComplete or advance.
     /// The failed slot is re-fetched on the next poll.
     #[tokio::test]
@@ -320,6 +480,7 @@ mod tests {
             solana_transaction_status::UiTransactionEncoding::Json,
             solana_sdk::commitment_config::CommitmentLevel::Finalized,
             ProgramType::Escrow,
+            None,
             None,
         );
 
@@ -374,6 +535,7 @@ mod tests {
             solana_sdk::commitment_config::CommitmentLevel::Finalized,
             ProgramType::Escrow,
             None,
+            None,
         );
 
         let (tx, mut rx) = mpsc::channel(64);
@@ -397,6 +559,170 @@ mod tests {
             seen.contains(&100) && seen.contains(&101) && seen.contains(&102),
             "expected SlotComplete for 100,101,102; got {:?}",
             seen
+        );
+    }
+
+    /// With no fallback configured, a block with a `meta: null` in-scope
+    /// transaction must not emit SlotComplete (no checkpoint advance), must
+    /// re-request the same slot, and must not emit a phantom Instruction. Without
+    /// the guard the WithdrawFunds in the block would be indexed and the slot
+    /// would advance, so both assertions are falsifiable.
+    #[tokio::test]
+    async fn missing_meta_does_not_emit_slot_complete_or_instruction() {
+        let mut server = Server::new_async().await;
+
+        // Chain tip stays ahead so get_slots_to_process always returns slot 100 first.
+        let _m_slot = mock_get_slot(&mut server, 105);
+        // Slot 100 always returns missing meta; expect >=2 fetches proving no advance.
+        let m_block = mock_get_block_missing_meta(&mut server, 100, 2);
+
+        let mut source = RpcPollingSource::new(
+            server.url(),
+            Some(100),
+            10,
+            10,
+            10,
+            solana_transaction_status::UiTransactionEncoding::Json,
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+            ProgramType::Withdraw,
+            None,
+            None,
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        cancel.cancel();
+        let _ = handle.await;
+
+        // Slot 100 re-requested at least twice: the guard did not advance past it.
+        m_block.assert();
+
+        let mut messages = vec![];
+        while let Ok(msg) = rx.try_recv() {
+            messages.push(msg);
+        }
+        let emitted_slot_complete = messages
+            .iter()
+            .any(|m| matches!(m, ProcessorMessage::SlotComplete { slot, .. } if *slot == 100));
+        assert!(
+            !emitted_slot_complete,
+            "SlotComplete{{slot:100}} must not be emitted for an incomplete block"
+        );
+        let emitted_instruction = messages
+            .iter()
+            .any(|m| matches!(m, ProcessorMessage::Instruction(_)));
+        assert!(
+            !emitted_instruction,
+            "no phantom Instruction must be emitted for an incomplete block"
+        );
+    }
+
+    /// The primary returns missing meta but a configured fallback returns the
+    /// complete block; the slot is parsed (Instruction emitted), SlotComplete is
+    /// emitted, and polling advances.
+    #[tokio::test]
+    async fn missing_meta_recovers_from_fallback() {
+        let mut primary = Server::new_async().await;
+        let mut fallback = Server::new_async().await;
+
+        let _m_slot = mock_get_slot(&mut primary, 103);
+        let _m_primary = mock_get_block_missing_meta(&mut primary, 100, 1);
+        // Later slots resolve cleanly so the loop can advance past 100.
+        let _m_p101 = mock_get_block_success(&mut primary, 101, 1);
+        let _m_p102 = mock_get_block_success(&mut primary, 102, 1);
+        let m_fallback = mock_get_block_complete_withdraw(&mut fallback, 100, 1);
+
+        let mut source = RpcPollingSource::new(
+            primary.url(),
+            Some(100),
+            10,
+            10,
+            10,
+            solana_transaction_status::UiTransactionEncoding::Json,
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+            ProgramType::Withdraw,
+            None,
+            Some(fallback.url()),
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+        let mut saw_slot_100 = false;
+        let mut saw_instruction = false;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(600);
+        while tokio::time::Instant::now() < deadline && !(saw_slot_100 && saw_instruction) {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await {
+                Ok(Some(ProcessorMessage::SlotComplete { slot: 100, .. })) => saw_slot_100 = true,
+                Ok(Some(ProcessorMessage::Instruction(_))) => saw_instruction = true,
+                Ok(Some(_)) => {}
+                _ => {}
+            }
+        }
+        cancel.cancel();
+        let _ = handle.await;
+
+        m_fallback.assert();
+        assert!(
+            saw_slot_100,
+            "SlotComplete{{slot:100}} must be emitted after fallback recovery"
+        );
+        assert!(
+            saw_instruction,
+            "the fallback block's WithdrawFunds must be indexed"
+        );
+    }
+
+    /// Primary and fallback both return missing meta; the fallback is consulted
+    /// but the slot still fails closed (behaves like the no-fallback case).
+    #[tokio::test]
+    async fn missing_meta_fallback_also_incomplete_fails_closed() {
+        let mut primary = Server::new_async().await;
+        let mut fallback = Server::new_async().await;
+
+        let _m_slot = mock_get_slot(&mut primary, 105);
+        let m_primary = mock_get_block_missing_meta(&mut primary, 100, 2);
+        let m_fallback = mock_get_block_missing_meta(&mut fallback, 100, 1);
+
+        let mut source = RpcPollingSource::new(
+            primary.url(),
+            Some(100),
+            10,
+            10,
+            10,
+            solana_transaction_status::UiTransactionEncoding::Json,
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+            ProgramType::Withdraw,
+            None,
+            Some(fallback.url()),
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        cancel.cancel();
+        let _ = handle.await;
+
+        // Primary re-requested (no advance) and the fallback was consulted.
+        m_primary.assert();
+        m_fallback.assert();
+
+        let mut messages = vec![];
+        while let Ok(msg) = rx.try_recv() {
+            messages.push(msg);
+        }
+        let emitted_slot_complete = messages
+            .iter()
+            .any(|m| matches!(m, ProcessorMessage::SlotComplete { slot, .. } if *slot == 100));
+        assert!(
+            !emitted_slot_complete,
+            "SlotComplete{{slot:100}} must not be emitted when both primary and fallback are incomplete"
         );
     }
 }

--- a/indexer/src/indexer/datasource/rpc_polling/source.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/source.rs
@@ -69,11 +69,23 @@ impl RpcPollingSource {
 }
 
 /// Re-fetches `slot` once from the fallback RPC, returning the block only if it now
-/// passes the missing-meta guard; any error, absent slot, or still-missing meta yields None.
-async fn refetch_missing_meta_via_fallback(fallback: &RpcPoller, slot: u64) -> Option<RpcBlock> {
+/// passes the missing-meta guard AND its blockhash matches `expected_blockhash` (the
+/// primary's). The blockhash check prevents a misconfigured (wrong-cluster, pruned) or
+/// compromised fallback from substituting a divergent-fork or fabricated block for the
+/// same slot number. Any error, absent slot, hash mismatch, or still-missing meta yields None.
+async fn refetch_missing_meta_via_fallback(
+    fallback: &RpcPoller,
+    slot: u64,
+    expected_blockhash: &str,
+) -> Option<RpcBlock> {
     let (_slot, result) = fallback.get_blocks_batch(vec![slot]).await.pop()?;
     match result {
-        Ok(Some(block)) if decoder::first_missing_meta(&block).is_none() => Some(block),
+        Ok(Some(block))
+            if block.blockhash == expected_blockhash
+                && decoder::first_missing_meta(&block).is_none() =>
+        {
+            Some(block)
+        }
         _ => None,
     }
 }
@@ -169,7 +181,12 @@ impl DataSource for RpcPollingSource {
                                 Some(signature) => {
                                     let recovered = match &fallback_poller {
                                         Some(fb) => {
-                                            refetch_missing_meta_via_fallback(fb, slot).await
+                                            refetch_missing_meta_via_fallback(
+                                                fb,
+                                                slot,
+                                                &block.blockhash,
+                                            )
+                                            .await
                                         }
                                         None => None,
                                     };
@@ -431,6 +448,22 @@ mod tests {
         slot: u64,
         expect_at_least: usize,
     ) -> mockito::Mock {
+        mock_get_block_complete_withdraw_with_hash(
+            server,
+            slot,
+            "TestBlockHash11111111111111111111111111111",
+            expect_at_least,
+        )
+    }
+
+    /// As `mock_get_block_complete_withdraw` but with a caller-chosen blockhash, to
+    /// exercise the primary/fallback blockhash cross-check.
+    fn mock_get_block_complete_withdraw_with_hash(
+        server: &mut Server,
+        slot: u64,
+        blockhash: &str,
+        expect_at_least: usize,
+    ) -> mockito::Mock {
         let meta = json!({
             "err": null,
             "logMessages": null,
@@ -448,7 +481,7 @@ mod tests {
                 json!({
                     "jsonrpc": "2.0",
                     "result": {
-                        "blockhash": "TestBlockHash11111111111111111111111111111",
+                        "blockhash": blockhash,
                         "parentSlot": slot - 1,
                         "transactions": [withdraw_block_transaction(meta)]
                     },
@@ -723,6 +756,68 @@ mod tests {
         assert!(
             !emitted_slot_complete,
             "SlotComplete{{slot:100}} must not be emitted when both primary and fallback are incomplete"
+        );
+    }
+
+    /// The fallback returns a complete block but for a different blockhash than the
+    /// primary's (wrong cluster or divergent fork). It must be rejected, not indexed,
+    /// and the slot fails closed (no SlotComplete, no advance).
+    #[tokio::test]
+    async fn missing_meta_fallback_wrong_blockhash_fails_closed() {
+        let mut primary = Server::new_async().await;
+        let mut fallback = Server::new_async().await;
+
+        let _m_slot = mock_get_slot(&mut primary, 105);
+        let m_primary = mock_get_block_missing_meta(&mut primary, 100, 2);
+        let m_fallback = mock_get_block_complete_withdraw_with_hash(
+            &mut fallback,
+            100,
+            "DifferentBlockHash2222222222222222222222222",
+            1,
+        );
+
+        let mut source = RpcPollingSource::new(
+            primary.url(),
+            Some(100),
+            10,
+            10,
+            10,
+            solana_transaction_status::UiTransactionEncoding::Json,
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+            ProgramType::Withdraw,
+            None,
+            Some(fallback.url()),
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        cancel.cancel();
+        let _ = handle.await;
+
+        // Primary re-requested (no advance) and the fallback was consulted but rejected.
+        m_primary.assert();
+        m_fallback.assert();
+
+        let mut messages = vec![];
+        while let Ok(msg) = rx.try_recv() {
+            messages.push(msg);
+        }
+        let emitted_slot_complete = messages
+            .iter()
+            .any(|m| matches!(m, ProcessorMessage::SlotComplete { slot, .. } if *slot == 100));
+        let emitted_instruction = messages
+            .iter()
+            .any(|m| matches!(m, ProcessorMessage::Instruction(_)));
+        assert!(
+            !emitted_slot_complete,
+            "SlotComplete{{slot:100}} must not be emitted when the fallback blockhash differs"
+        );
+        assert!(
+            !emitted_instruction,
+            "a fallback block with a mismatched blockhash must not be indexed"
         );
     }
 }

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -207,6 +207,7 @@ pub async fn run(
                 rpc_config.commitment,
                 common_config.program_type,
                 common_config.escrow_instance_id,
+                rpc_config.fallback_rpc_url.clone(),
             );
             if let Some(h) = health.clone() {
                 source = source.with_health(h);

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -187,7 +187,7 @@ pub fn init_labels(program_type: &str) {
     INDEXER_CHECKPOINT_FRONTIER_LAG.with_label_values(&[program_type]);
     INDEXER_SLOT_PROCESSING_DURATION.with_label_values(&[program_type]);
 
-    for error_type in &["stream", "get_slots", "get_block"] {
+    for error_type in &["stream", "get_slots", "get_block", "missing_meta"] {
         INDEXER_RPC_ERRORS.with_label_values(&[program_type, error_type]);
     }
 

--- a/monitoring/provisioning/alerting/alert-rules.yml
+++ b/monitoring/provisioning/alerting/alert-rules.yml
@@ -197,7 +197,7 @@ groups:
         noDataState: OK
         execErrState: Error
         annotations:
-          summary: "Indexer {{ $labels.program_type }} is rejecting a slot whose transactions are missing metadata (meta: null); the checkpoint cannot advance past it. Repoint the datasource RPC (or configure an archival fallback_rpc_url) at a full-history endpoint."
+          summary: "Indexer {{ $labels.program_type }} is rejecting a slot whose transactions are missing metadata (meta: null); the checkpoint cannot advance past it. Repoint the datasource RPC (or configure an archival fallback_rpc_url) at a full-history endpoint. This catches the sustained live-polling wedge; a backfill or resync hitting missing metadata instead aborts loudly with a MissingMeta error in the logs rather than sustaining this metric."
         labels:
           severity: critical
         data:

--- a/monitoring/provisioning/alerting/alert-rules.yml
+++ b/monitoring/provisioning/alerting/alert-rules.yml
@@ -184,3 +184,42 @@ groups:
                     type: lt
                     params: [0.5]
               refId: C
+
+  - orgId: 1
+    name: indexer-missing-meta-alerts
+    folder: Solana Private Channels Alerts
+    interval: 1m
+    rules:
+      - uid: indexer-missing-meta
+        title: "Indexer slot stuck on missing transaction metadata"
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: "Indexer {{ $labels.program_type }} is rejecting a slot whose transactions are missing metadata (meta: null); the checkpoint cannot advance past it. Repoint the datasource RPC (or configure an archival fallback_rpc_url) at a full-history endpoint."
+        labels:
+          severity: critical
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: rate(private_channel_indexer_rpc_errors_total{error_type="missing_meta"}[5m])
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              refId: C

--- a/scripts/devnet/config/indexer-private-channel.toml
+++ b/scripts/devnet/config/indexer-private-channel.toml
@@ -18,6 +18,9 @@ start_slot = 0
 poll_interval_ms = 1000
 error_retry_interval_ms = 5000
 batch_size = 50
+# Optional archival fallback for missing-meta slots (live polling only; backfill
+# fails closed). Omit to fail closed. Env: INDEXER_RPC_POLLING_FALLBACK_RPC_URL
+# fallback_rpc_url = "https://your-archival-endpoint"
 
 [indexer.backfill]
 enabled = false

--- a/scripts/devnet/config/indexer-solana.toml
+++ b/scripts/devnet/config/indexer-solana.toml
@@ -25,6 +25,9 @@ commitment = "finalized"
 poll_interval_ms = 1000
 error_retry_interval_ms = 5000
 batch_size = 50
+# Optional archival fallback for missing-meta slots (live polling only; backfill
+# fails closed). Omit to fail closed. Env: INDEXER_RPC_POLLING_FALLBACK_RPC_URL
+# fallback_rpc_url = "https://your-archival-endpoint"
 
 [indexer.backfill]
 enabled = false

--- a/test_utils/src/indexer_helper.rs
+++ b/test_utils/src/indexer_helper.rs
@@ -44,6 +44,7 @@ pub async fn start_private_channel_indexer(
         from_slot: Some(1),
         encoding: UiTransactionEncoding::Json,
         commitment: CommitmentLevel::Finalized,
+        fallback_rpc_url: None,
     };
 
     let (datasource_type, yellowstone_config) = if let Some(endpoint) = geyser_endpoint {
@@ -135,6 +136,7 @@ pub async fn start_solana_indexer_rpc_polling(
         // without geyser / tower-bft leaves the deposit slots indefinitely
         // unfinalized and `getBlock` returns -32009.
         commitment: CommitmentLevel::Confirmed,
+        fallback_rpc_url: None,
     };
 
     let backfill_config = BackfillConfig {
@@ -214,6 +216,7 @@ pub async fn start_solana_indexer(
         from_slot: Some(1),
         encoding: UiTransactionEncoding::Json,
         commitment: CommitmentLevel::Finalized,
+        fallback_rpc_url: None,
     };
 
     let backfill_config = BackfillConfig {


### PR DESCRIPTION
## Summary

Closes issue 5. Previously, if an RPC `getBlock` response contained any transaction with `meta: null`, the indexer still treated the block as valid and advanced the checkpoint. This is unsafe because `meta` contains critical information: whether a transaction succeeded (`meta.err`), CPI deposit events (`meta.inner_instructions`), and v0 address lookup table keys (`meta.loaded_addresses`). Without it, the indexer could either index a failed transaction as successful or silently miss a successful transaction while still advancing the checkpoint. This affected both live polling and backfill/resync.

The fix fails closed whenever a block contains a transaction with `meta: null`. Before any parsing or checkpointing, the indexer checks the block, and if any transaction is missing `meta`, it treats the entire slot as unverifiable. In live mode, it logs the error, increments `INDEXER_RPC_ERRORS{error_type="missing_meta"}`, and stops before emitting `SlotComplete` or advancing the checkpoint. In backfill/resync, it returns a `MissingMeta` error and aborts before processing the slot. 
An optional `fallback_rpc_url` can be configured for archival providers, allowing the slot to be fetched once more and validated using the same checks.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28451292821) |
| Indexer | 23,323 | 26,422 | 88.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28451292821) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28451292821) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28451292821) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,122 | 15,198 | 79.8% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28451292821) |
| **Total** | **48,751** | **56,838** | **85.8%** | |

> Last updated: 2026-06-30 14:47:18 UTC by E2E Integration