### PR TITLE
fix(indexer): make a finality Dead verdict mean coverage-proven, corroborated non-inclusion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,9 @@ ADMIN_PRIVATE_KEY=
 DEVNET_RPC_URL=solana_rpc_url
 DEVNET_YELLOWSTONE_ENDPOINT=yellowstone_url
 INDEXER_YELLOWSTONE_TOKEN=yellowstone_x_token
-# Optional archival Solana RPC (maps to COMMON_FALLBACK_RPC_URL). Re-checks a Dead finality
-# verdict; blank stays single-endpoint. Use a different provider than DEVNET_RPC_URL.
-DEVNET_FALLBACK_RPC_URL=
+# Archival Solana RPC (COMMON_FALLBACK_RPC_URL). Re-checks a Dead finality verdict. REQUIRED for the withdraw
+# operator: independent from and same-cluster as DEVNET_RPC_URL, or it refuses to start; optional for escrow.
+DEVNET_FALLBACK_RPC_URL=https://api.devnet.solana.com
 # Local validator RPC (Only if running docker locally)
 LOCAL_VALIDATOR_RPC_URL=http://validator:8899
 # Controls whether the local validator wipes its ledger on container start.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,7 +372,11 @@ services:
       --url https://api.mainnet-beta.solana.com
       --geyser-plugin-config /config/yellowstone-config.json
     networks:
-      - private-channel-network
+      # Second alias so the withdraw operator's mandatory fallback is a distinct
+      # URL reaching this same single local validator (no independent node exists).
+      private-channel-network:
+        aliases:
+          - validator-fallback
     healthcheck:
       test: ["CMD-SHELL", "solana cluster-version || exit 1"]
       interval: 10s
@@ -567,6 +571,9 @@ services:
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres-indexer:5432/${POSTGRES_INDEXER_DB}
       # rpc_url = Solana Solana validator (where ReleaseFunds transactions are sent)
       - COMMON_RPC_URL=${LOCAL_VALIDATOR_RPC_URL}
+      # Mandatory fallback for the withdraw operator; same validator via its distinct
+      # alias since local has no independent node. Use a real archival provider in prod.
+      - COMMON_FALLBACK_RPC_URL=http://validator-fallback:8899
       # source_rpc_url = Solana Private Channels gateway (source of withdrawal/burn state)
       - COMMON_SOURCE_RPC_URL=http://gateway:${GATEWAY_PORT}
       - ADMIN_SIGNER=memory

--- a/indexer/config/example-operator.toml
+++ b/indexer/config/example-operator.toml
@@ -8,8 +8,8 @@ program_type = "escrow"
 
 # RPC endpoint URL for transaction submission
 rpc_url = "http://localhost:8899"
-# Optional archival Solana fallback for rpc_url. Re-checks a Dead finality verdict
-# before a remint/re-release. Empty = unset. Env: COMMON_FALLBACK_RPC_URL
+# Archival Solana fallback for rpc_url (re-checks a Dead finality verdict). REQUIRED for the withdraw
+# operator (independent, same-cluster, reachable) or it refuses to start; optional for escrow. Env: COMMON_FALLBACK_RPC_URL
 # fallback_rpc_url = "https://your-archival-endpoint"
 
 # Escrow instance ID (required for escrow program type, omit for withdraw)

--- a/indexer/config/local/operator-private-channel.toml
+++ b/indexer/config/local/operator-private-channel.toml
@@ -4,9 +4,9 @@
 program_type = "withdraw"
 # Solana Solana validator — where ReleaseFunds transactions are sent
 rpc_url = "http://localhost:18899"
-# Optional archival Solana fallback for rpc_url. Re-checks a Dead finality verdict
-# before a remint/re-release. Empty = unset. Env: COMMON_FALLBACK_RPC_URL
-# fallback_rpc_url = "https://your-archival-endpoint"
+# REQUIRED for the withdraw operator: require an independent, same-cluster, reachable fallback or it refuses to start.
+# Local reuses the validator via a distinct host string (COMMON_FALLBACK_RPC_URL overrides in docker); use a real archival provider in prod.
+fallback_rpc_url = "http://127.0.0.1:18899"
 
 # Solana Private Channels gateway — source of withdrawal/burn state and mint account data
 source_rpc_url = "http://localhost:8898"

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -45,19 +45,19 @@ pub async fn run(
 
     // Optional destination fallback for recovery and the boot pre-flight to
     // re-check a Dead verdict. Empty means unset (env renders "") and maps to None.
-    let fallback_rpc_client = common_config
+    let normalized_fallback_url = common_config
         .fallback_rpc_url
         .as_deref()
-        .filter(|s| !s.is_empty())
-        .map(|url| {
-            Arc::new(RpcClientWithRetry::with_retry_config(
-                url.to_string(),
-                RetryConfig::default(),
-                CommitmentConfig {
-                    commitment: config.rpc_commitment,
-                },
-            ))
-        });
+        .filter(|s| !s.is_empty());
+    let fallback_rpc_client = normalized_fallback_url.map(|url| {
+        Arc::new(RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            RetryConfig::default(),
+            CommitmentConfig {
+                commitment: config.rpc_commitment,
+            },
+        ))
+    });
 
     // The withdraw operator's compensating remint MintTo must broadcast on the source
     // chain (PrivateChannel), where the burn happened. Without source_rpc_url the sender
@@ -74,11 +74,7 @@ pub async fn run(
     }
 
     // A lone prunable Solana RPC's absent status is not proof of non-inclusion, so require an
-    // independent, same-cluster, reachable fallback (empty env string treated as unset) before starting.
-    let normalized_fallback_url = common_config
-        .fallback_rpc_url
-        .as_deref()
-        .filter(|s| !s.is_empty());
+    // independent, same-cluster, reachable fallback before starting.
     validate_withdraw_fallback(
         common_config.program_type,
         &rpc_client,

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -73,6 +73,21 @@ pub async fn run(
         ));
     }
 
