### PR TITLE
fix(indexer): gate Solana-facing commitment paths on finalized

### DIFF
--- a/indexer/config/example-indexer.toml
+++ b/indexer/config/example-indexer.toml
@@ -48,15 +48,20 @@ batch_size = 50
 # The polling loop's missing-metadata failover reads common.fallback_rpc_url (see
 # [common] above); it must be archival. Backfill/resync ignore it and fail closed.
 
+# Ingestion commitment. MUST be "finalized" (enforced at startup); defaults to "finalized"
+# when omitted. Indexing is the value-finalizing source of truth, so a forkable commitment
+# is rejected.
+# commitment = "finalized"
+
 # === Yellowstone gRPC Configuration ===
 [indexer.yellowstone]
 # Yellowstone gRPC endpoint URL
 # endpoint = "grpc://your-yellowstone-endpoint:10000"
 
-# Commitment level: "processed", "confirmed", or "finalized".
-# Keep "finalized" for escrow ingestion: deposits become irreversible
-# private-channel mints, so a "confirmed" deposit lost to a Solana reorg would
-# produce an unbacked mint with no rollback path.
+# Commitment level. MUST be "finalized" (enforced at startup - a sub-finalized value is
+# rejected). Deposits become irreversible private-channel mints, so a "confirmed" deposit
+# lost to a Solana reorg would produce an unbacked mint with no rollback path. Omitting
+# this key defaults to "finalized". The gap-detection poller inherits this value.
 commitment = "finalized"
 
 # Token must be set via environment variable: INDEXER_YELLOWSTONE_TOKEN

--- a/indexer/config/example-indexer.toml
+++ b/indexer/config/example-indexer.toml
@@ -48,21 +48,10 @@ batch_size = 50
 # The polling loop's missing-metadata failover reads common.fallback_rpc_url (see
 # [common] above); it must be archival. Backfill/resync ignore it and fail closed.
 
-# Ingestion commitment. MUST be "finalized" (enforced at startup); defaults to "finalized"
-# when omitted. Indexing is the value-finalizing source of truth, so a forkable commitment
-# is rejected.
-# commitment = "finalized"
-
 # === Yellowstone gRPC Configuration ===
 [indexer.yellowstone]
 # Yellowstone gRPC endpoint URL
 # endpoint = "grpc://your-yellowstone-endpoint:10000"
-
-# Commitment level. MUST be "finalized" (enforced at startup - a sub-finalized value is
-# rejected). Deposits become irreversible private-channel mints, so a "confirmed" deposit
-# lost to a Solana reorg would produce an unbacked mint with no rollback path. Omitting
-# this key defaults to "finalized". The gap-detection poller inherits this value.
-commitment = "finalized"
 
 # Token must be set via environment variable: INDEXER_YELLOWSTONE_TOKEN
 # Example: export INDEXER_YELLOWSTONE_TOKEN="your-token"

--- a/indexer/config/example-operator.toml
+++ b/indexer/config/example-operator.toml
@@ -42,6 +42,12 @@ retry_base_delay_secs = 1
 # Channel buffer size for internal queues
 channel_buffer_size = 100
 
+# Operational RPC commitment for blockhash fetch and preflight ONLY. It does not gate
+# settlement: terminal Completed/FailedReminted writes and the recovery reconcile always
+# use a hardcoded `finalized` gate regardless of this value. "confirmed" (default) or
+# "finalized" are accepted; "processed" is rejected at startup as too weak.
+# rpc_commitment = "confirmed"
+
 # === Signer Configuration (via Environment Variables) ===
 #
 # Required for all operators:

--- a/indexer/config/local/indexer-solana.toml
+++ b/indexer/config/local/indexer-solana.toml
@@ -23,9 +23,6 @@ datasource_type = "yellowstone"
 
 [indexer.yellowstone]
 endpoint = "http://localhost:10000"
-# Must stay "finalized": deposits become irreversible private-channel mints, so
-# ingesting at "confirmed" would let a Solana reorg produce an unbacked mint.
-commitment = "finalized"
 
 [indexer.rpc_polling]
 poll_interval_ms = 1000

--- a/indexer/src/bin/indexer.rs
+++ b/indexer/src/bin/indexer.rs
@@ -4,7 +4,8 @@ use figment::{
     Figment,
 };
 use private_channel_indexer::config::{
-    default_safety_window, DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
+    default_safety_window, floor_operator_commitment, parse_indexing_commitment_str,
+    require_finalized_indexing, DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
 };
 use private_channel_indexer::{
     BackfillConfig, DatasourceType, IndexerConfig, OperatorConfig, PostgresConfig,
@@ -70,7 +71,8 @@ struct RpcPollingSection {
 #[derive(Deserialize)]
 struct YellowstoneSection {
     endpoint: Option<String>,
-    commitment: String,
+    #[serde(default)]
+    commitment: Option<String>,
     x_token: Option<String>,
     #[serde(default = "default_safety_window")]
     safety_window_slots: u64,
@@ -261,7 +263,9 @@ async fn run_indexer(figment: Figment, verbose: bool) -> Result<(), Box<dyn std:
                 batch_size: rpc.batch_size,
                 from_slot: rpc.start_slot,
                 encoding: rpc.encoding.unwrap_or(UiTransactionEncoding::Json),
-                commitment: rpc.commitment.unwrap_or(CommitmentLevel::Finalized),
+                commitment: require_finalized_indexing(
+                    rpc.commitment.unwrap_or(CommitmentLevel::Finalized),
+                )?,
             };
             (Some(config), None)
         }
@@ -281,19 +285,28 @@ async fn run_indexer(figment: Figment, verbose: bool) -> Result<(), Box<dyn std:
             let config = YellowstoneConfig {
                 endpoint,
                 x_token: token,
-                commitment: ys.commitment,
+                // Default and floor the primary stream to finalized; the gap poller below
+                // inherits this validated value.
+                commitment: parse_indexing_commitment_str(ys.commitment)?,
                 safety_window_slots: ys.safety_window_slots,
             };
 
             // Parse RPC polling config if provided (needed for backfill)
-            let rpc_config = indexer.rpc_polling.map(|rpc| RpcPollingConfig {
-                poll_interval_ms: rpc.poll_interval_ms,
-                error_retry_interval_ms: rpc.error_retry_interval_ms,
-                batch_size: rpc.batch_size,
-                from_slot: rpc.start_slot,
-                encoding: rpc.encoding.unwrap_or(UiTransactionEncoding::Json),
-                commitment: rpc.commitment.unwrap_or(CommitmentLevel::Finalized),
-            });
+            let rpc_config = indexer
+                .rpc_polling
+                .map(|rpc| {
+                    Ok::<_, String>(RpcPollingConfig {
+                        poll_interval_ms: rpc.poll_interval_ms,
+                        error_retry_interval_ms: rpc.error_retry_interval_ms,
+                        batch_size: rpc.batch_size,
+                        from_slot: rpc.start_slot,
+                        encoding: rpc.encoding.unwrap_or(UiTransactionEncoding::Json),
+                        commitment: require_finalized_indexing(
+                            rpc.commitment.unwrap_or(CommitmentLevel::Finalized),
+                        )?,
+                    })
+                })
+                .transpose()?;
 
             (rpc_config, Some(config))
         }
