### PR TITLE
fix(indexer): requeue withdrawals on pre-broadcast build/sign failure

### DIFF
--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -28,8 +28,9 @@ pub(crate) const STALE_THRESHOLD: Duration = Duration::from_secs(5 * 60);
 /// Per-tick batch cap; leftovers are picked up next tick.
 pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 
-/// Max durable Demote requeues before a stuck row is quarantined (paged).
-const MAX_RECOVERY_REQUEUE_ATTEMPTS: i32 = 3;
+/// Max durable requeues before a stuck row is quarantined (paged). Bumped and
+/// enforced by both this sweep and the sender's pre-broadcast requeue path.
+pub(crate) const MAX_RECOVERY_REQUEUE_ATTEMPTS: i32 = 3;
 
 /// Deposit recovery outcome. Uncertainty must NOT demote (double-mint risk); an
 /// in-flight signature leaves the row Processing for the next sweep.

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -3,6 +3,7 @@ use crate::config::ProgramType;
 use crate::error::TransactionError;
 use crate::error::{OperatorError, ProgramError};
 use crate::metrics;
+use crate::operator::recovery::MAX_RECOVERY_REQUEUE_ATTEMPTS;
 use crate::operator::tree_constants::MAX_TREE_LEAVES;
 use crate::operator::utils::instruction_util::{
     mint_extra_error_checks_policy, TransactionBuilder,
@@ -442,7 +443,35 @@ pub(super) async fn send_and_confirm(
                             .get(&nonce)
                             .is_none_or(|sigs| sigs.is_empty()) =>
                     {
-                        requeue_prebroadcast_failure(state, nonce, transaction_id).await;
+                        // The attempt cap above is in-memory and resets on restart,
+                        // so also enforce the durable requeue cap here. Fail open
+                        // on a read error: if the requeue write then fails too, the
+                        // row goes stale in Processing and recovery quarantines it.
+                        let requeue_attempts = match state
+                            .storage
+                            .get_recovery_requeue_attempts(transaction_id)
+                            .await
+                        {
+                            Ok(attempts) => attempts.unwrap_or(0),
+                            Err(read_err) => {
+                                warn!(
+                                    transaction_id,
+                                    "Requeue cap read failed, requeueing anyway: {read_err}"
+                                );
+                                0
+                            }
+                        };
+                        if requeue_attempts >= MAX_RECOVERY_REQUEUE_ATTEMPTS {
+                            metrics::OPERATOR_TRANSACTION_ERRORS
+                                .with_label_values(&[pt, "prebroadcast_requeue_cap"])
+                                .inc();
+                            let reason = format!(
+                            "build/sign failed after {MAX_RECOVERY_REQUEUE_ATTEMPTS} requeues: {e}"
+                        );
+                            handle_permanent_failure(state, ctx, storage_tx, &reason).await;
+                        } else {
+                            requeue_prebroadcast_failure(state, nonce, transaction_id).await;
+                        }
                     }
                     _ => handle_permanent_failure(state, ctx, storage_tx, &e.to_string()).await,
                 }
@@ -2528,6 +2557,122 @@ mod tests {
             TransactionStatus::Processing,
             "row left Processing for recovery"
         );
+    }
+
+    /// A row already at the durable requeue cap must not requeue again on a
+    /// build/sign failure: it pages via ManualReview instead of ping-ponging
+    /// Pending ↔ Processing forever across restarts.
+    #[tokio::test]
+    async fn build_sign_failure_at_requeue_cap_goes_to_manual_review() {
+        let txn_id = 10;
+        let nonce = 5;
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash_failure(&mut server);
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let mut smt = SenderSMTState {
+            smt_state: SmtState::new(0),
+            nonce_to_builder: HashMap::new(),
+        };
+        smt.smt_state.insert_nonce(nonce);
+        state.smt_state = Some(smt);
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+
+        let storage = state.storage.clone();
+        let Storage::Mock(ref mock) = *storage else {
+            panic!("expected mock storage");
+        };
+        let mut row = processing_withdrawal_row(txn_id, nonce);
+        row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS;
+        mock.pending_transactions.lock().unwrap().push(row);
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        send_and_confirm(
+            &mut state,
+            dummy_instruction(),
+            None,
+            &withdrawal_ctx(txn_id, nonce),
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        let update = storage_rx
+            .try_recv()
+            .expect("cap hit must surface a status update");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert!(update
+            .error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("requeues"));
+
+        let row = mock.pending_transactions.lock().unwrap()[0].clone();
+        assert_eq!(
+            row.status,
+            TransactionStatus::Processing,
+            "row must not requeue past the cap"
+        );
+        let smt = state.smt_state.as_ref().unwrap();
+        assert!(
+            !smt.smt_state.contains_nonce(nonce),
+            "permanent-failure cleanup rolls back the SMT nonce"
+        );
+    }
+
+    /// A failed durable-cap read must not block the retry: fail open and
+    /// requeue, since recovery still quarantines the row via the same counter
+    /// if the requeue write fails too.
+    #[tokio::test]
+    async fn build_sign_failure_cap_read_error_still_requeues() {
+        let txn_id = 10;
+        let nonce = 5;
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash_failure(&mut server);
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let mut smt = SenderSMTState {
+            smt_state: SmtState::new(0),
+            nonce_to_builder: HashMap::new(),
+        };
+        smt.smt_state.insert_nonce(nonce);
+        state.smt_state = Some(smt);
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+
+        let storage = state.storage.clone();
+        let Storage::Mock(ref mock) = *storage else {
+            panic!("expected mock storage");
+        };
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(txn_id, nonce));
+        mock.set_should_fail("get_recovery_requeue_attempts", true);
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        send_and_confirm(
+            &mut state,
+            dummy_instruction(),
+            None,
+            &withdrawal_ctx(txn_id, nonce),
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "fail-open must not write a terminal status"
+        );
+        let row = mock.pending_transactions.lock().unwrap()[0].clone();
+        assert_eq!(
+            row.status,
+            TransactionStatus::Pending,
+            "requeued despite the cap read error"
+        );
+        assert_eq!(row.recovery_requeue_attempts, 1);
     }
 
     // ── set_pending_remint persistence ───────────────────────────────

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -887,6 +887,10 @@ pub(super) async fn requeue_prebroadcast_failure(
     if let Some(ref mut smt_state) = state.smt_state {
         if smt_state.smt_state.remove_nonce(nonce) {
             warn!("Rolled back SMT state for nonce {nonce} after pre-broadcast failure");
+        } else {
+            // The builder inserted this nonce before build/sign ran, so a miss
+            // means the local SMT disagrees with the row being requeued.
+            error!("Nonce {nonce} missing from local SMT during pre-broadcast rollback");
         }
         smt_state.nonce_to_builder.remove(&nonce);
     }

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -429,7 +429,23 @@ pub(super) async fn send_and_confirm(
                     .with_label_values(&[pt, "build_sign_error"])
                     .inc();
                 error!("Failed to build/sign transaction: {}", e);
-                handle_permanent_failure(state, ctx, storage_tx, &e.to_string()).await;
+                // build_and_sign failed before a signature existed. A withdrawal
+                // with no signature stashed from an earlier attempt provably never
+                // broadcast, so requeue it for an automatic retry; the attempt cap
+                // above bounds the loop. With stashed signatures (Retry recursion
+                // after a broadcast) or no nonce (ResetSmtRoot), keep the
+                // permanent-failure path.
+                match (ctx.withdrawal_nonce, ctx.transaction_id) {
+                    (Some(nonce), Some(transaction_id))
+                        if state
+                            .pending_signatures
+                            .get(&nonce)
+                            .is_none_or(|sigs| sigs.is_empty()) =>
+                    {
+                        requeue_prebroadcast_failure(state, nonce, transaction_id).await;
+                    }
+                    _ => handle_permanent_failure(state, ctx, storage_tx, &e.to_string()).await,
+                }
                 return;
             }
         };
