### PR TITLE
fix(indexer): ownership-checked write-ahead persist so a requeued deposit cannot double-mint

### DIFF
--- a/docs/runbooks/deposit_failed.md
+++ b/docs/runbooks/deposit_failed.md
@@ -109,6 +109,18 @@ and Step 2's re-arm path applies. The retry is safe because the next
 attempt will run the memo scan again (and will detect any prior
 landed mint).
 
+## Not an alert - `deposit_ownership_lost` metric
+
+`OPERATOR_TRANSACTION_ERRORS{error_reason="deposit_ownership_lost"}` is
+**informational, not an incident**. It counts a deposit mint whose sender
+lost ownership of its row before broadcast: while the built mint was queued,
+the recovery worker demoted the row (or a re-fetch re-locked it), so the
+stale builder was dropped without broadcasting and without writing any
+status. The row's current owner or recovery mints it instead, so the
+one-deposit-one-mint invariant holds. No operator action; a sustained rate
+only signals the in-flight cap is stranding builders long enough for
+recovery to reclaim them (a throughput tuning signal, not a correctness bug).
+
 ## Post-incident artifacts
 
 - Transaction id, originating Solana deposit `signature`, `recipient`,

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -720,6 +720,8 @@ pub async fn process_deposit_funds(
                 builder,
                 txn_id: transaction.id,
                 trace_id: transaction.trace_id.clone(),
+                // The post-lock token the sender proves ownership against.
+                fetched_updated_at: transaction.updated_at,
             }));
 
             let send_t0 = tokio::time::Instant::now();

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -157,6 +157,45 @@ pub mod test_hooks {
         )
         .await
     }
