### PR TITLE
fix(indexer): make Yellowstone reconnect gap-fill fail closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ ci-integration-test-prebuilt:
 	@cd integration && cargo test --test yellowstone_wiring -- --nocapture
 	@cd integration && cargo test --test malformed_yellowstone_update -- --nocapture
 	@cd integration && cargo test --test yellowstone_reconnect_gap -- --nocapture
+	@cd integration && cargo test --test reconnect_gap_fill_fail_closed -- --nocapture
 	@cd integration && cargo test --test yellowstone_inner_and_unknown -- --nocapture
 	@cd integration && cargo test --test harness_sanity -- --nocapture
 	@cd integration && cargo test --test sender_poll_rpc_error -- --nocapture
@@ -233,6 +234,7 @@ ci-integration-test-indexer:
 	@cd integration && cargo test --test yellowstone_wiring -- --nocapture
 	@cd integration && cargo test --test malformed_yellowstone_update -- --nocapture
 	@cd integration && cargo test --test yellowstone_reconnect_gap -- --nocapture
+	@cd integration && cargo test --test reconnect_gap_fill_fail_closed -- --nocapture
 	@cd integration && cargo test --test yellowstone_inner_and_unknown -- --nocapture
 	@cd integration && cargo test --test harness_sanity -- --nocapture
 	@cd integration && cargo test --test sender_poll_rpc_error -- --nocapture