+    // A lone prunable Solana RPC's absent status is not proof of non-inclusion, so require an
+    // independent, same-cluster, reachable fallback (empty env string treated as unset) before starting.
+    let normalized_fallback_url = common_config
+        .fallback_rpc_url
+        .as_deref()
+        .filter(|s| !s.is_empty());
+    validate_withdraw_fallback(
+        common_config.program_type,
+        &rpc_client,
+        fallback_rpc_client.as_deref(),
+        &common_config.rpc_url,
+        normalized_fallback_url,
+    )
+    .await?;
+
     // Initialize source RPC client if configured
     let source_rpc_client = common_config.source_rpc_url.as_ref().map(|url| {
         Arc::new(RpcClientWithRetry::with_retry_config(
@@ -422,6 +437,53 @@ async fn run_withdraw_preflight(
     }
 }
 
+/// Withdraw-only gate for the mandatory Solana fallback: require a second endpoint that is independent, same-cluster
+/// (equal genesis hash), and reachable, or refuse to start. Archival depth is left to the per-attempt ledger-floor check.
+async fn validate_withdraw_fallback(
+    program_type: crate::config::ProgramType,
+    rpc_client: &RpcClientWithRetry,
+    fallback: Option<&RpcClientWithRetry>,
+    rpc_url: &str,
+    fallback_url: Option<&str>,
+) -> Result<(), OperatorError> {
+    if program_type != crate::config::ProgramType::Withdraw {
+        return Ok(());
+    }
+
+    let (Some(fallback), Some(fallback_url)) = (fallback, fallback_url) else {
+        return Err(OperatorError::RpcError(
+            "fallback_rpc_url is required for the withdraw operator: a lone Solana endpoint's \
+             absent status is not proof of non-inclusion"
+                .to_string(),
+        ));
+    };
+
+    if fallback_url == rpc_url {
+        return Err(OperatorError::RpcError(
+            "fallback_rpc_url must differ from rpc_url: an independent endpoint, not the same node"
+                .to_string(),
+        ));
+    }
+
+    // getGenesisHash doubles as a reachability probe for each endpoint.
+    let primary_genesis = rpc_client
+        .get_genesis_hash()
+        .await
+        .map_err(|e| OperatorError::RpcError(format!("rpc_url unreachable at startup: {e}")))?;
+    let fallback_genesis = fallback.get_genesis_hash().await.map_err(|e| {
+        OperatorError::RpcError(format!("fallback_rpc_url unreachable at startup: {e}"))
+    })?;
+
+    if primary_genesis != fallback_genesis {
+        return Err(OperatorError::RpcError(
+            "fallback_rpc_url is on a different cluster than rpc_url (genesis hash mismatch)"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 /// Log + metric for a critical task that exited before cancellation.
 ///
 /// We don't abort the process here — the caller falls through to
@@ -441,6 +503,7 @@ fn critical_exit(program_type_label: &str, task_name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ProgramType;
     use crate::operator::utils::rpc_util::RetryConfig;
     use crate::operator::utils::smt_util::SmtState;
     use crate::storage::common::storage::mock::MockStorage;
@@ -448,6 +511,7 @@ mod tests {
     use base64::Engine;
     use borsh::BorshSerialize;
     use private_channel_escrow_program_client::Instance;
+    use solana_sdk::hash::Hash;
     use solana_sdk::pubkey::Pubkey;
     use std::time::Duration;
 
@@ -572,6 +636,145 @@ mod tests {
                 ))
             ),
             "a real mismatch must refuse to start: {result:?}"
+        );
+    }
+
+    // ── withdraw fallback startup gate ───────────────────────────────
+
+    /// Register a `getGenesisHash` reply of `hash` (base58) on `server`.
+    fn mock_genesis(server: &mut mockito::ServerGuard, hash: &str) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getGenesisHash""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(r#"{{"jsonrpc":"2.0","result":"{hash}","id":0}}"#))
+            .create()
+    }
+
+    /// A withdraw operator with no fallback configured must refuse to start.
+    #[tokio::test]
+    async fn withdraw_missing_fallback_refuses_start() {
+        let primary = make_rpc_client("http://localhost:8899");
+        let result = validate_withdraw_fallback(
+            ProgramType::Withdraw,
+            &primary,
+            None,
+            "http://localhost:8899",
+            None,
+        )
+        .await;
+        assert!(matches!(result, Err(OperatorError::RpcError(_))));
+    }
+
+    /// A fallback whose URL equals rpc_url is not independent; refuse to start.
+    #[tokio::test]
+    async fn withdraw_fallback_same_url_refuses_start() {
+        let primary = make_rpc_client("http://localhost:8899");
+        let fallback = make_rpc_client("http://localhost:8899");
+        let result = validate_withdraw_fallback(
+            ProgramType::Withdraw,
+            &primary,
+            Some(&fallback),
+            "http://localhost:8899",
+            Some("http://localhost:8899"),
+        )
+        .await;
+        assert!(matches!(result, Err(OperatorError::RpcError(_))));
+    }
+
+    /// Two reachable endpoints on different clusters (differing genesis) refuse.
+    #[tokio::test]
+    async fn withdraw_fallback_different_genesis_refuses_start() {
+        let mut primary_server = mockito::Server::new_async().await;
+        let mut fallback_server = mockito::Server::new_async().await;
+        let _p = mock_genesis(&mut primary_server, &Hash::new_unique().to_string());
+        let _f = mock_genesis(&mut fallback_server, &Hash::new_unique().to_string());
+
+        let primary = make_rpc_client(&primary_server.url());
+        let fallback = make_rpc_client(&fallback_server.url());
+        let result = validate_withdraw_fallback(
+            ProgramType::Withdraw,
+            &primary,
+            Some(&fallback),
+            &primary_server.url(),
+            Some(&fallback_server.url()),
+        )
+        .await;
+        assert!(matches!(result, Err(OperatorError::RpcError(_))));
+    }
+
+    /// An unreachable fallback (genesis RPC error) refuses to start.
+    #[tokio::test]
+    async fn withdraw_fallback_unreachable_refuses_start() {
+        let mut primary_server = mockito::Server::new_async().await;
+        let mut fallback_server = mockito::Server::new_async().await;
+        let _p = mock_genesis(&mut primary_server, &Hash::new_unique().to_string());
+        let _f = fallback_server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getGenesisHash""#.into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"down"},"id":0}"#)
+            .create();
+
+        let primary = make_rpc_client(&primary_server.url());
+        let fallback = make_rpc_client(&fallback_server.url());
+        let result = validate_withdraw_fallback(
+            ProgramType::Withdraw,
+            &primary,
+            Some(&fallback),
+            &primary_server.url(),
+            Some(&fallback_server.url()),
+        )
+        .await;
+        assert!(matches!(result, Err(OperatorError::RpcError(_))));
+    }
+
+    /// Independent, same-cluster, reachable fallback: the gate passes.
+    #[tokio::test]
+    async fn withdraw_valid_fallback_passes() {
+        let mut primary_server = mockito::Server::new_async().await;
+        let mut fallback_server = mockito::Server::new_async().await;
+        let genesis = Hash::new_unique().to_string();
+        let _p = mock_genesis(&mut primary_server, &genesis);
+        let _f = mock_genesis(&mut fallback_server, &genesis);
+
+        let primary = make_rpc_client(&primary_server.url());
+        let fallback = make_rpc_client(&fallback_server.url());
+        let result = validate_withdraw_fallback(
+            ProgramType::Withdraw,
+            &primary,
+            Some(&fallback),
+            &primary_server.url(),
+            Some(&fallback_server.url()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "matching genesis + distinct URLs must pass: {result:?}"
+        );
+    }
+
+    /// The mandatory-fallback rule is withdraw-only: an escrow operator with no
+    /// fallback passes the gate untouched.
+    #[tokio::test]
+    async fn escrow_no_fallback_passes() {
+        let primary = make_rpc_client("http://localhost:8899");
+        let result = validate_withdraw_fallback(
+            ProgramType::Escrow,
+            &primary,
+            None,
+            "http://localhost:8899",
+            None,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "escrow must not require a fallback: {result:?}"
         );
     }
 }

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -617,6 +617,18 @@ mod tests {
             .create()
     }
 
+    /// Covered ledger floor so an absence-Dead resolves to Dead, not a prune.
+    fn mock_first_available_block(server: &mut mockito::ServerGuard, floor: u64) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getFirstAvailableBlock""#.into(),
+            ))
+            .with_status(200)
+            .with_body(format!(r#"{{"jsonrpc":"2.0","result":{floor},"id":1}}"#))
+            .create()
+    }
+
     /// The keystone divergence from withdrawal: a deposit with no persisted signature is
     /// provably never broadcast (pre-broadcast persist), so it Demotes for a safe re-mint
     /// rather than Quarantining. No RPC is consulted.
@@ -676,6 +688,8 @@ mod tests {
         let _status = mock_null_status(&mut server);
         // current_height (1000) > lvbh (100) means expired/dead.
         let _height = mock_block_height(&mut server, 1000);
+        // Covered floor (0) so the single-endpoint absence is proven Dead.
+        let _floor = mock_first_available_block(&mut server, 0);
 
         let mock = MockStorage::new();
         let row = make_deposit_row(1);
@@ -830,6 +844,8 @@ mod tests {
             .with_status(200)
             .with_body(r#"{"jsonrpc":"2.0","result":1000,"id":1}"#)
             .create();
+        // Covered floor (0) so the single-endpoint absence is proven Dead.
+        let _floor = mock_first_available_block(&mut server, 0);
 
         let mock = MockStorage::new();
         let row = make_withdrawal_row(1, Some(42));

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -324,18 +324,6 @@ pub(crate) enum SigFinality {
     Uncertain(String),
 }
 
-impl SigFinality {
-    /// Short variant name plus its payload, for triage logs.
-    fn label(&self) -> String {
-        match self {
-            SigFinality::Landed(sig) => format!("Landed: {sig}"),
-            SigFinality::Live(reason) => format!("Live: {reason}"),
-            SigFinality::Dead => "Dead".to_string(),
-            SigFinality::Uncertain(reason) => format!("Uncertain: {reason}"),
-        }
-    }
-}
-
 /// A primary RPC endpoint plus an optional fallback. One endpoint's missing status
 /// can be a prune or lag rather than proof, so only a `Dead` verdict re-checks it.
 pub(crate) struct FinalityRpc<'a> {
@@ -354,71 +342,167 @@ impl<'a> FinalityRpc<'a> {
     }
 }
 
-/// Classify `sigs`. Only a `Dead` verdict is re-checked against the fallback; the
-/// safe verdicts return from `primary` first, so the fallback is queried rarely.
+/// A blockhash is valid for this many blocks (`MAX_PROCESSING_AGE`), so a landed
+/// transaction's block height is at most this far below its `last_valid_block_height`.
+const BLOCKHASH_VALIDITY_BLOCKS: u64 = 150;
+
+/// Per-endpoint classification carrying the extra detail the policy layer needs
+/// to decide whether an absence-based `Dead` requires a ledger-coverage proof.
+enum EndpointVerdict {
+    Landed(Signature),
+    Live(String),
+    Uncertain(String),
+    /// Every signature carries a finalized-failed status: positive on-chain
+    /// evidence of non-inclusion, so no coverage proof is needed.
+    DeadFinalizedFailure,
+    /// At least one signature is null-status past its blockhash validity. Absence
+    /// is trustworthy only if the endpoint still retains the attempt's slot range;
+    /// `min_lvbh` is the lowest such height, bounding that range.
+    DeadByAbsence {
+        min_lvbh: u64,
+    },
+}
+
+/// Ledger-floor coverage decision for an absence-based `Dead`. `covered` is the
+/// verdict; `floor` and `bound` are surfaced so an uncovered `Uncertain` names the
+/// concrete slots an operator must retain to resolve it.
+struct AbsenceCoverage {
+    covered: bool,
+    floor: u64,
+    bound: u64,
+}
+
+/// True when the endpoint's ledger floor covers every slot the attempt could occupy.
+/// `lvbh - 150` lower-bounds the landing slot (slot >= height), so a floor at or below it proves retention.
+async fn absence_is_covered(
+    rpc: &RpcClientWithRetry,
+    min_lvbh: u64,
+) -> Result<AbsenceCoverage, String> {
+    let floor = rpc
+        .get_first_available_block()
+        .await
+        .map_err(|e| format!("ledger floor RPC failed: {e}"))?;
+    let bound = min_lvbh.saturating_sub(BLOCKHASH_VALIDITY_BLOCKS);
+    Ok(AbsenceCoverage {
+        covered: floor <= bound,
+        floor,
+        bound,
+    })
+}
+
+/// Resolve an absence-based `Dead`: `Dead` only when the endpoint proves it retains the
+/// attempt's slot range, else `Uncertain`. Assumes a single consistent archival endpoint, not a split pool.
+async fn coverage_verdict(
+    rpc: &RpcClientWithRetry,
+    min_lvbh: u64,
+    endpoint_label: &str,
+) -> SigFinality {
+    match absence_is_covered(rpc, min_lvbh).await {
+        Ok(c) if c.covered => SigFinality::Dead,
+        Ok(c) => SigFinality::Uncertain(format!(
+            "{endpoint_label}ledger floor {} above attempt window (lvbh {min_lvbh}, retained-slot bound {}); pruned or lagging, absence is not proof of non-inclusion",
+            c.floor, c.bound
+        )),
+        Err(e) => SigFinality::Uncertain(e),
+    }
+}
+
+/// Log the case corroboration exists to catch: the primary called signatures dead but the fallback disagrees.
+/// `detail` carries the overriding verdict's payload (landed signature or live reason) so triage needs no re-query.
+fn warn_fallback_override(verdict: &str, detail: &str, sigs: &[PendingSig]) {
+    warn!(
+        "finality fallback overrode a primary Dead verdict ({verdict}: {detail}) for signature(s): {}",
+        sigs.iter()
+            .map(|p| p.signature.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+}
+
+/// Classify `sigs` into a corroborated, coverage-proven verdict: a `Dead` must survive a ledger-floor
+/// check, so a prunable absence degrades to `Uncertain`. Safe verdicts return early, so the floor RPC is rare.
 pub(crate) async fn classify_signatures(
     finality: &FinalityRpc<'_>,
     sigs: &[PendingSig],
 ) -> SigFinality {
-    let verdict = classify_against(finality.primary, sigs).await;
-    if !matches!(verdict, SigFinality::Dead) {
-        return verdict;
-    }
+    let primary_lvbh = match classify_endpoint(finality.primary, sigs).await {
+        EndpointVerdict::Landed(sig) => return SigFinality::Landed(sig),
+        EndpointVerdict::Live(reason) => return SigFinality::Live(reason),
+        EndpointVerdict::Uncertain(reason) => return SigFinality::Uncertain(reason),
+        // A finalized-failed status is positive on-chain evidence; trust it directly.
+        EndpointVerdict::DeadFinalizedFailure => return SigFinality::Dead,
+        EndpointVerdict::DeadByAbsence { min_lvbh } => min_lvbh,
+    };
+
     match finality.fallback {
-        Some(fb) => {
-            // The fallback's verdict is final: it overrides a wrong Dead, or
-            // confirms it. Both sides run the same classifier.
-            let corroborated = classify_against(fb, sigs).await;
-            if !matches!(corroborated, SigFinality::Dead) {
-                // The case this feature exists to catch: the primary called it
-                // dead but an independent endpoint disagrees. Log for triage.
-                warn!(
-                    "finality fallback overrode a primary Dead verdict ({}) for signature(s): {}",
-                    corroborated.label(),
-                    sigs.iter()
-                        .map(|p| p.signature.to_string())
-                        .collect::<Vec<_>>()
-                        .join(",")
-                );
+        // Destination path: the primary is allowed to be pruned (that is why the
+        // fallback exists), so we trust the fallback's verdict and coverage-check
+        // the fallback, never the primary.
+        Some(fb) => match classify_endpoint(fb, sigs).await {
+            EndpointVerdict::Landed(sig) => {
+                warn_fallback_override("Landed", &sig.to_string(), sigs);
+                SigFinality::Landed(sig)
             }
-            corroborated
-        }
-        None => {
-            debug!("finality Dead on single endpoint (no fallback configured); trusting primary");
+            EndpointVerdict::Live(reason) => {
+                warn_fallback_override("Live", &reason, sigs);
+                SigFinality::Live(reason)
+            }
+            EndpointVerdict::Uncertain(reason) => SigFinality::Uncertain(reason),
+            EndpointVerdict::DeadFinalizedFailure => SigFinality::Dead,
+            EndpointVerdict::DeadByAbsence { min_lvbh } => {
+                coverage_verdict(fb, min_lvbh, "fallback ").await
+            }
+        },
+        // Source/escrow single endpoint: no second node can corroborate, so the
+        // sole endpoint's coverage is the whole protection.
+        None => coverage_verdict(finality.primary, primary_lvbh, "").await,
+    }
+}
+
+/// Thin test-only wrapper over `classify_endpoint` mapping both `Dead` shapes to `SigFinality::Dead`.
+/// Lets the per-endpoint unit tests assert status logic without the coverage gate `classify_signatures` adds.
+#[cfg(test)]
+pub(crate) async fn classify_against(rpc: &RpcClientWithRetry, sigs: &[PendingSig]) -> SigFinality {
+    match classify_endpoint(rpc, sigs).await {
+        EndpointVerdict::Landed(sig) => SigFinality::Landed(sig),
+        EndpointVerdict::Live(reason) => SigFinality::Live(reason),
+        EndpointVerdict::Uncertain(reason) => SigFinality::Uncertain(reason),
+        EndpointVerdict::DeadFinalizedFailure | EndpointVerdict::DeadByAbsence { .. } => {
             SigFinality::Dead
         }
     }
 }
 
-/// Classify `sigs` against a single endpoint (see `SigFinality` variants).
-pub(crate) async fn classify_against(rpc: &RpcClientWithRetry, sigs: &[PendingSig]) -> SigFinality {
+/// Classify `sigs` against one endpoint's `getSignatureStatuses` history, distinguishing a
+/// finalized-failed `Dead` from an absence-based one so only the latter needs a coverage proof.
+async fn classify_endpoint(rpc: &RpcClientWithRetry, sigs: &[PendingSig]) -> EndpointVerdict {
     let flat: Vec<Signature> = sigs.iter().map(|p| p.signature).collect();
 
     let response = match rpc.get_signature_statuses_with_history(&flat).await {
         Ok(r) => r,
         Err(e) => {
-            return SigFinality::Uncertain(format!("signature status RPC failed: {}", e));
+            return EndpointVerdict::Uncertain(format!("signature status RPC failed: {}", e));
         }
     };
 
     // RPC returns one status per signature in order; a length mismatch would
     // silently skip checks below, so treat it as uncertain.
     if response.value.len() != flat.len() {
-        return SigFinality::Uncertain(format!(
+        return EndpointVerdict::Uncertain(format!(
             "RPC returned {} statuses for {} signatures",
             response.value.len(),
             flat.len()
         ));
     }
 
-    // Any sig finalized successfully → the release landed.
+    // Any sig finalized successfully means the transaction landed.
     let finalized_success_index = response.value.iter().position(|signature_status| {
         signature_status.as_ref().is_some_and(|status| {
             status.satisfies_commitment(CommitmentConfig::finalized()) && status.err.is_none()
         })
     });
     if let Some(index) = finalized_success_index {
-        return SigFinality::Landed(flat[index]);
+        return EndpointVerdict::Landed(flat[index]);
     }
 
     // Fetch block height only for the lvbh check on null-status sigs, so a
@@ -427,13 +511,17 @@ pub(crate) async fn classify_against(rpc: &RpcClientWithRetry, sigs: &[PendingSi
         match rpc.get_block_height().await {
             Ok(h) => h,
             Err(e) => {
-                return SigFinality::Uncertain(format!("block height RPC failed: {}", e));
+                return EndpointVerdict::Uncertain(format!("block height RPC failed: {}", e));
             }
         }
     } else {
         // Unused: the null-status branch below only fires when some status is None.
         0
     };
+
+    // Lowest lvbh across null-status expired sigs bounds the slot range whose
+    // retention the coverage proof must cover.
+    let mut min_absent_lvbh: Option<u64> = None;
 
     // Walk the sigs to see if any could still land (index-aligned with response.value).
     for (index, pending_sig) in sigs.iter().enumerate() {
@@ -445,23 +533,32 @@ pub(crate) async fn classify_against(rpc: &RpcClientWithRetry, sigs: &[PendingSi
                 continue;
             }
             // confirmed/processed: in a block, will finalize regardless of blockhash validity.
-            return SigFinality::Live(
+            return EndpointVerdict::Live(
                 "signature is on-chain (confirmed/processed) and awaiting finalization".to_string(),
             );
         }
 
         // No status entry. lvbh is the only thing keeping it alive.
         if current_height > pending_sig.last_valid_block_height {
+            min_absent_lvbh = Some(
+                min_absent_lvbh.map_or(pending_sig.last_valid_block_height, |m| {
+                    m.min(pending_sig.last_valid_block_height)
+                }),
+            );
             continue;
         }
-        return SigFinality::Live(format!(
+        return EndpointVerdict::Live(format!(
             "signatures still within blockhash validity (current_height={})",
             current_height
         ));
     }
 
-    // Every sig is finalized-failed or expired.
-    SigFinality::Dead
+    match min_absent_lvbh {
+        // At least one sig is an expired absence: its non-inclusion needs a proof.
+        Some(min_lvbh) => EndpointVerdict::DeadByAbsence { min_lvbh },
+        // No absence: every sig carried a finalized-failed status.
+        None => EndpointVerdict::DeadFinalizedFailure,
+    }
 }
 
 /// Process matured entries in the deferred remint queue. For each matured
@@ -1498,6 +1595,13 @@ mod tests {
             r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
         )
         .await;
+        // Covered ledger floor so the absence-Dead is proven, not a prune.
+        let _floor_mock = mock_rpc(
+            &mut rpc_server,
+            "getFirstAvailableBlock",
+            r#"{"jsonrpc":"2.0","result":0,"id":0}"#,
+        )
+        .await;
 
         state.pending_remints.push(PendingRemint {
             ctx: TransactionContext {
@@ -1949,7 +2053,18 @@ mod tests {
         }]
     }
 
-    /// Make the endpoint return null + a block height past validity, i.e. Dead.
+    /// Register a `getFirstAvailableBlock` reply of `floor` on `server`.
+    async fn mock_floor(server: &mut mockito::Server, floor: u64) {
+        mock_rpc(
+            server,
+            "getFirstAvailableBlock",
+            &format!(r#"{{"jsonrpc":"2.0","result":{floor},"id":0}}"#),
+        )
+        .await;
+    }
+
+    /// Make the endpoint return null + a block height past validity (absence-Dead)
+    /// with a covered ledger floor (0), so the absence resolves to Dead.
     async fn mock_dead(server: &mut mockito::Server) {
         mock_rpc(
             server,
@@ -1963,6 +2078,25 @@ mod tests {
             r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
         )
         .await;
+        mock_floor(server, 0).await;
+    }
+
+    /// Like `mock_dead` but with a pruned ledger floor above the attempt window,
+    /// so the absence is uncovered and must resolve to Uncertain, never Dead.
+    async fn mock_dead_pruned(server: &mut mockito::Server, floor: u64) {
+        mock_rpc(
+            server,
+            "getSignatureStatuses",
+            status_body(StatusKind::Null),
+        )
+        .await;
+        mock_rpc(
+            server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+        mock_floor(server, floor).await;
     }
 
     /// The bug scenario. The primary reports the release gone but the fallback
@@ -1994,10 +2128,10 @@ mod tests {
         );
     }
 
-    /// Both endpoints agree the signatures are gone, so Dead stands and the
-    /// remint is safe.
+    /// Both endpoints agree the signatures are gone and the fallback's floor covers
+    /// the attempt window, so Dead stands and the remint is safe.
     #[tokio::test]
-    async fn dead_corroborated_by_fallback_stays_dead() {
+    async fn dead_corroborated_by_fallback_covered_stays_dead() {
         let mut primary = mockito::Server::new_async().await;
         let mut fb = mockito::Server::new_async().await;
         mock_dead(&mut primary).await;
@@ -2014,8 +2148,123 @@ mod tests {
                 classify_signatures(&finality, &one_expired_sig()).await,
                 SigFinality::Dead
             ),
-            "both endpoints Dead must stay Dead"
+            "both endpoints Dead with a covered fallback floor must stay Dead"
         );
+    }
+
+    /// The fallback also sees the signatures gone, but its ledger floor is above the attempt window
+    /// (pruned/lagging), so absence on the pruned fallback must be Uncertain, never Dead.
+    #[tokio::test]
+    async fn dead_by_fallback_uncovered_is_uncertain() {
+        let mut primary = mockito::Server::new_async().await;
+        let mut fb = mockito::Server::new_async().await;
+        mock_dead(&mut primary).await;
+        mock_dead_pruned(&mut fb, 1000).await;
+
+        let p = make_rpc(&primary.url());
+        let f = make_rpc(&fb.url());
+        let finality = FinalityRpc {
+            primary: &p,
+            fallback: Some(&f),
+        };
+        match classify_signatures(&finality, &one_expired_sig()).await {
+            SigFinality::Uncertain(reason) => {
+                assert!(
+                    reason.contains("fallback ledger floor"),
+                    "reason must name the fallback: {reason}"
+                );
+            }
+            _ => panic!("a pruned fallback absence must be Uncertain, not Dead/Live/Landed"),
+        }
+    }
+
+    /// Coverage is judged on the fallback only: the primary's floor is pruned high and never consulted,
+    /// while the fallback's floor covers the window, so the verdict is Dead.
+    #[tokio::test]
+    async fn primary_pruned_fallback_covered_is_dead() {
+        let mut primary = mockito::Server::new_async().await;
+        let mut fb = mockito::Server::new_async().await;
+        // Primary absence with a pruned floor; asserting it is never queried.
+        mock_rpc(
+            &mut primary,
+            "getSignatureStatuses",
+            status_body(StatusKind::Null),
+        )
+        .await;
+        mock_rpc(
+            &mut primary,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+        let primary_floor_untouched = primary
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getFirstAvailableBlock""#.into(),
+            ))
+            .expect(0)
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","result":9999,"id":0}"#)
+            .create_async()
+            .await;
+        // Fallback absence with a covered floor.
+        mock_dead(&mut fb).await;
+
+        let p = make_rpc(&primary.url());
+        let f = make_rpc(&fb.url());
+        let finality = FinalityRpc {
+            primary: &p,
+            fallback: Some(&f),
+        };
+        assert!(
+            matches!(
+                classify_signatures(&finality, &one_expired_sig()).await,
+                SigFinality::Dead
+            ),
+            "coverage on the fallback alone must decide Dead"
+        );
+        primary_floor_untouched.assert_async().await;
+    }
+
+    /// A finalized-failed primary status is definitive non-inclusion: neither a
+    /// coverage floor check nor the fallback is consulted.
+    #[tokio::test]
+    async fn primary_finalized_failure_is_dead_without_coverage_check() {
+        let mut primary = mockito::Server::new_async().await;
+        let mut fb = mockito::Server::new_async().await;
+        // Finalized-failed status: positive on-chain failure evidence.
+        mock_rpc(
+            &mut primary,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{
+                "slot":100,"confirmations":null,
+                "err":{"InstructionError":[0,{"Custom":1}]},
+                "status":{"Err":{"InstructionError":[0,{"Custom":1}]}},
+                "confirmationStatus":"finalized"}]},"id":0}"#,
+        )
+        .await;
+        // No floor mock: reaching getFirstAvailableBlock would 501-fail the test.
+        let fb_untouched = fb
+            .mock("POST", "/")
+            .expect(0)
+            .with_status(200)
+            .create_async()
+            .await;
+
+        let p = make_rpc(&primary.url());
+        let f = make_rpc(&fb.url());
+        let finality = FinalityRpc {
+            primary: &p,
+            fallback: Some(&f),
+        };
+        assert!(
+            matches!(
+                classify_signatures(&finality, &one_expired_sig()).await,
+                SigFinality::Dead
+            ),
+            "a finalized-failed status must be Dead with no coverage or fallback call"
+        );
+        fb_untouched.assert_async().await;
     }
 
     /// The fallback still sees the sig on-chain (confirmed), so defer rather
@@ -2076,10 +2325,10 @@ mod tests {
         );
     }
 
-    /// With no fallback configured, the primary's Dead is trusted exactly as
-    /// legacy single-endpoint behavior.
+    /// Single endpoint, absence-Dead, ledger floor covers the attempt window:
+    /// the absence is proven non-inclusion, so Dead stands.
     #[tokio::test]
-    async fn dead_without_fallback_stays_dead() {
+    async fn dead_by_absence_covered_single_endpoint_is_dead() {
         let mut primary = mockito::Server::new_async().await;
         mock_dead(&mut primary).await;
 
@@ -2090,7 +2339,63 @@ mod tests {
                 classify_signatures(&finality, &one_expired_sig()).await,
                 SigFinality::Dead
             ),
-            "no fallback means the primary's Dead is trusted as today"
+            "a covered single-endpoint absence must stay Dead"
+        );
+    }
+
+    /// Single endpoint, absence-Dead, but the ledger floor sits above the attempt window (pruned/lagging).
+    /// Absence is no longer proof of non-inclusion, so it must degrade to Uncertain and carry the floor.
+    #[tokio::test]
+    async fn dead_by_absence_uncovered_single_endpoint_is_uncertain() {
+        let mut primary = mockito::Server::new_async().await;
+        mock_dead_pruned(&mut primary, 1000).await;
+
+        let p = make_rpc(&primary.url());
+        let finality = FinalityRpc::single(&p);
+        match classify_signatures(&finality, &one_expired_sig()).await {
+            SigFinality::Uncertain(reason) => {
+                assert!(reason.contains("ledger floor"), "reason: {reason}");
+                assert!(
+                    reason.contains("1000"),
+                    "reason must carry the floor: {reason}"
+                );
+            }
+            _ => panic!("expected Uncertain on a pruned single endpoint, got Dead/Live/Landed"),
+        }
+    }
+
+    /// Single endpoint, absence-Dead, but the floor RPC itself fails. We cannot
+    /// prove coverage, so fail closed to Uncertain rather than trust the absence.
+    #[tokio::test]
+    async fn dead_by_absence_floor_rpc_error_single_endpoint_is_uncertain() {
+        let mut primary = mockito::Server::new_async().await;
+        mock_rpc(
+            &mut primary,
+            "getSignatureStatuses",
+            status_body(StatusKind::Null),
+        )
+        .await;
+        mock_rpc(
+            &mut primary,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+        mock_rpc(
+            &mut primary,
+            "getFirstAvailableBlock",
+            r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"node unavailable"},"id":0}"#,
+        )
+        .await;
+
+        let p = make_rpc(&primary.url());
+        let finality = FinalityRpc::single(&p);
+        assert!(
+            matches!(
+                classify_signatures(&finality, &one_expired_sig()).await,
+                SigFinality::Uncertain(_)
+            ),
+            "a floor-RPC failure must fail closed to Uncertain, never Dead"
         );
     }
 
@@ -2214,6 +2519,13 @@ mod tests {
             &mut rpc_server,
             "getBlockHeight",
             r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+        // Covered ledger floor so the absence-Dead is proven, not a prune.
+        let _floor_mock = mock_rpc(
+            &mut rpc_server,
+            "getFirstAvailableBlock",
+            r#"{"jsonrpc":"2.0","result":0,"id":0}"#,
         )
         .await;
 
@@ -2957,5 +3269,283 @@ mod tests {
         assert!(state.pending_remints.is_empty());
         // No compensating MintTo was broadcast.
         src_send.assert_async().await;
+    }
+
+    // ── absence_is_covered boundaries ───────────────────────────────
+
+    /// Register a single `getFirstAvailableBlock` reply and return a fast client.
+    async fn floor_client(floor: u64) -> (mockito::ServerGuard, RpcClientWithRetry) {
+        let mut server = mockito::Server::new_async().await;
+        mock_rpc(
+            &mut server,
+            "getFirstAvailableBlock",
+            &format!(r#"{{"jsonrpc":"2.0","result":{floor},"id":0}}"#),
+        )
+        .await;
+        let client = make_rpc(&server.url());
+        (server, client)
+    }
+
+    #[tokio::test]
+    async fn covered_when_floor_below_bound() {
+        // lvbh 1000 -> bound 850; floor 500 <= 850.
+        let (_s, rpc) = floor_client(500).await;
+        assert!(absence_is_covered(&rpc, 1000).await.unwrap().covered);
+    }
+
+    #[tokio::test]
+    async fn boundary_floor_equals_bound_is_covered() {
+        // lvbh 1000 -> bound 850; floor 850 == 850 is covered (inclusive).
+        let (_s, rpc) = floor_client(850).await;
+        assert!(absence_is_covered(&rpc, 1000).await.unwrap().covered);
+    }
+
+    #[tokio::test]
+    async fn boundary_floor_one_above_is_uncovered() {
+        // lvbh 1000 -> bound 850; floor 851 > 850 is uncovered.
+        let (_s, rpc) = floor_client(851).await;
+        assert!(!absence_is_covered(&rpc, 1000).await.unwrap().covered);
+    }
+
+    #[tokio::test]
+    async fn underflow_low_lvbh_requires_floor_zero() {
+        // lvbh 100 -> saturating bound 0. Only a floor of 0 covers it.
+        let (_s1, rpc1) = floor_client(1).await;
+        assert!(!absence_is_covered(&rpc1, 100).await.unwrap().covered);
+        let (_s0, rpc0) = floor_client(0).await;
+        assert!(absence_is_covered(&rpc0, 100).await.unwrap().covered);
+    }
+
+    #[tokio::test]
+    async fn floor_rpc_error_is_err() {
+        let mut server = mockito::Server::new_async().await;
+        mock_rpc(
+            &mut server,
+            "getFirstAvailableBlock",
+            r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"node unavailable"},"id":0}"#,
+        )
+        .await;
+        let rpc = make_rpc(&server.url());
+        assert!(absence_is_covered(&rpc, 1000).await.is_err());
+    }
+
+    // ── coverage-gated absence ──────────────────────────────────────
+
+    /// The release signatures are expired but the destination endpoint's ledger
+    /// floor is pruned above the attempt window, so absence is not proof of
+    /// non-inclusion. The gate must defer (no remint, no status write) and bump.
+    #[tokio::test]
+    async fn process_pending_remints_expired_but_pruned_dest_defers() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        seed_pending_remint_row(&mock, 110, 0);
+
+        let sig = Signature::new_unique();
+        let _status_mock = mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":0}"#,
+        )
+        .await;
+        let _block_height_mock = mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+        // Pruned floor: above the lvbh(100)-150 bound (0), so absence is uncovered.
+        let _floor_mock = mock_rpc(
+            &mut rpc_server,
+            "getFirstAvailableBlock",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(110),
+                withdrawal_nonce: Some(30),
+                trace_id: Some("trace-110".to_string()),
+            },
+            remint_info: make_remint_info(110),
+            signatures: vec![PendingSig {
+                signature: sig,
+                last_valid_block_height: 100,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a pruned dest absence must defer, not remint or write a status"
+        );
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
+    }
+
+    /// A prior remint signature exists but the source endpoint's ledger floor is
+    /// pruned above the attempt window, so its absence cannot prove non-inclusion.
+    /// attempt_remint must refuse to resend and escalate to ManualReview, never
+    /// broadcast a duplicate MintTo.
+    #[tokio::test]
+    async fn attempt_remint_source_pruned_refuses_and_escalates() {
+        ensure_test_signer();
+        let mut rpc_server = mockito::Server::new_async().await;
+        let (state, mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // A prior remint attempt is on record, so classification runs before resend.
+        mock.remint_signatures
+            .lock()
+            .unwrap()
+            .insert(710, vec![(Signature::new_unique().to_string(), 0)]);
+        mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":0}"#,
+        )
+        .await;
+        mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+        // Pruned floor: the source cannot prove the prior attempt did not land.
+        mock_rpc(
+            &mut rpc_server,
+            "getFirstAvailableBlock",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+        // A resend must never be broadcast.
+        let send = rpc_server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"sendTransaction""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","result":"{}","id":0}}"#,
+                Signature::new_unique()
+            ))
+            .expect(0)
+            .create_async()
+            .await;
+
+        let entry = PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(710),
+                withdrawal_nonce: Some(71),
+                trace_id: Some("trace-710".to_string()),
+            },
+            remint_info: make_remint_info(710),
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        };
+
+        let outcome = execute_deferred_remint(&state, entry, &storage_tx).await;
+        assert!(matches!(outcome, DeferredRemintOutcome::Resolved));
+        let update = storage_rx
+            .try_recv()
+            .expect("a pruned source must escalate to a status update");
+        assert_eq!(update.transaction_id, 710);
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let err = update.error_message.as_deref().unwrap_or("");
+        assert!(
+            err.contains("refusing to remint"),
+            "must fail closed: {err}"
+        );
+        send.assert_async().await;
+    }
+
+    /// The mirror of the pruned case: a prior remint signature exists and the
+    /// source floor covers the attempt window, so the absence is proven Dead and
+    /// the idempotency gate allows the resend to proceed.
+    #[tokio::test]
+    async fn attempt_remint_source_covered_dead_resends() {
+        ensure_test_signer();
+        let mut dest = mockito::Server::new_async().await;
+        let mut source = mockito::Server::new_async().await;
+        let (state, mock) = make_sender_state_split_rpc(&dest.url(), &source.url(), None);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        mock.remint_signatures
+            .lock()
+            .unwrap()
+            .insert(720, vec![(Signature::new_unique().to_string(), 0)]);
+        // Source: expired absence with a covered floor, so classification is Dead.
+        mock_rpc(
+            &mut source,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":0}"#,
+        )
+        .await;
+        mock_rpc(
+            &mut source,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
+        )
+        .await;
+        mock_rpc(
+            &mut source,
+            "getFirstAvailableBlock",
+            r#"{"jsonrpc":"2.0","result":0,"id":0}"#,
+        )
+        .await;
+        // The resend build needs a blockhash, then broadcasts a fresh MintTo.
+        mock_rpc(
+            &mut source,
+            "getLatestBlockhash",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":1000}},"id":0}"#,
+        )
+        .await;
+        let send = source
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"sendTransaction""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","result":"{}","id":0}}"#,
+                Signature::new_unique()
+            ))
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let entry = PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(720),
+                withdrawal_nonce: Some(72),
+                trace_id: Some("trace-720".to_string()),
+            },
+            remint_info: make_remint_info(720),
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        };
+
+        // Covered Dead classification lets the resend broadcast (confirmation then
+        // stays unconfirmed here, so the entry defers; the broadcast is the point).
+        let _ = execute_deferred_remint(&state, entry, &storage_tx).await;
+        send.assert_async().await;
     }
 }

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -19,7 +19,9 @@ use crate::{
 };
 use chrono::Utc;
 use solana_keychain::SolanaSigner;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Signature};