+
+    /// Drives one `fire_and_store_task` for a deposit-mint first-fire. Acquires
+    /// a permit from the sender's semaphore, then builds, (claims +) persists,
+    /// and broadcasts. Lets tests pin the ownership-claim routing (abort vs
+    /// broadcast) without the sender loop. Returns `false` if the semaphore was
+    /// already at capacity.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn run_fire_and_store_task(
+        state: &SenderState,
+        instruction: super::types::InstructionWithSigners,
+        compute_unit_price: Option<u64>,
+        ctx: super::types::TransactionContext,
+        retry_policy: crate::operator::utils::instruction_util::RetryPolicy,
+        extra_error_checks_policy: crate::operator::utils::instruction_util::ExtraErrorCheckPolicy,
+        storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+        persist: bool,
+        deposit_expected_updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> bool {
+        let Ok(permit) = Arc::clone(&state.semaphore).try_acquire_owned() else {
+            return false;
+        };
+        super::transaction::fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            instruction,
+            compute_unit_price,
+            ctx,
+            retry_policy,
+            extra_error_checks_policy,
+            storage_tx.clone(),
+            persist,
+            deposit_expected_updated_at,
+            permit,
+        )
+        .await;
+        true
+    }
 }
 
 use crate::channel_utils::send_guaranteed;

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -233,6 +233,9 @@ pub async fn handle_transaction_submission(
                         // Only a real user-fund Mint persists write-ahead; InitializeMint
                         // mints no balance and is on-chain idempotent, so it is excluded.
                         let persist = matches!(tx_builder, TransactionBuilder::Mint(_));
+                        // Some only for a deposit Mint: the fetch-time token the
+                        // write-ahead persist proves ownership against.
+                        let deposit_expected_updated_at = tx_builder.fetched_updated_at();
                         spawn_fire_and_store(
                             state,
                             instruction,
@@ -242,6 +245,7 @@ pub async fn handle_transaction_submission(
                             extra_error_checks_policy,
                             storage_tx.clone(),
                             persist,
+                            deposit_expected_updated_at,
                         );
                     }
                     _ => {
@@ -610,6 +614,8 @@ pub(super) fn handle_confirmation_result<'a>(
                                     mint_extra_error_checks_policy(),
                                     storage_tx.clone(),
                                     true,
+                                    // Plain persist: already owned by the bounded first claim.
+                                    None,
                                     permit,
                                 )
                                 .await;
@@ -1070,6 +1076,8 @@ pub(super) fn spawn_fire_and_store(
     storage_tx: mpsc::Sender<TransactionStatusUpdate>,
     // True only for a real user-fund Mint
     persist: bool,
+    // Deposit first-fire ownership token; `None` for InitializeMint (no persist).
+    deposit_expected_updated_at: Option<chrono::DateTime<chrono::Utc>>,
 ) -> bool {
     let permit = match Arc::clone(&state.semaphore).try_acquire_owned() {
         Ok(p) => p,
@@ -1103,6 +1111,7 @@ pub(super) fn spawn_fire_and_store(
         extra_error_checks_policy,
         storage_tx,
         persist,
+        deposit_expected_updated_at,
         permit,
     ));
 
@@ -1126,6 +1135,12 @@ pub(super) async fn fire_and_store_task(
     extra_error_checks_policy: ExtraErrorCheckPolicy,
     storage_tx: mpsc::Sender<TransactionStatusUpdate>,
     persist: bool,
+    // For a deposit's first mint attempt, this is the row's `updated_at` from
+    // fetch time. Before broadcasting we check the row still has it; if it
+    // changed, recovery requeued the row and we drop the mint instead of sending
+    // a duplicate. `None` skips the check (the JIT retry, which claimed the row
+    // moments earlier).
+    deposit_expected_updated_at: Option<chrono::DateTime<chrono::Utc>>,
     permit: OwnedSemaphorePermit,
 ) {
     let pt = program_type.as_label();
@@ -1149,8 +1164,60 @@ pub(super) async fn fire_and_store_task(
         };
 
     let persisted = if persist {
-        match ctx.transaction_id {
-            Some(txid) => {
+        let Some(txid) = ctx.transaction_id else {
+            // Persist required but no transaction_id to key on: abort before broadcasting an unrecoverable mint.
+            drop(permit);
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "pre_send_persist_error"])
+                .inc();
+            error!("Persist required but transaction has no id; aborting before broadcast");
+            return;
+        };
+        match deposit_expected_updated_at {
+            // Deposit first-fire: the persist doubles as an ownership claim,
+            // since the builder may have waited behind the cap long enough for
+            // recovery to demote the row. A lost claim drops it without broadcast.
+            Some(expected) => {
+                match storage
+                    .claim_and_persist_deposit_signature(
+                        txid,
+                        expected,
+                        signature.to_string(),
+                        last_valid_block_height as i64,
+                    )
+                    .await
+                {
+                    Ok(true) => true,
+                    Ok(false) => {
+                        drop(permit);
+                        metrics::OPERATOR_TRANSACTION_ERRORS
+                            .with_label_values(&[pt, "deposit_ownership_lost"])
+                            .inc();
+                        warn!(
+                            transaction_id = txid,
+                            signature = %signature,
+                            "Deposit ownership lost before broadcast; dropping stale builder without minting",
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        drop(permit);
+                        metrics::OPERATOR_TRANSACTION_ERRORS
+                            .with_label_values(&[pt, "pre_send_persist_error"])
+                            .inc();
+                        error!(
+                            transaction_id = txid,
+                            signature = %signature,
+                            "Aborting before broadcast, leaving row Processing for recovery: {e}",
+                        );
+                        return;
+                    }
+                }
+            }
+            // JIT re-fire: plain write-ahead insert. It runs only after a
+            // successful first claim, within a window far shorter than the
+            // recovery staleness threshold, so the row is provably still ours.
+            None => {
                 if persist_signature_or_abort(
                     &storage,
                     pt,
@@ -1165,15 +1232,6 @@ pub(super) async fn fire_and_store_task(
                     return;
                 }
                 true
-            }
-            // Persist required but no transaction_id to key on: abort before broadcasting an unrecoverable mint.
-            None => {
-                drop(permit);
-                metrics::OPERATOR_TRANSACTION_ERRORS
-                    .with_label_values(&[pt, "pre_send_persist_error"])
-                    .inc();
-                error!("Persist required but transaction has no id; aborting before broadcast");
-                return;
             }
         }
     } else {
@@ -3898,6 +3956,7 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             storage_tx,
             true,
+            None,
             permit,
         )
         .await;
@@ -3956,6 +4015,7 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             storage_tx,
             true,
+            None,
             permit,
         )
         .await;
@@ -4017,6 +4077,7 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             storage_tx,
             true,
+            None,
             permit,
         )
         .await;
@@ -4483,6 +4544,7 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             storage_tx,
             false,
+            None,
             permit,
         )
         .await;
@@ -4499,6 +4561,186 @@ mod tests {
             1,
             "broadcast still stashes in-flight"
         );
+    }
+
+    // ── deposit first-fire: ownership-checked claim routing ───────────
+
+    /// Seed one deposit row directly into the mock with an explicit status and
+    /// `updated_at` so the claim CAS can be exercised against it.
+    fn seed_mock_deposit(
+        state: &SenderState,
+        id: i64,
+        status: TransactionStatus,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) {
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let row = crate::storage::common::models::DbTransaction {
+            id,
+            signature: format!("src-sig-{id}"),
+            trace_id: format!("trace-{id}"),
+            slot: 100,
+            initiator: "initiator".to_string(),
+            recipient: "recipient".to_string(),
+            mint: "mint_addr".to_string(),
+            amount: crate::storage::common::amount::TokenAmount(1_000),
+            memo: None,
+            transaction_type: crate::storage::common::models::TransactionType::Deposit,
+            withdrawal_nonce: None,
+            status,
+            created_at: updated_at,
+            updated_at,
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            remint_last_valid_block_heights: None,
+            pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
+            instruction_index: 0,
+            inner_index: None,
+            landed_remint_signature: None,
+        };
+        mock.pending_transactions.lock().unwrap().push(row);
+    }
+
+    /// A deposit first-fire whose row was demoted (claim `Ok(false)`) must NOT
+    /// broadcast, must persist no signature, must write no status, must release
+    /// its permit, and must meter `deposit_ownership_lost`. This is the bug
+    /// closed in isolation: a stale sender-owned builder cannot double-mint.
+    #[tokio::test]
+    async fn deposit_first_fire_aborts_when_ownership_lost() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .expect(0)
+            .create();
+
+        let state = make_sender_state_with_server(&server.url());
+        // Recovery already demoted the row to Pending, so the fetch-time token
+        // no longer owns a Processing incarnation.
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Pending, t_lock);
+
+        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
+        let before_permits = state.semaphore.available_permits();
+        let metric = metrics::OPERATOR_TRANSACTION_ERRORS
+            .with_label_values(&[state.program_type.as_label(), "deposit_ownership_lost"]);
+        let before_metric = metric.get();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            dummy_instruction(),
+            None,
+            mint_ctx(77),
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+            true,
+            Some(t_lock),
+            permit,
+        )
+        .await;
+
+        send.assert();
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        assert!(
+            mock.get_release_signatures(77).await.unwrap().is_empty(),
+            "a lost claim must persist no signature"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a lost claim writes no status; the row's current owner handles it"
+        );
+        assert!(
+            state.in_flight.is_empty(),
+            "nothing broadcast, nothing stashed in-flight"
+        );
+        assert_eq!(
+            state.semaphore.available_permits(),
+            before_permits + 1,
+            "the permit must be released on abort"
+        );
+        assert_eq!(
+            metric.get(),
+            before_metric + 1.0,
+            "a lost claim increments deposit_ownership_lost"
+        );
+    }
+
+    /// A deposit first-fire that still owns its Processing incarnation (claim
+    /// `Ok(true)`) mints exactly once: the signature is persisted, the tx is
+    /// broadcast and stashed in-flight, and the token advances (the D3 bump).
+    #[tokio::test]
+    async fn deposit_first_fire_broadcasts_when_owned() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": Signature::default().to_string()
+                })
+                .to_string(),
+            )
+            .expect(1)
+            .create();
+
+        let state = make_sender_state_with_server(&server.url());
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Processing, t_lock);
+
+        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
+        let (storage_tx, _rx) = mpsc::channel(10);
+
+        fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            dummy_instruction(),
+            None,
+            mint_ctx(77),
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+            true,
+            Some(t_lock),
+            permit,
+        )
+        .await;
+
+        send.assert();
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let sigs = mock.get_release_signatures(77).await.unwrap();
+        assert_eq!(sigs.len(), 1, "owned claim persists exactly one signature");
+        assert_eq!(sigs[0].0, Signature::default().to_string());
+        assert_eq!(
+            state.in_flight.len(),
+            1,
+            "owned claim broadcasts and stashes"
+        );
+        let after = mock.pending_transactions.lock().unwrap()[0].updated_at;
+        assert_ne!(after, t_lock, "a successful claim bumps updated_at");
     }
 
     // ── spawn_fire_and_store: cap enforcement ─────────────────────────