@@ -857,6 +873,48 @@ fn leave_processing_for_recovery(
     );
 }
 
+/// Requeue a withdrawal whose build/sign failed before any signature existed.
+/// Nothing was broadcast, so an automatic retry is safe: roll back the nonce's
+/// local SMT state and CAS the row Processing → Pending for the fetcher to
+/// re-claim. Keeps `retry_counts` so the attempt cap in `send_and_confirm`
+/// still bounds the loop across requeues. If the requeue write fails the row
+/// stays Processing and recovery quarantines it (no signatures recorded).
+pub(super) async fn requeue_prebroadcast_failure(
+    state: &mut SenderState,
+    nonce: u64,
+    transaction_id: i64,
+) {
+    if let Some(ref mut smt_state) = state.smt_state {
+        if smt_state.smt_state.remove_nonce(nonce) {
+            warn!("Rolled back SMT state for nonce {nonce} after pre-broadcast failure");
+        }
+        smt_state.nonce_to_builder.remove(&nonce);
+    }
+    // Re-inserted by handle_transaction_builder on the next attempt.
+    state.remint_cache.remove(&nonce);
+
+    let pt = state.program_type.as_label();
+    match state.storage.try_requeue_prebroadcast(transaction_id).await {
+        Ok(true) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt, "prebroadcast_requeued"])
+                .inc();
+            info!(
+                transaction_id,
+                nonce, "Requeued withdrawal to Pending after pre-broadcast build/sign failure"
+            );
+        }
+        Ok(false) => warn!(
+            transaction_id,
+            nonce, "Pre-broadcast requeue skipped: row no longer Processing"
+        ),
+        Err(e) => warn!(
+            transaction_id,
+            nonce, "Pre-broadcast requeue failed, row left Processing for recovery: {e}"
+        ),
+    }
+}
+
 pub(super) async fn handle_permanent_failure(
     state: &mut SenderState,
     ctx: &TransactionContext,
@@ -882,8 +940,8 @@ pub(super) async fn handle_permanent_failure(
         return;
     };
 
-    // Zero signatures means sign_and_send itself failed — we have nothing to verify.
-    // The RPC may have broadcast the tx before erroring, so blind remint is unsafe.
+    // Zero signatures means no broadcast succeeded for this nonce, but the RPC
+    // may still have broadcast one before erroring, so blind remint is unsafe.
     if signatures.is_empty() {
         error!(
             "No signatures to verify for nonce {:?} — cannot safely remint, sending to ManualReview",
@@ -1629,6 +1687,8 @@ mod tests {
     use crate::operator::utils::smt_util::SmtState;
     use crate::operator::MintCache;
     use crate::operator::ReleaseFundsBuilderWithNonce;
+    use crate::storage::common::amount::TokenAmount;
+    use crate::storage::common::models::{DbTransaction, TransactionType};
     use crate::storage::common::storage::mock::MockStorage;
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine;
@@ -2245,6 +2305,225 @@ mod tests {
             .try_recv()
             .expect("send failure must surface a status update");
         assert_eq!(update.status, TransactionStatus::ManualReview);
+    }
+
+    // ── pre-broadcast build/sign failure requeues withdrawals ────────
+
+    fn processing_withdrawal_row(txn_id: i64, nonce: u64) -> DbTransaction {
+        let now = Utc::now();
+        DbTransaction {
+            id: txn_id,
+            signature: format!("sig-{txn_id}"),
+            instruction_index: 0,
+            trace_id: format!("trace-{txn_id}"),
+            slot: 100,
+            initiator: Pubkey::new_unique().to_string(),
+            recipient: Pubkey::new_unique().to_string(),
+            mint: Pubkey::new_unique().to_string(),
+            amount: TokenAmount(1_000),
+            memo: None,
+            transaction_type: TransactionType::Withdrawal,
+            withdrawal_nonce: Some(nonce as i64),
+            status: TransactionStatus::Processing,
+            created_at: now,
+            updated_at: now,
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            remint_last_valid_block_heights: None,
+            pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
+            inner_index: None,
+            landed_remint_signature: None,
+        }
+    }
+
+    fn mock_blockhash_failure(server: &mut mockito::ServerGuard) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getLatestBlockhash"
+            })))
+            .with_status(500)
+            .with_body("blockhash rpc down")
+            .create()
+    }
+
+    /// A withdrawal build/sign failure happens before any signature exists, so the
+    /// row must requeue Processing → Pending for an automatic retry: SMT rolled
+    /// back, no terminal status, retry count kept so the attempt cap still binds.
+    #[tokio::test]
+    async fn withdrawal_build_sign_failure_requeues_to_pending() {
+        let txn_id = 10;
+        let nonce = 5;
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash_failure(&mut server);
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let mut smt = SenderSMTState {
+            smt_state: SmtState::new(0),
+            nonce_to_builder: HashMap::new(),
+        };
+        smt.smt_state.insert_nonce(nonce);
+        smt.nonce_to_builder.insert(
+            nonce,
+            (withdrawal_ctx(txn_id, nonce), ReleaseFundsBuilder::new()),
+        );
+        state.smt_state = Some(smt);
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+
+        let storage = state.storage.clone();
+        let Storage::Mock(ref mock) = *storage else {
+            panic!("expected mock storage");
+        };
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(txn_id, nonce));
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        send_and_confirm(
+            &mut state,
+            dummy_instruction(),
+            None,
+            &withdrawal_ctx(txn_id, nonce),
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "pre-broadcast failure must not write a terminal status"
+        );
+        assert!(state.pending_remints.is_empty(), "no deferred remint");
+
+        let smt = state.smt_state.as_ref().unwrap();
+        assert!(
+            !smt.smt_state.contains_nonce(nonce),
+            "nonce rolled back from local SMT"
+        );
+        assert!(!smt.nonce_to_builder.contains_key(&nonce));
+        assert!(!state.remint_cache.contains_key(&nonce));
+        assert_eq!(
+            state.retry_counts.get(&nonce),
+            Some(&1),
+            "retry count survives the requeue so the attempt cap still binds"
+        );
+
+        let row = mock.pending_transactions.lock().unwrap()[0].clone();
+        assert_eq!(
+            row.status,
+            TransactionStatus::Pending,
+            "row requeued for the fetcher"
+        );
+        assert_eq!(row.recovery_requeue_attempts, 1);
+    }
+
+    /// With a signature stashed from an earlier broadcast of the same nonce, a
+    /// later build/sign failure is not provably pre-broadcast: it must take the
+    /// finality-checked remint path, not the requeue.
+    #[tokio::test]
+    async fn build_sign_failure_with_prior_broadcast_defers_remint() {
+        let txn_id = 10;
+        let nonce = 5;
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash_failure(&mut server);
+
+        let mut state = make_sender_state_with_server(&server.url());
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+        let prior_sig = Signature::new_unique();
+        state.pending_signatures.insert(
+            nonce,
+            vec![PendingSig {
+                signature: prior_sig,
+                last_valid_block_height: 0,
+            }],
+        );
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        send_and_confirm(
+            &mut state,
+            dummy_instruction(),
+            None,
+            &withdrawal_ctx(txn_id, nonce),
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "remint is deferred, no status update yet"
+        );
+        assert_eq!(
+            state.pending_remints.len(),
+            1,
+            "prior broadcast must defer a remint, not requeue"
+        );
+        assert_eq!(state.pending_remints[0].signatures[0].signature, prior_sig);
+    }
+
+    /// If the requeue write fails the row stays Processing: recovery quarantines
+    /// no-signature withdrawals, so the failure still pages instead of stranding.
+    #[tokio::test]
+    async fn build_sign_failure_requeue_write_error_leaves_processing() {
+        let txn_id = 10;
+        let nonce = 5;
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash_failure(&mut server);
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let mut smt = SenderSMTState {
+            smt_state: SmtState::new(0),
+            nonce_to_builder: HashMap::new(),
+        };
+        smt.smt_state.insert_nonce(nonce);
+        state.smt_state = Some(smt);
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+
+        let storage = state.storage.clone();
+        let Storage::Mock(ref mock) = *storage else {
+            panic!("expected mock storage");
+        };
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(txn_id, nonce));
+        mock.set_should_fail("try_requeue_prebroadcast", true);
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        send_and_confirm(
+            &mut state,
+            dummy_instruction(),
+            None,
+            &withdrawal_ctx(txn_id, nonce),
+            RetryPolicy::Idempotent,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no terminal status on requeue write failure"
+        );
+        assert!(state.pending_remints.is_empty());
+        let smt = state.smt_state.as_ref().unwrap();
+        assert!(
+            !smt.smt_state.contains_nonce(nonce),
+            "SMT rollback happens regardless of the requeue write"
+        );
+
+        let row = mock.pending_transactions.lock().unwrap()[0].clone();
+        assert_eq!(
+            row.status,
+            TransactionStatus::Processing,
+            "row left Processing for recovery"
+        );
     }
 
     // ── set_pending_remint persistence ───────────────────────────────

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -40,6 +40,7 @@ pub mod try_complete_processing;
 pub mod try_park_processing;
 pub mod try_quarantine_processing;
 pub mod try_requeue_parked;
