### PR TITLE
fix(indexer): bounded safety window for live `SlotComplete`

### DIFF
--- a/indexer/src/bin/indexer.rs
+++ b/indexer/src/bin/indexer.rs
@@ -3,7 +3,9 @@ use figment::{
     providers::{Env, Format, Toml},
     Figment,
 };
-use private_channel_indexer::config::DEFAULT_CONFIRMATION_POLL_INTERVAL_MS;
+use private_channel_indexer::config::{
+    default_safety_window, DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
+};
 use private_channel_indexer::{
     BackfillConfig, DatasourceType, IndexerConfig, OperatorConfig, PostgresConfig,
     PrivateChannelIndexerConfig, ProgramType, ReconciliationConfig, RpcPollingConfig, StorageType,
@@ -70,6 +72,8 @@ struct YellowstoneSection {
     endpoint: Option<String>,
     commitment: String,
     x_token: Option<String>,
+    #[serde(default = "default_safety_window")]
+    safety_window_slots: u64,
 }
 
 #[derive(Deserialize)]
@@ -272,6 +276,7 @@ async fn run_indexer(figment: Figment, verbose: bool) -> Result<(), Box<dyn std:
                 endpoint,
                 x_token: token,
                 commitment: ys.commitment,
+                safety_window_slots: ys.safety_window_slots,
             };
 
             // Parse RPC polling config if provided (needed for backfill)

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -98,6 +98,17 @@ pub struct YellowstoneConfig {
     pub x_token: Option<String>,
     /// Commitment level: "processed", "confirmed", or "finalized"
     pub commitment: String,
+    /// Slots to hold a live SlotComplete behind the highest BlockMeta seen, so a late tx still lands
+    /// before finalize. Live gRPC stream only; getBlock backfill/gap-fill never delayed. `0` = immediate.
+    #[serde(default = "default_safety_window")]
+    pub safety_window_slots: u64,
+}
+
+/// Default live SlotComplete lag in slots (~1.2s at ~2.5 slots/s); a conservative reorder margin.
+pub const DEFAULT_SLOT_SAFETY_WINDOW: u64 = 3;
+
+pub fn default_safety_window() -> u64 {
+    DEFAULT_SLOT_SAFETY_WINDOW
 }
 
 /// Backfill configuration
@@ -459,6 +470,36 @@ mod tests {
             let err_msg = result.unwrap_err();
             assert!(err_msg.contains("Yellowstone datasource not compiled"));
         }
+    }
+
+    #[test]
+    fn yellowstone_safety_window_defaults_when_absent() {
+        // The key is optional; an existing config without it must keep parsing.
+        let cfg: YellowstoneConfig = serde_json::from_value(serde_json::json!({
+            "endpoint": "http://localhost:10000",
+            "x_token": null,
+            "commitment": "confirmed"
+        }))
+        .unwrap();
+        assert_eq!(cfg.safety_window_slots, DEFAULT_SLOT_SAFETY_WINDOW);
+    }
+
+    #[test]
+    fn yellowstone_safety_window_explicit_value_honored() {
+        let cfg: YellowstoneConfig = serde_json::from_value(serde_json::json!({
+            "endpoint": "http://localhost:10000",
+            "x_token": null,
+            "commitment": "confirmed",
+            "safety_window_slots": 7
+        }))
+        .unwrap();
+        assert_eq!(cfg.safety_window_slots, 7);
+    }
+
+    #[test]
+    fn safety_window_default_constant_is_pinned() {
+        // A change to the default is a conscious edit, not an accident.
+        assert_eq!(DEFAULT_SLOT_SAFETY_WINDOW, 3);
     }
 
     #[test]