@@ -4533,6 +4775,7 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             storage_tx,
             false,
+            None,
         );
 
         assert!(!result, "must return false when at capacity");
@@ -4566,6 +4809,7 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             storage_tx,
             false,
+            None,
         );
 
         assert!(result, "must return true when capacity is available");

--- a/indexer/src/operator/utils/instruction_util.rs
+++ b/indexer/src/operator/utils/instruction_util.rs
@@ -196,6 +196,16 @@ impl TransactionBuilder {
         }
     }
 
+    /// The fetch-time ownership token, present only for a deposit `Mint`. The
+    /// sender CASes on it at the write-ahead persist; other variants have no
+    /// such token so they take the plain-insert path.
+    pub fn fetched_updated_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        match self {
+            Self::Mint(b) => Some(b.fetched_updated_at),
+            Self::ReleaseFunds(_) | Self::InitializeMint(_) | Self::ResetSmtRoot(_) => None,
+        }
+    }
+
     pub fn withdrawal_nonce(&self) -> Option<u64> {
         match self {
             Self::ReleaseFunds(builder) => Some(builder.nonce),
@@ -407,6 +417,10 @@ pub struct MintToBuilderWithTxnId {
     pub builder: MintToBuilder,
     pub txn_id: i64,
     pub trace_id: String,
+    /// The row's `updated_at` at fetch time, used as the ownership token the
+    /// sender CASes on when it persists the write-ahead signature. Proves the
+    /// deposit is still the same `Processing` incarnation before broadcast.
+    pub fetched_updated_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// Builder for initialize_mint instruction (sent before first mint)
@@ -569,6 +583,7 @@ mod tests {
             builder: fully_configured_builder(),
             txn_id: 10,
             trace_id: "trace-mint".to_string(),
+            fetched_updated_at: chrono::Utc::now(),
         }))
     }
 
@@ -633,6 +648,15 @@ mod tests {
             Some("trace-mint".to_string())
         );
         assert_eq!(make_reset_smt_builder().trace_id(), None);
+    }
+
+    #[test]
+    fn fetched_updated_at_some_only_for_mint() {
+        // Only a deposit Mint carries the ownership token the sender CASes on.
+        assert!(make_mint_builder().fetched_updated_at().is_some());
+        assert!(make_release_funds_builder().fetched_updated_at().is_none());
+        assert!(make_init_mint_builder().fetched_updated_at().is_none());
+        assert!(make_reset_smt_builder().fetched_updated_at().is_none());
     }
 
     #[test]

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -1,6 +1,7 @@
 pub use super::models::*;
 
 pub mod bump_pending_remint_finality_attempt;
+pub mod claim_and_persist_deposit_signature;
 pub mod close;
 pub mod count_pending_transactions;
 pub mod delete_release_signatures;
@@ -443,6 +444,27 @@ impl Storage {
         .await
     }
 