+pub mod try_requeue_prebroadcast;
 pub mod try_requeue_processing;
 pub mod try_unpark_to_processing;
 pub mod update_committed_checkpoint;
@@ -363,6 +364,15 @@ impl Storage {
     ) -> Result<bool, StorageError> {
         try_requeue_processing::try_requeue_processing(self, transaction_id, expected_updated_at)
             .await
+    }
+
+    /// Status-only CAS `Processing` → `Pending`; `Ok(false)` if the row is not `Processing`.
+    /// For sender-side pre-broadcast failures where the sender owns the Processing row.
+    pub async fn try_requeue_prebroadcast(
+        &self,
+        transaction_id: i64,
+    ) -> Result<bool, StorageError> {
+        try_requeue_prebroadcast::try_requeue_prebroadcast(self, transaction_id).await
     }
 
     /// CAS `Processing`/`Parked` → `Parked`; `Ok(false)` if the row is neither.

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -19,6 +19,7 @@ pub mod get_mint_status_at_slot;
 pub mod get_orphan_deposit_ids;
 pub mod get_pending_db_transactions;
 pub mod get_pending_remint_transactions;
+pub mod get_recovery_requeue_attempts;
 pub mod get_release_signatures;
 pub mod get_remint_signatures;
 pub mod get_stale_parked_transactions;