+use solana_sdk::{
+    clock::MAX_PROCESSING_AGE, commitment_config::CommitmentConfig, signature::Signature,
+};
 use std::str::FromStr;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
@@ -342,10 +344,6 @@ impl<'a> FinalityRpc<'a> {
     }
 }
 
-/// A blockhash is valid for this many blocks (`MAX_PROCESSING_AGE`), so a landed
-/// transaction's block height is at most this far below its `last_valid_block_height`.
-const BLOCKHASH_VALIDITY_BLOCKS: u64 = 150;
-
 /// Per-endpoint classification carrying the extra detail the policy layer needs
 /// to decide whether an absence-based `Dead` requires a ledger-coverage proof.
 enum EndpointVerdict {
@@ -363,48 +361,27 @@ enum EndpointVerdict {
     },
 }
 
-/// Ledger-floor coverage decision for an absence-based `Dead`. `covered` is the
-/// verdict; `floor` and `bound` are surfaced so an uncovered `Uncertain` names the
-/// concrete slots an operator must retain to resolve it.
-struct AbsenceCoverage {
-    covered: bool,
-    floor: u64,
-    bound: u64,
-}
-
-/// True when the endpoint's ledger floor covers every slot the attempt could occupy.
-/// `lvbh - 150` lower-bounds the landing slot (slot >= height), so a floor at or below it proves
-/// retention; comparing a floor slot to a height bound only over-reports Uncertain, never a false covered.
-async fn absence_is_covered(
-    rpc: &RpcClientWithRetry,
-    min_lvbh: u64,
-) -> Result<AbsenceCoverage, String> {
-    let floor = rpc
-        .get_first_available_block()
-        .await
-        .map_err(|e| format!("ledger floor RPC failed: {e}"))?;
-    let bound = min_lvbh.saturating_sub(BLOCKHASH_VALIDITY_BLOCKS);
-    Ok(AbsenceCoverage {
-        covered: floor <= bound,
-        floor,
-        bound,
-    })
-}
-
 /// Resolve an absence-based `Dead`: `Dead` only when the endpoint proves it retains the