+    /// Atomically claim a `Processing` deposit (CAS on `updated_at`) and persist
+    /// its broadcast signature in one transaction. `Ok(true)` means the sender
+    /// still owns the row and may broadcast; `Ok(false)` means it was demoted or
+    /// re-locked, so the builder must be dropped without broadcasting.
+    pub async fn claim_and_persist_deposit_signature(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+        signature: String,
+        last_valid_block_height: i64,
+    ) -> Result<bool, StorageError> {
+        claim_and_persist_deposit_signature::claim_and_persist_deposit_signature(
+            self,
+            transaction_id,
+            expected_updated_at,
+            signature,
+            last_valid_block_height,
+        )
+        .await
+    }
+
     /// Stored release signatures for a transaction as (signature, lvbh).
     pub async fn get_release_signatures(
         &self,
@@ -613,7 +635,7 @@ mod tests {
     // ── lock + drain filtering ───────────────────────────────────────
 
     #[tokio::test]
-    async fn get_and_lock_drains_matched_leaves_rest() {
+    async fn get_and_lock_marks_processing_and_leaves_pending() {
         let (storage, mock) = make_mock_storage();
         {
             let mut pending = mock.pending_transactions.lock().unwrap();
@@ -632,18 +654,123 @@ mod tests {
             .get_and_lock_pending_transactions(TransactionType::Deposit, 2)
             .await
             .unwrap();
-        assert_eq!(locked.len(), 2);
+        assert_eq!(locked.len(), 2, "two Pending deposits are locked");
 
-        // 1 deposit + 1 withdrawal remain
+        // Rows stay in the store (now Processing) so a later claim's CAS can find
+        // them, mirroring Postgres; nothing is drained.
         {
-            let remaining = mock.pending_transactions.lock().unwrap();
-            assert_eq!(remaining.len(), 2);
+            let all = mock.pending_transactions.lock().unwrap();
+            assert_eq!(all.len(), 4, "locking keeps rows in place, none removed");
+            let processing = all
+                .iter()
+                .filter(|t| t.status == TransactionStatus::Processing)
+                .count();
+            assert_eq!(processing, 2, "the two locked deposits are now Processing");
         }
+
+        // A second lock returns only the still-Pending deposit, not the Processing ones.
         let locked2 = storage
             .get_and_lock_pending_transactions(TransactionType::Deposit, 10)
             .await
             .unwrap();
-        assert_eq!(locked2.len(), 1);
+        assert_eq!(
+            locked2.len(),
+            1,
+            "only the remaining Pending deposit re-locks"
+        );
+    }
+
+    // ── claim_and_persist_deposit_signature disposition matrix ────────
+
+    /// Seed one deposit row directly with an explicit status + `updated_at` so
+    /// the claim CAS can be exercised against each disposition.
+    fn seed_claim_row(
+        mock: &MockStorage,
+        id: i64,
+        status: TransactionStatus,
+        updated_at: chrono::DateTime<Utc>,
+    ) {
+        let mut row = make_db_transaction();
+        row.id = id;
+        row.status = status;
+        row.updated_at = updated_at;
+        mock.pending_transactions.lock().unwrap().push(row);
+    }
+
+    /// Owned row (Processing, matching token): claim succeeds, the signature is
+    /// persisted, and `updated_at` advances (the D3 bump).
+    #[tokio::test]
+    async fn claim_succeeds_when_owned() {
+        let (storage, mock) = make_mock_storage();
+        let t0 = Utc::now();
+        seed_claim_row(&mock, 1, TransactionStatus::Processing, t0);
+
+        let claimed = storage
+            .claim_and_persist_deposit_signature(1, t0, "sig-owned".to_string(), 100)
+            .await
+            .unwrap();
+        assert!(claimed, "owning the Processing incarnation must claim");
+
+        let sigs = storage.get_release_signatures(1).await.unwrap();
+        assert_eq!(sigs.len(), 1, "the broadcast signature must be persisted");
+        assert_eq!(sigs[0].0, "sig-owned");
+
+        let after = mock.pending_transactions.lock().unwrap()[0].updated_at;
+        assert_ne!(after, t0, "a successful claim must bump updated_at");
+    }
+
+    /// Recovery already demoted the row to Pending: the claim must abort and
+    /// persist no signature. This is the keystone (the bug being closed).
+    #[tokio::test]
+    async fn claim_aborts_when_demoted_to_pending() {
+        let (storage, mock) = make_mock_storage();
+        let t0 = Utc::now();
+        seed_claim_row(&mock, 1, TransactionStatus::Pending, t0);
+
+        let claimed = storage
+            .claim_and_persist_deposit_signature(1, t0, "sig-demoted".to_string(), 100)
+            .await
+            .unwrap();
+        assert!(!claimed, "a demoted row must not be claimable");
+        assert!(
+            storage.get_release_signatures(1).await.unwrap().is_empty(),
+            "no signature may be persisted on a lost claim"
+        );
+    }
+
+    /// A second fetch re-locked the row, advancing its token: the stale builder's
+    /// CAS on the old token must abort.
+    #[tokio::test]
+    async fn claim_aborts_when_token_stale() {
+        let (storage, mock) = make_mock_storage();
+        let t0 = Utc::now();
+        let t1 = t0 + chrono::Duration::seconds(30);
+        seed_claim_row(&mock, 1, TransactionStatus::Processing, t1);
+
+        let claimed = storage
+            .claim_and_persist_deposit_signature(1, t0, "sig-stale".to_string(), 100)
+            .await
+            .unwrap();
+        assert!(
+            !claimed,
+            "a stale token must not claim the re-locked incarnation"
+        );
+        assert!(storage.get_release_signatures(1).await.unwrap().is_empty());
+    }
+
+    /// A terminal row (Completed) is never a valid claim target.
+    #[tokio::test]
+    async fn claim_aborts_when_terminal() {
+        let (storage, mock) = make_mock_storage();
+        let t0 = Utc::now();
+        seed_claim_row(&mock, 1, TransactionStatus::Completed, t0);
+
+        let claimed = storage
+            .claim_and_persist_deposit_signature(1, t0, "sig-terminal".to_string(), 100)
+            .await
+            .unwrap();
+        assert!(!claimed, "a terminal row must not be claimable");
+        assert!(storage.get_release_signatures(1).await.unwrap().is_empty());
     }
 
     // ── status update recording ──────────────────────────────────────

--- a/indexer/src/storage/common/storage/claim_and_persist_deposit_signature.rs
+++ b/indexer/src/storage/common/storage/claim_and_persist_deposit_signature.rs
@@ -1,0 +1,34 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Atomic ownership claim + write-ahead signature persist for a deposit mint.
+/// `Ok(true)` means the sender still owns the `Processing` incarnation it was
+/// handed and may broadcast; `Ok(false)` means the row was demoted or re-locked
+/// so the builder must be dropped without broadcasting.
+pub async fn claim_and_persist_deposit_signature(
+    storage: &Storage,
+    transaction_id: i64,
+    expected_updated_at: chrono::DateTime<chrono::Utc>,
+    signature: String,
+    last_valid_block_height: i64,
+) -> Result<bool, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .claim_and_persist_deposit_signature_internal(
+                transaction_id,
+                expected_updated_at,
+                signature,
+                last_valid_block_height,
+            )
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock) => {
+            mock.claim_and_persist_deposit_signature(
+                transaction_id,
+                expected_updated_at,
+                signature,
+                last_valid_block_height,
+            )
+            .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -230,18 +230,20 @@ impl MockStorage {
             return Ok(matched);
         }
 
-        // Deposits: FIFO by insertion order, removed from the queue on return.
+        // Deposits: FIFO by insertion order. Mirror Postgres: lock only Pending
+        // rows, flip them to Processing in place (keep them in the store so a
+        // later claim's CAS can find the row), and hand back the post-lock token.
         let mut matched = Vec::new();
-        let mut remaining = Vec::new();
-        for txn in pending.drain(..) {
-            if txn.transaction_type == transaction_type && (matched.len() as i64) < limit {
-                matched.push(txn);
-            } else {
-                remaining.push(txn);
+        for txn in pending.iter_mut() {
+            if txn.transaction_type == transaction_type
+                && txn.status == TransactionStatus::Pending
+                && (matched.len() as i64) < limit
+            {
+                txn.status = TransactionStatus::Processing;
+                txn.updated_at = Utc::now();
+                matched.push(txn.clone());
             }
         }
-
-        *pending = remaining;
         Ok(matched)
     }
 
@@ -820,6 +822,43 @@ impl MockStorage {
             .or_default()
             .push((signature, last_valid_block_height));
         Ok(())
+    }
+
+    /// Mirror `claim_and_persist_deposit_signature_internal`: CAS the row on
+    /// `(id, Processing, updated_at)`; on a hit bump `updated_at`, persist the
+    /// signature (mirroring the `ON CONFLICT (signature)` dedup) and return
+    /// `Ok(true)`; on a miss return `Ok(false)` and persist nothing.
+    pub async fn claim_and_persist_deposit_signature(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: DateTime<Utc>,
+        signature: String,
+        last_valid_block_height: i64,
+    ) -> Result<bool, StorageError> {
+        self.check_should_fail("claim_and_persist_deposit_signature")?;
+        // Scope the guard so it is released before the await below.
+        let claimed = {
+            let mut pending = self.pending_transactions.lock().unwrap();
+            match pending.iter_mut().find(|t| {
+                t.id == transaction_id
+                    && t.status == TransactionStatus::Processing
+                    && t.updated_at == expected_updated_at
+            }) {
+                Some(txn) => {
+                    txn.updated_at = Utc::now();
+                    true
+                }
+                None => false,
+            }
+        };
+        if !claimed {
+            return Ok(false);
+        }
+
+        // Reuse the write-ahead insert (mirrors the ON CONFLICT (signature) dedup).
+        self.insert_release_signature(transaction_id, signature, last_valid_block_height)
+            .await?;
+        Ok(true)
     }
 
     pub async fn get_release_signatures(

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1123,7 +1123,7 @@ impl PostgresDb {
         // Use a transaction to ensure atomicity
         let mut tx = self.pool.begin().await?;
 
-        let transactions = sqlx::query_as::<_, DbTransaction>(&format!(
+        let mut transactions = sqlx::query_as::<_, DbTransaction>(&format!(
             r#"
             SELECT
                 {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
@@ -1175,7 +1175,6 @@ impl PostgresDb {
         // Update status to Processing and RETURNING the trigger-bumped
         // `updated_at`, so the fetched row carries its true post-lock token (the
         // deposit sender CASes on it at broadcast, not the stale Pending value).
-        let mut transactions = transactions;
         if !transactions.is_empty() {
             let ids: Vec<i64> = transactions.iter().map(|txn| txn.id).collect();
             let bumped: Vec<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(&format!(

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1172,18 +1172,31 @@ impl PostgresDb {
         .fetch_all(&mut *tx)
         .await?;
 
-        // Update status to Processing in a single query
+        // Update status to Processing and RETURNING the trigger-bumped
+        // `updated_at`, so the fetched row carries its true post-lock token (the
+        // deposit sender CASes on it at broadcast, not the stale Pending value).
+        let mut transactions = transactions;
         if !transactions.is_empty() {
             let ids: Vec<i64> = transactions.iter().map(|txn| txn.id).collect();
-            sqlx::query(&format!(
-                "UPDATE transactions SET {} = $1 WHERE {} = ANY($2)",
+            let bumped: Vec<chrono::DateTime<chrono::Utc>> = sqlx::query_scalar(&format!(
+                "UPDATE transactions SET {} = $1 WHERE {} = ANY($2) RETURNING {}",
                 transaction_cols::STATUS,
-                transaction_cols::ID
+                transaction_cols::ID,
+                transaction_cols::UPDATED_AT,
             ))
             .bind(TransactionStatus::Processing)
             .bind(&ids)
-            .execute(&mut *tx)
+            .fetch_all(&mut *tx)
             .await?;
+
+            // NOW() is constant across this transaction, so every locked row got
+            // the same post-lock timestamp; apply that one value to all of them.
+            if let Some(&post_lock_updated_at) = bumped.first() {
+                for txn in transactions.iter_mut() {
+                    txn.status = TransactionStatus::Processing;
+                    txn.updated_at = post_lock_updated_at;
+                }
+            }
         }
 
         // Commit to release locks with Processing status
@@ -1643,6 +1656,57 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Atomically claim a `Processing` deposit and persist its broadcast
+    /// signature in one transaction. The CAS on `updated_at` bumps the row so a
+    /// racing recovery demote (also a CAS on that column) loses; sharing one
+    /// transaction leaves no bumped-but-unsigned window. `Ok(false)` means the
+    /// row was demoted or re-locked, so the caller must not broadcast.
+    pub async fn claim_and_persist_deposit_signature_internal(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+        signature: String,
+        last_valid_block_height: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        let claimed = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET updated_at = NOW()
+            WHERE id = $1
+              AND status = 'processing'
+              AND updated_at = $2
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(expected_updated_at)
+        .execute(&mut *tx)
+        .await?;
+
+        if claimed.rows_affected() != 1 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO pending_release_signatures
+                (transaction_id, signature, last_valid_block_height)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (signature) DO NOTHING
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(signature)
+        .bind(last_valid_block_height)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(true)
     }
 
     /// Return a transaction's release signatures as (signature, lvbh).

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -1210,3 +1210,121 @@ async fn try_requeue_processing_stale_cas_leaves_counter_unchanged(
     );
     Ok(())
 }
+
+// ── claim_and_persist_deposit_signature: ownership CAS + write-ahead ──────────
+
+/// The lock must hand back the post-lock token: the returned row's `status` is
+/// `Processing` and its `updated_at` is the trigger-bumped value equal to the
+/// DB's current value, not the stale Pending-era timestamp. Without this the
+/// deposit claim would CAS against a timestamp that never matches.
+#[tokio::test(flavor = "multi_thread")]
+async fn lock_returns_processing_era_updated_at() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let id = storage
+        .insert_db_transaction(&make_db_transaction("lock_token", TransactionType::Deposit))
+        .await?;
+    let pending_era = updated_at_of(&pool, id).await;
+
+    let locked = storage
+        .get_and_lock_pending_transactions(TransactionType::Deposit, 100)
+        .await?;
+    let row = locked.iter().find(|t| t.id == id).expect("row was locked");
+    assert_eq!(
+        row.status,
+        TransactionStatus::Processing,
+        "the returned row must carry the post-lock Processing status"
+    );
+    assert_ne!(
+        row.updated_at, pending_era,
+        "the returned updated_at must be the post-lock trigger-bumped value"
+    );
+    assert_eq!(
+        row.updated_at,
+        updated_at_of(&pool, id).await,
+        "the returned updated_at must equal the DB's current value"
+    );
+    Ok(())
+}
+
+/// A successful claim leaves exactly one signature and a changed `updated_at`;
+/// a failed claim (wrong token) leaves zero new signatures and an unchanged
+/// `updated_at` (proving there is no bumped-but-no-signature partial state).
+#[tokio::test(flavor = "multi_thread")]
+async fn claim_is_atomic() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let id = storage
+        .insert_db_transaction(&make_db_transaction(
+            "claim_atomic",
+            TransactionType::Deposit,
+        ))
+        .await?;
+    storage
+        .get_and_lock_pending_transactions(TransactionType::Deposit, 100)
+        .await?;
+    let token = updated_at_of(&pool, id).await;
+
+    let claimed = storage
+        .claim_and_persist_deposit_signature(id, token, "sig-claim".to_string(), 555)
+        .await?;
+    assert!(claimed, "owning the Processing incarnation must claim");
+    let sigs = storage.get_release_signatures(id).await?;
+    assert_eq!(sigs.len(), 1, "a successful claim persists exactly one sig");
+    assert_eq!(sigs[0], ("sig-claim".to_string(), 555));
+    let bumped = updated_at_of(&pool, id).await;
+    assert_ne!(bumped, token, "a successful claim bumps updated_at");
+
+    // A stale token must abort atomically: no new sig, no timestamp change.
+    let stale = bumped - chrono::Duration::seconds(60);
+    let failed = storage
+        .claim_and_persist_deposit_signature(id, stale, "sig-fail".to_string(), 1)
+        .await?;
+    assert!(!failed, "a stale token must not claim");
+    assert_eq!(
+        storage.get_release_signatures(id).await?.len(),
+        1,
+        "a failed claim persists no additional signature"
+    );
+    assert_eq!(
+        updated_at_of(&pool, id).await,
+        bumped,
+        "a failed claim leaves updated_at unchanged"
+    );
+    Ok(())
+}
+
+/// Claiming the same signature twice yields a single row (ON CONFLICT
+/// (signature) DO NOTHING), even though each claim owns the current token.
+#[tokio::test(flavor = "multi_thread")]
+async fn claim_dedups_signature_on_conflict() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let id = storage
+        .insert_db_transaction(&make_db_transaction(
+            "claim_dedup",
+            TransactionType::Deposit,
+        ))
+        .await?;
+    storage
+        .get_and_lock_pending_transactions(TransactionType::Deposit, 100)
+        .await?;
+
+    let token1 = updated_at_of(&pool, id).await;
+    assert!(
+        storage
+            .claim_and_persist_deposit_signature(id, token1, "dup-sig".to_string(), 1)
+            .await?
+    );
+    // The first claim bumped updated_at; the second claim owns the new token but
+    // re-inserts the same signature, which must be deduped.
+    let token2 = updated_at_of(&pool, id).await;
+    assert!(
+        storage
+            .claim_and_persist_deposit_signature(id, token2, "dup-sig".to_string(), 999)
+            .await?
+    );
+    assert_eq!(
+        storage.get_release_signatures(id).await?.len(),
+        1,
+        "a duplicate signature must persist only once"
+    );
+    Ok(())
+}

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1,20 +1,32 @@
 //! E2E tests for the stuck-`Processing` recovery worker.
 
+#[path = "sender_fixtures.rs"]
+mod sender_fixtures;
+
 use {
     chrono::{Duration as ChronoDuration, Utc},
     private_channel_indexer::{
         config::ProgramType,
-        metrics::OPERATOR_STALE_PROCESSING_RECOVERED,
+        metrics::{OPERATOR_STALE_PROCESSING_RECOVERED, OPERATOR_TRANSACTION_ERRORS},
         operator::{
             recovery::test_hooks,
+            sender::{test_hooks as sender_hooks, types::SenderState},
+            utils::instruction_util::{ExtraErrorCheckPolicy, RetryPolicy},
             utils::rpc_util::{RetryConfig, RpcClientWithRetry},
             TransactionStatusUpdate,
         },
         storage::{common::models::DbTransactionBuilder, PostgresDb, Storage, TransactionType},
         PostgresConfig,
     },
+    sender_fixtures::{
+        blockhash_reply, deposit_ctx, make_config, make_instruction, send_transaction_echo_reply,
+    },
     serde_json::json,
-    solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature},
+    solana_sdk::{
+        commitment_config::{CommitmentConfig, CommitmentLevel},
+        pubkey::Pubkey,
+        signature::Signature,
+    },
     std::{sync::Arc, time::Duration},
     test_utils::mock_rpc::{MockRpcServer, Reply},
     tokio::sync::mpsc,
@@ -1165,4 +1177,307 @@ async fn threshold_boundary_returns_only_strictly_older_rows() {
         returned_ids.contains(&ids[2]),
         "5:01-old row MUST be returned (older than threshold)"
     );
+}
+
+// ── ownership-checked deposit claim: the double-mint invariant end-to-end ─────
+//
+// One escrow deposit must produce at most one channel mint even when the
+// recovery worker demotes a row while a live in-memory Mint builder still
+// holds it. These drive the production sender's first-fire path
+// (`fire_and_store_task` via `run_fire_and_store_task`) against a real
+// Postgres, so the claim CAS and recovery's demote race on the same rows.
+
+const OWNERSHIP_LOST_REASON: &str = "deposit_ownership_lost";
+const MINT_BROADCAST_METHOD: &str = "sendTransaction";
+
+/// Count private-channel mint broadcasts so each assertion is falsifiable.
+fn mint_broadcast_count(mock: &MockRpcServer) -> usize {
+    mock.call_count(MINT_BROADCAST_METHOD)
+}
+
+async fn build_pg_sender_state(storage: Arc<Storage>, rpc_url: String) -> SenderState {
+    sender_fixtures::ensure_admin_signer_env();
+    sender_hooks::new_sender_state(
+        &make_config(rpc_url, ProgramType::Escrow),
+        CommitmentLevel::Confirmed,
+        None,
+        storage,
+        1,
+        1,
+        None,
+    )
+    .expect("sender state construction against Postgres storage")
+}
+
+/// Drive one deposit first-fire builder through the production persist/claim
+/// path with the given ownership token.
+async fn drive_first_fire(
+    state: &SenderState,
+    tx_id: i64,
+    token: chrono::DateTime<Utc>,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) {
+    sender_hooks::run_fire_and_store_task(
+        state,
+        make_instruction(),
+        None,
+        deposit_ctx(tx_id),
+        RetryPolicy::None,
+        ExtraErrorCheckPolicy::None,
+        storage_tx,
+        true,
+        Some(token),
+    )
+    .await;
+}
+
+// IT1: a stale sender-owned builder whose row recovery already demoted must NOT
+// broadcast. This is the exact reported bug, closed.
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_owned_builder_does_not_double_mint() {
+    let (db, url, _container) = start_pg("it_claim_stale").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_deposit(
+        &Signature::new_unique().to_string(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        100,
+    );
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    // The row was locked at T_lock; the stale builder still carries this token.
+    let t_lock = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    // build_and_sign needs a blockhash; the claim aborts before any broadcast.
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    let recovery_client = test_client(mock.url());
+    let state = build_pg_sender_state(storage.clone(), mock.url()).await;
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    // Recovery sees empty sigs and demotes the row to Pending (bumping updated_at).
+    test_hooks::run_recovery_once(&storage, &recovery_client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
+    assert_eq!(status_of(&pool, tx_id).await, "pending");
+
+    let metric = OPERATOR_TRANSACTION_ERRORS.with_label_values(&["escrow", OWNERSHIP_LOST_REASON]);
+    let metric_before = metric.get();
+
+    drive_first_fire(&state, tx_id, t_lock, &storage_tx).await;
+
+    assert_eq!(
+        mint_broadcast_count(&mock),
+        0,
+        "a demoted row's stale builder must not broadcast a mint"
+    );
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "pending",
+        "the lost claim must leave the row untouched for its current owner"
+    );
+    assert!(
+        db.get_release_signatures_internal(tx_id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "a lost claim persists no signature"
+    );
+    assert!(
+        metric.get() > metric_before,
+        "a lost claim increments deposit_ownership_lost"
+    );
+    mock.shutdown().await;
+}
+
+// Bug oracle: the unguarded write-ahead persist (a plain insert with no ownership
+// check) broadcasts a stale mint on a demoted row. This reproduces the reported
+// bug through production code: the mint lands on a Pending row, so its Completed
+// write no-ops (it9) and the row is re-fetched for a second mint (it3). IT1 is the
+// exact contrast: with its ownership token the first-fire broadcasts nothing on the
+// same setup. The JIT re-fire still uses this token-less path but is kept off a
+// demoted row by the bounded confirmation window.
+#[tokio::test(flavor = "multi_thread")]
+async fn unguarded_first_fire_would_broadcast_on_demoted_row() {
+    let (db, url, _container) = start_pg("it_oracle_unguarded").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_deposit(
+        &Signature::new_unique().to_string(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        100,
+    );
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("sendTransaction", send_transaction_echo_reply());
+    let recovery_client = test_client(mock.url());
+    let state = build_pg_sender_state(storage.clone(), mock.url()).await;
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    // Same setup as IT1: recovery demotes the stale row to Pending.
+    test_hooks::run_recovery_once(&storage, &recovery_client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
+    assert_eq!(status_of(&pool, tx_id).await, "pending");
+
+    // Drive the persist with no ownership token: the token-less (unguarded) path.
+    sender_hooks::run_fire_and_store_task(
+        &state,
+        make_instruction(),
+        None,
+        deposit_ctx(tx_id),
+        RetryPolicy::None,
+        ExtraErrorCheckPolicy::None,
+        &storage_tx,
+        true,
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        mint_broadcast_count(&mock),
+        1,
+        "the token-less path broadcasts a stale mint on a demoted (Pending) row"
+    );
+    assert!(
+        !db.get_release_signatures_internal(tx_id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "the token-less path persists a signature against a Pending row"
+    );
+    mock.shutdown().await;
+}
+
+// IT2: an owned deposit mints exactly once. The happy-path oracle proving the
+// guard does not strangle a legitimate mint.
+#[tokio::test(flavor = "multi_thread")]
+async fn owned_deposit_mints_once() {
+    let (db, url, _container) = start_pg("it_claim_owned").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_deposit(
+        &Signature::new_unique().to_string(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        100,
+    );
+    db.insert_transaction_internal(&tx).await.unwrap();
+
+    // Lock the deposit the way the fetcher does and carry its true post-lock token.
+    let locked = storage
+        .get_and_lock_pending_transactions(TransactionType::Deposit, 100)
+        .await
+        .unwrap();
+    let row = locked.first().expect("locked deposit");
+    let tx_id = row.id;
+    let token = row.updated_at;
+
+    let mock = MockRpcServer::start().await;
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("sendTransaction", send_transaction_echo_reply());
+    let state = build_pg_sender_state(storage.clone(), mock.url()).await;
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    drive_first_fire(&state, tx_id, token, &storage_tx).await;
+
+    assert_eq!(
+        mint_broadcast_count(&mock),
+        1,
+        "an owned deposit must broadcast exactly one mint"
+    );
+    assert_eq!(
+        db.get_release_signatures_internal(tx_id)
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "the owned claim persists exactly one write-ahead signature"
+    );
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "processing",
+        "the claim keeps the row Processing (its terminal write is status-guarded)"
+    );
+    assert_ne!(
+        updated_at_of(&pool, tx_id).await,
+        token,
+        "a successful claim bumps updated_at"
+    );
+    mock.shutdown().await;
+}
+
+// IT3: demote then re-fetch, then drive BOTH the stale first builder and the
+// second builder. Exactly one mint broadcasts across the whole sequence.
+#[tokio::test(flavor = "multi_thread")]
+async fn demote_then_refetch_mints_exactly_once() {
+    let (db, url, _container) = start_pg("it_claim_refetch").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_deposit(
+        &Signature::new_unique().to_string(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        100,
+    );
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    // First lock at T_lock1, held by the stale builder B1.
+    let t_lock1 = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    // Two first-fires each build+sign (blockhash); only the owned one broadcasts.
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+    mock.enqueue("sendTransaction", send_transaction_echo_reply());
+    let recovery_client = test_client(mock.url());
+    let state = build_pg_sender_state(storage.clone(), mock.url()).await;
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    // Recovery demotes B1's row to Pending.
+    test_hooks::run_recovery_once(&storage, &recovery_client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
+
+    // A fresh fetch re-locks the row as a new incarnation B2 with token T_lock2.
+    let relocked = storage
+        .get_and_lock_pending_transactions(TransactionType::Deposit, 100)
+        .await
+        .unwrap();
+    let t_lock2 = relocked
+        .iter()
+        .find(|r| r.id == tx_id)
+        .expect("row re-locked")
+        .updated_at;
+    assert_ne!(t_lock1, t_lock2, "the re-lock must advance the token");
+
+    // Drive the stale B1 first (must abort), then the owned B2 (mints once).
+    drive_first_fire(&state, tx_id, t_lock1, &storage_tx).await;
+    drive_first_fire(&state, tx_id, t_lock2, &storage_tx).await;
+
+    assert_eq!(
+        mint_broadcast_count(&mock),
+        1,
+        "across demote + re-fetch, exactly one mint broadcasts"
+    );
+    assert_eq!(
+        db.get_release_signatures_internal(tx_id)
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "only the owned incarnation persists a signature"
+    );
+    mock.shutdown().await;
 }


### PR DESCRIPTION
## Summary

Closes issue 113.  A deposit transaction could be requeued while a sender still held an in-memory `Mint` awaiting broadcast. Since the transaction signature had not yet been persisted, the recovery worker interpreted the `Processing` row as never broadcast, demoted it back to `Pending`, and allowed it to be fetched again. The original sender could still broadcast its transaction, causing the re-fetched deposit to be minted a second time and creating unbacked channel token supply.

This change makes persisting the deposit transaction signature an atomic ownership claim. Before broadcasting, the sender now performs a compare-and-swap (CAS) against the deposit row's fetch-time `updated_at` and only persists the signature if it still owns that exact `Processing` incarnation. If ownership has already been lost, the builder is discarded without broadcasting, preventing the recovery worker and a live sender from racing to mint the same deposit. The recovery flow itself is unchanged; it simply can no longer reclaim work owned by an active sender.

Unit and integration tests cover ownership claiming, race conditions, and end-to-end scenarios to verify that a deposit can be requeued safely without ever being double-minted.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29245886678) |
| Indexer | 26,354 | 29,700 | 88.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29245886678) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29245886678) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29245886678) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,557 | 15,819 | 79.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29245886678) |
| **Total** | **52,507** | **61,057** | **86.0%** | |

> Last updated: 2026-07-13 12:22:59 UTC by E2E Integration