### PR TITLE
fix(indexer): reconciliation fails closed on mismatch

### DIFF
--- a/indexer/src/bin/indexer.rs
+++ b/indexer/src/bin/indexer.rs
@@ -441,6 +441,10 @@ async fn run_operator(figment: Figment, verbose: bool) -> Result<(), Box<dyn std
     // Validate signer configuration early (from environment variables)
     OperatorConfig::validate_signers().map_err(|e| format!("Signer configuration error: {}", e))?;
 
+    operator_config
+        .validate(common_config.program_type)
+        .map_err(|e| format!("Operator configuration error: {}", e))?;
+
     private_channel_indexer::operator::run(storage, common_config, operator_config, Some(health))
         .await?;
 

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -346,6 +346,20 @@ impl OperatorConfig {
 
         Ok(())
     }
+
+    /// Reject a config where a detected reconciliation mismatch could not reach
+    /// an alert channel. Escrow operators run reconciliation, so they must have
+    /// a webhook configured.
+    pub fn validate(&self, program_type: ProgramType) -> Result<(), String> {
+        if program_type == ProgramType::Escrow && self.reconciliation_webhook_url.is_none() {
+            return Err(
+                "reconciliation_webhook_url is required for escrow operators \
+                 (set OPERATOR_RECONCILIATION_WEBHOOK_URL)"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -549,5 +563,42 @@ mod tests {
             floor_operator_commitment(CommitmentLevel::Finalized).unwrap(),
             CommitmentLevel::Finalized
         );
+    }
+
+    // ── operator reconciliation-webhook gate ────────────────────────────
+
+    fn operator_config_with_webhook(reconciliation_webhook_url: Option<String>) -> OperatorConfig {
+        OperatorConfig {
+            db_poll_interval: std::time::Duration::from_secs(1),
+            batch_size: 10,
+            retry_max_attempts: 3,
+            retry_base_delay: std::time::Duration::from_millis(100),
+            channel_buffer_size: 100,
+            rpc_commitment: CommitmentLevel::Confirmed,
+            alert_webhook_url: None,
+            reconciliation_interval: std::time::Duration::from_secs(60),
+            reconciliation_tolerance_bps: 10,
+            reconciliation_webhook_url,
+            feepayer_monitor_interval: std::time::Duration::from_secs(60),
+            confirmation_poll_interval_ms: 400,
+        }
+    }
+
+    #[test]
+    fn escrow_operator_requires_reconciliation_webhook() {
+        let config = operator_config_with_webhook(None);
+        assert!(config.validate(ProgramType::Escrow).is_err());
+    }
+
+    #[test]
+    fn escrow_operator_with_webhook_validates() {
+        let config = operator_config_with_webhook(Some("http://example.com/hook".to_string()));
+        assert!(config.validate(ProgramType::Escrow).is_ok());
+    }
+
+    #[test]
+    fn withdraw_operator_does_not_require_reconciliation_webhook() {
+        let config = operator_config_with_webhook(None);
+        assert!(config.validate(ProgramType::Withdraw).is_ok());
     }
 }

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -222,16 +222,22 @@ pub async fn run(
         if let Some(reconciliation_escrow) = common_config.escrow_instance_id {
             let reconciliation_storage = storage.clone();
             let reconciliation_config = config.clone();
+            // Solana escrow ATA sweep (source RPC).
             let reconciliation_rpc = source_rpc_client
                 .clone()
                 .unwrap_or_else(|| rpc_client.clone());
+            // PrivateChannel RPC (rpc_url) where channel-token mints live.
+            let reconciliation_channel_rpc = rpc_client.clone();
+            let reconciliation_health = health.clone();
             let reconciliation_token = cancellation_token.clone();
             tokio::spawn(async move {
                 if let Err(e) = reconciliation::run_reconciliation(
                     reconciliation_storage,
                     reconciliation_config,
                     reconciliation_rpc,
+                    reconciliation_channel_rpc,
                     reconciliation_escrow,
+                    reconciliation_health,
                     reconciliation_token,
                 )
                 .await

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -16,7 +16,13 @@ use crate::operator::RpcClientWithRetry;
 use crate::storage::common::amount::{net_to_u64, NetBalance};
 use crate::storage::Storage;
 use private_channel_core::webhook::{WebhookClient, WebhookRetryConfig};
+use private_channel_metrics::HealthState;
+use solana_rpc_client_api::client_error;
+use solana_rpc_client_api::client_error::ErrorKind;
+use solana_rpc_client_api::request::RpcError;
 use solana_sdk::pubkey::Pubkey;
+use spl_token::solana_program::program_pack::Pack;
+use spl_token::state::Mint;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -66,7 +72,9 @@ pub async fn run_reconciliation(
     storage: Arc<Storage>,
     config: OperatorConfig,
     rpc_client: Arc<RpcClientWithRetry>,
+    channel_rpc_client: Arc<RpcClientWithRetry>,
     escrow_instance_id: Pubkey,
+    health: Option<Arc<HealthState>>,
     cancellation_token: CancellationToken,
 ) -> Result<(), OperatorError> {
     info!("Starting reconciliation");
@@ -100,7 +108,9 @@ pub async fn run_reconciliation(
             &storage,
             &config,
             &rpc_client,
+            &channel_rpc_client,
             escrow_instance_id,
+            &health,
             &webhook_client,
             &mut previously_alerted_orphans,
         )
@@ -132,15 +142,22 @@ pub async fn run_reconciliation(
 ///
 /// This function orchestrates the complete reconciliation flow:
 /// 1. Surface orphan deposit rows
-/// 2. Fetch on-chain balances for all mints held by the escrow
+/// 2. Fetch on-chain escrow ATA balances (Solana) for all mints held by the escrow
 /// 3. Query database for sum of completed deposits minus withdrawals per mint
-/// 4. Compare balances with tolerance threshold
-/// 5. Send webhook alert if mismatch exceeds tolerance
+/// 4. Compare balances against the DB ledger; on a breach, alert and fail closed
+/// 5. Read channel-token supply on PrivateChannel and assert supply <= escrow
+///    balance; on a breach, alert and fail closed
+///
+/// `rpc_client` sweeps the Solana escrow ATAs; `channel_rpc_client` reads the
+/// PrivateChannel mints where channel-token supply lives.
+#[allow(clippy::too_many_arguments)]
 async fn perform_reconciliation_check(
     storage: &Arc<Storage>,
     config: &OperatorConfig,
     rpc_client: &Arc<RpcClientWithRetry>,
+    channel_rpc_client: &Arc<RpcClientWithRetry>,
     escrow_instance_id: Pubkey,
+    health: &Option<Arc<HealthState>>,
     webhook_client: &WebhookClient,
     previously_alerted_orphans: &mut Option<HashSet<i64>>,
 ) -> Result<(), OperatorError> {
@@ -183,7 +200,7 @@ async fn perform_reconciliation_check(
         config.reconciliation_tolerance_bps,
     );
 
-    // Step 5: Send webhook alert if mismatches found
+    // Step 5: On a custody-vs-ledger breach, fail closed then alert.
     if !mismatches.is_empty() {
         error!(
             "Balance reconciliation failed: found {} mismatch(es) exceeding tolerance of {} bps",
@@ -198,6 +215,9 @@ async fn perform_reconciliation_check(
             );
         }
 
+        // Teeth first: a webhook delivery failure must not skip quarantine/health.
+        enforce_fail_closed(storage, health).await;
+
         send_webhook_alert(
             &config.reconciliation_webhook_url,
             &mismatches,
@@ -208,7 +228,69 @@ async fn perform_reconciliation_check(
         info!("Balance reconciliation successful: all mints within tolerance");
     }
 
+    // Step 6: Assert channel-token supply on PrivateChannel does not exceed the
+    // on-chain escrow balance. This reads issuance from the chain directly, so
+    // an unbacked mint the DB ledger cannot see still trips the invariant.
+    let channel_supplies =
+        read_channel_supplies(channel_rpc_client, &on_chain_balances, &db_balances).await;
+    let supply_breaches = compare_channel_supply(
+        &channel_supplies,
+        &on_chain_balances,
+        config.reconciliation_tolerance_bps,
+    );
+
+    if !supply_breaches.is_empty() {
+        error!(
+            "Channel supply reconciliation failed: {} mint(s) issue more than the escrow backs",
+            supply_breaches.len()
+        );
+
+        for breach in &supply_breaches {
+            error!(
+                "Supply breach for mint {}: channel_supply={}, escrow={}, delta={} bps",
+                breach.mint, breach.channel_supply, breach.escrow_balance, breach.delta_bps
+            );
+        }
+
+        enforce_fail_closed(storage, health).await;
+
+        // Reuse the balance-mismatch webhook: escrow balance rides in
+        // `on_chain_balance`, channel supply in `db_balance`.
+        let alerts: Vec<BalanceMismatch> = supply_breaches
+            .iter()
+            .map(|breach| BalanceMismatch {
+                mint: breach.mint,
+                on_chain_balance: breach.escrow_balance,
+                db_balance: breach.channel_supply,
+                delta_bps: breach.delta_bps,
+            })
+            .collect();
+
+        send_webhook_alert(&config.reconciliation_webhook_url, &alerts, webhook_client).await?;
+    } else {
+        info!("Channel supply reconciliation successful: all mints backed by escrow");
+    }
+
     Ok(())
+}
+
+/// Fail closed on a detected reconciliation breach: quarantine every active
+/// withdrawal so the withdraw pipeline drains to nothing, and latch health
+/// degraded so `/health` returns 503 and orchestration reacts. Both effects
+/// are best-effort and logged; the loop keeps running so it re-checks and
+/// re-alerts on the next tick.
+async fn enforce_fail_closed(storage: &Arc<Storage>, health: &Option<Arc<HealthState>>) {
+    match storage.quarantine_all_active_withdrawals(None).await {
+        Ok(quarantined) => error!(
+            quarantined,
+            "Reconciliation breach: quarantined active withdrawals"
+        ),
+        Err(e) => error!("Reconciliation breach: failed to quarantine withdrawals: {}", e),
+    }
+
+    if let Some(health) = health {
+        health.set_degraded();
+    }
 }
 
 /// Surface orphan deposit rows (deposits whose mint was not `allowed` at the
@@ -367,6 +449,112 @@ pub fn compare_balances(
     }
 
     mismatches
+}
+
+/// A mint whose channel-token supply on PrivateChannel exceeds the on-chain
+/// escrow balance backing it beyond tolerance. Signals unbacked issuance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupplyBreach {
+    pub mint: Pubkey,
+    pub channel_supply: u64,
+    pub escrow_balance: u64,
+    pub delta_bps: u64,
+}
+
+/// True if `e` reports a missing account rather than a transient RPC failure.
+/// `get_account_data` surfaces a not-found as `ForUser("AccountNotFound...")`;
+/// the `-32602` code is the `getAccountInfo` response shape some providers use.
+fn is_missing_account(e: &client_error::Error) -> bool {
+    match &e.kind {
+        ErrorKind::RpcError(RpcError::ForUser(msg)) => msg.contains("AccountNotFound"),
+        ErrorKind::RpcError(RpcError::RpcResponseError { code, .. }) => *code == -32602,
+        _ => false,
+    }
+}
+
+/// Read one mint's channel-token supply from PrivateChannel.
+///
+/// A missing mint account means no channel tokens were ever issued (`Some(0)`).
+/// A transient RPC failure or a decode failure returns `None` so the caller
+/// skips the mint this tick rather than asserting on data it could not read.
+async fn read_channel_supply(channel_rpc: &RpcClientWithRetry, mint: &Pubkey) -> Option<u64> {
+    match channel_rpc.get_account_data(mint).await {
+        Ok(data) => match Mint::unpack_unchecked(&data) {
+            Ok(m) if m.is_initialized => Some(m.supply),
+            // Allocated but not yet a mint: no supply.
+            Ok(_) => Some(0),
+            Err(_) => {
+                warn!(mint = %mint, "Channel supply: account did not decode as SPL Mint; skipping");
+                None
+            }
+        },
+        Err(e) if is_missing_account(&e) => Some(0),
+        Err(e) => {
+            warn!(mint = %mint, "Channel supply: RPC read failed, skipping this tick: {}", e);
+            None
+        }
+    }
+}
+
+/// Read channel-token supply for the union of mints seen on-chain and in the DB.
+/// Mints whose supply could not be read are omitted (skipped this tick).
+async fn read_channel_supplies(
+    channel_rpc: &RpcClientWithRetry,
+    on_chain_balances: &HashMap<Pubkey, u64>,
+    db_balances: &HashMap<Pubkey, u64>,
+) -> HashMap<Pubkey, u64> {
+    let mut all_mints: HashSet<Pubkey> = on_chain_balances.keys().copied().collect();
+    all_mints.extend(db_balances.keys().copied());
+
+    let mut supplies = HashMap::new();
+    for mint in all_mints {
+        if let Some(supply) = read_channel_supply(channel_rpc, &mint).await {
+            supplies.insert(mint, supply);
+        }
+    }
+    supplies
+}
+
+/// Flag mints whose channel supply exceeds the escrow balance beyond tolerance.
+///
+/// The invariant is one-directional: only `channel_supply > escrow_balance`
+/// (over-issuance) is a breach. Under-supply is legitimate in-flight state
+/// (a mint lands after its deposit; a burn lands before its release), so it
+/// never alerts. `escrow_balance == 0` with non-zero supply is critical.
+pub fn compare_channel_supply(
+    channel_supplies: &HashMap<Pubkey, u64>,
+    on_chain_balances: &HashMap<Pubkey, u64>,
+    tolerance_bps: u16,
+) -> Vec<SupplyBreach> {
+    let mut breaches = Vec::new();
+
+    for (mint, &channel_supply) in channel_supplies {
+        let escrow_balance = *on_chain_balances.get(mint).unwrap_or(&0);
+
+        // Supply within (or under) what the escrow backs is fine.
+        if channel_supply <= escrow_balance {
+            continue;
+        }
+
+        let delta_bps = if escrow_balance == 0 {
+            // Issuance with zero backing: always a breach.
+            u64::MAX
+        } else {
+            let excess = channel_supply - escrow_balance;
+            ((excess as u128 * 10000) / escrow_balance as u128) as u64
+        };
+
+        if delta_bps > tolerance_bps as u64 {
+            breaches.push(SupplyBreach {
+                mint: *mint,
+                channel_supply,
+                escrow_balance,
+                delta_bps,
+            });
+        }
+    }
+
+    breaches
 }
 
 /// Fetches on-chain token balances for all token accounts owned by the escrow
@@ -770,6 +958,137 @@ mod tests {
         assert_eq!(mismatches.len(), 0);
     }
 
+    // ── compare_channel_supply ────────────────────────────────────────────
+
+    #[test]
+    fn supply_over_issuance_is_flagged() {
+        let mint = Pubkey::new_unique();
+        let supplies = HashMap::from([(mint, 1100)]);
+        let escrow = HashMap::from([(mint, 1000)]);
+
+        // 100 excess on 1000 base = 1000 bps, well past a 10 bps tolerance.
+        let breaches = compare_channel_supply(&supplies, &escrow, 10);
+        assert_eq!(breaches.len(), 1);
+        assert_eq!(breaches[0].mint, mint);
+        assert_eq!(breaches[0].channel_supply, 1100);
+        assert_eq!(breaches[0].escrow_balance, 1000);
+        assert_eq!(breaches[0].delta_bps, 1000);
+    }
+
+    #[test]
+    fn supply_under_escrow_is_not_flagged() {
+        // In-flight state (mint lands after deposit, burn before release) leaves
+        // supply below escrow; that must never alert.
+        let mint = Pubkey::new_unique();
+        let supplies = HashMap::from([(mint, 900)]);
+        let escrow = HashMap::from([(mint, 1000)]);
+
+        assert!(compare_channel_supply(&supplies, &escrow, 0).is_empty());
+    }
+
+    #[test]
+    fn supply_equal_to_escrow_is_not_flagged() {
+        let mint = Pubkey::new_unique();
+        let supplies = HashMap::from([(mint, 1000)]);
+        let escrow = HashMap::from([(mint, 1000)]);
+
+        assert!(compare_channel_supply(&supplies, &escrow, 0).is_empty());
+    }
+
+    #[test]
+    fn supply_with_zero_escrow_is_critical() {
+        let mint = Pubkey::new_unique();
+        let supplies = HashMap::from([(mint, 1)]);
+        let escrow = HashMap::new();
+
+        let breaches = compare_channel_supply(&supplies, &escrow, u16::MAX);
+        assert_eq!(breaches.len(), 1);
+        assert_eq!(breaches[0].delta_bps, u64::MAX);
+    }
+
+    #[test]
+    fn supply_excess_within_tolerance_is_not_flagged() {
+        let mint = Pubkey::new_unique();
+        // 10 excess on 100_000 base = 1 bps, within a 1 bps tolerance.
+        let supplies = HashMap::from([(mint, 100_010)]);
+        let escrow = HashMap::from([(mint, 100_000)]);
+
+        assert!(compare_channel_supply(&supplies, &escrow, 1).is_empty());
+    }
+
+    // ── enforce_fail_closed ───────────────────────────────────────────────
+
+    /// Push a single Pending withdrawal so the quarantine sweep has a row to flip.
+    fn seed_pending_withdrawal(mock: &MockStorage) {
+        use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
+        use chrono::Utc;
+        mock.pending_transactions.lock().unwrap().push(DbTransaction {
+            id: 1,
+            signature: "sig_w".to_string(),
+            trace_id: "trace_w".to_string(),
+            slot: 1,
+            initiator: "init".to_string(),
+            recipient: "recip".to_string(),
+            mint: "mint".to_string(),
+            amount: TokenAmount(1),
+            memo: None,
+            transaction_type: TransactionType::Withdrawal,
+            withdrawal_nonce: Some(0),
+            status: TransactionStatus::Pending,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            remint_last_valid_block_heights: None,
+            pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
+            instruction_index: 0,
+            inner_index: None,
+            landed_remint_signature: None,
+        });
+    }
+
+    #[tokio::test]
+    async fn enforce_fail_closed_quarantines_and_degrades_health() {
+        use crate::storage::common::models::TransactionStatus;
+        use private_channel_metrics::{HealthConfig, HealthState};
+
+        let mock = MockStorage::new();
+        seed_pending_withdrawal(&mock);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+
+        let health = HealthState::new(HealthConfig::operator());
+        assert!(health.is_healthy());
+
+        enforce_fail_closed(&storage, &Some(health.clone())).await;
+
+        assert!(!health.is_healthy(), "breach must degrade health");
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::ManualReview,
+            "active withdrawal must be quarantined"
+        );
+    }
+
+    #[tokio::test]
+    async fn enforce_fail_closed_degrades_health_even_when_quarantine_fails() {
+        use private_channel_metrics::{HealthConfig, HealthState};
+
+        let mock = MockStorage::new();
+        mock.set_should_fail("quarantine_all_active_withdrawals", true);
+        let storage = Arc::new(Storage::Mock(mock));
+
+        let health = HealthState::new(HealthConfig::operator());
+        enforce_fail_closed(&storage, &Some(health.clone())).await;
+
+        assert!(
+            !health.is_healthy(),
+            "health must degrade even if the quarantine sweep errors"
+        );
+    }
+
     fn make_operator_config() -> OperatorConfig {
         use solana_sdk::commitment_config::CommitmentLevel;
         OperatorConfig {
@@ -809,8 +1128,10 @@ mod tests {
         let result = run_reconciliation(
             storage,
             config,
+            rpc_client.clone(),
             rpc_client,
             solana_sdk::pubkey::Pubkey::new_unique(),
+            None,
             ct,
         )
         .await;

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -40,6 +40,7 @@ use private_channel_indexer::storage::common::models::{
 };
 use private_channel_indexer::storage::{PostgresDb, Storage, TransactionType};
 use private_channel_indexer::PostgresConfig;
+use private_channel_metrics::{HealthConfig, HealthState};
 use setup::{TestEnvironment, TEST_ADMIN_KEYPAIR};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::commitment_config::CommitmentConfig;
@@ -867,18 +868,21 @@ async fn test_operator_idle_no_pending_transactions() -> Result<(), Box<dyn std:
     Ok(())
 }
 
-/// (periodic reconciliation): the reconciliation loop fires a webhook
-/// alert when on-chain escrow balances diverge from the DB's completed totals.
+/// (periodic reconciliation): on a mismatch the reconciliation loop fires a
+/// webhook alert and fails closed, quarantining active withdrawals and
+/// degrading health.
 ///
 /// Approach:
 /// 1. `AllowMint` creates an escrow ATA with 0 on-chain balance.
 /// 2. A completed deposit is seeded in the DB so the DB shows a positive balance.
-/// 3. The operator runs with `reconciliation_interval = 500 ms` and
+/// 3. A Pending withdrawal is seeded so the quarantine sweep has a row to flip.
+/// 4. The operator runs with `reconciliation_interval = 500 ms` and
 ///    `reconciliation_tolerance_bps = 0`, guaranteeing that any delta triggers
 ///    the alert.
-/// 4. We verify the mock webhook received at least one POST request.
+/// 5. We verify the webhook fired, health degraded, and the withdrawal moved to
+///    `manual_review`.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_periodic_reconciliation_fires_webhook_on_mismatch(
+async fn test_periodic_reconciliation_fires_webhook_and_fails_closed_on_mismatch(
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Operator Lifecycle: Reconciliation Webhook on Mismatch ===");
 
@@ -940,6 +944,16 @@ async fn test_periodic_reconciliation_fires_webhook_on_mismatch(
     .execute(&pool)
     .await?;
 
+    // Seed a Pending withdrawal so the fail-closed teeth have a row to quarantine.
+    let withdrawal_sig = Signature::new_unique().to_string();
+    let withdrawal_txn =
+        DbTransactionBuilder::new(withdrawal_sig.clone(), 2, env.mint.to_string(), 1_000)
+            .initiator(Pubkey::new_unique().to_string())
+            .recipient(Pubkey::new_unique().to_string())
+            .transaction_type(TransactionType::Withdrawal)
+            .build();
+    storage.insert_db_transaction(&withdrawal_txn).await?;
+
     // Start a mock HTTP server; expect at least one reconciliation POST.
     // No content-type constraint here — the reconciliation webhook client sends
     // `Content-Type: application/json` via reqwest, but we only care that a POST
@@ -978,6 +992,11 @@ async fn test_periodic_reconciliation_fires_webhook_on_mismatch(
         .await?,
     ));
 
+    // Health starts healthy; a detected mismatch must degrade it.
+    let health = HealthState::new(HealthConfig::operator());
+    assert!(health.is_healthy(), "health should start healthy");
+    let recon_health = health.clone();
+
     // Spawn `run_reconciliation` directly so the test exercises the exact same
     // code path that the operator uses, without the ctrl_c() gate in `operator::run`.
     let recon_token_clone = cancellation_token.clone();
@@ -985,8 +1004,10 @@ async fn test_periodic_reconciliation_fires_webhook_on_mismatch(
         if let Err(e) = run_reconciliation(
             recon_storage,
             recon_config,
+            rpc_client.clone(),
             rpc_client,
             env.instance,
+            Some(recon_health),
             recon_token_clone,
         )
         .await
@@ -1004,6 +1025,173 @@ async fn test_periodic_reconciliation_fires_webhook_on_mismatch(
 
     // Confirm the reconciliation loop fired the webhook at least once.
     recon_mock.assert_async().await;
+
+    // The mismatch must have failed closed: health degraded and the active
+    // withdrawal quarantined to ManualReview.
+    assert!(
+        !health.is_healthy(),
+        "detected mismatch must degrade health"
+    );
+    let withdrawal_status: String =
+        sqlx::query_scalar("SELECT status::text FROM transactions WHERE signature = $1")
+            .bind(&withdrawal_sig)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(
+        withdrawal_status, "manual_review",
+        "active withdrawal must be quarantined by the fail-closed teeth"
+    );
+    Ok(())
+}
+
+/// (channel-supply reconciliation): the loop fails closed when a mint's total
+/// on-chain supply exceeds the escrow ATA that backs it.
+///
+/// Each check runs two independent comparisons:
+///   A. custody vs ledger: escrow ATA balance  vs  DB (deposits - withdrawals)
+///   B. supply vs escrow:   mint total supply   vs  escrow ATA balance
+///
+/// The setup keeps A balanced and trips only B, so the teeth are attributable
+/// to the supply invariant alone:
+/// 1. Escrow ATA stays at 0 and no deposit is seeded, so A is 0 == 0.
+/// 2. `SUPPLY` is minted to a NON-escrow ATA. That raises the mint's total
+///    supply (read by B) without changing the escrow ATA balance or the DB
+///    ledger (so A is untouched). B now sees supply=SUPPLY > escrow=0.
+/// 3. A Pending withdrawal is seeded so the quarantine sweep has a row to flip.
+/// 4. We verify the webhook fired, health degraded, and the withdrawal moved to
+///    `manual_review`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_periodic_reconciliation_fails_closed_on_channel_supply_breach(
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== Operator Lifecycle: Reconciliation Channel Supply Breach ===");
+
+    const SUPPLY: u64 = 1_000;
+
+    let (test_validator, faucet_keypair) = start_test_validator_no_geyser().await;
+    let client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::confirmed());
+
+    let pg_container = Postgres::default()
+        .with_db_name("operator_supply_breach")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await?;
+    let pg_host = pg_container.get_host().await?;
+    let pg_port = pg_container.get_host_port_ipv4(5432).await?;
+    let db_url = format!(
+        "postgres://postgres:password@{}:{}/operator_supply_breach",
+        pg_host, pg_port
+    );
+
+    let storage = Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: db_url.clone(),
+            max_connections: 10,
+        })
+        .await?,
+    );
+    storage.init_schema().await?;
+
+    // Escrow ATA is created at 0 balance; the mint starts at 0 total supply.
+    let env = TestEnvironment::setup(&client, &faucet_keypair, 0, 0, None).await?;
+
+    // Register the mint but seed no deposit, so check A (custody vs ledger) is 0 == 0.
+    let mint_meta = DbMint::new(env.mint.to_string(), 6, spl_token::id().to_string());
+    storage.upsert_mints_batch(&[mint_meta]).await?;
+    seed_mint_status_allowed(&storage, &env.mint.to_string()).await?;
+
+    // Raise the mint's total supply by minting to a NON-escrow ATA: check B now
+    // sees supply=SUPPLY > escrow=0, while the escrow ATA balance stays 0 (check
+    // A untouched). admin is the mint authority set by generate_mint.
+    let admin = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..]).expect("admin keypair");
+    mint_to_owner(&client, &admin, env.mint, Pubkey::new_unique(), &admin, SUPPLY).await?;
+
+    // Seed a Pending withdrawal so the quarantine sweep has a row to flip.
+    let withdrawal_sig = Signature::new_unique().to_string();
+    let withdrawal_txn =
+        DbTransactionBuilder::new(withdrawal_sig.clone(), 1, env.mint.to_string(), 500)
+            .initiator(Pubkey::new_unique().to_string())
+            .recipient(Pubkey::new_unique().to_string())
+            .transaction_type(TransactionType::Withdrawal)
+            .build();
+    storage.insert_db_transaction(&withdrawal_txn).await?;
+
+    let mut mock_server = Server::new_async().await;
+    let recon_mock = mock_server
+        .mock("POST", "/")
+        .with_status(200)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    // Short interval; zero tolerance so any supply excess trips.
+    let recon_config = OperatorConfig {
+        reconciliation_interval: Duration::from_millis(500),
+        reconciliation_tolerance_bps: 0,
+        reconciliation_webhook_url: Some(mock_server.url()),
+        ..default_operator_config(None)
+    };
+
+    // One validator backs both roles in this test: it is passed as the Solana
+    // custody-sweep client and the PrivateChannel channel-supply client. In
+    // production these are two distinct RPCs (mainnet vs internal channel).
+    let rpc_client = Arc::new(RpcClientWithRetry::with_retry_config(
+        test_validator.rpc_url(),
+        RetryConfig::default(),
+        CommitmentConfig::confirmed(),
+    ));
+
+    let cancellation_token = CancellationToken::new();
+    let recon_storage = Arc::new(Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: db_url.clone(),
+            max_connections: 5,
+        })
+        .await?,
+    ));
+
+    let health = HealthState::new(HealthConfig::operator());
+    assert!(health.is_healthy(), "health should start healthy");
+    let recon_health = health.clone();
+
+    let recon_token_clone = cancellation_token.clone();
+    let recon_handle: JoinHandle<()> = tokio::spawn(async move {
+        if let Err(e) = run_reconciliation(
+            recon_storage,
+            recon_config,
+            rpc_client.clone(),
+            rpc_client,
+            env.instance,
+            Some(recon_health),
+            recon_token_clone,
+        )
+        .await
+        {
+            tracing::error!("Reconciliation task error: {}", e);
+        }
+    });
+
+    // Give the reconciliation loop time to complete several cycles (interval = 500 ms).
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    cancellation_token.cancel();
+    let _ = recon_handle.await;
+
+    recon_mock.assert_async().await;
+
+    // Check A is balanced (escrow 0, DB ledger 0), so the teeth are attributable
+    // to check B (channel supply > escrow) alone.
+    assert!(!health.is_healthy(), "supply breach must degrade health");
+    let pool = db::connect(&db_url).await?;
+    let withdrawal_status: String =
+        sqlx::query_scalar("SELECT status::text FROM transactions WHERE signature = $1")
+            .bind(&withdrawal_sig)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(
+        withdrawal_status, "manual_review",
+        "supply breach must quarantine active withdrawals"
+    );
     Ok(())
 }
 