-/// attempt's slot range, else `Uncertain`. Assumes a single consistent archival endpoint, not a split pool.
+/// attempt's slot range, else `Uncertain`. A blockhash is valid for `MAX_PROCESSING_AGE`
+/// blocks, so `lvbh - MAX_PROCESSING_AGE` lower-bounds the landing slot (slot >= height); a
+/// floor at or below it proves retention, and the height-vs-slot slack only over-reports
+/// Uncertain, never a false covered. Assumes a single consistent archival endpoint, not a split pool.
 async fn coverage_verdict(
     rpc: &RpcClientWithRetry,
     min_lvbh: u64,
     endpoint_label: &str,
 ) -> SigFinality {
-    match absence_is_covered(rpc, min_lvbh).await {
-        Ok(c) if c.covered => SigFinality::Dead,
-        Ok(c) => SigFinality::Uncertain(format!(
-            "{endpoint_label}ledger floor {} above attempt window (lvbh {min_lvbh}, retained-slot bound {}); pruned or lagging, absence is not proof of non-inclusion",
-            c.floor, c.bound
-        )),
-        Err(e) => SigFinality::Uncertain(e),
+    let floor = match rpc.get_first_available_block().await {
+        Ok(floor) => floor,
+        Err(e) => return SigFinality::Uncertain(format!("ledger floor RPC failed: {e}")),
+    };
+    let bound = min_lvbh.saturating_sub(MAX_PROCESSING_AGE as u64);
+    if floor <= bound {
+        SigFinality::Dead
+    } else {
+        SigFinality::Uncertain(format!(
+            "{endpoint_label}ledger floor {floor} above attempt window (lvbh {min_lvbh}, retained-slot bound {bound}); pruned or lagging, absence is not proof of non-inclusion"
+        ))
     }
 }
 
@@ -3273,7 +3250,7 @@ mod tests {
         src_send.assert_async().await;
     }
 
-    // ── absence_is_covered boundaries ───────────────────────────────
+    // ── coverage_verdict boundaries ─────────────────────────────────
 
     /// Register a single `getFirstAvailableBlock` reply and return a fast client.
     async fn floor_client(floor: u64) -> (mockito::ServerGuard, RpcClientWithRetry) {
@@ -3292,34 +3269,49 @@ mod tests {
     async fn covered_when_floor_below_bound() {
         // lvbh 1000 -> bound 850; floor 500 <= 850.
         let (_s, rpc) = floor_client(500).await;
-        assert!(absence_is_covered(&rpc, 1000).await.unwrap().covered);
+        assert!(matches!(
+            coverage_verdict(&rpc, 1000, "").await,
+            SigFinality::Dead
+        ));
     }
 
     #[tokio::test]
     async fn boundary_floor_equals_bound_is_covered() {
         // lvbh 1000 -> bound 850; floor 850 == 850 is covered (inclusive).
         let (_s, rpc) = floor_client(850).await;
-        assert!(absence_is_covered(&rpc, 1000).await.unwrap().covered);
+        assert!(matches!(
+            coverage_verdict(&rpc, 1000, "").await,
+            SigFinality::Dead
+        ));
     }
 
     #[tokio::test]
     async fn boundary_floor_one_above_is_uncovered() {
         // lvbh 1000 -> bound 850; floor 851 > 850 is uncovered.
         let (_s, rpc) = floor_client(851).await;
-        assert!(!absence_is_covered(&rpc, 1000).await.unwrap().covered);
+        assert!(matches!(
+            coverage_verdict(&rpc, 1000, "").await,
+            SigFinality::Uncertain(_)
+        ));
     }
 
     #[tokio::test]
     async fn underflow_low_lvbh_requires_floor_zero() {
         // lvbh 100 -> saturating bound 0. Only a floor of 0 covers it.
         let (_s1, rpc1) = floor_client(1).await;
-        assert!(!absence_is_covered(&rpc1, 100).await.unwrap().covered);
+        assert!(matches!(
+            coverage_verdict(&rpc1, 100, "").await,
+            SigFinality::Uncertain(_)
+        ));
         let (_s0, rpc0) = floor_client(0).await;
-        assert!(absence_is_covered(&rpc0, 100).await.unwrap().covered);
+        assert!(matches!(
+            coverage_verdict(&rpc0, 100, "").await,
+            SigFinality::Dead
+        ));
     }
 
     #[tokio::test]
-    async fn floor_rpc_error_is_err() {
+    async fn floor_rpc_error_is_uncertain() {
         let mut server = mockito::Server::new_async().await;
         mock_rpc(
             &mut server,
@@ -3328,7 +3320,10 @@ mod tests {
         )
         .await;
         let rpc = make_rpc(&server.url());
-        assert!(absence_is_covered(&rpc, 1000).await.is_err());
+        assert!(matches!(
+            coverage_verdict(&rpc, 1000, "").await,
+            SigFinality::Uncertain(_)
+        ));
     }
 
     // ── coverage-gated absence ──────────────────────────────────────

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -373,7 +373,8 @@ struct AbsenceCoverage {
 }
 
 /// True when the endpoint's ledger floor covers every slot the attempt could occupy.
-/// `lvbh - 150` lower-bounds the landing slot (slot >= height), so a floor at or below it proves retention.
+/// `lvbh - 150` lower-bounds the landing slot (slot >= height), so a floor at or below it proves
+/// retention; comparing a floor slot to a height bound only over-reports Uncertain, never a false covered.
 async fn absence_is_covered(
     rpc: &RpcClientWithRetry,
     min_lvbh: u64,
@@ -429,7 +430,8 @@ pub(crate) async fn classify_signatures(
         EndpointVerdict::Landed(sig) => return SigFinality::Landed(sig),
         EndpointVerdict::Live(reason) => return SigFinality::Live(reason),
         EndpointVerdict::Uncertain(reason) => return SigFinality::Uncertain(reason),
-        // A finalized-failed status is positive on-chain evidence; trust it directly.
+        // A finalized-failed status is immutable on-chain evidence, so trust it directly and
+        // skip fallback corroboration; only an absence-based Dead needs a coverage proof.
         EndpointVerdict::DeadFinalizedFailure => return SigFinality::Dead,
         EndpointVerdict::DeadByAbsence { min_lvbh } => min_lvbh,
     };

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -3479,7 +3479,7 @@ mod tests {
     #[tokio::test]
     async fn attempt_remint_source_covered_dead_resends() {
         ensure_test_signer();
-        let mut dest = mockito::Server::new_async().await;
+        let dest = mockito::Server::new_async().await;
         let mut source = mockito::Server::new_async().await;
         let (state, mock) = make_sender_state_split_rpc(&dest.url(), &source.url(), None);
         let (storage_tx, _storage_rx) = mpsc::channel(10);

--- a/indexer/src/operator/utils/rpc_util.rs
+++ b/indexer/src/operator/utils/rpc_util.rs
@@ -163,6 +163,27 @@ impl RpcClientWithRetry {
         .await
     }
 
+    /// Get the node's lowest retained slot with retry. An absence-based `Dead`
+    /// finality verdict consults this to prove the endpoint still retains the
+    /// attempt's slot range.
+    pub async fn get_first_available_block(&self) -> Result<u64, Box<client_error::Error>> {
+        self.with_retry(
+            "get_first_available_block",
+            RetryPolicy::Idempotent,
+            || async { self.rpc_client.get_first_available_block().await },
+        )
+        .await
+    }
+
+    /// Get the cluster genesis hash with retry. Used once at withdraw startup to
+    /// prove the fallback endpoint is on the same cluster as the primary.
+    pub async fn get_genesis_hash(&self) -> Result<Hash, Box<client_error::Error>> {
+        self.with_retry("get_genesis_hash", RetryPolicy::Idempotent, || async {
+            self.rpc_client.get_genesis_hash().await
+        })
+        .await
+    }
+
     /// Send transaction with configurable retry policy
     ///
     /// # Arguments
@@ -687,5 +708,90 @@ mod tests {
             5,
             "unrelated ForUser error must be retried"
         );
+    }
+
+    fn make_client_at(url: &str) -> RpcClientWithRetry {
+        RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        )
+    }
+
+    #[tokio::test]
+    async fn get_first_available_block_success() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getFirstAvailableBlock""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"jsonrpc":"2.0","result":12345,"id":0}"#)
+            .create_async()
+            .await;
+        let client = make_client_at(&server.url());
+        assert_eq!(client.get_first_available_block().await.unwrap(), 12345);
+    }
+
+    #[tokio::test]
+    async fn get_first_available_block_rpc_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getFirstAvailableBlock""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"node unavailable"},"id":0}"#,
+            )
+            .create_async()
+            .await;
+        let client = make_client_at(&server.url());
+        assert!(client.get_first_available_block().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_genesis_hash_success() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getGenesisHash""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"jsonrpc":"2.0","result":"11111111111111111111111111111111","id":0}"#)
+            .create_async()
+            .await;
+        let client = make_client_at(&server.url());
+        let hash = client.get_genesis_hash().await.unwrap();
+        assert_eq!(hash, Hash::default());
+    }
+
+    #[tokio::test]
+    async fn get_genesis_hash_rpc_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getGenesisHash""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"node unavailable"},"id":0}"#,
+            )
+            .create_async()
+            .await;
+        let client = make_client_at(&server.url());
+        assert!(client.get_genesis_hash().await.is_err());
     }
 }

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -47,6 +47,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signature, Signer};
 use std::sync::Arc;
 use std::time::Duration;