--- a/indexer/src/error/indexer.rs
+++ b/indexer/src/error/indexer.rs
@@ -77,9 +77,6 @@ pub enum DataSourceError {
 
     #[error("Commitment level parse error: {value}")]
     InvalidCommitment { value: String },
-
-    #[error("Gap fill failed: {reason}")]
-    GapFillFailed { reason: String },
 }
 
 /// Errors specific to backfill operations

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -193,7 +193,8 @@ where
             Err(BackfillError::GapTooLarge { gap, max_gap }) => {
                 error!(
                     "Reconnect gap too large: {} slots (max {}). Checkpoint frozen at {}; \
-                     raise backfill.max_gap_slots or resync. This will not self-heal.",
+                     resync to advance the checkpoint (the loop recovers without a restart \
+                     once the gap is within bounds), or raise backfill.max_gap_slots and restart.",
                     gap, max_gap, checkpoint
                 );
                 record_gap_fill_error(program_type);

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -26,11 +26,17 @@ use crate::indexer::datasource::rpc_polling::types::{InnerInstruction, InnerInst
 use crate::storage::Storage;
 
 #[cfg(feature = "datasource-rpc")]
+use crate::error::{BackfillError, CheckpointError};
+#[cfg(feature = "datasource-rpc")]
 use crate::indexer::{
     backfill::{fill_slot_range, validate_gap},
     checkpoint::get_last_checkpoint,
     datasource::rpc_polling::rpc::RpcPoller,
 };
+#[cfg(feature = "datasource-rpc")]
+use std::future::Future;
+#[cfg(feature = "datasource-rpc")]
+use std::time::Duration;
 
 /// Yellowstone gRPC datasource - subscribes to atomic per-slot blocks
 pub struct YellowstoneSource {
@@ -104,57 +110,160 @@ impl YellowstoneSource {
 }
 
 #[cfg(feature = "datasource-rpc")]
-async fn try_fill_reconnect_gap(
-    checkpoint: u64,
+const RECONNECT_GAP_RETRY_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Terminal states of the reconnect gap repair; there is no error variant because
+/// failures retry inside the loop instead of falling through to a resubscribe.
+#[cfg(feature = "datasource-rpc")]
+#[derive(Debug, PartialEq, Eq)]
+enum GapFillOutcome {
+    Resolved,
+    Cancelled,
+}
+
+/// Repairs the reconnect gap (checkpoint, tip], returning Resolved only once every
+/// slot is indexed or proven empty; failures retry in place with backoff so the
+/// caller can never resubscribe over an open gap. Cancellation wins every wait.
+#[cfg(feature = "datasource-rpc")]
+#[allow(clippy::too_many_arguments)]
+async fn ensure_reconnect_gap_filled<F, Fut>(
+    get_checkpoint: F,
     rpc_poller: &RpcPoller,
     max_gap_slots: u64,
     batch_size: usize,
     program_type: ProgramType,
     escrow_instance_id: Option<Pubkey>,
     instruction_tx: &InstructionSender,
-) -> Result<u64, DataSourceError> {
-    let current_slot =
-        rpc_poller
-            .get_latest_slot()
-            .await
-            .map_err(|e| DataSourceError::GapFillFailed {
-                reason: format!("Failed to get latest slot: {}", e),
-            })?;
+    cancel: &CancellationToken,
+    backoff: Duration,
+) -> GapFillOutcome
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<u64, CheckpointError>>,
+{
+    loop {
+        if cancel.is_cancelled() {
+            return GapFillOutcome::Cancelled;
+        }
 
-    // Validate against the real checkpoint distance; the boundary slot is
-    // included only when handing off to fill_slot_range below.
-    match validate_gap(current_slot, checkpoint, max_gap_slots) {
-        Ok(None) => {
-            info!(
-                "No gap detected on reconnect. Current slot: {}, checkpoint: {}",
-                current_slot, checkpoint
-            );
-            Ok(0)
+        // Re-read every cycle so an operator resync moves the anchor without a restart.
+        let checkpoint = match get_checkpoint().await {
+            Ok(slot) => slot,
+            Err(e) => {
+                warn!(
+                    "Reconnect gap-fill: checkpoint read failed, retrying: {}",
+                    e
+                );
+                record_gap_fill_error(program_type);
+                if backoff_cancelled(cancel, backoff).await {
+                    return GapFillOutcome::Cancelled;
+                }
+                continue;
+            }
+        };
+
+        // Fresh system: startup backfill owns initial catch-up.
+        if checkpoint == 0 {
+            return GapFillOutcome::Resolved;
         }
-        Ok(Some(gap)) => {
-            let replay_anchor = checkpoint.saturating_sub(1);
-            info!(
-                "Gap detected on reconnect: {} slots (replaying from {} to {}). Backfilling...",
-                gap, replay_anchor, current_slot
-            );
-            fill_slot_range(
-                rpc_poller,
-                replay_anchor,
-                current_slot,
-                batch_size,
-                program_type,
-                escrow_instance_id,
-                instruction_tx,
-            )
-            .await
-            .map_err(|e| DataSourceError::GapFillFailed {
-                reason: e.to_string(),
-            })
+
+        let current_slot = match rpc_poller.get_latest_slot().await {
+            Ok(slot) => slot,
+            Err(e) => {
+                warn!("Reconnect gap-fill: tip fetch failed, retrying: {}", e);
+                record_gap_fill_error(program_type);
+                if backoff_cancelled(cancel, backoff).await {
+                    return GapFillOutcome::Cancelled;
+                }
+                continue;
+            }
+        };
+
+        let gap = match validate_gap(current_slot, checkpoint, max_gap_slots) {
+            Ok(None) => {
+                info!(
+                    "No gap detected on reconnect. Current slot: {}, checkpoint: {}",
+                    current_slot, checkpoint
+                );
+                return GapFillOutcome::Resolved;
+            }
+            Ok(Some(gap)) => gap,
+            // Retrying cannot shrink an oversized gap (validate_gap is endpoint-independent),
+            // so hold the checkpoint frozen and stay loud until an operator intervenes.
+            Err(BackfillError::GapTooLarge { gap, max_gap }) => {
+                error!(
+                    "Reconnect gap too large: {} slots (max {}). Checkpoint frozen at {}; \
+                     raise backfill.max_gap_slots or resync. This will not self-heal.",
+                    gap, max_gap, checkpoint
+                );
+                record_gap_fill_error(program_type);
+                if backoff_cancelled(cancel, backoff).await {
+                    return GapFillOutcome::Cancelled;
+                }
+                continue;
+            }
+            Err(e) => {
+                warn!("Reconnect gap validation failed, retrying: {}", e);
+                record_gap_fill_error(program_type);
+                if backoff_cancelled(cancel, backoff).await {
+                    return GapFillOutcome::Cancelled;
+                }
+                continue;
+            }
+        };
+
+        // The boundary slot may be half-forwarded when the stream died, so replay
+        // from checkpoint-1 to include it; inserts are idempotent.
+        let replay_anchor = checkpoint.saturating_sub(1);
+        info!(
+            "Gap detected on reconnect: {} slots (replaying from {} to {}). Backfilling...",
+            gap, replay_anchor, current_slot
+        );
+
+        match fill_slot_range(
+            rpc_poller,
+            replay_anchor,
+            current_slot,
+            batch_size,
+            program_type,
+            escrow_instance_id,
+            instruction_tx,
+        )
+        .await
+        {
+            Ok(filled) => {
+                info!(
+                    "Reconnect gap-fill complete: {} slots backfilled (from checkpoint {})",
+                    filled, checkpoint
+                );
+                return GapFillOutcome::Resolved;
+            }
+            Err(e) => {
+                warn!("Reconnect gap-fill failed, retrying: {}", e);
+                record_gap_fill_error(program_type);
+            }
         }
-        Err(e) => Err(DataSourceError::GapFillFailed {
-            reason: e.to_string(),
-        }),
+
+        if backoff_cancelled(cancel, backoff).await {
+            return GapFillOutcome::Cancelled;
+        }
     }
+}
+
+/// Waits one backoff period; true means cancellation fired first.
+#[cfg(feature = "datasource-rpc")]
+async fn backoff_cancelled(cancel: &CancellationToken, backoff: Duration) -> bool {
+    tokio::select! {
+        _ = cancel.cancelled() => true,
+        _ = tokio::time::sleep(backoff) => false,
+    }
+}
+
+#[cfg(feature = "datasource-rpc")]
+fn record_gap_fill_error(program_type: ProgramType) {
+    metrics::INDEXER_RPC_ERRORS
+        .with_label_values(&[program_type.as_label(), "gap_fill"])
+        .inc();
 }
 
 #[async_trait]
@@ -236,65 +345,25 @@ impl DataSource for YellowstoneSource {
 
                 #[cfg(feature = "datasource-rpc")]
                 {
-                    // Anchor on the durable checkpoint, not an in-memory watermark.
-                    // A live block can partially forward before erroring, so the boundary slot
-                    // may be incomplete; replay must include S itself. Inserts are idempotent,
-                    // so replaying the boundary slot is safe.
-                    if let (Some(ref poller), Some(ref storage)) = (&rpc_poller, &storage) {
-                        let checkpoint = match get_last_checkpoint(storage, program_type).await {
-                            Ok(slot) => slot,
-                            Err(e) => {
-                                warn!(
-                                    "Reconnect gap-fill skipped: failed to read checkpoint: {}",
-                                    e
-                                );
-                                // Backoff so a persistent storage outage paired with a
-                                // fast-failing Yellowstone endpoint can't spin the loop.
-                                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                                continue;
-                            }
-                        };
-
-                        if checkpoint == 0 {
-                            // Fresh system, startup backfill handles initial catch-up.
-                            continue;
-                        }
-
-                        match try_fill_reconnect_gap(
-                            checkpoint,
+                    // Repairing the gap is a hard precondition for resubscribing: a live
+                    // SlotComplete at the tip would advance the durable checkpoint past
+                    // the unfilled range, so the loop must not fall through on failure.
+                    if let (Some(poller), Some(storage)) = (&rpc_poller, &storage) {
+                        match ensure_reconnect_gap_filled(
+                            || get_last_checkpoint(storage, program_type),
                             poller,
                             max_gap_slots,
                             batch_size,
                             program_type,
                             escrow_instance_id,
                             &tx,
+                            &cancellation_token,
+                            RECONNECT_GAP_RETRY_BACKOFF,
                         )
                         .await
                         {
-                            Ok(filled) => {
-                                if filled > 0 {
-                                    info!(
-                                        "Reconnect gap-fill complete: {} slots backfilled \
-                                         (from checkpoint {})",
-                                        filled, checkpoint
-                                    );
-                                }
-                            }
-                            Err(DataSourceError::GapFillFailed { ref reason })
-                                if reason.contains("Gap too large") =>
-                            {
-                                error!(
-                                    "Reconnect gap too large (checkpoint: {}): {}. \
-                                     Operator should investigate; next startup backfill will catch it.",
-                                    checkpoint, reason
-                                );
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Reconnect gap-fill failed (checkpoint: {}): {}. Continuing reconnect.",
-                                    checkpoint, e
-                                );
-                            }
+                            GapFillOutcome::Resolved => {}
+                            GapFillOutcome::Cancelled => break,
                         }
                     }
                 }
@@ -525,48 +594,87 @@ mod tests {
             .create()
     }
 
-    #[tokio::test]
-    async fn try_fill_reconnect_gap_no_gap() {
-        let mut server = Server::new_async().await;
+    /// A short backoff keeps the retry-loop tests fast; prod uses RECONNECT_GAP_RETRY_BACKOFF.
+    const TEST_BACKOFF: Duration = Duration::from_millis(10);
 
-        let _m = mock_get_slot(&mut server, 100);
-
-        let poller = RpcPoller::new(
+    fn test_poller(server: &Server) -> RpcPoller {
+        RpcPoller::new(
             server.url(),
             UiTransactionEncoding::Json,
             CommitmentLevel::Finalized,
-        );
-
-        let (tx, _rx) = mpsc::channel(64);
-        let result =
-            try_fill_reconnect_gap(100, &poller, 1000, 10, ProgramType::Escrow, None, &tx).await;
-
-        assert_eq!(result.unwrap(), 0);
+        )
     }
 
+    fn checkpoint_ok(slot: u64) -> impl Fn() -> std::future::Ready<Result<u64, CheckpointError>> {
+        move || std::future::ready(Ok(slot))
+    }
+
+    /// no gap on reconnect resolves immediately without fetching any block.
     #[tokio::test]
-    async fn try_fill_reconnect_gap_fills_gap() {
+    async fn gap_fill_no_gap_resolves_without_fetching_blocks() {
         let mut server = Server::new_async().await;
+        let _m = mock_get_slot(&mut server, 100);
+        let no_blocks = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "getBlock"})))
+            .expect(0)
+            .create_async()
+            .await;
 
-        // checkpoint = 100, current_slot = 103 → replay anchor = 99,
-        // fill_slot_range emits slots 100..=103 (boundary slot included).
-        let _m_slot = mock_get_slot(&mut server, 103);
-        let _m0 = mock_get_block_success(&mut server, 100);
-        let _m1 = mock_get_block_success(&mut server, 101);
-        let _m2 = mock_get_block_success(&mut server, 102);
-        let _m3 = mock_get_block_success(&mut server, 103);
-
-        let poller = RpcPoller::new(
-            server.url(),
-            UiTransactionEncoding::Json,
-            CommitmentLevel::Finalized,
-        );
-
+        let poller = test_poller(&server);
         let (tx, mut rx) = mpsc::channel(64);
-        let result =
-            try_fill_reconnect_gap(100, &poller, 1000, 10, ProgramType::Escrow, None, &tx).await;
+        let cancel = CancellationToken::new();
 
-        assert_eq!(result.unwrap(), 4);
+        let outcome = ensure_reconnect_gap_filled(
+            checkpoint_ok(100),
+            &poller,
+            1000,
+            10,
+            ProgramType::Escrow,
+            None,
+            &tx,
+            &cancel,
+            TEST_BACKOFF,
+        )
+        .await;
+
+        assert_eq!(outcome, GapFillOutcome::Resolved);
+        no_blocks.assert_async().await;
+        drop(tx);
+        assert!(
+            rx.recv().await.is_none(),
+            "no messages may be emitted when there is no gap"
+        );
+    }
+
+    /// Checkpoint 100, tip 103; the fill replays the boundary slot (anchor 99)
+    /// and emits SlotComplete for exactly 100..=103.
+    #[tokio::test]
+    async fn gap_fill_fills_gap_and_replays_boundary_slot() {
+        let mut server = Server::new_async().await;
+        let _m_slot = mock_get_slot(&mut server, 103);
+        let _blocks: Vec<_> = (100..=103)
+            .map(|s| mock_get_block_success(&mut server, s))
+            .collect();
+
+        let poller = test_poller(&server);
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+
+        let outcome = ensure_reconnect_gap_filled(
+            checkpoint_ok(100),
+            &poller,
+            1000,
+            10,
+            ProgramType::Escrow,
+            None,
+            &tx,
+            &cancel,
+            TEST_BACKOFF,
+        )
+        .await;
+
+        assert_eq!(outcome, GapFillOutcome::Resolved);
         drop(tx);
 
         let mut slots = vec![];
@@ -575,20 +683,146 @@ mod tests {
                 slots.push(slot);
             }
         }
-
         assert_eq!(slots, vec![100, 101, 102, 103]);
     }
 
-    /// An unavailable slot encountered during reconnect gap-fill must abort the fill
-    /// with GapFillFailed rather than checkpoint past the gap.
+    /// Checkpoint 0 is a fresh system; startup backfill owns catch-up, so the
+    /// wrapper resolves without a single RPC call.
     #[tokio::test]
-    async fn try_fill_reconnect_gap_unavailable_slot_fails_closed() {
+    async fn gap_fill_fresh_system_resolves_without_rpc() {
         let mut server = Server::new_async().await;
+        let untouched = server.mock("POST", "/").expect(0).create_async().await;
 
-        // checkpoint = 100, current_slot = 103 => replay anchor 99, batch [100..=103].
-        // Slot 100 is absent below the floor (100 < 500) => Unavailable.
+        let poller = test_poller(&server);
+        let (tx, _rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+
+        let outcome = ensure_reconnect_gap_filled(
+            checkpoint_ok(0),
+            &poller,
+            1000,
+            10,
+            ProgramType::Escrow,
+            None,
+            &tx,
+            &cancel,
+            TEST_BACKOFF,
+        )
+        .await;
+
+        assert_eq!(outcome, GapFillOutcome::Resolved);
+        untouched.assert_async().await;
+    }
+
+    /// A failing checkpoint read retries instead of skipping the gap check.
+    #[tokio::test]
+    async fn gap_fill_retries_checkpoint_read_failures() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let mut server = Server::new_async().await;
+        let _m = mock_get_slot(&mut server, 100);
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in = calls.clone();
+        let get_checkpoint = move || {
+            let n = calls_in.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err(CheckpointError::InvalidCheckpoint { slot: 0, last: 0 })
+                } else {
+                    Ok(100)
+                }
+            }
+        };
+
+        let poller = test_poller(&server);
+        let (tx, _rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+
+        let outcome = ensure_reconnect_gap_filled(
+            get_checkpoint,
+            &poller,
+            1000,
+            10,
+            ProgramType::Escrow,
+            None,
+            &tx,
+            &cancel,
+            TEST_BACKOFF,
+        )
+        .await;
+
+        assert_eq!(outcome, GapFillOutcome::Resolved);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    /// A failing tip fetch retries in place and resolves once the endpoint heals.
+    #[tokio::test]
+    async fn gap_fill_retries_tip_fetch_failures() {
+        let mut server = Server::new_async().await;
+        let err_mock = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "getSlot"})))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "error": { "code": -32600, "message": "Invalid request" },
+                    "id": 1
+                })
+                .to_string(),
+            )
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        let poller = test_poller(&server);
+        let (tx, _rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let cancel_task = cancel.clone();
+
+        let handle = tokio::spawn(async move {
+            ensure_reconnect_gap_filled(
+                checkpoint_ok(100),
+                &poller,
+                1000,
+                10,
+                ProgramType::Escrow,
+                None,
+                &tx,
+                &cancel_task,
+                TEST_BACKOFF,
+            )
+            .await
+        });
+
+        // Observe at least one failed attempt before healing the endpoint.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !err_mock.matched_async().await {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("tip fetch error was never observed");
+
+        // mockito matches the newest-registered mock first, so this overrides the error.
+        let _ok = mock_get_slot(&mut server, 100);
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("must resolve after the tip fetch heals")
+            .unwrap();
+        assert_eq!(outcome, GapFillOutcome::Resolved);
+    }
+
+    /// An unavailable (pruned) slot stalls the loop with repeated attempts;
+    /// no SlotComplete ever leaks and cancellation ends the stall.
+    #[tokio::test]
+    async fn gap_fill_unavailable_slot_stalls_without_slot_complete() {
+        let mut server = Server::new_async().await;
         let _m_slot = mock_get_slot(&mut server, 103);
-        let _m_absent = server
+        // Slot 100 is absent below the floor (100 < 500) => Unavailable.
+        let absent = server
             .mock("POST", "/")
             .match_body(mockito::Matcher::PartialJson(json!({
                 "method": "getBlock",
@@ -603,55 +837,151 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .expect_at_least(2)
+            .create_async()
+            .await;
         let _floor = mock_first_available_block(&mut server, 500);
+        let _rest: Vec<_> = (101..=103)
+            .map(|s| mock_get_block_success(&mut server, s))
+            .collect();
 
-        let poller = RpcPoller::new(
-            server.url(),
-            UiTransactionEncoding::Json,
-            CommitmentLevel::Finalized,
-        );
+        let poller = test_poller(&server);
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let cancel_task = cancel.clone();
 
-        let (tx, _rx) = mpsc::channel(64);
-        let result =
-            try_fill_reconnect_gap(100, &poller, 1000, 10, ProgramType::Escrow, None, &tx).await;
+        let mut handle = tokio::spawn(async move {
+            ensure_reconnect_gap_filled(
+                checkpoint_ok(100),
+                &poller,
+                1000,
+                10,
+                ProgramType::Escrow,
+                None,
+                &tx,
+                &cancel_task,
+                TEST_BACKOFF,
+            )
+            .await
+        });
 
-        let err = result.unwrap_err();
-        let err_str = err.to_string();
+        // Stalls across at least two fill attempts instead of returning an error.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !absent.matched_async().await {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("expected at least two attempts on the pruned slot");
+
         assert!(
-            err_str.contains("Gap fill failed"),
-            "expected GapFillFailed: {err_str}"
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut handle)
+                .await
+                .is_err(),
+            "must not return while the slot is unavailable"
         );
-        assert!(
-            err_str.contains("unavailable") && err_str.contains("100"),
-            "error should name the unavailable slot: {err_str}"
-        );
+        while let Ok(msg) = rx.try_recv() {
+            assert!(
+                !matches!(msg, ProcessorMessage::SlotComplete { .. }),
+                "no SlotComplete may leak past an unavailable slot"
+            );
+        }
+
+        cancel.cancel();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("cancellation must end the stall")
+            .unwrap();
+        assert_eq!(outcome, GapFillOutcome::Cancelled);
     }
 
+    /// An oversized gap stalls loudly with no fill attempt at all, because
+    /// validate_gap rejects it before any block fetch.
     #[tokio::test]
-    async fn try_fill_reconnect_gap_too_large() {
+    async fn gap_fill_too_large_stalls_without_fill() {
         let mut server = Server::new_async().await;
+        let _m_slot = mock_get_slot(&mut server, 200);
+        let no_blocks = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "getBlock"})))
+            .expect(0)
+            .create_async()
+            .await;
 
-        let _m = mock_get_slot(&mut server, 200);
-
-        let poller = RpcPoller::new(
-            server.url(),
-            UiTransactionEncoding::Json,
-            CommitmentLevel::Finalized,
-        );
-
+        let poller = test_poller(&server);
         let (tx, _rx) = mpsc::channel(64);
-        let result =
-            try_fill_reconnect_gap(100, &poller, 10, 10, ProgramType::Escrow, None, &tx).await;
+        let cancel = CancellationToken::new();
+        let cancel_task = cancel.clone();
 
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        let err_str = err.to_string();
+        let mut handle = tokio::spawn(async move {
+            ensure_reconnect_gap_filled(
+                checkpoint_ok(100),
+                &poller,
+                10,
+                10,
+                ProgramType::Escrow,
+                None,
+                &tx,
+                &cancel_task,
+                TEST_BACKOFF,
+            )
+            .await
+        });
+
+        // Let several retry cycles elapse; the loop must neither resolve nor fill.
+        tokio::time::sleep(TEST_BACKOFF * 5).await;
         assert!(
-            err_str.contains("Gap too large"),
-            "Expected 'Gap too large' in error: {}",
-            err_str
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut handle)
+                .await
+                .is_err(),
+            "an oversized gap must stall, not resolve"
         );
+        no_blocks.assert_async().await;
+
+        cancel.cancel();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("cancellation must end the stall")
+            .unwrap();
+        assert_eq!(outcome, GapFillOutcome::Cancelled);
+    }
+
+    /// Cancellation during the backoff returns promptly instead of sleeping
+    /// out the full production backoff.
+    #[tokio::test]
+    async fn gap_fill_cancellation_interrupts_backoff_promptly() {
+        let mut server = Server::new_async().await;
+        let _err = mock_get_slot_error(&mut server);
+
+        let poller = test_poller(&server);
+        let (tx, _rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let cancel_task = cancel.clone();
+
+        let handle = tokio::spawn(async move {
+            ensure_reconnect_gap_filled(
+                checkpoint_ok(100),
+                &poller,
+                1000,
+                10,
+                ProgramType::Escrow,
+                None,
+                &tx,
+                &cancel_task,
+                RECONNECT_GAP_RETRY_BACKOFF,
+            )
+            .await
+        });
+
+        // Land inside the first (5s) backoff, then cancel.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        cancel.cancel();
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_millis(500), handle)
+            .await
+            .expect("cancellation must interrupt the backoff, not wait it out")
+            .unwrap();
+        assert_eq!(outcome, GapFillOutcome::Cancelled);
     }
 
     /// Borsh-encoded WithdrawFunds payload (discriminator 0, amount, None destination)