@@ -425,9 +438,11 @@ async fn run_operator(figment: Figment, verbose: bool) -> Result<(), Box<dyn std
         retry_max_attempts: operator.retry_max_attempts,
         retry_base_delay: Duration::from_secs(operator.retry_base_delay_secs),
         channel_buffer_size: operator.channel_buffer_size,
-        rpc_commitment: operator
-            .rpc_commitment
-            .unwrap_or(CommitmentLevel::Confirmed),
+        rpc_commitment: floor_operator_commitment(
+            operator
+                .rpc_commitment
+                .unwrap_or(CommitmentLevel::Confirmed),
+        )?,
         alert_webhook_url: std::env::var("ALERT_WEBHOOK_URL").ok(),
         reconciliation_interval: Duration::from_secs(operator.reconciliation_interval_secs),
         reconciliation_tolerance_bps: operator.reconciliation_tolerance_bps,
@@ -491,11 +506,13 @@ async fn run_resync(
         .as_ref()
         .and_then(|rpc| rpc.encoding)
         .unwrap_or(UiTransactionEncoding::Json);
-    let rpc_commitment = indexer
-        .rpc_polling
-        .as_ref()
-        .and_then(|rpc| rpc.commitment)
-        .unwrap_or(CommitmentLevel::Finalized);
+    let rpc_commitment = require_finalized_indexing(
+        indexer
+            .rpc_polling
+            .as_ref()
+            .and_then(|rpc| rpc.commitment)
+            .unwrap_or(CommitmentLevel::Finalized),
+    )?;
 
     let rpc_poller = Arc::new(
         private_channel_indexer::indexer::datasource::rpc_polling::rpc::RpcPoller::new(

--- a/indexer/src/bin/indexer.rs
+++ b/indexer/src/bin/indexer.rs
@@ -4,8 +4,7 @@ use figment::{
     Figment,
 };
 use private_channel_indexer::config::{
-    default_safety_window, floor_operator_commitment, parse_indexing_commitment_str,
-    require_finalized_indexing, DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
+    default_safety_window, floor_operator_commitment, DEFAULT_CONFIRMATION_POLL_INTERVAL_MS,
 };
 use private_channel_indexer::{
     BackfillConfig, DatasourceType, IndexerConfig, OperatorConfig, PostgresConfig,
@@ -64,15 +63,11 @@ struct RpcPollingSection {
     batch_size: usize,
     #[serde(default)]
     encoding: Option<UiTransactionEncoding>,
-    #[serde(default)]
-    commitment: Option<CommitmentLevel>,
 }
 
 #[derive(Deserialize)]
 struct YellowstoneSection {
     endpoint: Option<String>,
-    #[serde(default)]
-    commitment: Option<String>,
     x_token: Option<String>,
     #[serde(default = "default_safety_window")]
     safety_window_slots: u64,
@@ -263,9 +258,9 @@ async fn run_indexer(figment: Figment, verbose: bool) -> Result<(), Box<dyn std:
                 batch_size: rpc.batch_size,
                 from_slot: rpc.start_slot,
                 encoding: rpc.encoding.unwrap_or(UiTransactionEncoding::Json),
-                commitment: require_finalized_indexing(
-                    rpc.commitment.unwrap_or(CommitmentLevel::Finalized),
-                )?,
+                // Ingestion is the value-finalizing source of truth; fixed at finalized,
+                // so a forked block can never be indexed into an unbacked mint.
+                commitment: CommitmentLevel::Finalized,
             };
             (Some(config), None)
         }
@@ -285,28 +280,20 @@ async fn run_indexer(figment: Figment, verbose: bool) -> Result<(), Box<dyn std:
             let config = YellowstoneConfig {
                 endpoint,
                 x_token: token,
-                // Default and floor the primary stream to finalized; the gap poller below
-                // inherits this validated value.
-                commitment: parse_indexing_commitment_str(ys.commitment)?,
+                // Fixed at finalized; the gap poller below inherits it.
+                commitment: "finalized".to_string(),
                 safety_window_slots: ys.safety_window_slots,
             };
 
             // Parse RPC polling config if provided (needed for backfill)
-            let rpc_config = indexer
-                .rpc_polling
-                .map(|rpc| {
-                    Ok::<_, String>(RpcPollingConfig {
-                        poll_interval_ms: rpc.poll_interval_ms,
-                        error_retry_interval_ms: rpc.error_retry_interval_ms,
-                        batch_size: rpc.batch_size,
-                        from_slot: rpc.start_slot,
-                        encoding: rpc.encoding.unwrap_or(UiTransactionEncoding::Json),
-                        commitment: require_finalized_indexing(
-                            rpc.commitment.unwrap_or(CommitmentLevel::Finalized),
-                        )?,
-                    })
-                })
-                .transpose()?;
+            let rpc_config = indexer.rpc_polling.map(|rpc| RpcPollingConfig {
+                poll_interval_ms: rpc.poll_interval_ms,
+                error_retry_interval_ms: rpc.error_retry_interval_ms,
+                batch_size: rpc.batch_size,
+                from_slot: rpc.start_slot,
+                encoding: rpc.encoding.unwrap_or(UiTransactionEncoding::Json),
+                commitment: CommitmentLevel::Finalized,
+            });
 
             (rpc_config, Some(config))
         }
@@ -506,13 +493,8 @@ async fn run_resync(
         .as_ref()
         .and_then(|rpc| rpc.encoding)
         .unwrap_or(UiTransactionEncoding::Json);
-    let rpc_commitment = require_finalized_indexing(
-        indexer
-            .rpc_polling
-            .as_ref()
-            .and_then(|rpc| rpc.commitment)
-            .unwrap_or(CommitmentLevel::Finalized),
-    )?;
+    // Resync reads Solana blocks, so it uses the same fixed finalized ingestion commitment.
+    let rpc_commitment = CommitmentLevel::Finalized;
 
     let rpc_poller = Arc::new(
         private_channel_indexer::indexer::datasource::rpc_polling::rpc::RpcPoller::new(

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -81,8 +81,8 @@ pub struct RpcPollingConfig {
     pub batch_size: usize,
     /// RPC encoding format for getBlock calls
     pub encoding: UiTransactionEncoding,
-    /// RPC commitment for block ingestion. Must be `finalized` (floored at startup):
-    /// indexing is the value-finalizing source of truth, so a forkable commitment is rejected.
+    /// RPC commitment for block ingestion. Fixed at `finalized`: indexing is
+    /// the value-finalizing source of truth, so a forkable block must never be indexed.
     pub commitment: CommitmentLevel,
 }
 
@@ -93,8 +93,8 @@ pub struct YellowstoneConfig {
     pub endpoint: String,
     /// Token to use for authentication
     pub x_token: Option<String>,
-    /// Stream commitment. Must be "finalized": indexing is the value-finalizing source of
-    /// truth, so a sub-finalized stream could index a forked block. Validated at startup.
+    /// Stream commitment. Fixed at "finalized": indexing is the
+    /// value-finalizing source of truth, so a sub-finalized stream could index a forked block.
     pub commitment: String,
     /// Slots to hold a live SlotComplete behind the highest BlockMeta seen, so a late tx still lands
     /// before finalize. Live gRPC stream only; getBlock backfill/gap-fill never delayed. `0` = immediate.
@@ -107,35 +107,6 @@ pub const DEFAULT_SLOT_SAFETY_WINDOW: u64 = 3;
 
 pub fn default_safety_window() -> u64 {
     DEFAULT_SLOT_SAFETY_WINDOW
-}
-
-/// Commitment levels below `finalized` are forkable, so the value-finalizing indexing
-/// source of truth requires `finalized`. Returns the level unchanged on success.
-pub fn require_finalized_indexing(level: CommitmentLevel) -> Result<CommitmentLevel, String> {
-    match level {
-        CommitmentLevel::Finalized => Ok(level),
-        other => Err(format!(
-            "indexing requires commitment=finalized, got {:?}; a sub-finalized commitment can \
-             index a forked block and mint against a deposit that never settles",
-            other
-        )),
-    }
-}
-
-/// Parse and floor a string commitment for indexing: unset defaults to `finalized`;
-/// anything below `finalized` is rejected. Used for the Yellowstone stream commitment.
-pub fn parse_indexing_commitment_str(raw: Option<String>) -> Result<String, String> {
-    match raw
-        .unwrap_or_else(|| "finalized".to_string())
-        .to_lowercase()
-        .as_str()
-    {
-        "finalized" => Ok("finalized".to_string()),
-        other => Err(format!(
-            "indexing requires commitment=\"finalized\", got \"{other}\"; a sub-finalized \
-             commitment can index a forked block"
-        )),
-    }
 }
 
 /// Floor the operator's operational RPC commitment. This knob only affects blockhash/preflight
@@ -563,45 +534,10 @@ mod tests {
         }
     }
 
-    // ── commitment-floor validation (C1-C4) ─────────────────────────────
+    // ── operator operational commitment floor ───────────────────────────
 
-    /// C1: a sub-finalized Yellowstone stream commitment is rejected at startup.
-    #[test]
-    fn yellowstone_commitment_rejects_sub_finalized() {
-        for value in ["confirmed", "processed", "CONFIRMED"] {
-            assert!(
-                parse_indexing_commitment_str(Some(value.to_string())).is_err(),
-                "yellowstone commitment {value:?} must be rejected"
-            );
-        }
-    }
-
-    /// C2: an unset Yellowstone commitment defaults to finalized.
-    #[test]
-    fn yellowstone_commitment_defaults_finalized() {
-        assert_eq!(
-            parse_indexing_commitment_str(None).unwrap(),
-            "finalized".to_string()
-        );
-        // Case-insensitive accept of an explicit finalized.
-        assert_eq!(
-            parse_indexing_commitment_str(Some("Finalized".to_string())).unwrap(),
-            "finalized".to_string()
-        );
-    }
-
-    /// C3: RPC-polling ingestion floors to finalized; confirmed/processed are rejected.
-    #[test]
-    fn rpc_polling_commitment_floored_to_finalized() {
-        assert_eq!(
-            require_finalized_indexing(CommitmentLevel::Finalized).unwrap(),
-            CommitmentLevel::Finalized
-        );
-        assert!(require_finalized_indexing(CommitmentLevel::Confirmed).is_err());
-        assert!(require_finalized_indexing(CommitmentLevel::Processed).is_err());
-    }
-
-    /// C4: operator rpc_commitment rejects only `processed`; confirmed/finalized pass.
+    /// Operator rpc_commitment rejects only `processed`; confirmed/finalized pass.
+    /// (Indexing commitment is not configurable, so it has no validation test.)
     #[test]
     fn operator_commitment_rejects_only_processed() {
         assert!(floor_operator_commitment(CommitmentLevel::Processed).is_err());

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -81,7 +81,8 @@ pub struct RpcPollingConfig {
     pub batch_size: usize,
     /// RPC encoding format for getBlock calls
     pub encoding: UiTransactionEncoding,
-    /// RPC commitment level for getSlot calls
+    /// RPC commitment for block ingestion. Must be `finalized` (floored at startup):
+    /// indexing is the value-finalizing source of truth, so a forkable commitment is rejected.
     pub commitment: CommitmentLevel,
 }
 
@@ -92,7 +93,8 @@ pub struct YellowstoneConfig {
     pub endpoint: String,
     /// Token to use for authentication
     pub x_token: Option<String>,
-    /// Commitment level: "processed", "confirmed", or "finalized"
+    /// Stream commitment. Must be "finalized": indexing is the value-finalizing source of
+    /// truth, so a sub-finalized stream could index a forked block. Validated at startup.
     pub commitment: String,
     /// Slots to hold a live SlotComplete behind the highest BlockMeta seen, so a late tx still lands
     /// before finalize. Live gRPC stream only; getBlock backfill/gap-fill never delayed. `0` = immediate.
@@ -105,6 +107,50 @@ pub const DEFAULT_SLOT_SAFETY_WINDOW: u64 = 3;
 
 pub fn default_safety_window() -> u64 {
     DEFAULT_SLOT_SAFETY_WINDOW
+}
+
+/// Commitment levels below `finalized` are forkable, so the value-finalizing indexing
+/// source of truth requires `finalized`. Returns the level unchanged on success.
+pub fn require_finalized_indexing(level: CommitmentLevel) -> Result<CommitmentLevel, String> {
+    match level {
+        CommitmentLevel::Finalized => Ok(level),
+        other => Err(format!(
+            "indexing requires commitment=finalized, got {:?}; a sub-finalized commitment can \
+             index a forked block and mint against a deposit that never settles",
+            other
+        )),
+    }
+}
+
+/// Parse and floor a string commitment for indexing: unset defaults to `finalized`;
+/// anything below `finalized` is rejected. Used for the Yellowstone stream commitment.
+pub fn parse_indexing_commitment_str(raw: Option<String>) -> Result<String, String> {
+    match raw
+        .unwrap_or_else(|| "finalized".to_string())
+        .to_lowercase()
+        .as_str()
+    {
+        "finalized" => Ok("finalized".to_string()),
+        other => Err(format!(
+            "indexing requires commitment=\"finalized\", got \"{other}\"; a sub-finalized \
+             commitment can index a forked block"
+        )),
+    }
+}
+
+/// Floor the operator's operational RPC commitment. This knob only affects blockhash/preflight
+/// lifetime, never a settlement decision, so `confirmed` and `finalized` are both accepted;
+/// only `processed` is rejected as too weak for even operational use.
+pub fn floor_operator_commitment(level: CommitmentLevel) -> Result<CommitmentLevel, String> {
+    match level {
+        CommitmentLevel::Processed => Err(
+            "operator rpc_commitment=processed is too weak; use confirmed or finalized (this knob \
+             sets only the operational blockhash/preflight commitment, not the finalized \
+             settlement gate)"
+                .to_string(),
+        ),
+        other => Ok(other),
+    }
 }
 
 /// Backfill configuration
@@ -270,7 +316,11 @@ pub struct OperatorConfig {
     pub retry_base_delay: std::time::Duration,
     /// Size of channel buffers
     pub channel_buffer_size: usize,
-    /// RPC commitment level for operator transactions
+    /// Operational RPC commitment for the operator's blockhash fetch and preflight only.
+    /// It does NOT gate settlement: the terminal Completed/FailedReminted writes and the
+    /// recovery reconcile always use a hardcoded `finalized` gate regardless of this value.
+    /// `confirmed` is a reasonable default (a finalized blockhash is ~13s stale and shortens
+    /// transaction lifetime for no safety gain); `processed` is rejected as too weak.
     pub rpc_commitment: CommitmentLevel,
     /// Webhook URL for alerting on failed transactions. Set via ALERT_WEBHOOK env var.
     pub alert_webhook_url: Option<String>,
@@ -511,5 +561,57 @@ mod tests {
             let result = config.validate();
             assert!(result.is_ok());
         }
+    }
+
+    // ── commitment-floor validation (C1-C4) ─────────────────────────────
+
+    /// C1: a sub-finalized Yellowstone stream commitment is rejected at startup.
+    #[test]
+    fn yellowstone_commitment_rejects_sub_finalized() {
+        for value in ["confirmed", "processed", "CONFIRMED"] {
+            assert!(
+                parse_indexing_commitment_str(Some(value.to_string())).is_err(),
+                "yellowstone commitment {value:?} must be rejected"
+            );
+        }
+    }
+
+    /// C2: an unset Yellowstone commitment defaults to finalized.
+    #[test]
+    fn yellowstone_commitment_defaults_finalized() {
+        assert_eq!(
+            parse_indexing_commitment_str(None).unwrap(),
+            "finalized".to_string()
+        );
+        // Case-insensitive accept of an explicit finalized.
+        assert_eq!(
+            parse_indexing_commitment_str(Some("Finalized".to_string())).unwrap(),
+            "finalized".to_string()
+        );
+    }
+
+    /// C3: RPC-polling ingestion floors to finalized; confirmed/processed are rejected.
+    #[test]
+    fn rpc_polling_commitment_floored_to_finalized() {
+        assert_eq!(
+            require_finalized_indexing(CommitmentLevel::Finalized).unwrap(),
+            CommitmentLevel::Finalized
+        );
+        assert!(require_finalized_indexing(CommitmentLevel::Confirmed).is_err());
+        assert!(require_finalized_indexing(CommitmentLevel::Processed).is_err());
+    }
+
+    /// C4: operator rpc_commitment rejects only `processed`; confirmed/finalized pass.
+    #[test]
+    fn operator_commitment_rejects_only_processed() {
+        assert!(floor_operator_commitment(CommitmentLevel::Processed).is_err());
+        assert_eq!(
+            floor_operator_commitment(CommitmentLevel::Confirmed).unwrap(),
+            CommitmentLevel::Confirmed
+        );
+        assert_eq!(
+            floor_operator_commitment(CommitmentLevel::Finalized).unwrap(),
+            CommitmentLevel::Finalized
+        );
     }
 }

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -173,11 +173,10 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
         ));
     }
 
-    // Remint lands on PrivateChannel where finalized == confirmed; gate on finalized so a value write never settles on forkable state.
     let result = match check_transaction_status(
         state.source_rpc_client.clone(),
         &signature,
-        CommitmentConfig::finalized(),
+        CommitmentConfig::confirmed(),
         &ExtraErrorCheckPolicy::None,
         state.confirmation_poll_interval_ms,
     )

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -176,7 +176,7 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
     let result = match check_transaction_status(
         state.source_rpc_client.clone(),
         &signature,
-        CommitmentConfig::confirmed(),
+        CommitmentConfig::finalized(),
         &ExtraErrorCheckPolicy::None,
         state.confirmation_poll_interval_ms,
     )

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -173,10 +173,11 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
         ));
     }
 