+use test_utils::operator_helper::same_host_fallback_url;
 use test_utils::operator_helper::start_solana_to_private_channel_operator;
 use test_utils::operator_helper::OperatorHandle;
 use test_utils::validator_helper::start_test_validator_no_geyser;
@@ -122,7 +123,7 @@ async fn start_operator_with_alert(
         // The withdraw operator now requires an independent, same-cluster fallback.
         // Reach the same node via a distinct host string so the URL differs while
         // the genesis hash matches. Harmless for Escrow callers (never validated).
-        fallback_rpc_url: Some(rpc_url.replace("127.0.0.1", "localhost")),
+        fallback_rpc_url: Some(same_host_fallback_url(&rpc_url)),
         postgres: postgres_config,
         escrow_instance_id: Some(instance),
     };
@@ -173,7 +174,7 @@ async fn start_operator_with_config(
         // The withdraw operator now requires an independent, same-cluster fallback.
         // Reach the same node via a distinct host string so the URL differs while
         // the genesis hash matches. Harmless for Escrow callers (never validated).
-        fallback_rpc_url: Some(rpc_url.replace("127.0.0.1", "localhost")),
+        fallback_rpc_url: Some(same_host_fallback_url(&rpc_url)),
         postgres: postgres_config,
         escrow_instance_id: Some(instance),
     };

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -118,8 +118,11 @@ async fn start_operator_with_alert(
         rpc_url: rpc_url.clone(),
         // Withdraw operator requires a source chain for remints; single-validator
         // test, so point it at the same RPC. Harmless for Escrow callers.
-        source_rpc_url: Some(rpc_url),
-        fallback_rpc_url: None,
+        source_rpc_url: Some(rpc_url.clone()),
+        // The withdraw operator now requires an independent, same-cluster fallback.
+        // Reach the same node via a distinct host string so the URL differs while
+        // the genesis hash matches. Harmless for Escrow callers (never validated).
+        fallback_rpc_url: Some(rpc_url.replace("127.0.0.1", "localhost")),
         postgres: postgres_config,
         escrow_instance_id: Some(instance),
     };