--- a/indexer/src/indexer/datasource/yellowstone/completion_window.rs
+++ b/indexer/src/indexer/datasource/yellowstone/completion_window.rs
@@ -10,8 +10,6 @@ pub(crate) struct SlotCompletionWindow {
     high_meta: u64,
     // Observed-but-not-yet-released slots, ordered so they release ascending.
     pending: BTreeSet<u64>,
-    // Highest slot already released, so a duplicate/late BlockMeta never re-emits it.
-    last_emitted: Option<u64>,
 }
 
 impl SlotCompletionWindow {
@@ -20,27 +18,22 @@ impl SlotCompletionWindow {
             window,
             high_meta: 0,
             pending: BTreeSet::new(),
-            last_emitted: None,
         }
     }
 
     /// Record a BlockMeta for `slot` and return the slots now eligible for
-    /// SlotComplete, ascending. `window == 0` returns `slot` immediately,
-    /// except a slot already released is never repeated.
+    /// SlotComplete, ascending. Every slot is released once it falls `window`
+    /// behind the tip; a slot re-observed after release re-emits an idempotent
+    /// SlotComplete rather than being dropped, so none is ever stranded.
     pub(crate) fn observe(&mut self, slot: u64) -> Vec<u64> {
         self.high_meta = self.high_meta.max(slot);
-
-        // At or below the release frontier means already finalized (duplicate/reorder); never re-queue.
-        if self.last_emitted.is_none_or(|emitted| slot > emitted) {
-            self.pending.insert(slot);
-        }
+        self.pending.insert(slot);
 
         let threshold = self.high_meta.saturating_sub(self.window);
         let mut ready = Vec::new();
         while let Some(&s) = self.pending.first() {
             if s <= threshold {
                 self.pending.pop_first();
-                self.last_emitted = Some(s);
                 ready.push(s);
             } else {
                 break;
@@ -90,11 +83,12 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_meta_emits_once() {
-        let mut w = SlotCompletionWindow::new(0);
-        assert_eq!(w.observe(4), vec![4]);
-        // A repeated BlockMeta for the same slot must not re-finalize it.
-        assert_eq!(w.observe(4), Vec::<u64>::new());
+    fn duplicate_meta_while_pending_dedups() {
+        // A BlockMeta redelivered while its slot is still held releases the slot once.
+        let mut w = SlotCompletionWindow::new(2);
+        assert!(w.observe(4).is_empty());
+        assert!(w.observe(4).is_empty());
+        assert_eq!(w.observe(6), vec![4]);
     }
 
     #[test]
@@ -110,11 +104,13 @@ mod tests {
     }
 
     #[test]
-    fn emits_strictly_ascending() {
+    fn every_observed_slot_is_eventually_emitted() {
+        // A lower slot arriving after higher ones were already released must still
+        // be emitted, not dropped; its buffered transactions depend on it.
         let mut w = SlotCompletionWindow::new(2);
-        let sequence = [7u64, 5, 6, 9, 8, 12, 4, 20];
+        let observed = [7u64, 5, 6, 9, 8, 12, 4, 20];
         let mut all = Vec::new();
-        for slot in sequence {
+        for slot in observed {
             let ready = w.observe(slot);
             // Each individual return is itself ascending.
             let mut sorted = ready.clone();
@@ -122,10 +118,24 @@ mod tests {
             assert_eq!(ready, sorted, "each return must be ascending");
             all.extend(ready);
         }
-        // The global emission order is strictly ascending (frontier-friendly, no
-        // slot released twice, none out of order).
-        for pair in all.windows(2) {
-            assert!(pair[0] < pair[1], "global order must be strictly ascending");
-        }
+        all.sort_unstable();
+
+        // No slot is released more than once.
+        let mut deduped = all.clone();
+        deduped.dedup();
+        assert_eq!(all, deduped, "no slot released twice");
+
+        // Every slot at least `window` behind the highest observed is released.
+        let high = *observed.iter().max().unwrap();
+        let mut expected: Vec<u64> = observed
+            .iter()
+            .copied()
+            .filter(|s| *s <= high - 2)
+            .collect();
+        expected.sort_unstable();
+        assert_eq!(
+            all, expected,
+            "every eligible observed slot is emitted exactly once"
+        );
     }
 }

--- a/indexer/src/indexer/datasource/yellowstone/completion_window.rs
+++ b/indexer/src/indexer/datasource/yellowstone/completion_window.rs
@@ -1,0 +1,131 @@
+use std::collections::BTreeSet;
+
+/// Holds back live SlotComplete emission until a slot is `window` slots behind the
+/// highest BlockMeta seen, so a transaction update Yellowstone delivers after
+/// BlockMeta(S) still lands in slot S's buffer before S is finalized.
+pub(crate) struct SlotCompletionWindow {
+    // Slots a completion is held behind the tip; 0 emits immediately.
+    window: u64,
+    // Highest BlockMeta slot seen, used as the release clock.
+    high_meta: u64,
+    // Observed-but-not-yet-released slots, ordered so they release ascending.
+    pending: BTreeSet<u64>,
+    // Highest slot already released, so a duplicate/late BlockMeta never re-emits it.
+    last_emitted: Option<u64>,
+}
+
+impl SlotCompletionWindow {
+    pub(crate) fn new(window: u64) -> Self {
+        Self {
+            window,
+            high_meta: 0,
+            pending: BTreeSet::new(),
+            last_emitted: None,
+        }
+    }
+
+    /// Record a BlockMeta for `slot` and return the slots now eligible for
+    /// SlotComplete, ascending. `window == 0` returns `slot` immediately,
+    /// except a slot already released is never repeated.
+    pub(crate) fn observe(&mut self, slot: u64) -> Vec<u64> {
+        self.high_meta = self.high_meta.max(slot);
+
+        // At or below the release frontier means already finalized (duplicate/reorder); never re-queue.
+        if self.last_emitted.is_none_or(|emitted| slot > emitted) {
+            self.pending.insert(slot);
+        }
+
+        let threshold = self.high_meta.saturating_sub(self.window);
+        let mut ready = Vec::new();
+        while let Some(&s) = self.pending.first() {
+            if s <= threshold {
+                self.pending.pop_first();
+                self.last_emitted = Some(s);
+                ready.push(s);
+            } else {
+                break;
+            }
+        }
+        ready
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_zero_is_passthrough() {
+        let mut w = SlotCompletionWindow::new(0);
+        assert_eq!(w.observe(1), vec![1]);
+        assert_eq!(w.observe(2), vec![2]);
+        assert_eq!(w.observe(3), vec![3]);
+    }
+
+    #[test]
+    fn lags_by_window() {
+        let mut w = SlotCompletionWindow::new(3);
+        assert_eq!(w.observe(1), Vec::<u64>::new());
+        assert_eq!(w.observe(2), Vec::<u64>::new());
+        assert_eq!(w.observe(3), Vec::<u64>::new());
+        assert_eq!(w.observe(4), vec![1]);
+        assert_eq!(w.observe(5), vec![2]);
+    }
+
+    #[test]
+    fn startup_holds_until_high_ge_window() {
+        let mut w = SlotCompletionWindow::new(5);
+        assert_eq!(w.observe(1), Vec::<u64>::new());
+        assert_eq!(w.observe(2), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn out_of_order_meta() {
+        let mut w = SlotCompletionWindow::new(1);
+        // The higher slot arrives first and is held (it is the tip).
+        assert_eq!(w.observe(5), Vec::<u64>::new());
+        // The lower slot arrives late; it is now far enough behind to release,
+        // but the tip (5) stays pending.
+        assert_eq!(w.observe(3), vec![3]);
+    }
+
+    #[test]
+    fn duplicate_meta_emits_once() {
+        let mut w = SlotCompletionWindow::new(0);
+        assert_eq!(w.observe(4), vec![4]);
+        // A repeated BlockMeta for the same slot must not re-finalize it.
+        assert_eq!(w.observe(4), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn skipped_slots_flush_in_order() {
+        let mut w = SlotCompletionWindow::new(2);
+        let mut emitted = Vec::new();
+        for slot in [1u64, 2, 3, 10] {
+            emitted.extend(w.observe(slot));
+        }
+        // Slot 10 lifts the threshold to 8, flushing every earlier observed slot
+        // in ascending order. The absent slots (4..=9) never appear.
+        assert_eq!(emitted, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn emits_strictly_ascending() {
+        let mut w = SlotCompletionWindow::new(2);
+        let sequence = [7u64, 5, 6, 9, 8, 12, 4, 20];
+        let mut all = Vec::new();
+        for slot in sequence {
+            let ready = w.observe(slot);
+            // Each individual return is itself ascending.
+            let mut sorted = ready.clone();
+            sorted.sort_unstable();
+            assert_eq!(ready, sorted, "each return must be ascending");
+            all.extend(ready);
+        }
+        // The global emission order is strictly ascending (frontier-friendly, no
+        // slot released twice, none out of order).
+        for pair in all.windows(2) {
+            assert!(pair[0] < pair[1], "global order must be strictly ascending");
+        }
+    }
+}

--- a/indexer/src/indexer/datasource/yellowstone/mod.rs
+++ b/indexer/src/indexer/datasource/yellowstone/mod.rs
@@ -1,4 +1,6 @@
 mod convert;
+// Crate-visible so the end-to-end reordering test can drive the same window as the live source.
+pub(crate) mod completion_window;
 pub mod source;
 
 pub use source::YellowstoneSource;

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -1,4 +1,6 @@
+use super::completion_window::SlotCompletionWindow;
 use super::convert::create_message;
+use crate::config::DEFAULT_SLOT_SAFETY_WINDOW;
 use crate::metrics;
 use async_trait::async_trait;
 use futures::stream::StreamExt;
@@ -39,6 +41,8 @@ pub struct YellowstoneSource {
     commitment: String,
     program_type: ProgramType,
     escrow_instance_id: Option<Pubkey>,
+    // Slots to hold a live SlotComplete behind the tip so a late tx still lands before finalize.
+    safety_window: u64,
     #[cfg(feature = "datasource-rpc")]
     rpc_poller: Option<Arc<RpcPoller>>,
     #[cfg(feature = "datasource-rpc")]
@@ -64,6 +68,7 @@ impl YellowstoneSource {
             commitment,
             program_type,
             escrow_instance_id,
+            safety_window: DEFAULT_SLOT_SAFETY_WINDOW,
             #[cfg(feature = "datasource-rpc")]
             rpc_poller: None,
             #[cfg(feature = "datasource-rpc")]
@@ -78,6 +83,12 @@ impl YellowstoneSource {
 
     pub fn with_health(mut self, health: Arc<private_channel_metrics::HealthState>) -> Self {
         self.health = Some(health);
+        self
+    }
+
+    /// Slots to lag live SlotComplete behind the tip; `0` restores immediate emission.
+    pub fn with_safety_window(mut self, window: u64) -> Self {
+        self.safety_window = window;
         self
     }
 
@@ -181,6 +192,7 @@ impl DataSource for YellowstoneSource {
         let x_token = self.x_token.clone();
         let program_type = self.program_type;
         let escrow_instance_id = self.escrow_instance_id;
+        let safety_window = self.safety_window;
         let health = self.health.clone();
 
         #[cfg(feature = "datasource-rpc")]
@@ -205,6 +217,7 @@ impl DataSource for YellowstoneSource {
                     commitment_level,
                     program_type,
                     escrow_instance_id,
+                    safety_window,
                     tx.clone(),
                     cancellation_token.clone(),
                     health.as_ref(),
@@ -317,6 +330,7 @@ async fn connect_and_stream(
     commitment: CommitmentLevel,
     program_type: ProgramType,
     escrow_instance_id: Option<Pubkey>,
+    safety_window: u64,
     tx: InstructionSender,
     cancellation_token: CancellationToken,
     health: Option<&Arc<private_channel_metrics::HealthState>>,
@@ -397,7 +411,11 @@ async fn connect_and_stream(
             reason: e.to_string(),
         })?;
 
-    loop {
+    // Only the live push stream is delayed: BlockMeta(S) can arrive before a late tx for S, so we
+    // finalize a few slots behind the tip. Authoritative getBlock backfill/gap-fill are never delayed.
+    let mut completion_window = SlotCompletionWindow::new(safety_window);
+
+    'stream: loop {
         tokio::select! {
             _ = cancellation_token.cancelled() => {
                 info!("Yellowstone stream cancelled, closing connection...");
@@ -433,21 +451,20 @@ async fn connect_and_stream(
                     }
                     debug!("Yellowstone BlockMeta for slot {}", block_meta.slot);
 
-                    let res = send_guaranteed(
-                        &tx,
-                        ProcessorMessage::SlotComplete {
-                            slot: block_meta.slot,
-                            program_type,
-                        },
-                        "SlotComplete (yellowstone)",
-                    )
-                    .await;
-                    if let Err(e) = res {
-                        error!(
-                            "SlotComplete send failed, stopping Yellowstone gracefully: {}",
-                            e
-                        );
-                        break;
+                    for slot in completion_window.observe(block_meta.slot) {
+                        let res = send_guaranteed(
+                            &tx,
+                            ProcessorMessage::SlotComplete { slot, program_type },
+                            "SlotComplete (yellowstone)",
+                        )
+                        .await;
+                        if let Err(e) = res {
+                            error!(
+                                "SlotComplete send failed, stopping Yellowstone gracefully: {}",
+                                e
+                            );
+                            break 'stream;
+                        }
                     }
                 }
                 Some(UpdateOneof::Ping(_)) => {

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -258,7 +258,8 @@ pub async fn run(
                 yellowstone_config.commitment.clone(),
                 common_config.program_type,
                 common_config.escrow_instance_id,
-            );
+            )
+            .with_safety_window(yellowstone_config.safety_window_slots);
 
             #[cfg(feature = "datasource-rpc")]
             let source = {

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -1685,4 +1685,139 @@ mod tests {
         let inserted = mock.inserted_transactions.lock().unwrap();
         assert!(inserted.iter().flatten().all(|t| t.slot != N1 as i64));
     }
+
+    // Live safety-window end-to-end tests: the reordering race through the real processor + window + MockStorage.
+
+    /// With a non-zero window, a transaction Yellowstone delivers AFTER
+    /// BlockMeta(S) still lands in slot S before S is finalized, so the row is
+    /// persisted. This is the reordering bug the window fixes.
+    #[cfg(feature = "datasource-yellowstone")]
+    #[tokio::test]
+    async fn late_tx_included_with_window() {
+        use crate::indexer::datasource::yellowstone::completion_window::SlotCompletionWindow;
+        const S: u64 = 500;
+        const WINDOW: u64 = 1;
+
+        let (processor, _checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let mut window = SlotCompletionWindow::new(WINDOW);
+
+        // BlockMeta(S): the window holds S back, so no SlotComplete is emitted.
+        assert!(window.observe(S).is_empty());
+        // The late transaction for S arrives after its BlockMeta and is buffered.
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            S,
+            Some("late".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        // The tip advances; S is now WINDOW behind and releases, finalizing the buffered late tx.
+        for meta in (S + 1)..=(S + WINDOW) {
+            for slot in window.observe(meta) {
+                tx.send(ProcessorMessage::SlotComplete {
+                    slot,
+                    program_type: ProgramType::Escrow,
+                })
+                .await
+                .unwrap();
+            }
+        }
+        drop(tx);
+        processor.start(rx).await.unwrap();
+
+        let inserted = mock.inserted_transactions.lock().unwrap();
+        assert_eq!(
+            inserted.len(),
+            1,
+            "the late tx must be finalized into slot S"
+        );
+        assert_eq!(inserted[0][0].signature, "late");
+        assert_eq!(inserted[0][0].slot, S as i64);
+    }
+
+    /// Window 0 reproduces the original bug: BlockMeta(S) finalizes S immediately,
+    /// so a transaction that arrives afterward lands in an orphaned buffer that is
+    /// never finalized. This is the oracle proving the harness exercises the race.
+    #[cfg(feature = "datasource-yellowstone")]
+    #[tokio::test]
+    async fn late_tx_lost_with_window_zero() {
+        use crate::indexer::datasource::yellowstone::completion_window::SlotCompletionWindow;
+        const S: u64 = 600;
+
+        let (processor, _checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let mut window = SlotCompletionWindow::new(0);
+
+        // BlockMeta(S) finalizes S at once, before the late tx exists.
+        for slot in window.observe(S) {
+            tx.send(ProcessorMessage::SlotComplete {
+                slot,
+                program_type: ProgramType::Escrow,
+            })
+            .await
+            .unwrap();
+        }
+        // The late tx lands in a fresh buffer that no later SlotComplete drains.
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            S,
+            Some("late-lost".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        drop(tx);
+        processor.start(rx).await.unwrap();
+
+        assert!(
+            mock.inserted_transactions.lock().unwrap().is_empty(),
+            "row must be absent: the pre-window bug loses the late tx at window 0"
+        );
+    }
+
+    /// Empty (activity-free) slots still checkpoint under the window, just lagged:
+    /// the frontier advances across every observed slot once it is WINDOW behind
+    /// the tip.
+    #[cfg(feature = "datasource-yellowstone")]
+    #[tokio::test]
+    async fn empty_slots_still_checkpoint() {
+        use crate::indexer::datasource::yellowstone::completion_window::SlotCompletionWindow;
+        const WINDOW: u64 = 3;
+        const N: u64 = 8;
+
+        let (processor, mut checkpoint_rx, _mock) = make_processor_with_mock(deposit_instance());
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        let mut window = SlotCompletionWindow::new(WINDOW);
+
+        let mut emitted = Vec::new();
+        for meta in 1..=N {
+            for slot in window.observe(meta) {
+                emitted.push(slot);
+                tx.send(ProcessorMessage::SlotComplete {
+                    slot,
+                    program_type: ProgramType::Escrow,
+                })
+                .await
+                .unwrap();
+            }
+        }
+        drop(tx);
+        processor.start(rx).await.unwrap();
+
+        let mut checkpointed = Vec::new();
+        while let Ok(cp) = checkpoint_rx.try_recv() {
+            checkpointed.push(cp.slot);
+        }
+
+        // The window lags finalization by WINDOW, so slots 1..=(N-WINDOW) release.
+        let expected: Vec<u64> = (1..=(N - WINDOW)).collect();
+        assert_eq!(
+            emitted, expected,
+            "eligible slots are those WINDOW behind the tip"
+        );
+        assert_eq!(
+            checkpointed, expected,
+            "each eligible empty slot checkpoints"
+        );
+    }
 }

--- a/integration/tests/indexer/malformed_yellowstone_update.rs
+++ b/integration/tests/indexer/malformed_yellowstone_update.rs
@@ -208,7 +208,9 @@ async fn spin_up() -> TestHarness {
         "confirmed".to_string(),
         ProgramType::Escrow,
         None,
-    );
+    )
+    // Pin immediate emission: malformed-update handling is independent of the safety window.
+    .with_safety_window(0);
     let handle = source
         .start(tx, cancel.clone())
         .await

--- a/integration/tests/indexer/yellowstone_inner_and_unknown.rs
+++ b/integration/tests/indexer/yellowstone_inner_and_unknown.rs
@@ -242,7 +242,9 @@ async fn yellowstone_handles_inner_instructions_and_unknown_discriminator() {
         "confirmed".to_string(),
         ProgramType::Escrow,
         None,
-    );
+    )
+    // Pin immediate emission: this asserts raw stream ordering, not the safety-window lag.
+    .with_safety_window(0);
     let handle = source
         .start(tx, cancel.clone())
         .await

--- a/integration/tests/indexer/yellowstone_reconnect_gap.rs
+++ b/integration/tests/indexer/yellowstone_reconnect_gap.rs
@@ -115,6 +115,8 @@ async fn gap_fill_runs_after_drop_stream() {
         ProgramType::Escrow,
         None,
     )
+    // Pin immediate emission so the live checkpoint reaches the streamed slots and the gap math stays exact.
+    .with_safety_window(0)
     .with_gap_detection(rpc_poller, 1_000, 16)
     .with_storage(storage);
 
@@ -231,6 +233,8 @@ async fn fresh_system_reconnect_does_not_gap_fill() {
         ProgramType::Escrow,
         None,
     )
+    // Pin immediate emission so the live checkpoint reaches the streamed slots and the gap math stays exact.
+    .with_safety_window(0)
     .with_gap_detection(rpc_poller, 1_000, 16)
     .with_storage(storage);
 

--- a/integration/tests/indexer/yellowstone_wiring.rs
+++ b/integration/tests/indexer/yellowstone_wiring.rs
@@ -168,7 +168,9 @@ async fn yellowstone_source_consumes_scripted_stream() {
         "confirmed".to_string(),
         ProgramType::Escrow,
         None,
-    );
+    )
+    // Pin immediate emission: this covers raw stream wiring, not the safety-window lag.
+    .with_safety_window(0);
 
     let handle = source
         .start(tx, cancel.clone())

--- a/test_utils/src/indexer_helper.rs
+++ b/test_utils/src/indexer_helper.rs
@@ -1,5 +1,6 @@
 use {
     private_channel_indexer::{
+        config::DEFAULT_SLOT_SAFETY_WINDOW,
         storage::{PostgresDb, Storage},
         BackfillConfig, DatasourceType, IndexerConfig, PostgresConfig, PrivateChannelIndexerConfig,
         ProgramType, RpcPollingConfig, StorageType, YellowstoneConfig,
@@ -54,6 +55,7 @@ pub async fn start_private_channel_indexer(
                 endpoint,
                 x_token: None,
                 commitment: "finalized".to_string(),
+                safety_window_slots: DEFAULT_SLOT_SAFETY_WINDOW,
             }),
         )
     } else {
@@ -207,6 +209,7 @@ pub async fn start_solana_indexer(
         endpoint: geyser_endpoint,
         x_token: None,
         commitment: "finalized".to_string(),
+        safety_window_slots: DEFAULT_SLOT_SAFETY_WINDOW,
     };
 
     let rpc_polling_config = RpcPollingConfig {


### PR DESCRIPTION
## Summary

Closes issue 22. This PR mitigates a race in the live Yellowstone datasource where `BlockMeta` could arrive before all transaction updates for the same slot, causing the processor to finalize the slot too early and silently drop late transactions. Instead of immediately emitting `SlotComplete`, the live stream now delays finalization until a slot is a configurable number of slots behind the highest observed `BlockMeta`, giving late transactions time to arrive. The change is isolated to the live Yellowstone producer; backfill and reconnect paths remain unchanged.

The implementation introduces a small `SlotCompletionWindow` that determines when a slot is safe to finalize. The delay is measured in slot distance rather than wall-clock time, with a default safety window of 3 slots (~1.2s), and can be disabled by setting the window to 0.

The change is covered by comprehensive unit, configuration, and end-to-end tests.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28599266487) |
| Indexer | 23,963 | 27,144 | 88.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28599266487) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28599266487) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28599266487) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,047 | 15,235 | 79.1% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28599266487) |
| **Total** | **49,316** | **57,597** | **85.6%** | |

> Last updated: 2026-07-02 15:20:36 UTC by E2E Integration