--- a/metrics/src/health.rs
+++ b/metrics/src/health.rs
@@ -6,7 +6,7 @@
 //! (b) backlog is non-zero AND no progress has been recorded within the
 //! staleness window. Idle (no backlog, no progress) stays healthy.
 
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -58,12 +58,18 @@ pub struct HealthState {
     last_progress_at: AtomicI64,
     /// Service-defined backlog metric (slot lag for indexer, queue depth for operator).
     pending: AtomicU64,
+    /// One-way latch for an unrecoverable integrity failure (e.g. a
+    /// reconciliation mismatch). Once set, `check()` reports `Degraded`
+    /// regardless of backlog. Cleared only by a process restart.
+    degraded: AtomicBool,
     config: HealthConfig,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum HealthOutcome {
     Healthy,
+    /// Degraded latch tripped; takes precedence over backlog/staleness.
+    Degraded,
     /// Backlog has exceeded the configured ceiling.
     BacklogExceeded {
         pending: u64,
@@ -81,12 +87,18 @@ impl HealthState {
         Arc::new(Self {
             last_progress_at: AtomicI64::new(0),
             pending: AtomicU64::new(0),
+            degraded: AtomicBool::new(false),
             config,
         })
     }
 
     pub fn record_progress(&self) {
         self.last_progress_at.store(now_unix(), Ordering::Relaxed);
+    }
+
+    /// Trip the degraded latch. `/health` reports 503 until the next restart.
+    pub fn set_degraded(&self) {
+        self.degraded.store(true, Ordering::Relaxed);
     }
 
     pub fn set_pending(&self, value: u64) {
@@ -106,6 +118,10 @@ impl HealthState {
     /// Variant used by tests to inject a deterministic "now". Production code
     /// should call `check()`.
     pub fn check_at(&self, now: i64) -> HealthOutcome {
+        // Latch wins over every derived signal.
+        if self.degraded.load(Ordering::Relaxed) {
+            return HealthOutcome::Degraded;
+        }
         let pending = self.pending.load(Ordering::Relaxed);
         if pending > self.config.max_pending {
             return HealthOutcome::BacklogExceeded {
@@ -297,6 +313,24 @@ mod tests {
         h.last_progress_at.store(1000, Ordering::Relaxed);
         h.set_pending(0);
         assert_eq!(h.check_at(1010), HealthOutcome::Healthy);
+    }
+
+    #[test]
+    fn degraded_latch_reports_degraded() {
+        let h = HealthState::new(cfg(10, 30));
+        h.set_degraded();
+        assert_eq!(h.check_at(1000), HealthOutcome::Degraded);
+        assert!(!h.is_healthy());
+    }
+
+    #[test]
+    fn degraded_latch_wins_over_healthy_backlog() {
+        // Fresh progress would otherwise read Healthy; the latch overrides it.
+        let h = HealthState::new(cfg(10, 30));
+        h.last_progress_at.store(1000, Ordering::Relaxed);
+        h.set_pending(0);
+        h.set_degraded();
+        assert_eq!(h.check_at(1010), HealthOutcome::Degraded);
     }
 
     #[test]

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -97,6 +97,10 @@ async fn health_handler(
 ) -> (axum::http::StatusCode, String) {
     match health.check() {
         HealthOutcome::Healthy => (axum::http::StatusCode::OK, r#"{"status":"ok"}"#.to_string()),
+        HealthOutcome::Degraded => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"status":"degraded","reason":"reconciliation_mismatch"}"#.to_string(),
+        ),
         HealthOutcome::BacklogExceeded { pending, ceiling } => (
             axum::http::StatusCode::SERVICE_UNAVAILABLE,
             format!(


### PR DESCRIPTION
## Problem

The runtime escrow reconciliation loop was the main detective control for the burn-to-release trust boundary, but it had no teeth and a blind spot:

  - On a mismatch beyond tolerance it only logged and optionally posted a webhook (which defaults to `None`, reducing an insolvency to one log line). It never halted withdrawals or degraded health.
  - It only compared on-chain escrow balances against the DB ledger. Actual channel-token supply on PrivateChannel — operator-key-controlled issuance — was never read, so an unbacked mint was invisible to it.

  ## Changes

  - **Fail closed on any breach**: quarantine active withdrawals (`quarantine_all_active_withdrawals`) and degrade service health, in addition to the existing webhook. Added a one-way `Degraded` latch to `HealthState` so `/health` returns 503.
  - **Channel-supply invariant**: read each mint's on-chain `Mint::supply` from PrivateChannel and assert `supply <= escrow balance`, failing closed on over-issuance the DB ledger can't see.
  - **Config gate**: reject an escrow operator started without `reconciliation_webhook_url`.

Startup reconciliation (already fail-closed) is unchanged.

## Tests

  - Unit: health latch, `compare_channel_supply`, `enforce_fail_closed`, config gate.
  - Integration (live validator + Postgres): a custody mismatch and an isolated channel-supply breach each fire the webhook, degrade health, and quarantine an active withdrawal.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28975484042) |
| Indexer | 25,429 | 28,786 | 88.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28975484042) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28975484042) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28975484042) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,469 | 15,727 | 79.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/28975484042) |
| **Total** | **51,204** | **59,731** | **85.7%** | |

> Last updated: 2026-07-08 21:58:59 UTC by E2E Integration