@@ -166,8 +169,11 @@ async fn start_operator_with_config(
         rpc_url: rpc_url.clone(),
         // Withdraw operator requires a source chain for remints; single-validator
         // test, so point it at the same RPC. Harmless for Escrow callers.
-        source_rpc_url: Some(rpc_url),
-        fallback_rpc_url: None,
+        source_rpc_url: Some(rpc_url.clone()),
+        // The withdraw operator now requires an independent, same-cluster fallback.
+        // Reach the same node via a distinct host string so the URL differs while
+        // the genesis hash matches. Harmless for Escrow callers (never validated).
+        fallback_rpc_url: Some(rpc_url.replace("127.0.0.1", "localhost")),
         postgres: postgres_config,
         escrow_instance_id: Some(instance),
     };

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -300,6 +300,8 @@ async fn it2b_deposit_dead_signature_demoted() {
         Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
     );
     mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    // Ledger floor 0 covers the attempt window, so the expired absence is proven dead, not uncertain.
+    mock.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
@@ -339,6 +341,8 @@ async fn it3_withdrawal_dead_signature_demoted() {
         Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
     );
     mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    // Ledger floor 0 covers the attempt window, so the expired absence is proven dead, not uncertain.
+    mock.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -93,8 +93,11 @@ async fn start_withdraw_operator(
         rpc_url: rpc_url.clone(),
         // Withdraw operator requires a source chain for remints; single-validator
         // test, so point it at the same RPC.
-        source_rpc_url: Some(rpc_url),
-        fallback_rpc_url: None,
+        source_rpc_url: Some(rpc_url.clone()),
+        // The withdraw operator now requires an independent, same-cluster fallback.
+        // Single-validator test: reach the same node via a distinct host string so
+        // the URL differs while the genesis hash matches.
+        fallback_rpc_url: Some(rpc_url.replace("127.0.0.1", "localhost")),
         postgres: postgres_config,
         escrow_instance_id: Some(instance),
     };