+    // Remint lands on PrivateChannel where finalized == confirmed; gate on finalized so a value write never settles on forkable state.
     let result = match check_transaction_status(
         state.source_rpc_client.clone(),
         &signature,
-        CommitmentConfig::confirmed(),
+        CommitmentConfig::finalized(),
         &ExtraErrorCheckPolicy::None,
         state.confirmation_poll_interval_ms,
     )

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1244,9 +1244,8 @@ pub(super) async fn route_poll_results(
 ) {
     for (mut tx, status_opt) in results {
         match status_opt {
-            // Mint lands on PrivateChannel where finalized == confirmed; gate on finalized so a value write never settles on forkable state.
-            Some(status) if status.satisfies_commitment(CommitmentConfig::finalized()) => {
-                // Free this finalized tx's in-flight slot now so a continuation (the JIT
+            Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
+                // Free this confirmed tx's in-flight slot now so a continuation (the JIT
                 // mint retry) can reuse it instead of being refused when in-flight is full.
                 drop(tx.permit);
                 let result = if let Some(err) = &status.err {
@@ -1505,10 +1504,9 @@ pub(super) async fn run_poll_task(
 
         for (mut tx, status_opt) in batch.into_iter().zip(statuses) {
             match status_opt {
-                // Mint lands on PrivateChannel where finalized == confirmed; gate on finalized so a value write never settles on forkable state.
-                Some(status) if status.satisfies_commitment(CommitmentConfig::finalized()) => {
+                Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
                     if status.err.is_none() {
-                        // ── Finalized success (hot path) ──────────────────────────────
+                        // ── Confirmed success (hot path) ──────────────────────────────
                         // Handle entirely here — no need to wake the sender loop.
                         metrics::OPERATOR_MINTS_SENT
                             .with_label_values(&[program_type.as_label()])
@@ -3252,7 +3250,7 @@ mod tests {
     /// A confirmed signature in the batch must route to handle_success, emitting
     /// a Completed status and removing the entry from in_flight.
     #[tokio::test]
-    async fn poll_in_flight_finalized_tx_emits_completed() {
+    async fn poll_in_flight_confirmed_tx_emits_completed() {
         let mut server = mockito::Server::new_async().await;
 
         let sig = Signature::new_unique();
@@ -3270,8 +3268,8 @@ mod tests {
                     "result": {
                         "context": {"slot": 100},
                         "value": [{
-                            "confirmationStatus": "finalized",
-                            "confirmations": null,
+                            "confirmationStatus": "confirmed",
+                            "confirmations": 1,
                             "err": null,
                             "slot": 100,
                             "status": {"Ok": null}
@@ -3425,100 +3423,6 @@ mod tests {
         assert!(
             storage_rx.try_recv().is_err(),
             "no status update for pending tx"
-        );
-    }
-
-    /// A status that is confirmed but NOT finalized must not settle the mint; it stays
-    /// in-flight for the next poll. On PrivateChannel every status is finalized so this
-    /// never fires in production, but the test pins the gate: a revert to confirmed()
-    /// (which would settle a mint on forkable state) makes this assertion fail.
-    #[tokio::test]
-    async fn poll_in_flight_confirmed_not_finalized_stays_in_flight() {
-        let mut server = mockito::Server::new_async().await;
-
-        let sig = Signature::new_unique();
-
-        let _m = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "getSignatureStatuses"
-            })))
-            .with_status(200)
-            .with_body(
-                serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {
-                        "context": {"slot": 100},
-                        "value": [{
-                            "confirmationStatus": "confirmed",
-                            "confirmations": 1,
-                            "err": null,
-                            "slot": 100,
-                            "status": {"Ok": null}
-                        }]
-                    }
-                })
-                .to_string(),
-            )
-            .create();
-
-        let storage = Arc::new(Storage::Mock(MockStorage::new()));
-        let mut state = SenderState {
-            rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
-                server.url(),
-                crate::operator::utils::rpc_util::RetryConfig {
-                    max_attempts: 1,
-                    base_delay: std::time::Duration::from_millis(1),
-                    max_delay: std::time::Duration::from_millis(1),
-                },
-                CommitmentConfig::confirmed(),
-            )),
-            source_rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
-                server.url(),
-                crate::operator::utils::rpc_util::RetryConfig {
-                    max_attempts: 1,
-                    base_delay: std::time::Duration::from_millis(1),
-                    max_delay: std::time::Duration::from_millis(1),
-                },
-                CommitmentConfig::confirmed(),
-            )),
-            storage: storage.clone(),
-            instance_pda: None,
-            smt_state: None,
-            retry_counts: HashMap::new(),
-            mint_builders: HashMap::new(),
-            mint_cache: crate::operator::MintCache::new(storage),
-            retry_max_attempts: 3,
-            confirmation_poll_interval_ms: 400,
-            rotation_retry_queue: Vec::new(),
-            ambiguous_retry_queue: Vec::new(),
-            pending_rotation: None,
-            program_type: ProgramType::Escrow,
-            remint_cache: HashMap::new(),
-            pending_signatures: HashMap::new(),
-            pending_remints: Vec::new(),
-            in_flight: {
-                let q = InFlightQueue::new();
-                q.push(make_in_flight_tx(sig, 88));
-                q
-            },
-            fallback_rpc_client: None,
-            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
-        };
-
-        let (storage_tx, mut storage_rx) = mpsc::channel(10);
-
-        poll_in_flight(&mut state, &storage_tx).await;
-
-        assert_eq!(
-            state.in_flight.len(),
-            1,
-            "confirmed-not-finalized mint must stay in-flight, not settle"
-        );
-        assert!(
-            storage_rx.try_recv().is_err(),
-            "confirmed-not-finalized mint must not emit a Completed status"
         );
     }
 
@@ -3740,10 +3644,10 @@ mod tests {
                     "result": {
                         "context": {"slot": 200},
                         "value": [
-                            // sig1 finalized
+                            // sig1 confirmed
                             {
-                                "confirmationStatus": "finalized",
-                                "confirmations": null,
+                                "confirmationStatus": "confirmed",
+                                "confirmations": 1,
                                 "err": null,
                                 "slot": 200,
                                 "status": {"Ok": null}
@@ -4434,8 +4338,8 @@ mod tests {
                         "context": {"slot": 200},
                         "value": [
                             {
-                                "confirmationStatus": "finalized",
-                                "confirmations": null,
+                                "confirmationStatus": "confirmed",
+                                "confirmations": 1,
                                 "err": {"InstructionError": [0, "InvalidAccountData"]},
                                 "slot": 200,
                                 "status": {"Err": {"InstructionError": [0, "InvalidAccountData"]}}

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1244,8 +1244,8 @@ pub(super) async fn route_poll_results(
 ) {
     for (mut tx, status_opt) in results {
         match status_opt {
-            Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
-                // Free this confirmed tx's in-flight slot now so a continuation (the JIT
+            Some(status) if status.satisfies_commitment(CommitmentConfig::finalized()) => {
+                // Free this finalized tx's in-flight slot now so a continuation (the JIT
                 // mint retry) can reuse it instead of being refused when in-flight is full.
                 drop(tx.permit);
                 let result = if let Some(err) = &status.err {
@@ -1504,9 +1504,9 @@ pub(super) async fn run_poll_task(
 
         for (mut tx, status_opt) in batch.into_iter().zip(statuses) {
             match status_opt {
-                Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
+                Some(status) if status.satisfies_commitment(CommitmentConfig::finalized()) => {
                     if status.err.is_none() {
-                        // ── Confirmed success (hot path) ──────────────────────────────
+                        // ── Finalized success (hot path) ──────────────────────────────
                         // Handle entirely here — no need to wake the sender loop.
                         metrics::OPERATOR_MINTS_SENT
                             .with_label_values(&[program_type.as_label()])
@@ -3250,7 +3250,7 @@ mod tests {
     /// A confirmed signature in the batch must route to handle_success, emitting
     /// a Completed status and removing the entry from in_flight.
     #[tokio::test]
-    async fn poll_in_flight_confirmed_tx_emits_completed() {
+    async fn poll_in_flight_finalized_tx_emits_completed() {
         let mut server = mockito::Server::new_async().await;
 
         let sig = Signature::new_unique();
@@ -3268,8 +3268,8 @@ mod tests {
                     "result": {
                         "context": {"slot": 100},
                         "value": [{
-                            "confirmationStatus": "confirmed",
-                            "confirmations": 1,
+                            "confirmationStatus": "finalized",
+                            "confirmations": null,
                             "err": null,
                             "slot": 100,
                             "status": {"Ok": null}
@@ -3646,8 +3646,8 @@ mod tests {
                         "value": [
                             // sig1 confirmed
                             {
-                                "confirmationStatus": "confirmed",
-                                "confirmations": 1,
+                                "confirmationStatus": "finalized",
+                                "confirmations": null,
                                 "err": null,
                                 "slot": 200,
                                 "status": {"Ok": null}
@@ -4338,8 +4338,8 @@ mod tests {
                         "context": {"slot": 200},
                         "value": [
                             {
-                                "confirmationStatus": "confirmed",
-                                "confirmations": 1,
+                                "confirmationStatus": "finalized",
+                                "confirmations": null,
                                 "err": {"InstructionError": [0, "InvalidAccountData"]},
                                 "slot": 200,
                                 "status": {"Err": {"InstructionError": [0, "InvalidAccountData"]}}

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1244,7 +1244,8 @@ pub(super) async fn route_poll_results(
 ) {
     for (mut tx, status_opt) in results {
         match status_opt {
-            Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
+            // Mint lands on PrivateChannel where finalized == confirmed; gate on finalized so a value write never settles on forkable state.
+            Some(status) if status.satisfies_commitment(CommitmentConfig::finalized()) => {
                 // Free this confirmed tx's in-flight slot now so a continuation (the JIT
                 // mint retry) can reuse it instead of being refused when in-flight is full.
                 drop(tx.permit);
@@ -1504,7 +1505,8 @@ pub(super) async fn run_poll_task(
 
         for (mut tx, status_opt) in batch.into_iter().zip(statuses) {
             match status_opt {
-                Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
+                // Mint lands on PrivateChannel where finalized == confirmed; gate on finalized so a value write never settles on forkable state.
+                Some(status) if status.satisfies_commitment(CommitmentConfig::finalized()) => {
                     if status.err.is_none() {
                         // ── Confirmed success (hot path) ──────────────────────────────
                         // Handle entirely here — no need to wake the sender loop.
@@ -3250,7 +3252,7 @@ mod tests {
     /// A confirmed signature in the batch must route to handle_success, emitting
     /// a Completed status and removing the entry from in_flight.
     #[tokio::test]
-    async fn poll_in_flight_confirmed_tx_emits_completed() {
+    async fn poll_in_flight_finalized_tx_emits_completed() {
         let mut server = mockito::Server::new_async().await;
 
         let sig = Signature::new_unique();
@@ -3268,8 +3270,8 @@ mod tests {
                     "result": {
                         "context": {"slot": 100},
                         "value": [{
-                            "confirmationStatus": "confirmed",
-                            "confirmations": 1,
+                            "confirmationStatus": "finalized",
+                            "confirmations": null,
                             "err": null,
                             "slot": 100,
                             "status": {"Ok": null}
@@ -3423,6 +3425,100 @@ mod tests {
         assert!(
             storage_rx.try_recv().is_err(),
             "no status update for pending tx"
+        );
+    }
+
+    /// A status that is confirmed but NOT finalized must not settle the mint; it stays
+    /// in-flight for the next poll. On PrivateChannel every status is finalized so this
+    /// never fires in production, but the test pins the gate: a revert to confirmed()
+    /// (which would settle a mint on forkable state) makes this assertion fail.
+    #[tokio::test]
+    async fn poll_in_flight_confirmed_not_finalized_stays_in_flight() {
+        let mut server = mockito::Server::new_async().await;
+
+        let sig = Signature::new_unique();
+
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": 100},
+                        "value": [{
+                            "confirmationStatus": "confirmed",
+                            "confirmations": 1,
+                            "err": null,
+                            "slot": 100,
+                            "status": {"Ok": null}
+                        }]
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mut state = SenderState {
+            rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                server.url(),
+                crate::operator::utils::rpc_util::RetryConfig {
+                    max_attempts: 1,
+                    base_delay: std::time::Duration::from_millis(1),
+                    max_delay: std::time::Duration::from_millis(1),
+                },
+                CommitmentConfig::confirmed(),
+            )),
+            source_rpc_client: Arc::new(RpcClientWithRetry::with_retry_config(
+                server.url(),
+                crate::operator::utils::rpc_util::RetryConfig {
+                    max_attempts: 1,
+                    base_delay: std::time::Duration::from_millis(1),
+                    max_delay: std::time::Duration::from_millis(1),
+                },
+                CommitmentConfig::confirmed(),
+            )),
+            storage: storage.clone(),
+            instance_pda: None,
+            smt_state: None,
+            retry_counts: HashMap::new(),
+            mint_builders: HashMap::new(),
+            mint_cache: crate::operator::MintCache::new(storage),
+            retry_max_attempts: 3,
+            confirmation_poll_interval_ms: 400,
+            rotation_retry_queue: Vec::new(),
+            ambiguous_retry_queue: Vec::new(),
+            pending_rotation: None,
+            program_type: ProgramType::Escrow,
+            remint_cache: HashMap::new(),
+            pending_signatures: HashMap::new(),
+            pending_remints: Vec::new(),
+            in_flight: {
+                let q = InFlightQueue::new();
+                q.push(make_in_flight_tx(sig, 88));
+                q
+            },
+            fallback_rpc_client: None,
+            semaphore: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
+        };
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        assert_eq!(
+            state.in_flight.len(),
+            1,
+            "confirmed-not-finalized mint must stay in-flight, not settle"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "confirmed-not-finalized mint must not emit a Completed status"
         );
     }
 
@@ -3644,10 +3740,10 @@ mod tests {
                     "result": {
                         "context": {"slot": 200},
                         "value": [
-                            // sig1 confirmed
+                            // sig1 finalized
                             {
-                                "confirmationStatus": "confirmed",
-                                "confirmations": 1,
+                                "confirmationStatus": "finalized",
+                                "confirmations": null,
                                 "err": null,
                                 "slot": 200,
                                 "status": {"Ok": null}
@@ -4338,8 +4434,8 @@ mod tests {
                         "context": {"slot": 200},
                         "value": [
                             {
-                                "confirmationStatus": "confirmed",
-                                "confirmations": 1,
+                                "confirmationStatus": "finalized",
+                                "confirmations": null,
                                 "err": {"InstructionError": [0, "InvalidAccountData"]},
                                 "slot": 200,
                                 "status": {"Err": {"InstructionError": [0, "InvalidAccountData"]}}

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1246,7 +1246,7 @@ pub(super) async fn route_poll_results(
         match status_opt {
             // Mint lands on PrivateChannel where finalized == confirmed; gate on finalized so a value write never settles on forkable state.
             Some(status) if status.satisfies_commitment(CommitmentConfig::finalized()) => {
-                // Free this confirmed tx's in-flight slot now so a continuation (the JIT
+                // Free this finalized tx's in-flight slot now so a continuation (the JIT
                 // mint retry) can reuse it instead of being refused when in-flight is full.
                 drop(tx.permit);
                 let result = if let Some(err) = &status.err {
@@ -1508,7 +1508,7 @@ pub(super) async fn run_poll_task(
                 // Mint lands on PrivateChannel where finalized == confirmed; gate on finalized so a value write never settles on forkable state.
                 Some(status) if status.satisfies_commitment(CommitmentConfig::finalized()) => {
                     if status.err.is_none() {
-                        // ── Confirmed success (hot path) ──────────────────────────────
+                        // ── Finalized success (hot path) ──────────────────────────────
                         // Handle entirely here — no need to wake the sender loop.
                         metrics::OPERATOR_MINTS_SENT
                             .with_label_values(&[program_type.as_label()])

--- a/integration/tests/indexer/helpers/mod.rs
+++ b/integration/tests/indexer/helpers/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod db;
 pub mod operator_util;
+pub mod private_channel_node;
 pub mod test_types;
 pub mod tokens;
 pub mod transaction_executor;
@@ -10,6 +11,7 @@ pub mod verification;
 
 pub use db::*;
 pub use operator_util::*;
+pub use private_channel_node::*;
 pub use test_types::*;
 pub use tokens::*;
 pub use transaction_executor::*;

--- a/integration/tests/indexer/helpers/private_channel_node.rs
+++ b/integration/tests/indexer/helpers/private_channel_node.rs
@@ -64,8 +64,10 @@ pub async fn start_private_channel_node(
         .await?;
     let host = db_container.get_host().await?;
     let port = db_container.get_host_port_ipv4(5432).await?;
-    let accountsdb_connection_url =
-        format!("postgres://postgres:password@{}:{}/private_channel_node", host, port);
+    let accountsdb_connection_url = format!(
+        "postgres://postgres:password@{}:{}/private_channel_node",
+        host, port
+    );
 
     let node_port = get_free_port();
     let node_config = NodeConfig {

--- a/integration/tests/indexer/helpers/private_channel_node.rs
+++ b/integration/tests/indexer/helpers/private_channel_node.rs
@@ -1,0 +1,117 @@
+#![allow(dead_code)]
+
+//! Shared helper that stands up a real PrivateChannel core node (SVM) with its
+//! own Postgres accountsdb, for operator-lifecycle tests that need the deposit
+//! operator to mint against an instant-finality target.
+//!
+//! In production a deposit mint lands on the PrivateChannel core node, which
+//! reports every found transaction as `finalized` immediately. A
+//! `solana-test-validator` finalizes slowly (~37s/tx), so pointing the mint
+//! operator at a real PC node here makes the `finalized` mint gate complete on
+//! the first poll, exactly as in production.
+
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::time::Duration;
+
+use private_channel_core::nodes::node::{run_node, NodeConfig, NodeHandles, NodeMode};
+use private_channel_core::stage_metrics::NoopMetrics;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::pubkey::Pubkey;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+
+/// A running PrivateChannel core node plus the Postgres container backing its
+/// accountsdb. Keep this alive for the duration of the test; drop or call
+/// [`PrivateChannelNode::shutdown`] to tear it down.
+pub struct PrivateChannelNode {
+    pub url: String,
+    handles: Option<NodeHandles>,
+    _db: ContainerAsync<Postgres>,
+}
+
+impl PrivateChannelNode {
+    pub async fn shutdown(mut self) {
+        if let Some(handles) = self.handles.take() {
+            handles.shutdown().await;
+        }
+    }
+}
+
+fn get_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind to port 0");
+    let port = listener
+        .local_addr()
+        .expect("Failed to get local address")
+        .port();
+    drop(listener);
+    port
+}
+
+/// Start a PrivateChannel core node whose admin/mint authority is `admin_pubkey`
+/// (the operator key). The node JIT-initializes mints and creates recipient
+/// ATAs when the operator's `MintTo` arrives, so no explicit mint setup is
+/// needed here.
+pub async fn start_private_channel_node(
+    admin_pubkey: Pubkey,
+) -> Result<PrivateChannelNode, Box<dyn std::error::Error>> {
+    let db_container = Postgres::default()
+        .with_db_name("private_channel_node")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await?;
+    let host = db_container.get_host().await?;
+    let port = db_container.get_host_port_ipv4(5432).await?;
+    let accountsdb_connection_url =
+        format!("postgres://postgres:password@{}:{}/private_channel_node", host, port);
+
+    let node_port = get_free_port();
+    let node_config = NodeConfig {
+        mode: NodeMode::Aio,
+        port: node_port,
+        sigverify_queue_size: 100,
+        sigverify_workers: 2,
+        max_connections: 50,
+        max_tx_per_batch: 32,
+        batch_deadline_ms: 50,
+        batch_channel_capacity: 16,
+        ingress_queue_capacity: private_channel_core::nodes::node::DEFAULT_INGRESS_QUEUE_CAPACITY,
+        sequencer_queue_capacity:
+            private_channel_core::nodes::node::DEFAULT_SEQUENCER_QUEUE_CAPACITY,
+        execution_results_capacity:
+            private_channel_core::nodes::node::DEFAULT_EXECUTION_RESULTS_CAPACITY,
+        max_svm_workers: 4,
+        accountsdb_connection_url,
+        admin_keys: vec![admin_pubkey],
+        transaction_expiration_ms: 15000,
+        blocktime_ms: 100,
+        perf_sample_period_secs: 10,
+        metrics: Arc::new(NoopMetrics),
+    };
+
+    let handles = run_node(node_config)
+        .await
+        .map_err(|e| format!("Failed to start PrivateChannel node: {}", e))?;
+
+    let url = format!("http://127.0.0.1:{}", node_port);
+
+    // Poll until the node has produced its first block (get_latest_blockhash
+    // succeeds), meaning the RPC + settler + DB pipeline is ready.
+    let client = RpcClient::new(url.clone());
+    for _ in 0..50 {
+        if client.get_latest_blockhash().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    println!("=== PrivateChannel node started at {} ===", url);
+
+    Ok(PrivateChannelNode {
+        url,
+        handles: Some(handles),
+        _db: db_container,
+    })
+}

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -25,6 +25,7 @@ mod setup;
 
 use chrono::Utc;
 use helpers::test_types::WAIT_TIMEOUT_SECS;
+use helpers::private_channel_node::start_private_channel_node;
 use helpers::{db, generate_mint, get_token_balance, mint_to_owner, operator_util};
 use mockito::Server;
 use private_channel_indexer::config::{
@@ -309,10 +310,16 @@ async fn test_deposit_operator_processes_single_mint() -> Result<(), Box<dyn std
 
     storage.insert_db_transaction(&deposit_txn).await?;
 
-    // 3. Start start_solana_to_private_channel_operator()
+    // 3. Start a PrivateChannel core node as the mint target. It reports every
+    // found transaction as `finalized` instantly, so the operator's finalized
+    // mint gate completes on the first poll - mirroring production, where mints
+    // land on the PC node rather than slow Solana.
     let operator_keypair = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..])?;
+    let pc_node = start_private_channel_node(operator_keypair.pubkey()).await?;
+
+    // rpc_url (mint target) = PC node; the escrow instance stays on Solana.
     let operator_handle = start_solana_to_private_channel_operator(
-        test_validator.rpc_url(),
+        pc_node.url.clone(),
         db_url.clone(),
         operator_keypair,
         env.instance,
@@ -330,6 +337,7 @@ async fn test_deposit_operator_processes_single_mint() -> Result<(), Box<dyn std
     assert!(db_tx.counterpart_signature.is_some());
 
     operator_handle.shutdown().await;
+    pc_node.shutdown().await;
 
     Ok(())
 }
@@ -400,11 +408,18 @@ async fn test_issuance_operator_idempotent_no_double_mint() -> Result<(), Box<dy
     // Duplicate insert with same signature should not create a second mint.
     storage.insert_db_transaction(&deposit_txn).await?;
 
-    let balance_before = get_token_balance(&client, &user_pubkey, &env.mint).await?;
-
+    // Mint target is the PrivateChannel node (instant finality), so balances are
+    // checked there, not on the Solana validator. The recipient ATA does not
+    // exist on the PC node until the first mint, so treat "before" as 0.
     let operator_keypair = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..])?;
+    let pc_node = start_private_channel_node(operator_keypair.pubkey()).await?;
+    let pc_client = RpcClient::new(pc_node.url.clone());
+    let balance_before = get_token_balance(&pc_client, &user_pubkey, &env.mint)
+        .await
+        .unwrap_or(0);
+
     let operator_handle = start_solana_to_private_channel_operator(
-        test_validator.rpc_url(),
+        pc_node.url.clone(),
         db_url.clone(),
         operator_keypair,
         env.instance,
@@ -413,7 +428,7 @@ async fn test_issuance_operator_idempotent_no_double_mint() -> Result<(), Box<dy
 
     operator_util::wait_for_transaction_completion(&pool, &signature, 180).await?;
 
-    let balance_after = get_token_balance(&client, &user_pubkey, &env.mint).await?;
+    let balance_after = get_token_balance(&pc_client, &user_pubkey, &env.mint).await?;
     assert_eq!(
         balance_after,
         balance_before + amount,
@@ -421,6 +436,7 @@ async fn test_issuance_operator_idempotent_no_double_mint() -> Result<(), Box<dy
     );
 
     operator_handle.shutdown().await;
+    pc_node.shutdown().await;
     Ok(())
 }
 
@@ -747,10 +763,14 @@ async fn test_batch_deposits_multiple_recipients() -> Result<(), Box<dyn std::er
         signatures.push(sig);
     }
 
-    // Start the Solana → PrivateChannel operator and wait for all deposits to be processed.
+    // Start the Solana -> PrivateChannel operator and wait for all deposits to be processed.
+    // The mint target is a PrivateChannel node (instant finality), so balances
+    // are verified there rather than on the Solana validator.
     let operator_keypair = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..])?;
+    let pc_node = start_private_channel_node(operator_keypair.pubkey()).await?;
+    let pc_client = RpcClient::new(pc_node.url.clone());
     let operator_handle = start_solana_to_private_channel_operator(
-        test_validator.rpc_url(),
+        pc_node.url.clone(),
         db_url.clone(),
         operator_keypair,
         env.instance,
@@ -771,7 +791,7 @@ async fn test_batch_deposits_multiple_recipients() -> Result<(), Box<dyn std::er
             "Deposit {i} missing counterpart signature"
         );
 
-        let balance = get_token_balance(&client, &env.users[i].pubkey(), &env.mint).await?;
+        let balance = get_token_balance(&pc_client, &env.users[i].pubkey(), &env.mint).await?;
         assert_eq!(
             balance, DEPOSIT_AMOUNT,
             "User {i} balance mismatch after deposit"
@@ -779,6 +799,7 @@ async fn test_batch_deposits_multiple_recipients() -> Result<(), Box<dyn std::er
     }
 
     operator_handle.shutdown().await;
+    pc_node.shutdown().await;
     Ok(())
 }
 

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -24,8 +24,8 @@ mod helpers;
 mod setup;
 
 use chrono::Utc;
-use helpers::test_types::WAIT_TIMEOUT_SECS;
 use helpers::private_channel_node::start_private_channel_node;
+use helpers::test_types::WAIT_TIMEOUT_SECS;
 use helpers::{db, generate_mint, get_token_balance, mint_to_owner, operator_util};
 use mockito::Server;
 use private_channel_indexer::config::{

--- a/scripts/devnet/config/indexer-solana.toml
+++ b/scripts/devnet/config/indexer-solana.toml
@@ -20,9 +20,6 @@ datasource_type = "yellowstone"
 [indexer.yellowstone]
 # TODO: Add devnet solana yellowstone endpoint
 endpoint = "your_devnet_solana_yellowstone_endpoint"
-# Must stay "finalized": deposits become irreversible private-channel mints, so
-# ingesting at "confirmed" would let a Solana reorg produce an unbacked mint.
-commitment = "finalized"
 
 [indexer.rpc_polling]
 poll_interval_ms = 1000


### PR DESCRIPTION
## Summary

Closes issue 6 by ensuring all bridge operations that can safely do so use `finalized` instead of `confirmed`, eliminating settlement on forkable Solana where practical. The only exception is withdrawal release, which remains on `confirmed` and is intentionally deferred until Alpenglow due to the complexity and liveness impact of asynchronous finalization.

| Operation | Before | After |
|---|---|---|
| Detect deposits/withdrawals - RPC polling | finalized | finalized |
| Detect deposits/withdrawals - Yellowstone | confirmed | finalized |
| Operator general RPC default | confirmed | confirmed (rejects `processed`) |
| Mark deposit mint complete | confirmed | finalized |
| Mark withdrawal release complete | confirmed | confirmed (unchanged) |
| Mark refund (remint) complete | confirmed | finalized |
| Failed withdrawal detection | finalized | finalized |
| Crash recovery | finalized | finalized |

### Changes

- Hardcode datasource indexing to `finalized` (remove configurable commitment).
- Reject `processed` for the operator RPC commitment.
- Require `finalized` before completing deposit mints and remints (runtime no-op on `PrivateChannel`, but makes the guarantee explicit).
- **Leave withdrawal releases on `confirmed`; defer `finalized` to Alpenglow.** This is the only operation that settles value on forkable Solana, so unlike deposit mints and remints (which run on `PrivateChannel`, where `confirmed == finalized`), moving to `finalized` requires an asynchronous finalization pipeline to avoid hurting liveness. Given the complexity and the very low likelihood of a confirmed block being reverted, this PR intentionally keeps the current behavior. Once Alpenglow's fast finality is available, the release gate can be switched to `finalized` with a simple commitment change.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28867252458) |
| Indexer | 25,248 | 28,547 | 88.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28867252458) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28867252458) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28867252458) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,381 | 15,612 | 79.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28867252458) |
| **Total** | **50,935** | **59,377** | **85.8%** | |

> Last updated: 2026-07-07 13:37:35 UTC by E2E Integration