@@ -797,32 +1127,6 @@ mod tests {
         assert_eq!(metas.len(), 2);
         assert_eq!(metas[0].instruction_index, 0);
         assert_eq!(metas[1].instruction_index, 2);
-    }
-
-    #[tokio::test]
-    async fn try_fill_reconnect_gap_rpc_failure() {
-        let mut server = Server::new_async().await;
-
-        let _m = mock_get_slot_error(&mut server);
-
-        let poller = RpcPoller::new(
-            server.url(),
-            UiTransactionEncoding::Json,
-            CommitmentLevel::Finalized,
-        );
-
-        let (tx, _rx) = mpsc::channel(64);
-        let result =
-            try_fill_reconnect_gap(100, &poller, 1000, 10, ProgramType::Escrow, None, &tx).await;
-
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        let err_str = err.to_string();
-        assert!(
-            err_str.contains("Failed to get latest slot"),
-            "Expected 'Failed to get latest slot' in error: {}",
-            err_str
-        );
     }
 
     /// A CPI-only withdraw surfaces as a row carrying the parent's top-level index and the inner position.

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -193,6 +193,7 @@ pub fn init_labels(program_type: &str) {
         "get_block",
         "missing_meta",
         "block_unavailable",
+        "gap_fill",
     ] {
         INDEXER_RPC_ERRORS.with_label_values(&[program_type, error_type]);
     }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -103,6 +103,10 @@ path = "tests/indexer/malformed_yellowstone_update.rs"
 name = "yellowstone_reconnect_gap"
 path = "tests/indexer/yellowstone_reconnect_gap.rs"
 