--- a/integration/tests/indexer/withdrawal_null_nonce.rs
+++ b/integration/tests/indexer/withdrawal_null_nonce.rs
@@ -43,7 +43,7 @@ use {
         signature::{Keypair, Signature, Signer},
     },
     std::{sync::Arc, time::Duration},
-    test_utils::operator_helper::OperatorHandle,
+    test_utils::operator_helper::{same_host_fallback_url, OperatorHandle},
     test_utils::validator_helper::start_test_validator_no_geyser,
     testcontainers::runners::AsyncRunner,
     testcontainers_modules::postgres::Postgres,
@@ -97,7 +97,7 @@ async fn start_withdraw_operator(
         // The withdraw operator now requires an independent, same-cluster fallback.
         // Single-validator test: reach the same node via a distinct host string so
         // the URL differs while the genesis hash matches.
-        fallback_rpc_url: Some(rpc_url.replace("127.0.0.1", "localhost")),
+        fallback_rpc_url: Some(same_host_fallback_url(&rpc_url)),
         postgres: postgres_config,
         escrow_instance_id: Some(instance),
     };

--- a/private-channel-deploy/deploy.yml
+++ b/private-channel-deploy/deploy.yml
@@ -92,6 +92,19 @@
 
           Fix: solana-keygen new --no-bip39-passphrase --silent --outfile {{ admin_keypair_path }}
 
