### PR TITLE
fix: drain rotation retry queue from a snapshot (finding-18)

### DIFF
--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -47,6 +47,7 @@ have prefixes.
 | `no broadcast signatures recorded; cannot verify release landed` | C - ambiguous (recovery cannot prove outcome) | no | recovery worker quarantine |
 | `could not verify release landed (` | C - ambiguous (RPC unreachable during recovery) | no | recovery worker quarantine |
 | `recovery requeues without progress` | G - requeue cap exhausted (release never landed) | no | recovery worker quarantine |
+| `stale tree index:` ... `release can never land on current SMT` | H - stale tree index (release can never land) | no | `sender/mod.rs` rotation drain |
 
 ## Path A.halting - build error that halted the pipeline
 
@@ -364,6 +365,49 @@ coordination:
 UPDATE transactions SET status = 'failed', updated_at = NOW()
  WHERE id = :transaction_id;
 ```
+
+## Path H - stale tree index (release can never land)
+
+`error_message`: `stale tree index: nonce <n> belongs to tree <a>, sender on
+<b>; release can never land on current SMT`. The sender held this withdrawal
+in its rotation-retry queue, but the local SMT rotated forward past the
+nonce's tree (`a < b`). The withdrawal's tree window is closed, so forward
+rotation can never make the release valid again - retrying or re-arming will
+not help (distinct from Path A/C, where a re-arm can succeed). The release
+failed at build and was never broadcast, so it definitively never landed.
+
+### Step 1 - verify on-chain
+
+Run [`_verify_onchain_release.md`](_verify_onchain_release.md). Expected
+verdict: `NOT_LANDED` (build-time failure, no RPC call). If `LANDED` -> the
+tree-index check is reading a stale local SMT; switch to Path C reconciliation
+and [escalate](_escalation.md) (Tier 2) - the sender's tree tracking has a
+defect.
+
+### Step 2 - confirm the burn, then escalate for refund
+
+`signature` is the originating PrivateChannel burn. Confirm whether the user's
+tokens were burned (channel read node). Burned, release can never land -> the
+user's funds are stuck and there is no automated recovery: forward rotation
+will not reopen the tree. [Escalate](_escalation.md) (Tier 1) for out-of-band
+restoration (manual `release_funds` to the depositor or a manual remint of the
+burned tokens), then mark the row terminal:
+
+```sql
+UPDATE transactions SET status = 'failed', updated_at = NOW()
+ WHERE id = :transaction_id;
+```
+
+If the burn did not land, there is no user impact; close the alert and mark
+`failed`.
+
+### Step 3 - capture why the sender fell behind its own tree
+
+A stale tree index means the rotation-retry queue outran the local SMT (e.g.
+the queue held a withdrawal across two rotations). [Escalate](_escalation.md)
+(Tier 3) with the row's nonce, the two tree indices from the message, and the
+surrounding rotation logs so engineering can confirm whether the rotation
+cadence or the queue retention needs tightening.
 
 ## Post-incident artifacts (required)
 

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -90,6 +90,16 @@ pub mod test_hooks {
         super::transaction::poll_in_flight(state, storage_tx).await
     }
 
+    /// Drives one `drain_rotation_retry_queue` pass. Classifies each queued
+    /// tree-mismatched withdrawal as future (requeue), matched (rebuild+submit),
+    /// or stale (escalate to ManualReview).
+    pub async fn drain_rotation_retry_queue(
+        state: &mut SenderState,
+        storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    ) {
+        super::drain_rotation_retry_queue(state, storage_tx).await
+    }
+
     /// Drives `handle_confirmation_result` end-to-end. Used by tests
     /// that synthesise a `Result<ConfirmationResult, TransactionError>`
     /// to pin which on-chain error arm routes where without going
@@ -399,32 +409,37 @@ pub(super) async fn drain_rotation_retry_queue(
             // Never broadcast, so the release never landed: scrub state and
             // escalate to ManualReview (runbook: withdrawal_manual_review).
             Ordering::Less => {
+                let Some(transaction_id) = ctx.transaction_id else {
+                    error!(
+                        "Stale rotation retry for nonce {} has no transaction_id; skipping escalation",
+                        nonce
+                    );
+                    continue;
+                };
                 warn!(
                     "Stale rotation retry: nonce {} belongs to tree {} but sender is on {} - escalating to ManualReview",
                     nonce, expected_tree_index, current_tree_index
                 );
                 cleanup_failed_transaction(state, Some(nonce));
-                if let Some(transaction_id) = ctx.transaction_id {
-                    send_guaranteed(
-                        storage_tx,
-                        TransactionStatusUpdate {
-                            transaction_id,
-                            trace_id: ctx.trace_id.clone(),
-                            status: TransactionStatus::ManualReview,
-                            counterpart_signature: None,
-                            processed_at: Some(Utc::now()),
-                            error_message: Some(format!(
-                                "stale tree index: nonce {} belongs to tree {}, sender on {}; release can never land on current SMT",
-                                nonce, expected_tree_index, current_tree_index
-                            )),
-                            remint_signature: None,
-                            remint_attempted: false,
-                        },
-                        "transaction status update",
-                    )
-                    .await
-                    .ok();
-                }
+                send_guaranteed(
+                    storage_tx,
+                    TransactionStatusUpdate {
+                        transaction_id,
+                        trace_id: ctx.trace_id.clone(),
+                        status: TransactionStatus::ManualReview,
+                        counterpart_signature: None,
+                        processed_at: Some(Utc::now()),
+                        error_message: Some(format!(
+                            "stale tree index: nonce {} belongs to tree {}, sender on {}; release can never land on current SMT",
+                            nonce, expected_tree_index, current_tree_index
+                        )),
+                        remint_signature: None,
+                        remint_attempted: false,
+                    },
+                    "transaction status update",
+                )
+                .await
+                .ok();
             }
             // Future: local tree hasn't reached this nonce's tree; requeue and wait.
             Ordering::Greater => {

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -149,21 +149,25 @@ pub mod test_hooks {
     }
 }
 
+use crate::channel_utils::send_guaranteed;
 use crate::error::OperatorError;
 use crate::operator::tree_constants::MAX_TREE_LEAVES;
 use crate::operator::utils::instruction_util::TransactionBuilder;
 use crate::operator::ReleaseFundsBuilderWithNonce;
 use crate::operator::RpcClientWithRetry;
+use crate::storage::common::models::TransactionStatus;
 use crate::storage::common::storage::Storage;
 use crate::PrivateChannelIndexerConfig;
 use crate::ProgramType;
+use chrono::Utc;
 use solana_sdk::commitment_config::CommitmentLevel;
+use std::cmp::Ordering;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::time::{interval, Duration};
 use tracing::{debug, error, info, warn};
 
-use proof::take_pending_rotation_if_ready;
+use proof::{cleanup_failed_transaction, take_pending_rotation_if_ready};
 use transaction::{
     handle_transaction_submission, poll_in_flight, route_poll_results, run_poll_task,
 };
@@ -335,21 +339,8 @@ pub async fn run_sender(
                 // Retry withdrawals parked while an ambiguous nonce blocked their tree
                 drain_ambiguous_retry_queue(&mut state, &storage_tx).await;
 
-                // Process any transactions that were blocked by rotation
-                while let Some((ctx, builder)) = state.rotation_retry_queue.pop() {
-                    let nonce = ctx.withdrawal_nonce.expect("rotation retry must have nonce");
-                    let transaction_id = ctx.transaction_id.expect("rotation retry must have transaction_id");
-                    let trace_id = ctx.trace_id.clone().expect("rotation retry must have trace_id");
-                    let remint_info = state.remint_cache.get(&nonce).cloned();
-                    if remint_info.is_none() {
-                        error!("Missing remint_info for rotation retry nonce {} - remint will not be possible on failure", nonce);
-                    }
-                    info!(trace_id = %trace_id, "Retrying blocked nonce {} after rotation", nonce);
-                    let tx_builder = TransactionBuilder::ReleaseFunds(Box::new(
-                        ReleaseFundsBuilderWithNonce { builder, nonce, transaction_id, trace_id, remint_info },
-                    ));
-                    handle_transaction_submission(&mut state, tx_builder, &storage_tx).await;
-                }
+                // Retry withdrawals blocked by a tree-index mismatch after rotation
+                drain_rotation_retry_queue(&mut state, &storage_tx).await;
             }
 
             // Back-pressure: stop consuming new transactions when in_flight is full.
@@ -382,6 +373,89 @@ pub async fn run_sender(
 
     info!("Sender stopped gracefully");
     Ok(())
+}
+
+/// Retry withdrawals blocked by a tree-index mismatch after a rotation.
+/// Drains a snapshot, not the live queue: a still-mismatched item is requeued
+/// for a later tick, never re-popped in this pass (the live queue would spin).
+pub(super) async fn drain_rotation_retry_queue(
+    state: &mut SenderState,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) {
+    for (ctx, builder) in std::mem::take(&mut state.rotation_retry_queue) {
+        let nonce = ctx
+            .withdrawal_nonce
+            .expect("rotation retry must have nonce");
+        let Some(current_tree_index) = state.smt_state.as_ref().map(|s| s.smt_state.tree_index())
+        else {
+            // No local SMT (not expected here); keep it for the next tick.
+            state.rotation_retry_queue.push((ctx, builder));
+            continue;
+        };
+        let expected_tree_index = nonce / MAX_TREE_LEAVES as u64;
+
+        match expected_tree_index.cmp(&current_tree_index) {
+            // Stale: tree rotated past this nonce; retrying can never succeed.
+            // Never broadcast, so the release never landed: scrub state and
+            // escalate to ManualReview (runbook: withdrawal_manual_review).
+            Ordering::Less => {
+                warn!(
+                    "Stale rotation retry: nonce {} belongs to tree {} but sender is on {} - escalating to ManualReview",
+                    nonce, expected_tree_index, current_tree_index
+                );
+                cleanup_failed_transaction(state, Some(nonce));
+                if let Some(transaction_id) = ctx.transaction_id {
+                    send_guaranteed(
+                        storage_tx,
+                        TransactionStatusUpdate {
+                            transaction_id,
+                            trace_id: ctx.trace_id.clone(),
+                            status: TransactionStatus::ManualReview,
+                            counterpart_signature: None,
+                            processed_at: Some(Utc::now()),
+                            error_message: Some(format!(
+                                "stale tree index: nonce {} belongs to tree {}, sender on {}; release can never land on current SMT",
+                                nonce, expected_tree_index, current_tree_index
+                            )),
+                            remint_signature: None,
+                            remint_attempted: false,
+                        },
+                        "transaction status update",
+                    )
+                    .await
+                    .ok();
+                }
+            }
+            // Future: local tree hasn't reached this nonce's tree; requeue and wait.
+            Ordering::Greater => {
+                state.rotation_retry_queue.push((ctx, builder));
+            }
+            // Tree caught up: rebuild and submit.
+            Ordering::Equal => {
+                let transaction_id = ctx
+                    .transaction_id
+                    .expect("rotation retry must have transaction_id");
+                let trace_id = ctx
+                    .trace_id
+                    .clone()
+                    .expect("rotation retry must have trace_id");
+                let remint_info = state.remint_cache.get(&nonce).cloned();
+                if remint_info.is_none() {
+                    error!("Missing remint_info for rotation retry nonce {} - remint will not be possible on failure", nonce);
+                }
+                info!(trace_id = %trace_id, "Retrying blocked nonce {} after rotation", nonce);
+                let tx_builder =
+                    TransactionBuilder::ReleaseFunds(Box::new(ReleaseFundsBuilderWithNonce {
+                        builder,
+                        nonce,
+                        transaction_id,
+                        trace_id,
+                        remint_info,
+                    }));
+                handle_transaction_submission(state, tx_builder, storage_tx).await;
+            }
+        }
+    }
 }
 
 /// Retry withdrawals parked while an ambiguous nonce blocked their tree.
@@ -484,13 +558,14 @@ mod tests {
     use crate::config::DEFAULT_CONFIRMATION_POLL_INTERVAL_MS;
     use crate::config::{PostgresConfig, ProgramType, StorageType};
     use crate::operator::sender::types::{
-        InFlightQueue, InFlightTx, InstructionWithSigners, PendingRemint, SenderState,
-        TransactionContext, MAX_IN_FLIGHT,
+        InFlightQueue, InFlightTx, InstructionWithSigners, PendingRemint, SenderSMTState,
+        SenderState, TransactionContext, MAX_IN_FLIGHT,
     };
     use crate::operator::utils::instruction_util::{
         ExtraErrorCheckPolicy, ReleaseFundsBuilderWithNonce, RetryPolicy, WithdrawalRemintInfo,
     };
     use crate::operator::utils::rpc_util::{RetryConfig, RpcClientWithRetry};
+    use crate::operator::utils::smt_util::SmtState;
     use crate::operator::MintCache;
     use crate::storage::common::amount::TokenAmount;
     use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
@@ -538,6 +613,15 @@ mod tests {
             pending_remints: Vec::new(),
             in_flight: InFlightQueue::new(),
             semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
+        }
+    }
+
+    /// Local SMT pinned to `tree_index`, so a test can pick the mismatch direction
+    /// against a queued nonce (test config: MAX_TREE_LEAVES = 8, so tree = nonce / 8).
+    fn smt_at(tree_index: u64) -> SenderSMTState {
+        SenderSMTState {
+            smt_state: SmtState::new(tree_index),
+            nonce_to_builder: HashMap::new(),
         }
     }
 
@@ -896,6 +980,143 @@ mod tests {
         assert!(
             storage_rx.try_recv().is_err(),
             "heartbeat is a direct CAS, not a status update"
+        );
+    }
+
+    // ── drain_rotation_retry_queue ────────────────────────────────────
+
+    /// Future mismatch: the nonce's tree is ahead of the local SMT, so it can't
+    /// build yet. It must be requeued for a later tick, never retried in this pass.
+    /// Reaching the asserts proves the snapshot drain returns instead of spinning.
+    #[tokio::test]
+    async fn rotation_drain_future_requeues() {
+        let mut state = make_sender_state("http://localhost:8899");
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // Local SMT on tree 0; first nonce of tree 1 is a future mismatch.
+        let future_nonce = MAX_TREE_LEAVES as u64;
+        state.smt_state = Some(smt_at(0));
+        state.rotation_retry_queue.push((
+            TransactionContext {
+                transaction_id: Some(80),
+                withdrawal_nonce: Some(future_nonce),
+                trace_id: Some("trace-8".to_string()),
+            },
+            ReleaseFundsBuilder::new(),
+        ));
+
+        drain_rotation_retry_queue(&mut state, &storage_tx).await;
+
+        // Item is back in the queue for the next tick, unchanged.
+        assert_eq!(state.rotation_retry_queue.len(), 1);
+        assert_eq!(
+            state.rotation_retry_queue[0].0.withdrawal_nonce,
+            Some(future_nonce)
+        );
+        // Not escalated: no status update emitted.
+        assert!(storage_rx.try_recv().is_err());
+    }
+
+    /// Stale mismatch: the local SMT has rotated past this nonce's tree, so a
+    /// retry can never succeed. It must leave the queue, get its remint_cache
+    /// entry scrubbed, and be escalated to ManualReview.
+    #[tokio::test]
+    async fn rotation_drain_stale_escalates_to_manual_review() {
+        let mut state = make_sender_state("http://localhost:8899");
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // Local SMT on tree 1; nonce 2 belongs to tree 0 (stale, can't return).
+        let stale_nonce = 2u64;
+        state.smt_state = Some(smt_at(1));
+        state.remint_cache.insert(
+            stale_nonce,
+            WithdrawalRemintInfo {
+                transaction_id: 20,
+                trace_id: "trace-2".to_string(),
+                mint: Pubkey::new_unique(),
+                user: Pubkey::new_unique(),
+                user_ata: Pubkey::new_unique(),
+                token_program: spl_token::id(),
+                amount: 1000,
+            },
+        );
+        state.rotation_retry_queue.push((
+            TransactionContext {
+                transaction_id: Some(20),
+                withdrawal_nonce: Some(stale_nonce),
+                trace_id: Some("trace-2".to_string()),
+            },
+            ReleaseFundsBuilder::new(),
+        ));
+
+        drain_rotation_retry_queue(&mut state, &storage_tx).await;
+
+        // Dropped from the queue, not retried.
+        assert!(state.rotation_retry_queue.is_empty());
+        // In-memory state scrubbed.
+        assert!(!state.remint_cache.contains_key(&stale_nonce));
+        // Escalated to ManualReview for the right row.
+        let update = storage_rx.try_recv().expect("a status update");
+        assert_eq!(update.transaction_id, 20);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+    }
+
+    /// One drain pass classifies a mixed batch correctly: the future item is
+    /// requeued, the stale item is escalated, and the pass returns (no re-pop).
+    #[tokio::test]
+    async fn rotation_drain_mixed_batch_single_pass() {
+        let mut state = make_sender_state("http://localhost:8899");
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // Local SMT on tree 1: nonce 2 is stale (tree 0), first nonce of tree 2
+        // is future.
+        let stale_nonce = 2u64;
+        let future_nonce = 2 * MAX_TREE_LEAVES as u64;
+        state.smt_state = Some(smt_at(1));
+        state.remint_cache.insert(
+            stale_nonce,
+            WithdrawalRemintInfo {
+                transaction_id: 20,
+                trace_id: "trace-2".to_string(),
+                mint: Pubkey::new_unique(),
+                user: Pubkey::new_unique(),
+                user_ata: Pubkey::new_unique(),
+                token_program: spl_token::id(),
+                amount: 1000,
+            },
+        );
+        state.rotation_retry_queue.push((
+            TransactionContext {
+                transaction_id: Some(20),
+                withdrawal_nonce: Some(stale_nonce),
+                trace_id: Some("trace-2".to_string()),
+            },
+            ReleaseFundsBuilder::new(),
+        ));
+        state.rotation_retry_queue.push((
+            TransactionContext {
+                transaction_id: Some(200),
+                withdrawal_nonce: Some(future_nonce),
+                trace_id: Some("trace-future".to_string()),
+            },
+            ReleaseFundsBuilder::new(),
+        ));
+
+        drain_rotation_retry_queue(&mut state, &storage_tx).await;
+
+        // Only the future item remains, queued for a later tick.
+        assert_eq!(state.rotation_retry_queue.len(), 1);
+        assert_eq!(
+            state.rotation_retry_queue[0].0.withdrawal_nonce,
+            Some(future_nonce)
+        );
+        // The stale item was escalated to ManualReview.
+        let update = storage_rx.try_recv().expect("a status update");
+        assert_eq!(update.transaction_id, 20);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "only the stale item escalates"
         );
     }
 }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -134,6 +134,10 @@ name = "sender_onchain_error_arms"
 path = "tests/indexer/sender_onchain_error_arms.rs"
 
 [[test]]
+name = "sender_rotation_retry"
+path = "tests/indexer/sender_rotation_retry.rs"
+
+[[test]]
 name = "jit_mint_helper"
 path = "tests/indexer/jit_mint_helper.rs"
 

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -66,6 +66,7 @@ integration-test:
 	@cargo test --test sender_sign_and_send_error -- --nocapture
 	@cargo test --test sender_max_retries -- --nocapture
 	@cargo test --test sender_onchain_error_arms -- --nocapture
+	@cargo test --test sender_rotation_retry -- --nocapture
 	@cargo test --test jit_mint_helper -- --nocapture
 	@cargo test --test storage_update_failure -- --nocapture
 	@cargo test --test processor_quarantine -- --nocapture
@@ -277,6 +278,8 @@ integration-coverage-indexer:
 	@cargo llvm-cov test --no-report --workspace --test sender_max_retries -- --nocapture
 	@echo "Running sender on-chain error-arm tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test sender_onchain_error_arms -- --nocapture
+	@echo "Running sender rotation-retry drain tests with coverage instrumentation..."
+	@cargo llvm-cov test --no-report --workspace --test sender_rotation_retry -- --nocapture
 	@echo "Running JIT-mint helper coverage tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test jit_mint_helper -- --nocapture
 	@echo "Running storage-update-failure tests with coverage instrumentation..."

--- a/integration/tests/indexer/sender_rotation_retry.rs
+++ b/integration/tests/indexer/sender_rotation_retry.rs
@@ -1,0 +1,96 @@
+//! Coverage for the `Ordering::Equal` (tree-matched) branch of
+//! `drain_rotation_retry_queue`. The future and stale branches are pure
+//! in-memory logic and live in the sender module's unit tests; the matched
+//! branch hands off to `handle_transaction_submission`, which needs the admin
+//! signer and a live RPC — so it is exercised here, against the mock-RPC
+//! harness, rather than in a unit test.
+
+#[path = "sender_fixtures.rs"]
+mod sender_fixtures;
+
+use {
+    private_channel_escrow_program_client::instructions::ReleaseFundsBuilder,
+    private_channel_indexer::{
+        operator::{
+            sender::{
+                test_hooks,
+                types::{SenderSMTState, TransactionContext},
+            },
+            utils::smt_util::SmtState,
+        },
+        storage::TransactionStatus,
+    },
+    sender_fixtures::{
+        blockhash_reply, build_default_sender_state, confirmed_status_reply, make_remint_info,
+        send_transaction_echo_reply,
+    },
+    solana_sdk::pubkey::Pubkey,
+    std::collections::HashMap,
+};
+
+/// A `ReleaseFundsBuilder` with every account populated, so the proof build
+/// produces a real instruction. Mirrors the sender module's proof tests.
+fn make_release_funds_builder(nonce: u64) -> ReleaseFundsBuilder {
+    let pk = Pubkey::new_unique();
+    let mut builder = ReleaseFundsBuilder::new();
+    builder
+        .payer(pk)
+        .operator(pk)
+        .instance(pk)
+        .operator_pda(pk)
+        .mint(pk)
+        .allowed_mint(pk)
+        .user_ata(pk)
+        .instance_ata(pk)
+        .token_program(spl_token::id())
+        .user(pk)
+        .amount(1000)
+        .transaction_nonce(nonce);
+    builder
+}
+
+/// Matched mismatch: the queued nonce's tree equals the local SMT tree, so the
+/// drain rebuilds and submits it rather than requeuing or escalating. The item
+/// must leave the queue and land in the SMT, and no ManualReview is emitted.
+#[tokio::test(flavor = "multi_thread")]
+async fn rotation_drain_matched_submits() {
+    let (mut state, mut storage_rx, storage_tx, mock) = build_default_sender_state().await;
+
+    // Full happy-path wire script so the submission builds, sends, and confirms.
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("sendTransaction", send_transaction_echo_reply());
+    mock.enqueue("getSignatureStatuses", confirmed_status_reply());
+
+    // Local SMT on tree 0; nonce 2 belongs to tree 0 (matched).
+    let nonce = 2u64;
+    state.smt_state = Some(SenderSMTState {
+        smt_state: SmtState::new(0),
+        nonce_to_builder: HashMap::new(),
+    });
+    state.remint_cache.insert(nonce, make_remint_info(20));
+    state.rotation_retry_queue.push((
+        TransactionContext {
+            transaction_id: Some(20),
+            withdrawal_nonce: Some(nonce),
+            trace_id: Some("trace-2".to_string()),
+        },
+        make_release_funds_builder(nonce),
+    ));
+
+    test_hooks::drain_rotation_retry_queue(&mut state, &storage_tx).await;
+
+    // Routed to submission: gone from the queue and inserted into the tree.
+    assert!(state.rotation_retry_queue.is_empty());
+    assert!(state
+        .smt_state
+        .as_ref()
+        .unwrap()
+        .smt_state
+        .contains_nonce(nonce));
+    // A matched item is submitted, never escalated.
+    if let Ok(update) = storage_rx.try_recv() {
+        assert_ne!(update.status, TransactionStatus::ManualReview);
+    }
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
fix: drain rotation retry queue from a snapshot (finding-18)

Problem

The sender retried tree-mismatched withdrawals by popping the live rotation_retry_queue in a while let loop. On a TreeIndexMismatch, route_builder_error pushes the builder right back, so the same item is re-popped within the same tick — and nothing in the loop advances the local SMT, so it spins forever. The sender task never returns to its select!: confirmations stop being polled, remints stop, parked/new withdrawals stall until restart. High-severity liveness/fund-lockup risk around SMT rotation boundaries.

Fix

Extract drain_rotation_retry_queue, draining a std::mem::take snapshot instead of the live queue, and classify each mismatch by direction:
  - future (expected > current) → requeue for a later tick
  - matched (expected == current) → rebuild + submit (unchanged behavior)
  - stale (expected < current) → can never succeed; scrub the nonce's in-memory state and escalate to ManualReview (it never broadcast, so the release definitively never landed)

 A requeued item now waits for the next tick instead of being re-popped, so the drain always returns control to select!.

Tests

3 unit tests (feature-agnostic, no signer/network deps): future requeues, stale escalates to ManualReview + cache scrubbed, mixed batch classified in a single pass
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28471603000) |
| Indexer | 22,616 | 25,737 | 87.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28471603000) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28471603000) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28471603000) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,922 | 15,022 | 79.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28471603000) |
| **Total** | **47,844** | **55,977** | **85.5%** | |

> Last updated: 2026-06-30 20:13:17 UTC by E2E Integration