### PR TITLE
fix: enforce withdrawal nonce frontier in dequeue and rotation (finding 26(

### DIFF
--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -1146,18 +1146,18 @@ mod tests {
             },
         );
 
-        // Seed a lower-nonce withdrawal that is still active (nonce 1 < boundary).
-        // This is what the guard must see and refuse to rotate past.
-        mock.pending_transactions
-            .lock()
-            .unwrap()
-            .push(make_db_transaction(
-                2,
-                &mint_pubkey.to_string(),
-                &recipient.to_string(),
-                Some(1),
-                TransactionType::Withdrawal,
-            ));
+        // Seed a lower-nonce withdrawal stuck off the sender path (Parked, nonce 1
+        // < boundary). This is what the guard must see and refuse to rotate past.
+        // (Processing rows are excluded - the sender's in-flight guard covers those.)
+        let mut lower = make_db_transaction(
+            2,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            Some(1),
+            TransactionType::Withdrawal,
+        );
+        lower.status = TransactionStatus::Parked;
+        mock.pending_transactions.lock().unwrap().push(lower);
 
         // Boundary nonce → target tree 1; on-chain index 0 means a rotation WOULD
         // fire here (0 < 1) absent the guard — so an empty sender proves the guard.

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -535,6 +535,18 @@ pub async fn process_release_funds(
             if let Some(nonce_i64) = transaction.withdrawal_nonce {
                 let nonce = nonce_i64 as u64;
                 if nonce > 0 && nonce.is_multiple_of(MAX_TREE_LEAVES as u64) {
+                    // Durable frontier guard: never rotate while a lower withdrawal
+                    // is still active, or it gets stranded on the closed tree. The
+                    // dequeue frontier normally keeps a boundary from arriving out of
+                    // order; this catches paths that bypass it (e.g. a manual re-arm).
+                    // Leave the row Processing for recovery rather than dispatch it.
+                    if storage.has_active_withdrawal_below(nonce_i64).await? {
+                        warn!(
+                            nonce,
+                            "Lower active withdrawal exists - deferring boundary rotation"
+                        );
+                        return Ok(());
+                    }
                     let target_tree_index = nonce / MAX_TREE_LEAVES as u64;
                     let release_funds_state = processor_state
                         .release_funds_state
@@ -1109,6 +1121,88 @@ mod tests {
 
         // No further messages — exactly two were sent
         assert!(sender_rx.try_recv().is_err(), "unexpected third message");
+    }
+
+    /// A boundary nonce must not rotate or dispatch while a lower withdrawal is
+    /// still active in the DB. Nothing is sent; the boundary row is left
+    /// Processing for recovery.
+    #[tokio::test]
+    async fn process_release_funds_boundary_defers_when_lower_active() {
+        let mock = MockStorage::new();
+
+        // Allow the mint so build_release_funds succeeds before the guard runs.
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        mock.mints.lock().unwrap().insert(
+            mint_pubkey.to_string(),
+            DbMint {
+                mint_address: mint_pubkey.to_string(),
+                decimals: 6,
+                token_program: spl_token::id().to_string(),
+                created_at: chrono::Utc::now(),
+                status: "allowed".to_string(),
+                is_pausable: Some(false),
+                has_permanent_delegate: Some(false),
+            },
+        );
+
+        // Seed a lower-nonce withdrawal that is still active (nonce 1 < boundary).
+        // This is what the guard must see and refuse to rotate past.
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(make_db_transaction(
+                2,
+                &mint_pubkey.to_string(),
+                &recipient.to_string(),
+                Some(1),
+                TransactionType::Withdrawal,
+            ));
+
+        // Boundary nonce → target tree 1; on-chain index 0 means a rotation WOULD
+        // fire here (0 < 1) absent the guard — so an empty sender proves the guard.
+        let storage = Arc::new(Storage::Mock(mock));
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, instance_account_response(0));
+        let rpc_client = RpcClientWithRetry::new_mocked(mocks);
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::with_rpc(storage.clone(), Arc::new(rpc_client)),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        // Feed the boundary withdrawal (nonce == MAX_TREE_LEAVES, first of next tree).
+        let boundary = make_db_transaction(
+            1,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            Some(MAX_TREE_LEAVES as i64),
+            TransactionType::Withdrawal,
+        );
+        fetcher_tx.send(boundary).await.unwrap();
+        drop(fetcher_tx); // close the channel so the processor loop exits
+
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        // Guard fired: neither the ResetSmtRoot nor the boundary ReleaseFunds
+        // was dispatched, because lower nonce 1 is still active.
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "boundary must be deferred while a lower nonce is active"
+        );
     }
 
     /// Regression for the boundary-quarantine wedge: a boundary nonce whose

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -23,6 +23,7 @@ pub mod get_release_signatures;
 pub mod get_remint_signatures;
 pub mod get_stale_parked_transactions;
 pub mod get_stale_processing_transactions;
+pub mod has_active_withdrawal_below;
 pub mod init_schema;
 pub mod insert_db_transaction;
 pub mod insert_db_transactions_batch;
@@ -247,6 +248,10 @@ impl Storage {
         transaction_type: TransactionType,
     ) -> Result<i64, StorageError> {
         count_pending_transactions::count_pending_transactions(self, transaction_type).await
+    }
+
+    pub async fn has_active_withdrawal_below(&self, nonce: i64) -> Result<bool, StorageError> {
+        has_active_withdrawal_below::has_active_withdrawal_below(self, nonce).await
     }
 
     /// Get completed withdrawal nonces in the given range [min_nonce, max_nonce)

--- a/indexer/src/storage/common/storage/has_active_withdrawal_below.rs
+++ b/indexer/src/storage/common/storage/has_active_withdrawal_below.rs
@@ -1,0 +1,15 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// True if any withdrawal with a lower nonce is still active (non-terminal:
+/// Pending/Processing/Parked/PendingRemint/ManualReview). Used to gate the
+/// boundary-rotation so a lower nonce is never stranded on a closed tree.
+pub async fn has_active_withdrawal_below(
+    storage: &Storage,
+    nonce: i64,
+) -> Result<bool, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db.has_active_withdrawal_below_internal(nonce).await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.has_active_withdrawal_below(nonce).await,
+    }
+}