+    # The withdraw operator re-checks a Dead finality verdict against this fallback
+    # before reminting and refuses to start without one. localnet reuses the local
+    # validator via the compose file, so the var is only required off localnet.
+    - name: Assert archival fallback RPC is set off localnet
+      ansible.builtin.assert:
+        that: network == 'localnet' or (fallback_rpc_url | default('') | length > 0)
+        fail_msg: |
+          fallback_rpc_url is empty for network={{ network }}.
+          The withdraw operator needs an independent, same-cluster archival Solana
+          RPC to corroborate a Dead finality verdict and refuses to start without
+          one. Set fallback_rpc_url in vars/{{ network }}.yml to a provider
+          independent from rpc_url ({{ rpc_url | default('unset') }}).
+
     - name: Derive admin pubkey via solana-keygen
       ansible.builtin.command: "solana-keygen pubkey {{ admin_keypair_path }}"
       changed_when: false

--- a/private-channel-deploy/vars/common.yml
+++ b/private-channel-deploy/vars/common.yml
@@ -69,9 +69,10 @@ reset_state: false
 # empty chain.
 validator_reset: true
 
-# --- Optional archival RPC fallback ---
+# --- Archival RPC fallback ---
 # Cross-env default for the archival Solana RPC that re-checks a Dead finality
-# verdict. Empty (single-endpoint) by default; set per-env in vars/<env>.yml.
+# verdict. Empty by default; REQUIRED off localnet (set per-env in vars/<env>.yml)
+# since the withdraw operator refuses to start without it.
 fallback_rpc_url: ""
 
 # --- Optional notification webhook posted from the report phase ---

--- a/private-channel-deploy/vars/dev.yml
+++ b/private-channel-deploy/vars/dev.yml
@@ -25,8 +25,9 @@ network: localnet
 #   mainnet  : your dedicated RPC (Helius, Triton, QuickNode, etc.).
 rpc_url: http://127.0.0.1:18899
 
-# fallback_rpc_url - optional archival Solana RPC that re-checks a Dead finality
-# verdict. Set on devnet/mainnet (different provider); leave empty on localnet.
+# fallback_rpc_url - archival Solana RPC that re-checks a Dead finality verdict.
+# REQUIRED off localnet: the withdraw operator refuses to start without an
+# independent, same-cluster endpoint. Leave empty only on localnet.
 fallback_rpc_url: ""
 
 # yellowstone_endpoint — Yellowstone gRPC endpoint for indexer-solana real-time

--- a/test_utils/src/operator_helper.rs
+++ b/test_utils/src/operator_helper.rs
@@ -268,6 +268,16 @@ pub async fn start_solana_to_private_channel_operator_with_mocks(
     })
 }
 
+/// A distinct URL for the same local validator so a withdraw-operator test satisfies the
+/// "fallback must differ from rpc_url" gate with one node. Toggling a trailing slash keeps
+/// the exact host (swapping 127.0.0.1<->localhost risks an IPv4/IPv6 bind mismatch).
+pub fn same_host_fallback_url(rpc_url: &str) -> String {
+    match rpc_url.strip_suffix('/') {
+        Some(stripped) => stripped.to_string(),
+        None => format!("{rpc_url}/"),
+    }
+}
+
 /// Start the operator that reads from PrivateChannel indexer and releases funds on Solana.
 pub async fn start_private_channel_to_solana_operator(
     solana_rpc_url: String,
@@ -283,13 +293,17 @@ pub async fn start_private_channel_to_solana_operator(
 
     let storage = Arc::new(Storage::Postgres(PostgresDb::new(&postgres_config).await?));
 
+    // The withdraw operator now requires an independent, same-cluster fallback;
+    // reuse the same validator via a distinct URL string (single-validator harness).
+    let fallback_url = same_host_fallback_url(&solana_rpc_url);
+
     let common_config = PrivateChannelIndexerConfig {
         program_type: ProgramType::Withdraw,
         storage_type: StorageType::Postgres,
         rpc_url: solana_rpc_url,
         // Source chain (PrivateChannel), where the burn happened and remints land.
         source_rpc_url: Some(private_channel_rpc_url),
-        fallback_rpc_url: None,
+        fallback_rpc_url: Some(fallback_url),
         postgres: postgres_config,
         escrow_instance_id: Some(escrow_instance_id),
     };


### PR DESCRIPTION
## Summary

Closes issue 15. Builds on PR #187 by making a `Dead` verdict mean **coverage-proven, corroborated non-inclusion**. Previously, an absent `getSignatureStatuses` response could be incorrectly treated as proof that a transaction never landed, even if the RPC node had pruned history or was behind.

The fix adds a ledger-floor (`getFirstAvailableBlock`) check before trusting any absence-based `Dead` verdict. If the endpoint cannot prove it still covers the transaction window, the result becomes `Uncertain` and the system refuses to remint. The withdraw operator now requires an independent fallback RPC, validated at startup for reachability, distinct URL, and same-cluster genesis hash.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29085887826) |
| Indexer | 25,892 | 29,175 | 88.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29085887826) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29085887826) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29085887826) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,418 | 15,666 | 79.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29085887826) |
| **Total** | **51,906** | **60,379** | **86.0%** | |

> Last updated: 2026-07-10 11:22:01 UTC by E2E Integration