+[[test]]
+name = "reconnect_gap_fill_fail_closed"
+path = "tests/indexer/reconnect_gap_fill_fail_closed.rs"
+
 # Yellowstone inner_instructions + unknown-discriminator arms.
 [[test]]
 name = "yellowstone_inner_and_unknown"

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -60,6 +60,7 @@ integration-test:
 	@cargo test --test yellowstone_wiring -- --nocapture
 	@cargo test --test malformed_yellowstone_update -- --nocapture
 	@cargo test --test yellowstone_reconnect_gap -- --nocapture
+	@cargo test --test reconnect_gap_fill_fail_closed -- --nocapture
 	@cargo test --test yellowstone_inner_and_unknown -- --nocapture
 	@cargo test --test harness_sanity -- --nocapture
 	@cargo test --test sender_poll_rpc_error -- --nocapture
@@ -266,6 +267,8 @@ integration-coverage-indexer:
 	@cargo llvm-cov test --no-report --workspace --test malformed_yellowstone_update -- --nocapture
 	@echo "Running Yellowstone reconnect-gap tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test yellowstone_reconnect_gap -- --nocapture
+	@echo "Running fail-closed reconnect gap-fill tests with coverage instrumentation..."
+	@cargo llvm-cov test --no-report --workspace --test reconnect_gap_fill_fail_closed -- --nocapture
 	@echo "Running Yellowstone inner-ix + unknown-discriminator tests with coverage instrumentation..."
 	@cargo llvm-cov test --no-report --workspace --test yellowstone_inner_and_unknown -- --nocapture
 	@echo "Running OperatorMockHarness sanity test with coverage instrumentation..."