--- a/indexer/src/storage/common/storage/has_active_withdrawal_below.rs
+++ b/indexer/src/storage/common/storage/has_active_withdrawal_below.rs
@@ -1,8 +1,10 @@
 use crate::{error::StorageError, storage::common::storage::Storage};
 
-/// True if any withdrawal with a lower nonce is still active (non-terminal:
-/// Pending/Processing/Parked/PendingRemint/ManualReview). Used to gate the
-/// boundary-rotation so a lower nonce is never stranded on a closed tree.
+/// True if any withdrawal with a lower nonce is unresolved and not yet handed to
+/// the sender (Pending/Parked/PendingRemint/ManualReview). Gates the boundary
+/// rotation so a lower nonce is never stranded on a closed tree. Processing is
+/// excluded: those are already dispatched ahead of the rotation and held by the
+/// sender's in-flight guard.
 pub async fn has_active_withdrawal_below(
     storage: &Storage,
     nonce: i64,

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -168,7 +168,8 @@ impl MockStorage {
                 .filter_map(|t| t.withdrawal_nonce)
                 .min();
 
-            let mut eligible: Vec<(i64, i64)> = pending
+            // Numbered nonces below the frontier, in nonce order.
+            let mut numbered: Vec<(i64, i64)> = pending
                 .iter()
                 .filter(|t| {
                     t.transaction_type == TransactionType::Withdrawal
@@ -177,11 +178,26 @@ impl MockStorage {
                 .filter_map(|t| t.withdrawal_nonce.map(|nonce| (nonce, t.id)))
                 .filter(|(nonce, _)| barrier.is_none_or(|b| *nonce < b))
                 .collect();
-            eligible.sort_by_key(|(nonce, _)| *nonce);
-            eligible.truncate(limit.max(0) as usize);
+            numbered.sort_by_key(|(nonce, _)| *nonce);
+
+            // NULL-nonce rows are poison; the frontier doesn't apply. Dequeue them
+            // (sorted last, mirroring SQL ORDER BY ... ASC) so the processor can
+            // quarantine them.
+            let null_nonce_ids = pending
+                .iter()
+                .filter(|t| {
+                    t.transaction_type == TransactionType::Withdrawal
+                        && t.status == TransactionStatus::Pending
+                        && t.withdrawal_nonce.is_none()
+                })
+                .map(|t| t.id);
+
+            let mut ids: Vec<i64> = numbered.into_iter().map(|(_, id)| id).collect();
+            ids.extend(null_nonce_ids);
+            ids.truncate(limit.max(0) as usize);
 
             let mut matched = Vec::new();
-            for (_, id) in eligible {
+            for id in ids {
                 if let Some(txn) = pending.iter_mut().find(|t| t.id == id) {
                     txn.status = TransactionStatus::Processing;
                     matched.push(txn.clone());
@@ -207,13 +223,14 @@ impl MockStorage {
 
     pub async fn has_active_withdrawal_below(&self, nonce: i64) -> Result<bool, StorageError> {
         let pending = self.pending_transactions.lock().unwrap();
+        // Processing excluded on purpose: those are already dispatched ahead of
+        // the rotation, so the sender's in-flight guard covers them.
         Ok(pending.iter().any(|t| {
             t.transaction_type == TransactionType::Withdrawal
                 && t.withdrawal_nonce.is_some_and(|n| n < nonce)
                 && matches!(
                     t.status,
                     TransactionStatus::Pending
-                        | TransactionStatus::Processing
                         | TransactionStatus::Parked
                         | TransactionStatus::PendingRemint
                         | TransactionStatus::ManualReview

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -147,9 +147,52 @@ impl MockStorage {
         limit: i64,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         let mut pending = self.pending_transactions.lock().unwrap();
+
+        // Withdrawals: mirror the Postgres frontier dequeue. Return Pending
+        // withdrawals in nonce order, only those below the lowest active
+        // (non-Pending) nonce, and mark them Processing in place (kept in the
+        // store so they act as the barrier on the next call).
+        if matches!(transaction_type, TransactionType::Withdrawal) {
+            let barrier = pending
+                .iter()
+                .filter(|t| {
+                    t.transaction_type == TransactionType::Withdrawal
+                        && matches!(
+                            t.status,
+                            TransactionStatus::Processing
+                                | TransactionStatus::Parked
+                                | TransactionStatus::PendingRemint
+                                | TransactionStatus::ManualReview
+                        )
+                })
+                .filter_map(|t| t.withdrawal_nonce)
+                .min();
+
+            let mut eligible: Vec<(i64, i64)> = pending
+                .iter()
+                .filter(|t| {
+                    t.transaction_type == TransactionType::Withdrawal
+                        && t.status == TransactionStatus::Pending
+                })
+                .filter_map(|t| t.withdrawal_nonce.map(|nonce| (nonce, t.id)))
+                .filter(|(nonce, _)| barrier.is_none_or(|b| *nonce < b))
+                .collect();
+            eligible.sort_by_key(|(nonce, _)| *nonce);
+            eligible.truncate(limit.max(0) as usize);
+
+            let mut matched = Vec::new();
+            for (_, id) in eligible {
+                if let Some(txn) = pending.iter_mut().find(|t| t.id == id) {
+                    txn.status = TransactionStatus::Processing;
+                    matched.push(txn.clone());
+                }
+            }
+            return Ok(matched);
+        }
+
+        // Deposits: FIFO by insertion order, removed from the queue on return.
         let mut matched = Vec::new();
         let mut remaining = Vec::new();
-
         for txn in pending.drain(..) {
             if txn.transaction_type == transaction_type && (matched.len() as i64) < limit {
                 matched.push(txn);
@@ -160,6 +203,22 @@ impl MockStorage {
 
         *pending = remaining;
         Ok(matched)
+    }
+
+    pub async fn has_active_withdrawal_below(&self, nonce: i64) -> Result<bool, StorageError> {
+        let pending = self.pending_transactions.lock().unwrap();
+        Ok(pending.iter().any(|t| {
+            t.transaction_type == TransactionType::Withdrawal
+                && t.withdrawal_nonce.is_some_and(|n| n < nonce)
+                && matches!(
+                    t.status,
+                    TransactionStatus::Pending
+                        | TransactionStatus::Processing
+                        | TransactionStatus::Parked
+                        | TransactionStatus::PendingRemint
+                        | TransactionStatus::ManualReview
+                )
+        }))
     }
 
     pub async fn get_committed_checkpoint(

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1091,10 +1091,13 @@ impl PostgresDb {
         let (order_col, frontier_filter, lock_clause) = if is_withdrawal {
             (
                 transaction_cols::WITHDRAWAL_NONCE,
+                // NULL-nonce rows are poison (e.g. a corrupt withdrawal); they have
+                // no tree, so the frontier doesn't apply - still dequeue them so the
+                // processor can quarantine them. ORDER BY ... ASC sorts them last.
                 format!(
-                    " AND {nonce} < COALESCE((SELECT MIN({nonce}) FROM transactions \
-                     WHERE {ttype} = $2 AND {status} IN \
-                     ('processing', 'parked', 'pending_remint', 'manual_review')), {max})",
+                    " AND ({nonce} IS NULL OR {nonce} < COALESCE((SELECT MIN({nonce}) \
+                     FROM transactions WHERE {ttype} = $2 AND {status} IN \
+                     ('processing', 'parked', 'pending_remint', 'manual_review')), {max}))",
                     nonce = transaction_cols::WITHDRAWAL_NONCE,
                     ttype = transaction_cols::TRANSACTION_TYPE,
                     status = transaction_cols::STATUS,
@@ -1182,9 +1185,11 @@ impl PostgresDb {
         Ok(transactions)
     }
 
-    /// True if any withdrawal with a lower nonce is still active (non-terminal).
-    /// Gates the boundary rotation: rotating while a lower nonce is unresolved
-    /// would strand it on the closed tree.
+    /// True if any withdrawal with a lower nonce is unresolved and not yet handed
+    /// to the sender. Gates the boundary rotation: rotating past such a nonce
+    /// would strand it on the closed tree. `Processing` rows are excluded on
+    /// purpose - they are already dispatched ahead of the rotation, so the
+    /// sender's in-flight guard holds the rotation until they settle.
     pub async fn has_active_withdrawal_below_internal(
         &self,
         nonce: i64,
@@ -1195,8 +1200,7 @@ impl PostgresDb {
                 SELECT 1 FROM transactions
                 WHERE {ttype} = $2
                   AND {nonce} < $1
-                  AND {status} IN
-                      ('pending', 'processing', 'parked', 'pending_remint', 'manual_review')
+                  AND {status} IN ('pending', 'parked', 'pending_remint', 'manual_review')
             )
             "#,
             ttype = transaction_cols::TRANSACTION_TYPE,

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1081,20 +1081,48 @@ impl PostgresDb {
         transaction_type: TransactionType,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, sqlx::Error> {
+        // Deposits dequeue FIFO by created_at. Withdrawals dequeue by nonce and
+        // enforce a frontier: never hand out a nonce while a lower one is still
+        // active, or the lower nonce gets stranded on a closed SMT tree after a
+        // boundary rotation. The `< MIN(lower active nonce)` filter is the
+        // frontier; dropping SKIP LOCKED stops a second worker from skipping a
+        // locked lower nonce and leapfrogging to a higher one.
+        let is_withdrawal = matches!(transaction_type, TransactionType::Withdrawal);
+        let (order_col, frontier_filter, lock_clause) = if is_withdrawal {
+            (
+                transaction_cols::WITHDRAWAL_NONCE,
+                format!(
+                    " AND {nonce} < COALESCE((SELECT MIN({nonce}) FROM transactions \
+                     WHERE {ttype} = $2 AND {status} IN \
+                     ('processing', 'parked', 'pending_remint', 'manual_review')), {max})",
+                    nonce = transaction_cols::WITHDRAWAL_NONCE,
+                    ttype = transaction_cols::TRANSACTION_TYPE,
+                    status = transaction_cols::STATUS,
+                    max = i64::MAX,
+                ),
+                "FOR UPDATE",
+            )
+        } else {
+            (
+                transaction_cols::CREATED_AT,
+                String::new(),
+                "FOR UPDATE SKIP LOCKED",
+            )
+        };
+
         // Use a transaction to ensure atomicity
         let mut tx = self.pool.begin().await?;
 
-        // Lock rows with FOR UPDATE SKIP LOCKED
         let transactions = sqlx::query_as::<_, DbTransaction>(&format!(
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
             FROM transactions
-            WHERE {} = $1 AND {} = $2
+            WHERE {} = $1 AND {} = $2{frontier}
             ORDER BY {} ASC
             LIMIT $3
-            FOR UPDATE SKIP LOCKED
+            {lock}
             "#,
             transaction_cols::ID,
             transaction_cols::SIGNATURE,
@@ -1123,8 +1151,10 @@ impl PostgresDb {
             // Filters
             transaction_cols::STATUS,
             transaction_cols::TRANSACTION_TYPE,
-            // Ordering (FIFO)
-            transaction_cols::CREATED_AT,
+            // Ordering: nonce for withdrawals, created_at for deposits
+            order_col,
+            frontier = frontier_filter,
+            lock = lock_clause,
         ))
         .bind(TransactionStatus::Pending)
         .bind(transaction_type)
@@ -1150,6 +1180,34 @@ impl PostgresDb {
         tx.commit().await?;
 
         Ok(transactions)
+    }
+
+    /// True if any withdrawal with a lower nonce is still active (non-terminal).
+    /// Gates the boundary rotation: rotating while a lower nonce is unresolved
+    /// would strand it on the closed tree.
+    pub async fn has_active_withdrawal_below_internal(
+        &self,
+        nonce: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let exists: bool = sqlx::query_scalar(&format!(
+            r#"
+            SELECT EXISTS (
+                SELECT 1 FROM transactions
+                WHERE {ttype} = $2
+                  AND {nonce} < $1
+                  AND {status} IN
+                      ('pending', 'processing', 'parked', 'pending_remint', 'manual_review')
+            )
+            "#,
+            ttype = transaction_cols::TRANSACTION_TYPE,
+            nonce = transaction_cols::WITHDRAWAL_NONCE,
+            status = transaction_cols::STATUS,
+        ))
+        .bind(nonce)
+        .bind(TransactionType::Withdrawal)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(exists)
     }
 
     /// Returns true if the row was updated; false if already terminal.

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -431,6 +431,45 @@ async fn lock_pending_second_call_empty() -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
+/// Withdrawals dequeue under a nonce frontier: a lower active (non-Pending)
+/// nonce blocks every higher nonce, so a boundary can't be handed out ahead of
+/// an unresolved lower withdrawal.
+#[tokio::test(flavor = "multi_thread")]
+async fn withdrawal_dequeue_respects_nonce_frontier() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    // Sequential inserts get sequential nonces (0, 1, 2) from the trigger.
+    let w0 = storage
+        .insert_db_transaction(&make_db_transaction("w0", TransactionType::Withdrawal))
+        .await?;
+    let w1 = storage
+        .insert_db_transaction(&make_db_transaction("w1", TransactionType::Withdrawal))
+        .await?;
+    storage
+        .insert_db_transaction(&make_db_transaction("w2", TransactionType::Withdrawal))
+        .await?;
+
+    // Park the middle nonce: an active, non-Pending lower nonce.
+    sqlx::query("UPDATE transactions SET status = 'parked' WHERE id = $1")
+        .bind(w1)
+        .execute(&pool)
+        .await?;
+
+    // Only Pending nonces below the parked one are eligible → just w0.
+    // w2 is Pending but sits above the frontier, so it must be withheld.
+    let locked = storage
+        .get_and_lock_pending_transactions(TransactionType::Withdrawal, 100)
+        .await?;
+    assert_eq!(
+        locked.len(),
+        1,
+        "only the nonce below the frontier is dequeued"
+    );
+    assert_eq!(locked[0].id, w0);
+
+    Ok(())
+}
+
 // ── 5. Get all transactions ──────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
fix: enforce withdrawal nonce frontier in dequeue and rotation (finding-26)

Problem

Withdrawal ReleaseFunds txs are bound to an SMT tree generation by their nonce (tree = nonce / MAX_TREE_LEAVES), and a boundary nonce makes the processor rotate the tree before releasing. But the dequeue (get_and_lock_pending_transactions) used the deposit FIFO query — ORDER BY created_at … FOR UPDATE SKIP LOCKED, filtered to status = Pending. That doesn't preserve the nonce frontier: a higher boundary nonce can be handed out while a lower nonce is still active (Processing/Parked/PendingRemint/ManualReview, or locked by another worker). The processor then rotates the tree, and when the lower nonce finally reaches the sender it fails TreeIndexMismatch — a valid user withdrawal stranded on a closed tree by the operator's own ordering. The sender's in-memory rotation guard can't catch this because it only sees in-flight builders, not durable pending rows.

Fix

  - Frontier dequeue (withdrawals only): order by withdrawal_nonce, return only Pending nonces below the lowest active non-Pending nonce (< COALESCE(MIN(...), i64::MAX)), and drop SKIP LOCKED so a second worker blocks on a locked lower nonce instead of leapfrogging it. Deposits keep FIFO + SKIP LOCKED unchanged.
  - Durable rotation guard: before emitting ResetSmtRoot for a boundary nonce, the processor checks has_active_withdrawal_below(nonce); if any lower withdrawal is still active it defers (no rotation, no dispatch, row left Processing for recovery). Backstop for paths that bypass the dequeue (e.g. a manual re-arm).

ManualReview counts as active/blocking by design — chosen over advancing past it and resurrecting a stranded nonce on re-arm.

Tests

  - withdrawal_dequeue_respects_nonce_frontier (Postgres/testcontainers): a parked lower nonce withholds higher nonces.
  - process_release_funds_boundary_defers_when_lower_active: boundary deferred while a lower nonce is active.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28481622630) |
| Indexer | 22,571 | 25,752 | 87.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28481622630) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28481622630) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28481622630) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 11,950 | 15,019 | 79.6% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28481622630) |
| **Total** | **47,827** | **55,989** | **85.4%** | |

> Last updated: 2026-06-30 23:28:27 UTC by E2E Integration