@@ -373,6 +374,14 @@ impl Storage {
         transaction_id: i64,
     ) -> Result<bool, StorageError> {
         try_requeue_prebroadcast::try_requeue_prebroadcast(self, transaction_id).await
+    }
+
+    /// Read a row's durable requeue counter; `None` if the row does not exist.
+    pub async fn get_recovery_requeue_attempts(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Option<i32>, StorageError> {
+        get_recovery_requeue_attempts::get_recovery_requeue_attempts(self, transaction_id).await
     }
 
     /// CAS `Processing`/`Parked` → `Parked`; `Ok(false)` if the row is neither.

--- a/indexer/src/storage/common/storage/get_recovery_requeue_attempts.rs
+++ b/indexer/src/storage/common/storage/get_recovery_requeue_attempts.rs
@@ -1,0 +1,15 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Read a row's durable requeue counter; `None` if the row does not exist.
+pub async fn get_recovery_requeue_attempts(
+    storage: &Storage,
+    transaction_id: i64,
+) -> Result<Option<i32>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .get_recovery_requeue_attempts_internal(transaction_id)
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.get_recovery_requeue_attempts(transaction_id).await,
+    }
+}

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -698,6 +698,18 @@ impl MockStorage {
         Ok(false)
     }
 
+    pub async fn get_recovery_requeue_attempts(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Option<i32>, StorageError> {
+        self.check_should_fail("get_recovery_requeue_attempts")?;
+        let pending = self.pending_transactions.lock().unwrap();
+        Ok(pending
+            .iter()
+            .find(|txn| txn.id == transaction_id)
+            .map(|txn| txn.recovery_requeue_attempts))
+    }
+
     pub async fn try_park_processing(&self, transaction_id: i64) -> Result<bool, StorageError> {
         self.check_should_fail("try_park_processing")?;
         let mut pending = self.pending_transactions.lock().unwrap();

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -681,6 +681,23 @@ impl MockStorage {
         Ok(false)
     }
 
+    pub async fn try_requeue_prebroadcast(
+        &self,
+        transaction_id: i64,
+    ) -> Result<bool, StorageError> {
+        self.check_should_fail("try_requeue_prebroadcast")?;
+        let mut pending = self.pending_transactions.lock().unwrap();
+        for txn in pending.iter_mut() {
+            if txn.id == transaction_id && txn.status == TransactionStatus::Processing {
+                txn.status = TransactionStatus::Pending;
+                txn.recovery_requeue_attempts += 1;
+                txn.updated_at = Utc::now();
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     pub async fn try_park_processing(&self, transaction_id: i64) -> Result<bool, StorageError> {
         self.check_should_fail("try_park_processing")?;
         let mut pending = self.pending_transactions.lock().unwrap();

--- a/indexer/src/storage/common/storage/try_requeue_prebroadcast.rs
+++ b/indexer/src/storage/common/storage/try_requeue_prebroadcast.rs
@@ -1,0 +1,13 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Status-only CAS `Processing` → `Pending`; `Ok(false)` if the row is not `Processing`.
+pub async fn try_requeue_prebroadcast(
+    storage: &Storage,
+    transaction_id: i64,
+) -> Result<bool, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db.try_requeue_prebroadcast_internal(transaction_id).await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.try_requeue_prebroadcast(transaction_id).await,
+    }
+}

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1329,6 +1329,30 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
+    /// Status-only CAS `Processing` → `Pending` for pre-broadcast build/sign
+    /// failures. The sender owns the row while `processing`, so no `updated_at`
+    /// guard is needed. Bumps `recovery_requeue_attempts` so the recovery
+    /// quarantine cap survives restarts.
+    pub async fn try_requeue_prebroadcast_internal(
+        &self,
+        transaction_id: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'pending',
+                recovery_requeue_attempts = recovery_requeue_attempts + 1
+            WHERE id = $1
+              AND status = 'processing'
+            "#,
+        )
+        .bind(transaction_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
     /// CAS `Processing`/`Parked` → `Parked`. Accepts an already-parked row so the
     /// drain's per-tick re-park bumps `updated_at` (the heartbeat).
     pub async fn try_park_processing_internal(

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1353,6 +1353,17 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
+    /// Read a row's durable requeue counter; `None` if the row does not exist.
+    pub async fn get_recovery_requeue_attempts_internal(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Option<i32>, sqlx::Error> {
+        sqlx::query_scalar("SELECT recovery_requeue_attempts FROM transactions WHERE id = $1")
+            .bind(transaction_id)
+            .fetch_optional(&self.pool)
+            .await
+    }
+
     /// CAS `Processing`/`Parked` → `Parked`. Accepts an already-parked row so the
     /// drain's per-tick re-park bumps `updated_at` (the heartbeat).
     pub async fn try_park_processing_internal(


### PR DESCRIPTION
## Problem

`send_and_confirm` treats a `build_and_sign` error as a permanent withdrawal failure. This error happens before any signature exists or is broadcast (blockhash fetch or signer failure), so `handle_permanent_failure` finds zero stashed signatures and routes the row to `ManualReview`. No worker claims `ManualReview` rows, so a transient RPC outage strands a withdrawal that already burned private-channel tokens until an operator intervenes.

## Fix

  - On a pre-broadcast build/sign failure for a withdrawal with no signature from an earlier attempt, roll the nonce back out of the local SMT and requeue the row `Processing` -> `Pending`. The fetcher re-claims it on the next poll.
  - New status-only CAS `try_requeue_prebroadcast`: no `updated_at` guard needed since the sender owns the row while Processing. Bumps `recovery_requeue_attempts` so recovery's quarantine cap survives restarts.
  - The existing retry cap still bounds the loop: after `retry_max_attempts` the row goes to `ManualReview` with the webhook alert.
  - Withdrawals with a stashed signature from a prior broadcast keep the finality-checked remint path. ResetSmtRoot and mint paths are unchanged.
  - If the requeue write fails the row stays Processing; recovery quarantines no-signature withdrawals, so it still pages.

## Tests

  - Requeue happy path, prior-broadcast guard, requeue write failure (unit).
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29266605187) |
| Indexer | 26,727 | 30,113 | 88.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29266605187) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29266605187) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29266605187) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,573 | 15,911 | 79.0% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29266605187) |
| **Total** | **52,896** | **61,562** | **85.9%** | |

> Last updated: 2026-07-13 17:32:30 UTC by E2E Integration