### PR TITLE
fix(indexer): prevent checkpoint advancement over unavailable slots

### DIFF
--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -92,6 +92,9 @@ pub enum BackfillError {
     #[error("Slot {slot} transaction {signature} is missing metadata; block is incomplete")]
     MissingMeta { slot: u64, signature: String },
 
+    #[error("Slot {slot} is unavailable (pruned or snapshot-jumped); block contents are unknown")]
+    SlotUnavailable { slot: u64 },
+
     // Channel errors
     #[error("Channel send failed: {0}")]
     ChannelSend(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -7,7 +7,7 @@ use crate::{
         checkpoint::get_last_checkpoint,
         datasource::{
             common::types::{InstructionSender, ProcessorMessage},
-            rpc_polling::{decoder, rpc::RpcPoller, types::RpcBlock},
+            rpc_polling::{decoder, rpc::RpcPoller, types::BlockFetch},
         },
     },
     storage::Storage,
@@ -62,7 +62,7 @@ async fn fetch_blocks_with_retry(
     rpc_poller: &RpcPoller,
     slots: &[u64],
     retry_count: usize,
-) -> Result<Vec<(u64, Result<Option<RpcBlock>, BackfillError>)>, IndexerError> {
+) -> Result<Vec<(u64, Result<BlockFetch, BackfillError>)>, IndexerError> {
     if retry_count > 0 {
         tokio::time::sleep(Duration::from_millis(
             BACKFILL_RETRY_DELAY_MS * retry_count as u64,
@@ -80,7 +80,7 @@ async fn fetch_blocks_with_retry(
                 result.map_err(|e| BackfillError::SlotFetchFailed { slot, source: e }),
             )
         })
-        .collect::<Vec<(u64, Result<Option<RpcBlock>, BackfillError>)>>())
+        .collect::<Vec<(u64, Result<BlockFetch, BackfillError>)>>())
 }
 
 /// Fill a range of slots by fetching blocks via RPC and sending parsed instructions.
@@ -132,7 +132,7 @@ pub async fn fill_slot_range(
 
         for (slot, block_result) in blocks {
             match block_result {
-                Ok(Some(block)) => {
+                Ok(BlockFetch::Present(block)) => {
                     // A missing-meta block is unverifiable: abort before the SlotComplete send so the
                     // checkpoint never advances past it; the caller surfaces the error and retries.
                     if let Some(signature) = decoder::first_missing_meta(&block) {
@@ -164,8 +164,18 @@ pub async fn fill_slot_range(
                     }
                     processed_count += 1;
                 }
-                Ok(None) => {
+                Ok(BlockFetch::Skipped) => {
                     processed_count += 1;
+                }
+                Ok(BlockFetch::Unavailable) => {
+                    error!(
+                        "Backfill slot {} is unavailable (pruned/snapshot-jumped); aborting before checkpoint",
+                        slot
+                    );
+                    metrics::INDEXER_RPC_ERRORS
+                        .with_label_values(&[program_type.as_label(), "block_unavailable"])
+                        .inc();
+                    return Err(BackfillError::SlotUnavailable { slot }.into());
                 }
                 Err(e) => {
                     warn!("Error fetching block {}: {}", slot, e);
@@ -442,6 +452,7 @@ mod tests {
     mod fill_slot_range_tests {
         use super::*;
         use crate::indexer::datasource::rpc_polling::rpc::RpcPoller;
+        use crate::test_utils::rpc_mocks::mock_first_available_block;
         use mockito::Server;
         use serde_json::json;
         use solana_sdk::commitment_config::CommitmentLevel;
@@ -589,6 +600,8 @@ mod tests {
 
             let _m1 = mock_get_block_skipped(&mut server, 101);
             let _m2 = mock_get_block_skipped(&mut server, 102);
+            // Floor 0 so both absent slots (>= 0) resolve as proven Skipped.
+            let _floor = mock_first_available_block(&mut server, 0);
 
             let poller = RpcPoller::new(
                 server.url(),
@@ -612,6 +625,45 @@ mod tests {
             for msg in &messages {
                 assert!(matches!(msg, ProcessorMessage::SlotComplete { .. }));
             }
+        }
+
+        /// A batch where slot N is absent below the ledger floor (Unavailable) must
+        /// abort with `SlotUnavailable { slot: N }` before sending SlotComplete{N}
+        /// (and before any later slot's SlotComplete), so the checkpoint never
+        /// advances past a slot whose contents are unknown.
+        #[tokio::test]
+        async fn fill_slot_range_unavailable_aborts_before_slot_complete() {
+            let mut server = Server::new_async().await;
+
+            // Batch over (100, 102] = [101, 102]; slot 101 is absent below the floor.
+            let _m1 = mock_get_block_skipped(&mut server, 101);
+            let _m2 = mock_get_block_success(&mut server, 102);
+            let _floor = mock_first_available_block(&mut server, 500);
+
+            let poller = RpcPoller::new(
+                server.url(),
+                UiTransactionEncoding::Json,
+                CommitmentLevel::Finalized,
+            );
+
+            let (tx, mut rx) = mpsc::channel(64);
+            let result =
+                fill_slot_range(&poller, 100, 102, 10, ProgramType::Escrow, None, &tx).await;
+
+            let err = result.unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("unavailable"), "unexpected error: {msg}");
+            assert!(msg.contains("101"), "error should name the slot: {msg}");
+
+            drop(tx);
+            let messages: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+            let advanced = messages
+                .iter()
+                .any(|m| matches!(m, ProcessorMessage::SlotComplete { slot, .. } if *slot >= 101));
+            assert!(
+                !advanced,
+                "no SlotComplete must be sent for slot 101 or beyond on an unavailable block"
+            );
         }
 
         #[tokio::test]

--- a/indexer/src/indexer/datasource/rpc_polling/rpc.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/rpc.rs
@@ -1,5 +1,5 @@
 use crate::error::DataSourceRpcError;
-use crate::indexer::datasource::rpc_polling::types::RpcBlock;
+use crate::indexer::datasource::rpc_polling::types::{BlockFetch, RpcBlock};
 use futures::future::join_all;
 use serde_json::json;
 use solana_sdk::commitment_config::CommitmentLevel;
@@ -28,7 +28,7 @@ impl RpcPoller {
     }
 
     /// Get a single block by slot
-    async fn get_block(&self, slot: u64) -> Result<Option<RpcBlock>, DataSourceRpcError> {
+    async fn get_block(&self, slot: u64) -> Result<BlockFetch, DataSourceRpcError> {
         let response = self
             .client
             .post(&self.rpc_url)
@@ -54,33 +54,47 @@ impl RpcPoller {
 
         // Check for RPC error
         if let Some(error) = json.get("error") {
-            // Slot was skipped or missing:
+            // Slot skipped or missing; the node cannot tell the two apart:
             // -32007: Slot skipped or missing due to ledger jump to recent snapshot
             // -32009: Slot skipped or missing in long-term storage
             if error["code"] == -32007 || error["code"] == -32009 {
-                return Ok(None);
+                return self.classify_absent_slot(slot).await;
             }
             return Err(DataSourceRpcError::Protocol {
                 reason: format!("RPC error: {}", error),
             });
         }
 
-        // Check if result is null (block not available)
+        // A null result is the same "skipped or missing" ambiguity as the errors above.
         if json["result"].is_null() {
-            return Ok(None);
+            return self.classify_absent_slot(slot).await;
         }
 
         // Parse the block
         let block: RpcBlock =
             serde_json::from_value(json["result"].clone()).map_err(DataSourceRpcError::from)?;
-        Ok(Some(block))
+        Ok(BlockFetch::Present(block))
+    }
+
+    /// A `-32007/-32009/null` response means "skipped OR unavailable". It is a
+    /// proven skip only if the node still retains the ledger region for `slot`;
+    /// below the retained floor the block was pruned and its contents are unknown.
+    async fn classify_absent_slot(&self, slot: u64) -> Result<BlockFetch, DataSourceRpcError> {
+        let floor = self.get_first_available_block().await?;
+        // Inclusive: `floor` is itself a retained slot, so `slot >= floor` is within
+        // the region the node can vouch for; `slot < floor` was pruned.
+        if slot >= floor {
+            Ok(BlockFetch::Skipped)
+        } else {
+            Ok(BlockFetch::Unavailable)
+        }
     }
 
     /// Get multiple blocks in parallel
     pub async fn get_blocks_batch(
         &self,
         slots: Vec<u64>,
-    ) -> Vec<(u64, Result<Option<RpcBlock>, DataSourceRpcError>)> {
+    ) -> Vec<(u64, Result<BlockFetch, DataSourceRpcError>)> {
         let futures = slots.into_iter().map(|slot| async move {
             let result = self.get_block(slot).await;
             (slot, result)
@@ -118,6 +132,37 @@ impl RpcPoller {
             .as_u64()
             .ok_or_else(|| DataSourceRpcError::Protocol {
                 reason: "Invalid slot response".to_string(),
+            })
+    }
+
+    /// Get the first slot the node still retains (its ledger floor). Takes no
+    /// params and returns node-local ledger state, so no commitment argument.
+    pub async fn get_first_available_block(&self) -> Result<u64, DataSourceRpcError> {
+        let response = self
+            .client
+            .post(&self.rpc_url)
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getFirstAvailableBlock",
+                "params": []
+            }))
+            .send()
+            .await
+            .map_err(DataSourceRpcError::from)?;
+
+        let json: serde_json::Value = response.json().await.map_err(DataSourceRpcError::from)?;
+
+        if let Some(error) = json.get("error") {
+            return Err(DataSourceRpcError::Protocol {
+                reason: format!("RPC error: {}", error),
+            });
+        }
+
+        json["result"]
+            .as_u64()
+            .ok_or_else(|| DataSourceRpcError::Protocol {
+                reason: "Invalid getFirstAvailableBlock response".to_string(),
             })
     }
 
@@ -169,9 +214,10 @@ mod tests {
         let result = poller.get_block(101).await;
 
         assert!(result.is_ok());
-        let block = result.unwrap();
-        assert!(block.is_some());
-        let block = block.unwrap();
+        let block = match result.unwrap() {
+            BlockFetch::Present(block) => block,
+            other => panic!("expected Present, got {other:?}"),
+        };
         assert_eq!(
             block.blockhash,
             "TestBlockHash11111111111111111111111111111"
@@ -179,10 +225,12 @@ mod tests {
         assert_eq!(block.parent_slot, 100);
     }
 
+    /// -32009 at or above the retained floor is a proven skip, safe to advance.
     #[tokio::test]
-    async fn test_get_block_skipped_slot() {
+    async fn get_block_skipped_when_slot_at_or_above_floor() {
         let mut server = Server::new_async().await;
         let _m = mock_rpc_error(&mut server, -32009, "Slot was skipped").await;
+        let _floor = mock_first_available_block(&mut server, 50);
 
         let poller = RpcPoller::new(
             server.url(),
@@ -191,24 +239,122 @@ mod tests {
         );
         let result = poller.get_block(101).await;
 
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(matches!(result, Ok(BlockFetch::Skipped)));
+    }
+
+    /// -32009 below the retained floor is pruned history: Unavailable, must not advance.
+    #[tokio::test]
+    async fn get_block_unavailable_when_slot_below_floor() {
+        let mut server = Server::new_async().await;
+        let _m = mock_rpc_error(&mut server, -32009, "Slot missing in long-term storage").await;
+        let _floor = mock_first_available_block(&mut server, 50);
+
+        let poller = RpcPoller::new(
+            server.url(),
+            UiTransactionEncoding::Json,
+            CommitmentLevel::Finalized,
+        );
+        let result = poller.get_block(40).await;
+
+        assert!(matches!(result, Ok(BlockFetch::Unavailable)));
+    }
+
+    /// A null result takes the same floor-classified path; below floor is Unavailable.
+    #[tokio::test]
+    async fn get_block_null_result_classified_by_floor() {
+        let mut server = Server::new_async().await;
+        let _m = mock_rpc_success(&mut server, "null").await;
+        let _floor = mock_first_available_block(&mut server, 50);
+
+        let poller = RpcPoller::new(
+            server.url(),
+            UiTransactionEncoding::Json,
+            CommitmentLevel::Finalized,
+        );
+        let result = poller.get_block(40).await;
+
+        assert!(matches!(result, Ok(BlockFetch::Unavailable)));
+    }
+
+    /// The `slot >= floor` boundary is inclusive: slot exactly at the floor is Skipped.
+    #[tokio::test]
+    async fn get_block_floor_boundary_inclusive() {
+        let mut server = Server::new_async().await;
+        let _m = mock_rpc_error(&mut server, -32007, "Slot skipped or ledger jump").await;
+        let _floor = mock_first_available_block(&mut server, 50);
+
+        let poller = RpcPoller::new(
+            server.url(),
+            UiTransactionEncoding::Json,
+            CommitmentLevel::Finalized,
+        );
+        let result = poller.get_block(50).await;
+
+        assert!(matches!(result, Ok(BlockFetch::Skipped)));
+    }
+
+    /// A failed floor fetch is transient and retryable, so it propagates as Err,
+    /// never as a proven-unavailable verdict.
+    #[tokio::test]
+    async fn get_block_floor_fetch_error_propagates_err() {
+        let mut server = Server::new_async().await;
+        let _m = mock_rpc_error(&mut server, -32009, "Slot was skipped").await;
+        // Floor call errors; body-matched so it only answers getFirstAvailableBlock.
+        let _floor_err = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getFirstAvailableBlock"
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32600, "message": "Invalid request" },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .create();
+
+        let poller = RpcPoller::new(
+            server.url(),
+            UiTransactionEncoding::Json,
+            CommitmentLevel::Finalized,
+        );
+        let result = poller.get_block(40).await;
+
+        assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn test_get_block_null_result() {
+    async fn get_first_available_block_success() {
         let mut server = Server::new_async().await;
-        let _m = mock_rpc_success(&mut server, "null").await;
+        let _m = mock_rpc_success(&mut server, "42").await;
 
         let poller = RpcPoller::new(
             server.url(),
             UiTransactionEncoding::Json,
             CommitmentLevel::Finalized,
         );
-        let result = poller.get_block(101).await;
+        let result = poller.get_first_available_block().await;
 
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn get_first_available_block_rpc_error() {
+        let mut server = Server::new_async().await;
+        let _m = mock_rpc_error(&mut server, -32600, "Invalid request").await;
+
+        let poller = RpcPoller::new(
+            server.url(),
+            UiTransactionEncoding::Json,
+            CommitmentLevel::Finalized,
+        );
+        let result = poller.get_first_available_block().await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("RPC error"));
     }
 
     #[tokio::test]
@@ -413,6 +559,9 @@ mod tests {
             .create_async()
             .await;
 
+        // Floor 100 so slot 101's -32009 (101 >= 100) classifies as Skipped.
+        let _floor = mock_first_available_block(&mut server, 100);
+
         let poller = RpcPoller::new(
             server.url(),
             UiTransactionEncoding::Json,
@@ -422,24 +571,26 @@ mod tests {
 
         assert_eq!(results.len(), 3);
 
-        // Slot 100: success
+        // Slot 100: present
         assert_eq!(results[0].0, 100);
-        assert!(results[0].1.is_ok());
-        let block = results[0].1.as_ref().unwrap();
-        assert!(block.is_some());
-        assert_eq!(block.as_ref().unwrap().blockhash, "Block100");
+        match results[0].1.as_ref().unwrap() {
+            BlockFetch::Present(block) => assert_eq!(block.blockhash, "Block100"),
+            other => panic!("slot 100 expected Present, got {other:?}"),
+        }
 
-        // Slot 101: skipped
+        // Slot 101: proven skipped (>= floor)
         assert_eq!(results[1].0, 101);
-        assert!(results[1].1.is_ok());
-        assert!(results[1].1.as_ref().unwrap().is_none());
+        assert!(matches!(
+            results[1].1.as_ref().unwrap(),
+            BlockFetch::Skipped
+        ));
 
-        // Slot 102: success
+        // Slot 102: present
         assert_eq!(results[2].0, 102);
-        assert!(results[2].1.is_ok());
-        let block = results[2].1.as_ref().unwrap();
-        assert!(block.is_some());
-        assert_eq!(block.as_ref().unwrap().blockhash, "Block102");
+        match results[2].1.as_ref().unwrap() {
+            BlockFetch::Present(block) => assert_eq!(block.blockhash, "Block102"),
+            other => panic!("slot 102 expected Present, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/indexer/src/indexer/datasource/rpc_polling/rpc.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/rpc.rs
@@ -27,8 +27,10 @@ impl RpcPoller {
         }
     }
 
-    /// Get a single block by slot
-    async fn get_block(&self, slot: u64) -> Result<BlockFetch, DataSourceRpcError> {
+    /// Fetch just the getBlock result: `Some(block)` when present, `None` for a
+    /// `-32004/-32007/-32009/null` "skipped or missing" response (which the node
+    /// cannot tell apart from unavailable). Other RPC errors surface as `Err`.
+    async fn fetch_block_raw(&self, slot: u64) -> Result<Option<RpcBlock>, DataSourceRpcError> {
         let response = self
             .client
             .post(&self.rpc_url)
@@ -52,14 +54,12 @@ impl RpcPoller {
 
         let json: serde_json::Value = response.json().await?;
 
-        // Check for RPC error
         if let Some(error) = json.get("error") {
-            // Slot skipped or missing; the node cannot tell the two apart:
             // -32004: Block not available for slot (skipped or missing)
             // -32007: Slot skipped or missing due to ledger jump to recent snapshot
             // -32009: Slot skipped or missing in long-term storage
             if error["code"] == -32004 || error["code"] == -32007 || error["code"] == -32009 {
-                return self.classify_absent_slot(slot).await;
+                return Ok(None);
             }
             return Err(DataSourceRpcError::Protocol {
                 reason: format!("RPC error: {}", error),
@@ -68,40 +68,80 @@ impl RpcPoller {
 
         // A null result is the same "skipped or missing" ambiguity as the errors above.
         if json["result"].is_null() {
-            return self.classify_absent_slot(slot).await;
+            return Ok(None);
         }
 
-        // Parse the block
         let block: RpcBlock =
             serde_json::from_value(json["result"].clone()).map_err(DataSourceRpcError::from)?;
-        Ok(BlockFetch::Present(block))
+        Ok(Some(block))
     }
 
-    /// A `-32007/-32009/null` response means "skipped OR unavailable". It is a
-    /// proven skip only if the node still retains the ledger region for `slot`;
-    /// below the retained floor the block was pruned and its contents are unknown.
-    async fn classify_absent_slot(&self, slot: u64) -> Result<BlockFetch, DataSourceRpcError> {
-        let floor = self.get_first_available_block().await?;
-        // Inclusive: `floor` is itself a retained slot, so `slot >= floor` is within
-        // the region the node can vouch for; `slot < floor` was pruned.
+    /// Classify a "skipped or missing" slot against the node's retained ledger
+    /// floor: at or above `floor` it is a proven skip (safe to advance), below it
+    /// the block was pruned and its contents are unknown. Inclusive because `floor`
+    /// is itself a retained slot. Assumes the getBlock and getFirstAvailableBlock
+    /// calls observe a consistent node view; a load-balanced endpoint split across
+    /// lagging replicas can still misclassify.
+    fn classify_absent(slot: u64, floor: u64) -> BlockFetch {
         if slot >= floor {
-            Ok(BlockFetch::Skipped)
+            BlockFetch::Skipped
         } else {
-            Ok(BlockFetch::Unavailable)
+            BlockFetch::Unavailable
         }
     }
 
-    /// Get multiple blocks in parallel
+    /// Get a single block by slot, classifying an absent slot with its own floor
+    /// query. Only the batch path runs in production; this is the single-slot form
+    /// the unit tests drive.
+    #[cfg(test)]
+    async fn get_block(&self, slot: u64) -> Result<BlockFetch, DataSourceRpcError> {
+        match self.fetch_block_raw(slot).await? {
+            Some(block) => Ok(BlockFetch::Present(block)),
+            None => Ok(Self::classify_absent(
+                slot,
+                self.get_first_available_block().await?,
+            )),
+        }
+    }
+
+    /// Get multiple blocks in parallel. The ledger floor is queried at most once
+    /// per batch, and only when some slot is absent, so a fully-present batch adds
+    /// no extra round-trips and N absent slots do not each re-query the floor.
     pub async fn get_blocks_batch(
         &self,
         slots: Vec<u64>,
     ) -> Vec<(u64, Result<BlockFetch, DataSourceRpcError>)> {
-        let futures = slots.into_iter().map(|slot| async move {
-            let result = self.get_block(slot).await;
-            (slot, result)
-        });
+        let raws = join_all(
+            slots
+                .into_iter()
+                .map(|slot| async move { (slot, self.fetch_block_raw(slot).await) }),
+        )
+        .await;
 
-        join_all(futures).await
+        let floor = if raws.iter().any(|(_, r)| matches!(r, Ok(None))) {
+            Some(self.get_first_available_block().await)
+        } else {
+            None
+        };
+
+        raws.into_iter()
+            .map(|(slot, raw)| {
+                let result = match raw {
+                    Ok(Some(block)) => Ok(BlockFetch::Present(block)),
+                    Ok(None) => match &floor {
+                        Some(Ok(f)) => Ok(Self::classify_absent(slot, *f)),
+                        // The single floor query failed, so no absent slot in this
+                        // batch can be classified; fail closed for each.
+                        Some(Err(e)) => Err(DataSourceRpcError::Protocol {
+                            reason: format!("getFirstAvailableBlock failed: {e}"),
+                        }),
+                        None => unreachable!("floor is queried whenever a slot is absent"),
+                    },
+                    Err(e) => Err(e),
+                };
+                (slot, result)
+            })
+            .collect()
     }
 
     /// Get the latest slot
@@ -414,15 +454,18 @@ mod tests {
             .expect(1)
             .create_async()
             .await;
+        // The null result routes through the floor check; slot 101 >= 0 is a proven skip.
+        let _floor = mock_first_available_block(&mut server, 0);
 
         let poller = RpcPoller::new(
             server.url(),
             UiTransactionEncoding::Json,
             CommitmentLevel::Confirmed,
         );
-        let _ = poller.get_block(101).await;
+        let result = poller.get_block(101).await;
 
         m.assert_async().await;
+        assert!(matches!(result.unwrap(), BlockFetch::Skipped));
     }
 
     // ============================================================================

--- a/indexer/src/indexer/datasource/rpc_polling/source.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/source.rs
@@ -1,5 +1,5 @@
 use super::rpc::RpcPoller;
-use super::types::RpcBlock;
+use super::types::{BlockFetch, RpcBlock};
 use crate::channel_utils::send_guaranteed;
 use crate::config::ProgramType;
 use crate::error::DataSourceError;
@@ -80,7 +80,7 @@ async fn refetch_missing_meta_via_fallback(
 ) -> Option<RpcBlock> {
     let (_slot, result) = fallback.get_blocks_batch(vec![slot]).await.pop()?;
     match result {
-        Ok(Some(block))
+        Ok(BlockFetch::Present(block))
             if block.blockhash == expected_blockhash
                 && decoder::first_missing_meta(&block).is_none() =>
         {
@@ -175,7 +175,7 @@ impl DataSource for RpcPollingSource {
                 // Parse and send instructions from each block
                 for (slot, block_result) in blocks {
                     match block_result {
-                        Ok(Some(block)) => {
+                        Ok(BlockFetch::Present(block)) => {
                             // A missing-meta block is unverifiable: try one fallback re-fetch, and if that
                             // is unavailable or also incomplete, fail closed (no SlotComplete, no advance).
                             let block = match decoder::first_missing_meta(&block) {
@@ -256,8 +256,21 @@ impl DataSource for RpcPollingSource {
                                 }
                             }
                         }
-                        Ok(None) => {
-                            info!("Slot {} was skipped", slot);
+                        Ok(BlockFetch::Skipped) => {
+                            debug!("Slot {} proven skipped (>= first_available_block)", slot);
+                        }
+                        Ok(BlockFetch::Unavailable) => {
+                            error!(
+                                "Slot {} is unavailable (pruned/snapshot-jumped); refusing to checkpoint past unknown contents",
+                                slot
+                            );
+                            metrics::INDEXER_RPC_ERRORS
+                                .with_label_values(&[program_type.as_label(), "block_unavailable"])
+                                .inc();
+                            // Fail closed, Break so the next poll re-fetches from `current_slot`.
+                            tokio::time::sleep(Duration::from_millis(error_retry_interval_ms))
+                                .await;
+                            break;
                         }
                         Err(e) => {
                             error!("Failed to fetch block {}: {}", slot, e);
@@ -315,6 +328,7 @@ impl DataSource for RpcPollingSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::rpc_mocks::mock_first_available_block;
     use mockito::Server;
     use serde_json::json;
     use tokio::sync::mpsc;
@@ -351,6 +365,32 @@ mod tests {
                         "parentSlot": slot - 1,
                         "transactions": []
                     },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .expect_at_least(expect_at_least)
+            .create()
+    }
+
+    /// getBlock returns a `-32009` skipped-or-missing response for `slot`, which the
+    /// classifier resolves against the ledger floor.
+    fn mock_get_block_absent(
+        server: &mut Server,
+        slot: u64,
+        expect_at_least: usize,
+    ) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [slot]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32009, "message": "Slot was skipped" },
                     "id": 1
                 })
                 .to_string(),
@@ -493,6 +533,108 @@ mod tests {
             )
             .expect_at_least(expect_at_least)
             .create()
+    }
+
+    /// An Unavailable slot (absent below the ledger floor) must fail closed exactly
+    /// like a transport error: no SlotComplete, and the slot is re-fetched.
+    #[tokio::test]
+    async fn unavailable_does_not_emit_slot_complete_and_retries() {
+        let mut server = Server::new_async().await;
+
+        // Chain tip ahead so get_slots_to_process always returns [100].
+        let _m_slot = mock_get_slot(&mut server, 105);
+        // Slot 100 is absent; floor 200 > 100 => Unavailable. Expect >=2 retries.
+        let m_block = mock_get_block_absent(&mut server, 100, 2);
+        let _floor = mock_first_available_block(&mut server, 200);
+
+        let mut source = RpcPollingSource::new(
+            server.url(),
+            Some(100),
+            10,
+            10,
+            10,
+            solana_transaction_status::UiTransactionEncoding::Json,
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+            ProgramType::Escrow,
+            None,
+            None,
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        cancel.cancel();
+        let _ = handle.await;
+
+        // Slot 100 re-requested at least twice: it did not advance past the unavailable slot.
+        m_block.assert();
+
+        let mut messages = vec![];
+        while let Ok(msg) = rx.try_recv() {
+            messages.push(msg);
+        }
+        let advanced_past_100 = messages
+            .iter()
+            .any(|m| matches!(m, ProcessorMessage::SlotComplete { slot, .. } if *slot == 100));
+        assert!(
+            !advanced_past_100,
+            "SlotComplete{{slot:100}} must not be emitted for an unavailable slot"
+        );
+    }
+
+    /// A proven skip (absent at or above the ledger floor) keeps the old behavior:
+    /// SlotComplete is emitted and polling advances past the slot.
+    #[tokio::test]
+    async fn proven_skip_emits_slot_complete_and_advances() {
+        let mut server = Server::new_async().await;
+
+        // Chain tip 103 => get_slots_to_process(100, 10) returns [100,101,102].
+        let _m_slot = mock_get_slot(&mut server, 103);
+        // Slot 100 is absent; floor 0 <= 100 => proven Skipped, so it must advance.
+        let _m100 = mock_get_block_absent(&mut server, 100, 1);
+        let _floor = mock_first_available_block(&mut server, 0);
+        let _m101 = mock_get_block_success(&mut server, 101, 1);
+        let _m102 = mock_get_block_success(&mut server, 102, 1);
+
+        let mut source = RpcPollingSource::new(
+            server.url(),
+            Some(100),
+            10,
+            10,
+            10,
+            solana_transaction_status::UiTransactionEncoding::Json,
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+            ProgramType::Escrow,
+            None,
+            None,
+        );
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let handle = source.start(tx, cancel.clone()).await.unwrap();
+
+        let mut seen = std::collections::HashSet::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+        while seen.len() < 3 && tokio::time::Instant::now() < deadline {
+            if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
+                tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await
+            {
+                seen.insert(slot);
+            }
+        }
+        cancel.cancel();
+        let _ = handle.await;
+
+        assert!(
+            seen.contains(&100),
+            "SlotComplete{{slot:100}} must be emitted for a proven-skipped slot; got {seen:?}"
+        );
+        assert!(
+            seen.contains(&101) && seen.contains(&102),
+            "polling must advance past the skipped slot; got {seen:?}"
+        );
     }
 
     /// getBlock failure must not emit SlotComplete or advance.

--- a/indexer/src/indexer/datasource/rpc_polling/types.rs
+++ b/indexer/src/indexer/datasource/rpc_polling/types.rs
@@ -10,6 +10,20 @@ pub struct RpcBlock {
     pub transactions: Vec<RpcTransactionWithMeta>,
 }
 
+/// Outcome of fetching one slot's block. The domain has three states:
+/// a proven-empty slot is safe to checkpoint past, but a slot the endpoint
+/// cannot serve (pruned or snapshot-jumped) has unknown contents and must never
+/// be checkpointed past. Transport and protocol failures stay on the outer
+/// `Result::Err` so existing error handling is untouched.
+#[derive(Debug, Clone)]
+pub enum BlockFetch {
+    Present(RpcBlock),
+    /// Node retains the ledger region and reports no block: safe to advance.
+    Skipped,
+    /// Pruned or snapshot-jumped past: contents unknown, must not advance.
+    Unavailable,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct RpcTransactionWithMeta {
     pub transaction: EncodedTransaction,

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -502,6 +502,7 @@ async fn connect_and_stream(
 mod tests {
     use super::*;
     use crate::indexer::datasource::rpc_polling::rpc::RpcPoller;
+    use crate::test_utils::rpc_mocks::mock_first_available_block;
     use mockito::Server;
     use serde_json::json;
     use solana_sdk::commitment_config::CommitmentLevel;
@@ -623,6 +624,55 @@ mod tests {
         }
 
         assert_eq!(slots, vec![100, 101, 102, 103]);
+    }
+
+    /// An unavailable slot encountered during reconnect gap-fill must abort the fill
+    /// with GapFillFailed rather than checkpoint past the gap.
+    #[tokio::test]
+    async fn try_fill_reconnect_gap_unavailable_slot_fails_closed() {
+        let mut server = Server::new_async().await;
+
+        // checkpoint = 100, current_slot = 103 => replay anchor 99, batch [100..=103].
+        // Slot 100 is absent below the floor (100 < 500) => Unavailable.
+        let _m_slot = mock_get_slot(&mut server, 103);
+        let _m_absent = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getBlock",
+                "params": [100]
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32009, "message": "Slot was skipped" },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .create();
+        let _floor = mock_first_available_block(&mut server, 500);
+
+        let poller = RpcPoller::new(
+            server.url(),
+            UiTransactionEncoding::Json,
+            CommitmentLevel::Finalized,
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        let result =
+            try_fill_reconnect_gap(100, &poller, 1000, 10, ProgramType::Escrow, None, &tx).await;
+
+        let err = result.unwrap_err();
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("Gap fill failed"),
+            "expected GapFillFailed: {err_str}"
+        );
+        assert!(
+            err_str.contains("unavailable") && err_str.contains("100"),
+            "error should name the unavailable slot: {err_str}"
+        );
     }
 
     #[tokio::test]

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -187,7 +187,13 @@ pub fn init_labels(program_type: &str) {
     INDEXER_CHECKPOINT_FRONTIER_LAG.with_label_values(&[program_type]);
     INDEXER_SLOT_PROCESSING_DURATION.with_label_values(&[program_type]);
 
-    for error_type in &["stream", "get_slots", "get_block", "missing_meta"] {
+    for error_type in &[
+        "stream",
+        "get_slots",
+        "get_block",
+        "missing_meta",
+        "block_unavailable",
+    ] {
         INDEXER_RPC_ERRORS.with_label_values(&[program_type, error_type]);
     }
 

--- a/indexer/src/test_utils.rs
+++ b/indexer/src/test_utils.rs
@@ -171,6 +171,20 @@ pub mod escrow_fixtures {
 #[cfg(test)]
 pub mod rpc_mocks {
     use mockito::{Mock, Server};
+    use serde_json::json;
+
+    /// Mock `getFirstAvailableBlock` replying with `floor`. Body-matched so it only
+    /// answers the floor call and coexists with the getBlock mocks in the same test.
+    pub fn mock_first_available_block(server: &mut Server, floor: u64) -> Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({
+                "method": "getFirstAvailableBlock"
+            })))
+            .with_status(200)
+            .with_body(json!({ "jsonrpc": "2.0", "result": floor, "id": 1 }).to_string())
+            .create()
+    }
 
     /// Create a mock JSON-RPC response with a successful result
     pub async fn mock_rpc_success(server: &mut Server, result: &str) -> Mock {


### PR DESCRIPTION
## Summary

Closes issue 16. Previously, `RpcPoller::get_block` treated several fundamentally different RPC responses (`-32007`, `-32009`, and `null`) as the same outcome (`Ok(None)`). Downstream code interpreted this as a skipped slot and advanced the indexer's durable checkpoint, emitting `SlotComplete` even when the slot may actually have been unavailable due to pruned history or a snapshot jump. This created a data-loss risk: if the slot contained transactions, the checkpoint could move past it and a restart would never revisit that data.

This change introduces an explicit three-state result model: `Present`, `Skipped`, and `Unavailable`. When a block is absent, the indexer now calls `getFirstAvailableBlock` to determine whether the slot can be proven skipped or is simply below the node’s retained ledger floor. Only proven skipped slots are allowed to advance processing and checkpointing. Slots classified as `Unavailable` follow existing fail-closed behavior, preventing `SlotComplete` emission and ensuring the indexer never checkpoints past data whose contents cannot be verified.

The update preserves current behavior for valid blocks and genuinely skipped slots while improving correctness for pruned or unavailable history. Live polling now retries unavailable slots instead of advancing, and backfill or reconnect gap-fill operations abort with a dedicated `SlotUnavailable` error. 

Comprehensive unit and integration tests cover slot classification, checkpoint behavior, retry logic, and fail-closed handling, ensuring the indexer prioritizes data integrity over liveness when historical data cannot be proven absent.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28803477934) |
| Indexer | 25,240 | 28,530 | 88.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28803477934) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28803477934) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28803477934) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,351 | 15,602 | 79.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28803477934) |
| **Total** | **50,897** | **59,350** | **85.8%** | |

> Last updated: 2026-07-06 16:17:16 UTC by E2E Integration