--- a/integration/tests/indexer/reconnect_gap_fill_fail_closed.rs
+++ b/integration/tests/indexer/reconnect_gap_fill_fail_closed.rs
@@ -1,0 +1,416 @@
+//! Fail-closed reconnect gap-fill for `YellowstoneSource`: after a stream drop the
+//! source must not resubscribe until the gap `(checkpoint, tip]` is repaired, so no
+//! live `SlotComplete` can advance the durable checkpoint over the missing range.
+
+use mockito::{Matcher, Server as MockitoServer};
+use private_channel_indexer::config::ProgramType;
+use private_channel_indexer::indexer::checkpoint::CheckpointWriter;
+use private_channel_indexer::indexer::datasource::common::datasource::DataSource;
+use private_channel_indexer::indexer::datasource::common::types::ProcessorMessage;
+use private_channel_indexer::indexer::datasource::rpc_polling::rpc::RpcPoller;
+use private_channel_indexer::indexer::datasource::yellowstone::YellowstoneSource;
+use private_channel_indexer::indexer::transaction_processor::TransactionProcessor;
+use private_channel_indexer::storage::{PostgresDb, Storage};
+use private_channel_indexer::PostgresConfig;
+use serde_json::json;
+use solana_sdk::commitment_config::CommitmentLevel;
+use solana_transaction_status::UiTransactionEncoding;
+use std::sync::Arc;
+use std::time::Duration;
+use test_utils::mock_yellowstone::{MockYellowstoneServer, Update, UpdateMatcher};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+#[path = "yellowstone_helpers.rs"]
+mod yellowstone_helpers;
+use yellowstone_helpers::empty_block;
+
+const CHECKPOINT: u64 = 100;
+const TIP: u64 = 103;
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,private_channel_indexer=debug")
+        .with_test_writer()
+        .try_init();
+}
+
+/// Real Postgres via testcontainers; the container must stay alive for the test.
+async fn start_postgres() -> (testcontainers::ContainerAsync<Postgres>, Arc<Storage>) {
+    let pg = Postgres::default()
+        .with_db_name("reconnect_gap")
+        .with_user("postgres")
+        .with_password("password")
+        .start()
+        .await
+        .expect("postgres container");
+    let host = pg.get_host().await.expect("pg host");
+    let port = pg.get_host_port_ipv4(5432).await.expect("pg port");
+    let db_url = format!("postgres://postgres:password@{host}:{port}/reconnect_gap");
+
+    let storage = Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: db_url,
+            max_connections: 10,
+        })
+        .await
+        .expect("postgres storage"),
+    );
+    storage.init_schema().await.expect("init schema");
+    (pg, Arc::new(storage))
+}
+
+fn empty_block_json() -> serde_json::Value {
+    json!({
+        "blockhash": "TestBlockHash11111111111111111111111111111",
+        "parentSlot": 0,
+        "transactions": []
+    })
+}
+
+async fn mock_get_slot(server: &mut MockitoServer, slot: u64) -> mockito::Mock {
+    server
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": slot, "id": 1}).to_string())
+        .expect_at_least(1)
+        .create_async()
+        .await
+}
+
+async fn mock_block_ok(server: &mut MockitoServer, slot: u64) -> mockito::Mock {
+    server
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlock", "params": [slot]}),
+        ))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": empty_block_json(), "id": 1}).to_string())
+        .create_async()
+        .await
+}
+
+/// Slot answers -32009 below the retention floor, so the poller reports it
+/// Unavailable and the fill aborts before any SlotComplete.
+async fn mock_block_pruned(
+    server: &mut MockitoServer,
+    slot: u64,
+    min_hits: usize,
+) -> mockito::Mock {
+    server
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getBlock", "params": [slot]}),
+        ))
+        .with_status(200)
+        .with_body(
+            json!({
+                "jsonrpc": "2.0",
+                "error": { "code": -32009, "message": "Slot was skipped" },
+                "id": 1
+            })
+            .to_string(),
+        )
+        .expect_at_least(min_hits)
+        .create_async()
+        .await
+}
+
+async fn mock_retention_floor(server: &mut MockitoServer, floor: u64) -> mockito::Mock {
+    server
+        .mock("POST", "/")
+        .match_body(Matcher::PartialJson(
+            json!({"method": "getFirstAvailableBlock"}),
+        ))
+        .with_status(200)
+        .with_body(json!({"jsonrpc": "2.0", "result": floor, "id": 1}).to_string())
+        .create_async()
+        .await
+}
+
+async fn wait_for_subscribes(ys: &MockYellowstoneServer, n: usize, secs: u64) {
+    tokio::time::timeout(Duration::from_secs(secs), async {
+        while ys.call_count("subscribe") < n {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "expected {} subscribe handshakes, got {}",
+            n,
+            ys.call_count("subscribe")
+        )
+    });
+}
+
+async fn wait_until_matched(mock: &mockito::Mock, secs: u64, what: &str) {
+    tokio::time::timeout(Duration::from_secs(secs), async {
+        while !mock.matched_async().await {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for: {what}"));
+}
+
+fn poller(server: &MockitoServer) -> Arc<RpcPoller> {
+    Arc::new(RpcPoller::new(
+        server.url(),
+        UiTransactionEncoding::Json,
+        CommitmentLevel::Confirmed,
+    ))
+}
+
+/// While the fill fails the source stalls fail-closed (no resubscribe, no
+/// SlotComplete, checkpoint frozen); once the RPC heals, the gap slots land
+/// first and only then does live delivery resume on subscribe #2.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stalls_while_gap_fill_fails_then_recovers_in_order() {
+    init_tracing();
+    let (_pg, storage) = start_postgres().await;
+    storage
+        .update_committed_checkpoint("escrow", CHECKPOINT)
+        .await
+        .expect("seed checkpoint");
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _slot = mock_get_slot(&mut rpc, TIP).await;
+    for s in (CHECKPOINT + 1)..=TIP {
+        let _m = mock_block_ok(&mut rpc, s).await;
+    }
+    // The boundary slot is the blocker: expect the initial attempt plus at
+    // least one retry, proving the loop retries instead of falling through.
+    let pruned = mock_block_pruned(&mut rpc, CHECKPOINT, 2).await;
+    let _floor = mock_retention_floor(&mut rpc, 500).await;
+
+    let ys = MockYellowstoneServer::start().await;
+    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(256);
+    let cancel = CancellationToken::new();
+
+    let mut source = YellowstoneSource::new(
+        ys.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(poller(&rpc), 1_000, 16)
+    .with_storage(storage.clone());
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    wait_for_subscribes(&ys, 1, 10).await;
+    ys.drop_stream();
+
+    // Failing phase: two attempts on the pruned slot means one full 5s backoff
+    // elapsed with the gap still open.
+    wait_until_matched(&pruned, 20, "two gap-fill attempts on the pruned slot").await;
+
+    assert_eq!(
+        ys.call_count("subscribe"),
+        1,
+        "must not resubscribe while the gap is open"
+    );
+    while let Ok(msg) = rx.try_recv() {
+        assert!(
+            !matches!(msg, ProcessorMessage::SlotComplete { .. }),
+            "no SlotComplete may be emitted while the gap-fill is failing"
+        );
+    }
+    assert_eq!(
+        storage
+            .get_committed_checkpoint("escrow")
+            .await
+            .expect("read checkpoint"),
+        Some(CHECKPOINT),
+        "durable checkpoint must stay frozen during the stall"
+    );
+
+    // Heal: mockito matches the newest-registered mock first, so slot 100 now
+    // serves an empty block. Queue a live slot for the post-repair stream.
+    let _healed = mock_block_ok(&mut rpc, CHECKPOINT).await;
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP + 1)));
+
+    let mut slots = vec![];
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    while slots.len() < 5 {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            panic!("timed out waiting for recovery; slots so far: {slots:?}");
+        }
+        if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
+            tokio::time::timeout(remaining, rx.recv()).await
+        {
+            slots.push(slot);
+        }
+    }
+    assert_eq!(
+        slots,
+        vec![100, 101, 102, 103, 104],
+        "gap slots must land before the first live slot of subscribe #2"
+    );
+    assert!(
+        ys.call_count("subscribe") >= 2,
+        "the source must resubscribe only after the gap is repaired"
+    );
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    ys.shutdown().await;
+}
+
+/// Cancellation during a stalled gap-fill joins the source task promptly
+/// and stops all RPC traffic.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_while_gap_fill_stalled_joins_promptly() {
+    init_tracing();
+    let (_pg, storage) = start_postgres().await;
+    storage
+        .update_committed_checkpoint("escrow", CHECKPOINT)
+        .await
+        .expect("seed checkpoint");
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _slot = mock_get_slot(&mut rpc, TIP).await;
+    for s in (CHECKPOINT + 1)..=TIP {
+        let _m = mock_block_ok(&mut rpc, s).await;
+    }
+    let pruned = mock_block_pruned(&mut rpc, CHECKPOINT, 1).await;
+    let _floor = mock_retention_floor(&mut rpc, 500).await;
+
+    let ys = MockYellowstoneServer::start().await;
+    let (tx, _rx) = mpsc::channel::<ProcessorMessage>(256);
+    let cancel = CancellationToken::new();
+
+    let mut source = YellowstoneSource::new(
+        ys.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(poller(&rpc), 1_000, 16)
+    .with_storage(storage.clone());
+
+    let handle = source
+        .start(tx, cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    wait_for_subscribes(&ys, 1, 10).await;
+    ys.drop_stream();
+    wait_until_matched(&pruned, 20, "a failed gap-fill attempt").await;
+
+    // Cancel mid-stall; the select! on the backoff must wake immediately, far
+    // inside the 5s production backoff.
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(3), handle)
+        .await
+        .expect("source must join promptly when cancelled during a stall")
+        .expect("source task must not panic");
+
+    // Newest-registered mock matches first: any RPC call after the join would
+    // land here and fail the zero-hit expectation.
+    let quiet = rpc.mock("POST", "/").expect(0).create_async().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    quiet.assert_async().await;
+
+    ys.shutdown().await;
+}
+
+/// The exact bug (#21) end-to-end: a live tip beyond the gap must never advance
+/// the durable checkpoint while the gap is unfilled. This wires the real
+/// processor and the ungated plain-max checkpoint writer, the component that
+/// corrupted the checkpoint in the bug, so the DB value is the observable. The
+/// boundary slot stays pruned for the whole test, so gap-fill can never resolve;
+/// a live block past the tip is queued but only a resubscribe would deliver it,
+/// and a fail-open regression would resubscribe and leap the checkpoint to it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stalled_gap_fill_never_advances_checkpoint_over_live_tip() {
+    init_tracing();
+    let (_pg, storage) = start_postgres().await;
+    storage
+        .update_committed_checkpoint("escrow", CHECKPOINT)
+        .await
+        .expect("seed checkpoint");
+
+    let mut rpc = MockitoServer::new_async().await;
+    let _slot = mock_get_slot(&mut rpc, TIP).await;
+    for s in (CHECKPOINT + 1)..=TIP {
+        let _m = mock_block_ok(&mut rpc, s).await;
+    }
+    // Never healed: the gap stays open for the whole test.
+    let pruned = mock_block_pruned(&mut rpc, CHECKPOINT, 1).await;
+    let _floor = mock_retention_floor(&mut rpc, 500).await;
+
+    // Real pipeline: the processor finalizes slots and the ungated writer
+    // plain-maxes each SlotComplete into the durable checkpoint.
+    let (checkpoint_tx, checkpoint_rx) = mpsc::channel(64);
+    let writer_handle = CheckpointWriter::new(storage.clone())
+        .with_batch_interval(1)
+        .start(checkpoint_rx);
+    let (tx, instruction_rx) = mpsc::channel::<ProcessorMessage>(256);
+    let processor = TransactionProcessor::new(storage.clone(), checkpoint_tx);
+    let processor_handle = tokio::spawn(processor.start(instruction_rx));
+
+    let ys = MockYellowstoneServer::start().await;
+    let cancel = CancellationToken::new();
+
+    let mut source = YellowstoneSource::new(
+        ys.url(),
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(poller(&rpc), 1_000, 16)
+    .with_storage(storage.clone());
+
+    let handle = source
+        .start(tx.clone(), cancel.clone())
+        .await
+        .expect("yellowstone source start");
+
+    wait_for_subscribes(&ys, 1, 10).await;
+    ys.drop_stream();
+
+    // Queued after the drop, so only a resubscribe (subscribe #2) could deliver
+    // it. Under the fix that never happens; under the old fail-open it would land
+    // and push the checkpoint to TIP + 1.
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP + 1)));
+    wait_until_matched(&pruned, 20, "a gap-fill attempt on the pruned slot").await;
+
+    // Hold well past the 5s backoff so a regressed fail-open would have
+    // resubscribed and advanced the checkpoint by now; it must stay at the seed.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        assert_eq!(
+            storage
+                .get_committed_checkpoint("escrow")
+                .await
+                .expect("read checkpoint"),
+            Some(CHECKPOINT),
+            "checkpoint must never advance past the unfilled gap"
+        );
+        assert_eq!(
+            ys.call_count("subscribe"),
+            1,
+            "the source must not resubscribe while the gap is open"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    drop(tx);
+    let _ = tokio::time::timeout(Duration::from_secs(3), processor_handle).await;
+    let _ = tokio::time::timeout(Duration::from_secs(3), writer_handle).await;
+    ys.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Closes issue 21. Previously, if Yellowstone disconnected, the reconnect logic attempted to backfill the missed slot range but resumed live streaming even when gap-fill failed (e.g. checkpoint read errors, unavailable slots, or oversized gaps). This allowed new `SlotComplete` events to advance the durable checkpoint past an unfilled gap, permanently violating the invariant that every committed checkpoint represents slots that have been indexed or proven empty.

This change makes reconnect gap-fill a mandatory precondition for resubscribing. The new `ensure_reconnect_gap_filled` loop retries until every slot between the checkpoint and chain tip has been indexed or proven empty, logging failures, incrementing the `gap_fill` RPC error metric, and backing off between attempts. As a result, live streaming cannot resume while a gap exists, preventing checkpoint advancement past missing history. The checkpoint is re-read on every retry to support operator resyncs without requiring a restart, and cancellation cleanly aborts the retry loop.

The implementation reserves the existing health monitoring, which naturally reports prolonged stalls. Comprehensive unit and integration tests cover successful recovery, transient failures, unavailable slots, oversized gaps, cancellation, and fail-closed behavior.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29324679185) |
| Indexer | 27,645 | 30,932 | 89.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29324679185) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29324679185) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29324679185) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,927 | 16,208 | 79.8% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29324679185) |
| **Total** | **54,168** | **62,678** | **86.4%** | |

> Last updated: 2026-07-14 11:12:34 UTC by E2E Integration