### PR TITLE
fix(indexer): close cross-operator recovery and deposit-replay holes

### DIFF
--- a/docs/runbooks/deposit_failed.md
+++ b/docs/runbooks/deposit_failed.md
@@ -66,6 +66,16 @@ Re-arm the row to `pending`. The idempotency memo is a safety net even
 if a previous attempt did broadcast: the operator's pre-send memo scan
 short-circuits to `Completed` if it finds a memo'd signature.
 
+Re-arming is additionally guarded by the pre-mint signature gate: a
+non-terminal row keeps its persisted broadcast signatures
+(`pending_release_signatures` is only GC'd once the row is terminal), and
+the deposit processor re-classifies them on the channel before building a
+new mint. A signature that turns out to have landed completes the row
+instead of re-minting; an unverifiable one is left `processing` for the
+recovery sweep, which re-checks it on the channel and is the sole owner of
+the quarantine decision (see
+[`deposit_manual_review.md`](deposit_manual_review.md) Path E).
+
 ```sql
 UPDATE transactions SET status = 'pending', recovery_requeue_attempts = 0, updated_at = NOW()
  WHERE id = :transaction_id;

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -176,9 +176,10 @@ counter_vec!(
 
 // Reopened-deposit gate: a deposit picked up with persisted write-ahead mint
 // signatures was resolved by classifying them on the channel before minting.
-// `outcome` ∈ {completed, deferred_live, deferred_unverifiable}; the normal
-// proceed path is the plain mint flow and is not counted. The gate never
-// quarantines; an unresolved row is left Processing for the recovery sweep.
+// `outcome` ∈ {completed, complete_raced, complete_write_failed, deferred_live,
+// deferred_unverifiable}; the normal proceed path is the plain mint flow and is
+// not counted. The gate never quarantines; an unresolved row is left Processing
+// for the recovery sweep.
 counter_vec!(
     OPERATOR_REOPENED_DEPOSIT_GATE,
     "private_channel_operator_reopened_deposit_gate_total",
@@ -246,7 +247,13 @@ pub fn init_labels(program_type: &str) {
         OPERATOR_TRANSACTION_QUARANTINED.with_label_values(&[program_type, reason]);
     }
 
-    for outcome in &["completed", "deferred_live", "deferred_unverifiable"] {
+    for outcome in &[
+        "completed",
+        "complete_raced",
+        "complete_write_failed",
+        "deferred_live",
+        "deferred_unverifiable",
+    ] {
         OPERATOR_REOPENED_DEPOSIT_GATE.with_label_values(&[program_type, outcome]);
     }
 

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -174,6 +174,18 @@ counter_vec!(
     &["program_type", "outcome", "type"]
 );
 
+// Reopened-deposit gate: a deposit picked up with persisted write-ahead mint
+// signatures was resolved by classifying them on the channel before minting.
+// `outcome` ∈ {completed, deferred_live, deferred_unverifiable}; the normal
+// proceed path is the plain mint flow and is not counted. The gate never
+// quarantines; an unresolved row is left Processing for the recovery sweep.
+counter_vec!(
+    OPERATOR_REOPENED_DEPOSIT_GATE,
+    "private_channel_operator_reopened_deposit_gate_total",
+    "Reopened deposits resolved by the pre-mint signature gate",
+    &["program_type", "outcome"]
+);
+
 pub fn init_labels(program_type: &str) {
     INDEXER_MINTS_SAVED.with_label_values(&[program_type]);
     INDEXER_TRANSACTIONS_SAVED.with_label_values(&[program_type]);
@@ -234,6 +246,10 @@ pub fn init_labels(program_type: &str) {
         OPERATOR_TRANSACTION_QUARANTINED.with_label_values(&[program_type, reason]);
     }
 
+    for outcome in &["completed", "deferred_live", "deferred_unverifiable"] {
+        OPERATOR_REOPENED_DEPOSIT_GATE.with_label_values(&[program_type, outcome]);
+    }
+
     for task in &[
         "fetcher",
         "processor",
@@ -283,6 +299,7 @@ pub fn init() {
         OPERATOR_TRANSACTION_QUARANTINED,
         OPERATOR_TASK_EXIT,
         OPERATOR_STALE_PROCESSING_RECOVERED,
+        OPERATOR_REOPENED_DEPOSIT_GATE,
     );
 }
 
@@ -372,6 +389,7 @@ mod tests {
             "private_channel_operator_transaction_quarantined_total",
             "private_channel_operator_task_exit_total",
             "private_channel_operator_stale_processing_recovered_total",
+            "private_channel_operator_reopened_deposit_gate_total",
         ];
 
         let families = prometheus::gather();

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -222,6 +222,7 @@ pub async fn run(
     // the sender uses for status updates.
     let processor_storage = storage.clone();
     let processor_rpc = rpc_client.clone();
+    let processor_fallback_rpc = fallback_rpc_client.clone();
     let processor_source_rpc = source_rpc_client.clone();
     let processor_storage_tx = storage_tx.clone();
     let processor_handle = tokio::spawn(async move {
@@ -233,6 +234,7 @@ pub async fn run(
             instance_pda,
             processor_storage,
             processor_rpc,
+            processor_fallback_rpc,
             processor_source_rpc,
         )
         .await;

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -725,15 +725,27 @@ pub async fn process_deposit_funds(
                                 .with_label_values(&[pt_label, "completed"])
                                 .inc();
                         }
-                        // Row moved under us; another writer owns it now.
-                        Ok(false) => debug!(
-                            "reopened-deposit complete skipped; another writer touched the row"
-                        ),
-                        // Retries exhausted; the row stays Processing for recovery.
-                        Err(e) => warn!(
-                            "reopened-deposit complete write error after retries; leaving for recovery: {}",
-                            e
-                        ),
+                        // Row moved under us; another writer owns it now. The
+                        // gate still detected a landed mint, so signal it.
+                        Ok(false) => {
+                            debug!(
+                                "reopened-deposit complete skipped; another writer touched the row"
+                            );
+                            metrics::OPERATOR_REOPENED_DEPOSIT_GATE
+                                .with_label_values(&[pt_label, "complete_raced"])
+                                .inc();
+                        }
+                        // Retries exhausted; the row stays Processing for
+                        // recovery. Counted so the failed record is observable.
+                        Err(e) => {
+                            warn!(
+                                "reopened-deposit complete write error after retries; leaving for recovery: {}",
+                                e
+                            );
+                            metrics::OPERATOR_REOPENED_DEPOSIT_GATE
+                                .with_label_values(&[pt_label, "complete_write_failed"])
+                                .inc();
+                        }
                     }
                     return Ok(());
                 }

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -4,13 +4,15 @@ use crate::metrics;
 use crate::operator::instruction_util::{
     mint_idempotency_memo, MintToBuilder, SourceEventId, TransactionBuilder, WithdrawalRemintInfo,
 };
-use crate::operator::sender::TransactionStatusUpdate;
-use crate::operator::utils::mint_util::MintCache;
+use crate::operator::recovery::{classify_deposit_signatures, DepositOutcome};
+use crate::operator::sender::{FinalityRpc, TransactionStatusUpdate};
+use crate::operator::utils::storage_util::with_storage_backoff;
 use crate::operator::{
     fetch_current_tree_index, find_allowed_mint_pda, find_event_authority_pda, find_operator_pda,
     tree_constants::MAX_TREE_LEAVES, MintToBuilderWithTxnId, ReleaseFundsBuilderWithNonce,
     SignerUtil,
 };
+use crate::operator::{utils::mint_util::MintCache, RpcClientWithRetry};
 use crate::storage::common::models::{DbTransaction, TransactionStatus};
 use crate::storage::Storage;
 use crate::ProgramType;
@@ -47,7 +49,7 @@ impl ProcessorState {
     pub fn new_with_release_funds_state(
         instance_pda: Pubkey,
         storage: Arc<Storage>,
-        rpc_client: Arc<crate::operator::RpcClientWithRetry>,
+        rpc_client: Arc<RpcClientWithRetry>,
     ) -> Self {
         let operator_pubkey = SignerUtil::get_operator_pubkey();
         let operator_pda = find_operator_pda(&instance_pda, &operator_pubkey);
@@ -70,7 +72,7 @@ impl ProcessorState {
 
     pub fn new_with_storage(
         storage: Arc<Storage>,
-        mint_rpc_client: Arc<crate::operator::RpcClientWithRetry>,
+        mint_rpc_client: Arc<RpcClientWithRetry>,
     ) -> Self {
         Self {
             admin_pubkey: SignerUtil::get_admin_pubkey(),
@@ -263,8 +265,9 @@ pub async fn run_processor(
     program_type: ProgramType,
     instance_pda: Option<Pubkey>,
     storage: Arc<Storage>,
-    rpc_client: Arc<crate::operator::RpcClientWithRetry>,
-    source_rpc_client: Option<Arc<crate::operator::RpcClientWithRetry>>,
+    rpc_client: Arc<RpcClientWithRetry>,
+    fallback_rpc_client: Option<Arc<RpcClientWithRetry>>,
+    source_rpc_client: Option<Arc<RpcClientWithRetry>>,
 ) {
     info!("Starting processor");
 
@@ -299,13 +302,20 @@ pub async fn run_processor(
         ProgramType::Escrow => {
             // Use source_rpc_client for mint cache if available, otherwise fall back to rpc_client
             let mint_rpc_client = source_rpc_client.unwrap_or_else(|| rpc_client.clone());
-            let mut processor_state = ProcessorState::new_with_storage(storage, mint_rpc_client);
+            let mut processor_state =
+                ProcessorState::new_with_storage(storage.clone(), mint_rpc_client);
 
+            // rpc_client is the channel chain for an escrow operator: the chain
+            // its deposit mints broadcast to, which is what the reopened-row
+            // gate must classify persisted signatures against.
             if let Err(e) = process_deposit_funds(
                 &mut processor_state,
                 fetcher_rx,
                 sender_tx,
                 storage_tx,
+                storage,
+                rpc_client,
+                fallback_rpc_client,
                 program_type,
             )
             .await
@@ -654,19 +664,108 @@ pub async fn process_release_funds(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn process_deposit_funds(
     processor_state: &mut ProcessorState,
     mut fetcher_rx: mpsc::Receiver<DbTransaction>,
     sender_tx: mpsc::Sender<TransactionBuilder>,
     storage_tx: mpsc::Sender<TransactionStatusUpdate>,
+    storage: Arc<Storage>,
+    channel_rpc: Arc<RpcClientWithRetry>,
+    channel_fallback: Option<Arc<RpcClientWithRetry>>,
     program_type: ProgramType,
 ) -> Result<(), OperatorError> {
     let pt_label = program_type.as_label();
+
+    // Classifies persisted write-ahead signatures on the channel
+    let gate_finality = FinalityRpc {
+        primary: &channel_rpc,
+        fallback: channel_fallback.as_deref(),
+    };
 
     while let Some(transaction) = fetcher_rx.recv().await {
         let span = info_span!("process", trace_id = %transaction.trace_id, txn_id = transaction.id);
 
         let outcome: Result<(), OperatorError> = async {
+            // Idempotency gate for reopened rows. Read the write-ahead journal
+            // (retrying a transient DB blip); an exhausted read propagates as a
+            // transient error, and a first-time row (no signatures) falls
+            // straight through with no RPC. Each outcome is handled below.
+            let stored = with_storage_backoff("journal read", transaction.id, || {
+                storage.get_release_signatures(transaction.id)
+            })
+            .await?;
+            match classify_deposit_signatures(&stored, &gate_finality).await {
+                DepositOutcome::NotLanded => {}
+                DepositOutcome::Landed { signature } => {
+                    // CAS on the fetch-time token; a miss means another writer
+                    // took the row, and either way nothing is minted. A transient
+                    // write error is retried; the mint already landed, so an
+                    // exhausted write leaves the row Processing for the recovery
+                    // sweep to complete rather than exiting the task.
+                    let completed = with_storage_backoff(
+                        "reopened-deposit complete",
+                        transaction.id,
+                        || {
+                            storage.try_complete_processing(
+                                transaction.id,
+                                transaction.updated_at,
+                                Some(signature.clone()),
+                            )
+                        },
+                    )
+                    .await;
+                    match completed {
+                        Ok(true) => {
+                            info!(
+                                signature,
+                                "Reopened deposit's prior mint landed; completed without re-mint"
+                            );
+                            metrics::OPERATOR_REOPENED_DEPOSIT_GATE
+                                .with_label_values(&[pt_label, "completed"])
+                                .inc();
+                        }
+                        // Row moved under us; another writer owns it now.
+                        Ok(false) => debug!(
+                            "reopened-deposit complete skipped; another writer touched the row"
+                        ),
+                        // Retries exhausted; the row stays Processing for recovery.
+                        Err(e) => warn!(
+                            "reopened-deposit complete write error after retries; leaving for recovery: {}",
+                            e
+                        ),
+                    }
+                    return Ok(());
+                }
+                DepositOutcome::Live { reason } => {
+                    // Still in flight: leave the row Processing; the recovery
+                    // sweep re-examines it after the stale threshold.
+                    info!(
+                        reason = %reason,
+                        "Reopened deposit's prior mint may still land; deferring to recovery"
+                    );
+                    metrics::OPERATOR_REOPENED_DEPOSIT_GATE
+                        .with_label_values(&[pt_label, "deferred_live"])
+                        .inc();
+                    return Ok(());
+                }
+                DepositOutcome::Ambiguous { reason } => {
+                    // Uncertain (transient channel RPC, or a corrupt stored
+                    // signature). Do not mint and do not quarantine here: leaving
+                    // the row Processing hands it to the recovery sweep, which
+                    // re-checks on the same chain and self-heals a transient
+                    // outage instead of dead-ending a healthy row in ManualReview.
+                    warn!(
+                        reason = %reason,
+                        "Reopened deposit's prior mint unverifiable; deferring to recovery"
+                    );
+                    metrics::OPERATOR_REOPENED_DEPOSIT_GATE
+                        .with_label_values(&[pt_label, "deferred_unverifiable"])
+                        .inc();
+                    return Ok(());
+                }
+            }
+
             let proc_t0 = tokio::time::Instant::now();
             let mint =
                 Pubkey::from_str(&transaction.mint).map_err(|e| OperatorError::InvalidPubkey {
@@ -787,6 +886,25 @@ mod tests {
     use borsh::BorshSerialize;
     use private_channel_escrow_program_client::Instance;
     use solana_client::rpc_request::RpcRequest;
+
+    /// Channel RPC client with a single fast attempt against `url`.
+    fn channel_client(url: &str) -> Arc<RpcClientWithRetry> {
+        Arc::new(RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            crate::operator::utils::rpc_util::RetryConfig {
+                max_attempts: 1,
+                base_delay: std::time::Duration::from_millis(1),
+                max_delay: std::time::Duration::from_millis(1),
+            },
+            solana_sdk::commitment_config::CommitmentConfig::confirmed(),
+        ))
+    }
+
+    /// Channel RPC that refuses every connection: rows with no persisted
+    /// signatures must pass the reopened-row gate without any RPC call.
+    fn unreachable_channel_rpc() -> Arc<RpcClientWithRetry> {
+        channel_client("http://localhost:1")
+    }
 
     fn make_release_funds_state() -> ReleaseFundsState {
         ReleaseFundsState {
@@ -1449,6 +1567,9 @@ mod tests {
             fetcher_rx,
             sender_tx,
             storage_tx,
+            storage.clone(),
+            unreachable_channel_rpc(),
+            None,
             ProgramType::Escrow,
         )
         .await;
@@ -1494,6 +1615,9 @@ mod tests {
             fetcher_rx,
             sender_tx,
             storage_tx,
+            storage.clone(),
+            unreachable_channel_rpc(),
+            None,
             ProgramType::Escrow,
         )
         .await;
@@ -1531,6 +1655,9 @@ mod tests {
             fetcher_rx,
             sender_tx,
             storage_tx,
+            storage.clone(),
+            unreachable_channel_rpc(),
+            None,
             ProgramType::Escrow,
         )
         .await
@@ -1575,6 +1702,9 @@ mod tests {
             fetcher_rx,
             sender_tx,
             storage_tx,
+            storage.clone(),
+            unreachable_channel_rpc(),
+            None,
             ProgramType::Escrow,
         )
         .await;
@@ -2183,6 +2313,9 @@ mod tests {
             fetcher_rx,
             sender_tx,
             storage_tx,
+            storage.clone(),
+            unreachable_channel_rpc(),
+            None,
             ProgramType::Escrow,
         )
         .await;
@@ -2269,6 +2402,9 @@ mod tests {
             fetcher_rx,
             sender_tx,
             storage_tx,
+            storage.clone(),
+            unreachable_channel_rpc(),
+            None,
             ProgramType::Escrow,
         )
         .await;
@@ -2681,6 +2817,9 @@ mod tests {
             fetcher_rx,
             sender_tx,
             storage_tx,
+            storage.clone(),
+            unreachable_channel_rpc(),
+            None,
             ProgramType::Escrow,
         )
         .await;
@@ -2707,6 +2846,499 @@ mod tests {
         assert!(
             sender_rx.try_recv().is_err(),
             "no Mint builder should be forwarded for an unknown mint",
+        );
+    }
+
+    // ── reopened-deposit gate (pre-broadcast idempotency) ───────────────
+
+    fn mock_status_reply(server: &mut mockito::ServerGuard, body: &str) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(body)
+            .create()
+    }
+
+    fn mock_block_height(server: &mut mockito::ServerGuard, height: u64) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getBlockHeight""#.into(),
+            ))
+            .with_status(200)
+            .with_body(format!(r#"{{"jsonrpc":"2.0","result":{height},"id":1}}"#))
+            .create()
+    }
+
+    fn mock_first_available_block(server: &mut mockito::ServerGuard, floor: u64) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getFirstAvailableBlock""#.into(),
+            ))
+            .with_status(200)
+            .with_body(format!(r#"{{"jsonrpc":"2.0","result":{floor},"id":1}}"#))
+            .create()
+    }
+
+    const FINALIZED_STATUS_BODY: &str = r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":null,"status":{"Ok":null},"confirmationStatus":"finalized"}]},"id":1}"#;
+    const NULL_STATUS_BODY: &str =
+        r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":1}"#;
+
+    /// Seed one Processing deposit row with a persisted write-ahead signature
+    /// and return the txn to feed the processor (same updated_at as the store).
+    async fn seed_reopened_deposit(
+        mock: &MockStorage,
+        mint: &Pubkey,
+        sig: &str,
+        lvbh: i64,
+    ) -> DbTransaction {
+        let txn = make_db_transaction(
+            1,
+            &mint.to_string(),
+            &Pubkey::new_unique().to_string(),
+            None,
+            TransactionType::Deposit,
+        );
+        mock.pending_transactions.lock().unwrap().push(txn.clone());
+        mock.insert_release_signature(txn.id, sig.to_string(), lvbh)
+            .await
+            .unwrap();
+        txn
+    }
+
+    /// A reopened deposit whose persisted mint signature finalized on the
+    /// channel is completed in place; no second mint may reach the sender.
+    #[tokio::test]
+    async fn reopened_deposit_with_landed_sig_completes_without_mint() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_status_reply(&mut server, FINALIZED_STATUS_BODY);
+
+        let mock = MockStorage::new();
+        let landed_sig = solana_sdk::signature::Signature::new_unique();
+        let mint = Pubkey::new_unique();
+        let txn = seed_reopened_deposit(&mock, &mint, &landed_sig.to_string(), 100).await;
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            channel_client(&server.url()),
+            None,
+            ProgramType::Escrow,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "a landed mint must never be re-minted"
+        );
+        let rows = mock.pending_transactions.lock().unwrap();
+        assert_eq!(rows[0].status, TransactionStatus::Completed);
+        assert_eq!(
+            rows[0].counterpart_signature.as_deref(),
+            Some(landed_sig.to_string().as_str())
+        );
+        drop(rows);
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no quarantine update for a landed mint"
+        );
+    }
+
+    /// A reopened deposit whose signature could still land is deferred: no
+    /// mint, no quarantine, row left Processing for the recovery sweep.
+    #[tokio::test]
+    async fn reopened_deposit_with_live_sig_defers_without_mint() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_status_reply(&mut server, NULL_STATUS_BODY);
+        // current_height (50) <= lvbh (1000) means still live.
+        let _height = mock_block_height(&mut server, 50);
+
+        let mock = MockStorage::new();
+        let mint = Pubkey::new_unique();
+        let sig = solana_sdk::signature::Signature::new_unique();
+        let txn = seed_reopened_deposit(&mock, &mint, &sig.to_string(), 1000).await;
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            channel_client(&server.url()),
+            None,
+            ProgramType::Escrow,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "a possibly-live mint must not be re-minted"
+        );
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Processing,
+            "live signature defers the row to the recovery sweep"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no quarantine update for a live signature"
+        );
+    }
+
+    /// A reopened deposit whose signatures are coverage-proven dead proceeds
+    /// to a normal re-mint (the first attempt provably never landed).
+    #[tokio::test]
+    async fn reopened_deposit_with_dead_sigs_proceeds_to_mint() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_status_reply(&mut server, NULL_STATUS_BODY);
+        // current_height (1000) > lvbh (100) means expired; floor 0 proves coverage.
+        let _height = mock_block_height(&mut server, 1000);
+        let _floor = mock_first_available_block(&mut server, 0);
+
+        let mock = MockStorage::new();
+        let mint = Pubkey::new_unique();
+        let sig = solana_sdk::signature::Signature::new_unique();
+        let txn = seed_reopened_deposit(&mock, &mint, &sig.to_string(), 100).await;
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        insert_mint_row(&storage, &mint);
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            channel_client(&server.url()),
+            None,
+            ProgramType::Escrow,
+        )
+        .await
+        .unwrap();
+
+        let msg = sender_rx
+            .try_recv()
+            .expect("proven-dead first attempt must still re-mint");
+        let TransactionBuilder::Mint(b) = msg else {
+            panic!("expected Mint builder");
+        };
+        assert_eq!(b.txn_id, 1);
+    }
+
+    /// A reopened deposit whose signatures cannot be classified (transient
+    /// channel RPC) is deferred, not quarantined: uncertainty must never mint,
+    /// and it must never dead-end a possibly-landed row in ManualReview. The row
+    /// stays Processing for the recovery sweep to re-check on the same chain.
+    #[tokio::test]
+    async fn reopened_deposit_uncertain_defers_to_recovery() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = server
+            .mock("POST", "/")
+            .with_status(500)
+            .with_body("internal server error")
+            .create();
+
+        let mock = MockStorage::new();
+        let mint = Pubkey::new_unique();
+        let sig = solana_sdk::signature::Signature::new_unique();
+        let txn = seed_reopened_deposit(&mock, &mint, &sig.to_string(), 100).await;
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            channel_client(&server.url()),
+            None,
+            ProgramType::Escrow,
+        )
+        .await
+        .unwrap();
+
+        assert!(sender_rx.try_recv().is_err(), "uncertainty must never mint");
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "the gate must not quarantine; recovery owns that decision"
+        );
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Processing,
+            "an unverifiable reopened deposit stays Processing for the recovery sweep"
+        );
+    }
+
+    /// A sustained storage failure reading the write-ahead journal (retries
+    /// exhausted) surfaces as a transient error, never a quarantine. The gate's
+    /// point-read runs on every deposit, so it must stay retryable, never a
+    /// permanent ManualReview flip of a healthy row.
+    #[tokio::test]
+    async fn reopened_deposit_storage_read_error_is_transient_not_quarantine() {
+        let mock = MockStorage::new();
+        let mint = Pubkey::new_unique();
+        let sig = solana_sdk::signature::Signature::new_unique();
+        let txn = seed_reopened_deposit(&mock, &mint, &sig.to_string(), 100).await;
+        // The journal read fails; the gate must surface a transient error, not
+        // classify the row as unverifiable.
+        mock.set_should_fail("get_release_signatures", true);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            channel_client("http://localhost:1"),
+            None,
+            ProgramType::Escrow,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(OperatorError::Storage(_))),
+            "a journal read failure must be a transient Storage error, got {result:?}"
+        );
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "no mint on a transient read error"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a transient read error must not quarantine the row"
+        );
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Processing,
+            "row must stay Processing for retry, not flip to ManualReview"
+        );
+    }
+
+    /// A brief DB blip on the journal read is absorbed by the gate's bounded
+    /// retry: the read recovers within budget and the landed prior mint
+    /// completes the row, without exiting the processor task.
+    #[tokio::test]
+    async fn reopened_deposit_transient_read_blip_recovers_and_completes() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_status_reply(&mut server, FINALIZED_STATUS_BODY);
+
+        let mock = MockStorage::new();
+        let landed_sig = solana_sdk::signature::Signature::new_unique();
+        let mint = Pubkey::new_unique();
+        let txn = seed_reopened_deposit(&mock, &mint, &landed_sig.to_string(), 100).await;
+        // The first two reads fail, the third succeeds: inside the retry budget.
+        mock.set_fail_times("get_release_signatures", 2);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            channel_client(&server.url()),
+            None,
+            ProgramType::Escrow,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "a landed mint must never be re-minted"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a recovered blip must not quarantine the row"
+        );
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Completed,
+            "the retry absorbs the blip and the landed mint completes the row"
+        );
+    }
+
+    /// A brief DB blip on the completion write is absorbed by the same bounded
+    /// retry: the CAS recovers within budget and the landed row is completed.
+    #[tokio::test]
+    async fn reopened_deposit_transient_complete_blip_recovers_and_completes() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_status_reply(&mut server, FINALIZED_STATUS_BODY);
+
+        let mock = MockStorage::new();
+        let landed_sig = solana_sdk::signature::Signature::new_unique();
+        let mint = Pubkey::new_unique();
+        let txn = seed_reopened_deposit(&mock, &mint, &landed_sig.to_string(), 100).await;
+        // The first two completion writes fail, the third succeeds: inside budget.
+        mock.set_fail_times("try_complete_processing", 2);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            channel_client(&server.url()),
+            None,
+            ProgramType::Escrow,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "a landed mint must never be re-minted"
+        );
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Completed,
+            "the retry absorbs the write blip and the row completes"
+        );
+    }
+
+    /// A sustained completion-write failure (retries exhausted) does not exit
+    /// the task or quarantine: the mint already landed, so the row is left
+    /// Processing for the recovery sweep to complete.
+    #[tokio::test]
+    async fn reopened_deposit_sustained_complete_failure_left_for_recovery() {
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_status_reply(&mut server, FINALIZED_STATUS_BODY);
+
+        let mock = MockStorage::new();
+        let landed_sig = solana_sdk::signature::Signature::new_unique();
+        let mint = Pubkey::new_unique();
+        let txn = seed_reopened_deposit(&mock, &mint, &landed_sig.to_string(), 100).await;
+        mock.set_should_fail("try_complete_processing", true);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: None,
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(1);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_deposit_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage.clone(),
+            channel_client(&server.url()),
+            None,
+            ProgramType::Escrow,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "a completion-write failure must not exit the task: {result:?}"
+        );
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "a landed mint must never be re-minted"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "leaving for recovery must not quarantine the row"
+        );
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Processing,
+            "the row stays Processing for the recovery sweep to complete"
         );
     }
 }

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -7,6 +7,7 @@ use crate::metrics::OPERATOR_STALE_PROCESSING_RECOVERED;
 use crate::operator::sender::types::PendingSig;
 use crate::operator::sender::{classify_signatures, FinalityRpc, SigFinality};
 use crate::operator::utils::rpc_util::RpcClientWithRetry;
+use crate::operator::utils::storage_util::with_storage_backoff;
 use crate::operator::TransactionStatusUpdate;
 use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
 use crate::storage::common::storage::Storage;
@@ -33,8 +34,9 @@ pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 pub(crate) const MAX_RECOVERY_REQUEUE_ATTEMPTS: i32 = 3;
 
 /// Deposit recovery outcome. Uncertainty must NOT demote (double-mint risk); an
-/// in-flight signature leaves the row Processing for the next sweep.
-enum DepositOutcome {
+/// in-flight signature leaves the row Processing for the next sweep. Shared with
+/// the processor's pre-mint gate, which asks the same question at pickup time.
+pub(crate) enum DepositOutcome {
     Landed { signature: String },
     NotLanded,
     Live { reason: String },
@@ -112,6 +114,16 @@ pub async fn run_recovery_worker(
     Ok(())
 }
 
+/// The row type this operator services (same mapping the fetcher uses). Recovery
+/// sweeps are scoped to it so an operator never classifies another chain's
+/// signatures against its own RPC and wrongly demotes a landed row.
+fn expected_transaction_type(program_type: ProgramType) -> TransactionType {
+    match program_type {
+        ProgramType::Escrow => TransactionType::Deposit,
+        ProgramType::Withdraw => TransactionType::Withdrawal,
+    }
+}
+
 async fn recover_once(
     storage: &Storage,
     finality: &FinalityRpc<'_>,
@@ -132,7 +144,11 @@ async fn recover_once(
     }
 
     let stale = storage
-        .get_stale_processing_transactions(threshold, RECOVERY_BATCH_LIMIT)
+        .get_stale_processing_transactions(
+            expected_transaction_type(program_type),
+            threshold,
+            RECOVERY_BATCH_LIMIT,
+        )
         .await?;
 
     if !stale.is_empty() {
@@ -158,7 +174,11 @@ async fn recover_once(
     // these itself, so anything stale here lost its in-memory driver. Parked
     // rows were never sent on-chain, so requeue them without verifying finality.
     let stale_parked = storage
-        .get_stale_parked_transactions(threshold, RECOVERY_BATCH_LIMIT)
+        .get_stale_parked_transactions(
+            expected_transaction_type(program_type),
+            threshold,
+            RECOVERY_BATCH_LIMIT,
+        )
         .await?;
     for row in stale_parked {
         if cancellation_token.is_cancelled() {
@@ -175,6 +195,9 @@ async fn decide_action(
     storage: &Storage,
     finality: &FinalityRpc<'_>,
 ) -> RecoveryAction {
+    // Recovery is same-type by construction: the sweep queries filter on the
+    // operator's own row type, so `finality` is always the chain the row's
+    // signatures were broadcast to.
     let action = match row.transaction_type {
         TransactionType::Deposit => match check_deposit(row, storage, finality).await {
             DepositOutcome::Landed { signature } => RecoveryAction::Complete { signature },
@@ -209,22 +232,58 @@ async fn decide_action(
 /// where a withdrawal Quarantines: the pre-broadcast persist makes "no signature" mean
 /// "never broadcast", so re-minting cannot double-mint, and quarantining every such row
 /// would flood manual review at deposit volume.
-async fn check_deposit(
+pub(crate) async fn check_deposit(
     row: &DbTransaction,
     storage: &Storage,
     finality: &FinalityRpc<'_>,
 ) -> DepositOutcome {
-    let pending = match load_pending_sigs(storage, row.id).await {
-        Ok(p) => p,
-        Err(reason) => {
+    // Retry a transient DB blip before treating the read as uncertainty; an
+    // exhausted read still quarantines rather than risk a blind re-mint.
+    let stored = match with_storage_backoff("journal read", row.id, || {
+        storage.get_release_signatures(row.id)
+    })
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
             return DepositOutcome::Ambiguous {
-                reason: format!("could not verify mint landed ({reason})"),
+                reason: format!(
+                    "could not verify mint landed (release signature lookup failed: {e})"
+                ),
             }
         }
     };
+    classify_deposit_signatures(&stored, finality).await
+}
 
-    if pending.is_empty() {
+/// Classify a deposit's already-read write-ahead signatures. Shared by the
+/// recovery sweep and the processor's pre-mint gate so the journal is read
+/// exactly once per decision. A malformed stored signature is uncertainty,
+/// never Dead, so a re-mint can never be authorized on an unreadable journal.
+pub(crate) async fn classify_deposit_signatures(
+    stored: &[(String, i64)],
+    finality: &FinalityRpc<'_>,
+) -> DepositOutcome {
+    if stored.is_empty() {
         return DepositOutcome::NotLanded;
+    }
+
+    let mut pending = Vec::with_capacity(stored.len());
+    for (sig_str, lvbh) in stored {
+        match Signature::from_str(sig_str) {
+            Ok(signature) => pending.push(PendingSig {
+                signature,
+                last_valid_block_height: *lvbh as u64,
+            }),
+             // Corrupt or tampered stored signature: treat as uncertain, never mint.
+            Err(e) => {
+                return DepositOutcome::Ambiguous {
+                    reason: format!(
+                        "could not verify mint landed (malformed stored release signature {sig_str}: {e})"
+                    ),
+                }
+            }
+        }
     }
 
     match classify_signatures(finality, &pending).await {
@@ -234,7 +293,7 @@ async fn check_deposit(
         SigFinality::Dead => DepositOutcome::NotLanded,
         // Still in flight; re-check next sweep rather than demote or complete.
         SigFinality::Live(reason) => DepositOutcome::Live { reason },
-        // Never demote on uncertainty — risks a double-mint on re-pickup.
+        // Never demote on uncertainty; risks a double-mint on re-pickup.
         SigFinality::Uncertain(reason) => DepositOutcome::Ambiguous {
             reason: format!("could not verify mint landed ({reason})"),
         },
@@ -486,7 +545,11 @@ pub async fn boot_reconcile_processing(
         .await?;
 
         let remaining = storage
-            .get_stale_processing_transactions(Duration::ZERO, RECOVERY_BATCH_LIMIT)
+            .get_stale_processing_transactions(
+                expected_transaction_type(program_type),
+                Duration::ZERO,
+                RECOVERY_BATCH_LIMIT,
+            )
             .await?;
         if remaining.is_empty() {
             return Ok(());
@@ -652,6 +715,24 @@ mod tests {
         );
     }
 
+    /// A transient DB blip on the deposit journal read is absorbed by the
+    /// bounded retry: the read recovers and classifies normally instead of
+    /// quarantining the row as uncertain.
+    #[tokio::test]
+    async fn deposit_read_blip_recovers_not_quarantined() {
+        let mock = MockStorage::new();
+        // First two reads fail, the third succeeds (empty): inside the budget.
+        mock.set_fail_times("get_release_signatures", 2);
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client("http://localhost:1");
+        let row = make_deposit_row(1);
+        let outcome = check_deposit(&row, &storage, &FinalityRpc::single(&client)).await;
+        assert!(
+            matches!(outcome, DepositOutcome::NotLanded),
+            "a transient read blip must be retried, not quarantined as Ambiguous"
+        );
+    }
+
     /// A finalized-success signature returns Landed and is never re-minted.
     #[tokio::test]
     async fn deposit_landed_sig_completes_without_remint() {
@@ -763,8 +844,8 @@ mod tests {
         }
     }
 
-    /// A malformed stored signature (via the shared `load_pending_sigs`) is uncertainty,
-    /// never read as "dead"; it must Quarantine rather than demote.
+    /// A malformed stored signature is uncertainty, never read as "dead"; it
+    /// must Quarantine rather than demote.
     #[tokio::test]
     async fn deposit_malformed_stored_sig_quarantines() {
         let mock = MockStorage::new();
@@ -1123,6 +1204,137 @@ mod tests {
             mock.pending_transactions.lock().unwrap()[0].status,
             TransactionStatus::Parked,
             "fresh parked row must be left alone"
+        );
+    }
+
+    // ── type-scoped sweeps ───────────────────────────────────────────
+
+    /// A withdraw operator's sweep must leave stale deposit rows alone: their
+    /// mint signatures live on the channel chain, which this operator's RPC
+    /// cannot see, so classifying them here would wrongly demote a landed mint.
+    #[tokio::test]
+    async fn withdraw_recovery_ignores_stale_deposit_rows() {
+        let mock = MockStorage::new();
+        let mut row = make_deposit_row(80);
+        row.status = TransactionStatus::Processing;
+        row.updated_at = Utc::now() - chrono::Duration::minutes(10);
+        mock.pending_transactions.lock().unwrap().push(row);
+        let storage = Storage::Mock(mock.clone());
+        // Unreachable RPC doubles as proof the row is never classified.
+        let client = make_rpc_client("http://localhost:1");
+        let (storage_tx, mut storage_rx) = mpsc::channel(8);
+
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+            .await
+            .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Processing,
+            "withdraw sweep must not touch a deposit row"
+        );
+        assert_eq!(after[0].recovery_requeue_attempts, 0);
+        drop(after);
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update may be sent for a cross-type row"
+        );
+    }
+
+    /// Mirrored direction: the escrow operator must not classify withdrawal
+    /// release signatures against the channel RPC.
+    #[tokio::test]
+    async fn escrow_recovery_ignores_stale_withdrawal_rows() {
+        let mock = MockStorage::new();
+        let mut row = make_withdrawal_row(81, Some(9));
+        row.status = TransactionStatus::Processing;
+        row.updated_at = Utc::now() - chrono::Duration::minutes(10);
+        mock.pending_transactions.lock().unwrap().push(row);
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client("http://localhost:1");
+        let (storage_tx, mut storage_rx) = mpsc::channel(8);
+
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+            .await
+            .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Processing,
+            "escrow sweep must not touch a withdrawal row"
+        );
+        drop(after);
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no alert may fire for a cross-type row"
+        );
+    }
+
+    /// The parked sweep is type-scoped too: only the withdraw operator may
+    /// requeue orphaned parked withdrawals.
+    #[tokio::test]
+    async fn escrow_parked_sweep_ignores_parked_withdrawals() {
+        let mock = MockStorage::new();
+        let mut row = make_withdrawal_row(82, Some(3));
+        row.status = TransactionStatus::Parked;
+        row.updated_at = Utc::now() - chrono::Duration::minutes(10);
+        mock.pending_transactions.lock().unwrap().push(row);
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client("http://localhost:1");
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Parked,
+            "escrow sweep must leave parked withdrawals for the withdraw operator"
+        );
+    }
+
+    /// A withdraw boot reconcile with only deposit rows in flight must leave
+    /// them untouched and converge on the first pass instead of exhausting
+    /// max_passes on rows it can never resolve.
+    #[tokio::test]
+    async fn boot_reconcile_converges_ignoring_other_type_rows() {
+        let mock = MockStorage::new();
+        // Fresh Processing deposit: the ZERO boot threshold would select it if unscoped.
+        let mut row = make_deposit_row(83);
+        row.status = TransactionStatus::Processing;
+        mock.pending_transactions.lock().unwrap().push(row);
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client("http://localhost:1");
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        boot_reconcile_processing(
+            &storage,
+            &client,
+            None,
+            ProgramType::Withdraw,
+            &storage_tx,
+            &CancellationToken::new(),
+            5,
+        )
+        .await
+        .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Processing,
+            "withdraw boot must not demote or quarantine an in-flight deposit"
+        );
+        drop(after);
+        // One sweep read plus one convergence read; more means the pass loop
+        // failed to converge and burned extra passes on the deposit row.
+        assert_eq!(
+            mock.calls("get_stale_processing_transactions"),
+            2,
+            "boot reconcile must converge after the first pass"
         );
     }
 

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -350,8 +350,9 @@ async fn check_withdrawal(
 /// malformed stored signature returns a quarantine reason (uncertainty, never "dead"),
 /// so callers never demote a row whose signatures could not be read or parsed.
 async fn load_pending_sigs(storage: &Storage, id: i64) -> Result<Vec<PendingSig>, String> {
-    let stored = storage
-        .get_release_signatures(id)
+    // Retry a transient DB blip before quarantining; matches the deposit gate so
+    // a momentary read failure never pages ops for a healthy withdrawal.
+    let stored = with_storage_backoff("journal read", id, || storage.get_release_signatures(id))
         .await
         .map_err(|e| format!("release signature lookup failed: {e}"))?;
 

--- a/indexer/src/operator/utils/mod.rs
+++ b/indexer/src/operator/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod mint_util;
 pub mod rpc_util;
 pub mod signer_util;
 pub mod smt_util;
+pub mod storage_util;
 pub mod transaction_util;
 
 pub use account_util::*;

--- a/indexer/src/operator/utils/storage_util.rs
+++ b/indexer/src/operator/utils/storage_util.rs
@@ -1,0 +1,38 @@
+use crate::error::StorageError;
+use std::future::Future;
+use tracing::warn;
+
+/// Run a storage read or write, retrying a transient error a few times with a
+/// short backoff. A brief DB blip should not force the caller's failure path on
+/// the first error; an exhausted retry returns the error for the caller to
+/// handle. `transaction_id` and `op_name` are for log context only.
+pub(crate) async fn with_storage_backoff<T, F, Fut>(
+    op_name: &str,
+    transaction_id: i64,
+    mut op: F,
+) -> Result<T, StorageError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, StorageError>>,
+{
+    const ATTEMPTS: u32 = 3;
+    const BACKOFF_MS: u64 = 100;
+
+    let mut last_err = None;
+    for attempt in 0..ATTEMPTS {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(e) => {
+                if attempt + 1 < ATTEMPTS {
+                    warn!(
+                        transaction_id,
+                        attempt, "{op_name} failed; retrying after backoff: {e}"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(BACKOFF_MS)).await;
+                }
+                last_err = Some(e);
+            }
+        }
+    }
+    Err(last_err.expect("loop body runs at least once"))
+}

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -374,14 +374,22 @@ impl Storage {
         quarantine_all_active_withdrawals::quarantine_all_active_withdrawals(self, exclude_id).await
     }
 
-    /// Stale `Processing` rows past the threshold (used by recovery).
+    /// Stale `Processing` rows of one type past the threshold (used by recovery).
+    /// Type-scoped so each operator only recovers rows whose broadcasts target
+    /// the chain its RPC client points at.
     pub async fn get_stale_processing_transactions(
         &self,
+        transaction_type: TransactionType,
         threshold: std::time::Duration,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, StorageError> {
-        get_stale_processing_transactions::get_stale_processing_transactions(self, threshold, limit)
-            .await
+        get_stale_processing_transactions::get_stale_processing_transactions(
+            self,
+            transaction_type,
+            threshold,
+            limit,
+        )
+        .await
     }
 
     /// CAS `Processing` → `Pending` on `updated_at`; `Ok(false)` if stale.
@@ -424,13 +432,20 @@ impl Storage {
         try_unpark_to_processing::try_unpark_to_processing(self, transaction_id).await
     }
 
-    /// Stale `Parked` rows older than the threshold, oldest-first.
+    /// Stale `Parked` rows of one type older than the threshold, oldest-first.
     pub async fn get_stale_parked_transactions(
         &self,
+        transaction_type: TransactionType,
         threshold: std::time::Duration,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, StorageError> {
-        get_stale_parked_transactions::get_stale_parked_transactions(self, threshold, limit).await
+        get_stale_parked_transactions::get_stale_parked_transactions(
+            self,
+            transaction_type,
+            threshold,
+            limit,
+        )
+        .await
     }
 
     /// CAS `Parked` → `Pending` on `updated_at`; `Ok(false)` if stale.
@@ -523,8 +538,9 @@ impl Storage {
         delete_release_signatures::delete_release_signatures(self, transaction_id).await
     }
 
-    /// Drop release signatures whose parent transaction is no longer
-    /// `Processing`. Returns the number of rows removed.
+    /// Drop release signatures only for genuinely terminal parents (completed,
+    /// failed, failed_reminted). Every non-terminal row keeps its write-ahead
+    /// evidence so the pre-mint gate can re-verify it. Returns the rows removed.
     pub async fn gc_stale_release_signatures(&self) -> Result<u64, StorageError> {
         gc_stale_release_signatures::gc_stale_release_signatures(self).await
     }

--- a/indexer/src/storage/common/storage/get_stale_parked_transactions.rs
+++ b/indexer/src/storage/common/storage/get_stale_parked_transactions.rs
@@ -1,22 +1,26 @@
 use crate::{
     error::StorageError,
-    storage::common::{models::DbTransaction, storage::Storage},
+    storage::common::{
+        models::{DbTransaction, TransactionType},
+        storage::Storage,
+    },
 };
 
-/// Stale `Parked` rows older than the threshold, oldest-first.
+/// Stale `Parked` rows of one type older than the threshold, oldest-first.
 pub async fn get_stale_parked_transactions(
     storage: &Storage,
+    transaction_type: TransactionType,
     threshold: std::time::Duration,
     limit: i64,
 ) -> Result<Vec<DbTransaction>, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
-            .get_stale_parked_transactions_internal(threshold, limit)
+            .get_stale_parked_transactions_internal(transaction_type, threshold, limit)
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .get_stale_parked_transactions(threshold, limit)
+                .get_stale_parked_transactions(transaction_type, threshold, limit)
                 .await
         }
     }

--- a/indexer/src/storage/common/storage/get_stale_processing_transactions.rs
+++ b/indexer/src/storage/common/storage/get_stale_processing_transactions.rs
@@ -1,23 +1,27 @@
 use crate::{
     error::StorageError,
-    storage::common::{models::DbTransaction, storage::Storage},
+    storage::common::{
+        models::{DbTransaction, TransactionType},
+        storage::Storage,
+    },
 };
 use std::time::Duration;
 
-/// Stale `Processing` rows past the threshold, oldest-first.
+/// Stale `Processing` rows of one type past the threshold, oldest-first.
 pub async fn get_stale_processing_transactions(
     storage: &Storage,
+    transaction_type: TransactionType,
     threshold: Duration,
     limit: i64,
 ) -> Result<Vec<DbTransaction>, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
-            .get_stale_processing_transactions_internal(threshold, limit)
+            .get_stale_processing_transactions_internal(transaction_type, threshold, limit)
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .get_stale_processing_transactions(threshold, limit)
+                .get_stale_processing_transactions(transaction_type, threshold, limit)
                 .await
         }
     }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -23,6 +23,8 @@ pub struct MockStorage {
     pub should_fail: std::sync::Arc<Mutex<HashMap<String, bool>>>,
     /// Per-op transient-failure counters: fail the first N calls of an op, then succeed.
     pub fail_times: std::sync::Arc<Mutex<HashMap<String, usize>>>,
+    /// Per-op call counts (bumped in `check_should_fail`); tests assert loop convergence.
+    pub call_counts: std::sync::Arc<Mutex<HashMap<String, usize>>>,
     pub mints: std::sync::Arc<Mutex<HashMap<String, DbMint>>>,
     pub mint_balances: std::sync::Arc<Mutex<Vec<MintDbBalance>>>,
     pub pending_transactions: std::sync::Arc<Mutex<Vec<DbTransaction>>>,
@@ -49,6 +51,12 @@ impl MockStorage {
     }
 
     fn check_should_fail(&self, operation: &str) -> Result<(), StorageError> {
+        *self
+            .call_counts
+            .lock()
+            .unwrap()
+            .entry(operation.to_string())
+            .or_default() += 1;
         // Transient injection takes precedence: fail the first N calls, then
         // fall through to the sticky bool (and otherwise succeed).
         {
@@ -89,6 +97,16 @@ impl MockStorage {
             .lock()
             .unwrap()
             .insert(program_type.to_string(), should_fail);
+    }
+
+    /// How many times `operation` has been invoked on this mock.
+    pub fn calls(&self, operation: &str) -> usize {
+        self.call_counts
+            .lock()
+            .unwrap()
+            .get(operation)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Make `operation` fail its next `times` calls, then succeed. Used to
@@ -706,6 +724,7 @@ impl MockStorage {
 
     pub async fn get_stale_processing_transactions(
         &self,
+        transaction_type: TransactionType,
         threshold: std::time::Duration,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, StorageError> {
@@ -715,9 +734,14 @@ impl MockStorage {
             .unwrap_or_else(|_| chrono::Duration::days(1));
         let cutoff = Utc::now() - threshold_chrono;
         let pending = self.pending_transactions.lock().unwrap();
+        // Mirrors the Postgres type filter: recovery only sees its own row type.
         let mut matched: Vec<DbTransaction> = pending
             .iter()
-            .filter(|t| t.status == TransactionStatus::Processing && t.updated_at < cutoff)
+            .filter(|t| {
+                t.transaction_type == transaction_type
+                    && t.status == TransactionStatus::Processing
+                    && t.updated_at < cutoff
+            })
             .cloned()
             .collect();
         matched.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
@@ -811,6 +835,7 @@ impl MockStorage {
 
     pub async fn get_stale_parked_transactions(
         &self,
+        transaction_type: TransactionType,
         threshold: std::time::Duration,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, StorageError> {
@@ -820,9 +845,14 @@ impl MockStorage {
             .unwrap_or_else(|_| chrono::Duration::days(1));
         let cutoff = Utc::now() - threshold_chrono;
         let pending = self.pending_transactions.lock().unwrap();
+        // Mirrors the Postgres type filter: recovery only sees its own row type.
         let mut matched: Vec<DbTransaction> = pending
             .iter()
-            .filter(|t| t.status == TransactionStatus::Parked && t.updated_at < cutoff)
+            .filter(|t| {
+                t.transaction_type == transaction_type
+                    && t.status == TransactionStatus::Parked
+                    && t.updated_at < cutoff
+            })
             .cloned()
             .collect();
         matched.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
@@ -978,24 +1008,33 @@ impl MockStorage {
 
     pub async fn gc_stale_release_signatures(&self) -> Result<u64, StorageError> {
         self.check_should_fail("gc_stale_release_signatures")?;
-        // Mirror the Postgres predicate: drop sigs whose parent is not
-        // `Processing`; an unknown transaction id counts as non-processing.
-        let processing_ids: std::collections::HashSet<i64> = self
+        // Mirror the Postgres predicate: reclaim only sigs whose parent row is
+        // terminal (completed, failed, failed_reminted). Every non-terminal row
+        // keeps its write-ahead journal for the pre-mint gate to re-verify; a
+        // sig with no matching row is retained, matching the SQL subquery.
+        let terminal_ids: std::collections::HashSet<i64> = self
             .pending_transactions
             .lock()
             .unwrap()
             .iter()
-            .filter(|t| t.status == TransactionStatus::Processing)
+            .filter(|t| {
+                matches!(
+                    t.status,
+                    TransactionStatus::Completed
+                        | TransactionStatus::Failed
+                        | TransactionStatus::FailedReminted
+                )
+            })
             .map(|t| t.id)
             .collect();
         let mut map = self.release_signatures.lock().unwrap();
         let mut removed = 0u64;
         map.retain(|txn_id, sigs| {
-            if processing_ids.contains(txn_id) {
-                true
-            } else {
+            if terminal_ids.contains(txn_id) {
                 removed += sigs.len() as u64;
                 false
+            } else {
+                true
             }
         });
         Ok(removed)

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1283,9 +1283,10 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
-    /// Stale `Processing` rows older than the threshold, oldest-first.
+    /// Stale `Processing` rows of one type older than the threshold, oldest-first.
     pub async fn get_stale_processing_transactions_internal(
         &self,
+        transaction_type: TransactionType,
         threshold: Duration,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, sqlx::Error> {
@@ -1298,8 +1299,9 @@ impl PostgresDb {
             FROM transactions
             WHERE {} = 'processing'
               AND {} < NOW() - make_interval(secs => $1)
+              AND {} = $2
             ORDER BY {} ASC
-            LIMIT $2
+            LIMIT $3
             "#,
             transaction_cols::ID,
             transaction_cols::SIGNATURE,
@@ -1328,10 +1330,12 @@ impl PostgresDb {
             // Filters
             transaction_cols::STATUS,
             transaction_cols::UPDATED_AT,
+            transaction_cols::TRANSACTION_TYPE,
             // Ordering (FIFO over stale)
             transaction_cols::UPDATED_AT,
         ))
         .bind(threshold_secs)
+        .bind(transaction_type)
         .bind(limit)
         .fetch_all(&self.pool)
         .await
@@ -1439,9 +1443,10 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
-    /// Stale `Parked` rows older than the threshold, oldest-first.
+    /// Stale `Parked` rows of one type older than the threshold, oldest-first.
     pub async fn get_stale_parked_transactions_internal(
         &self,
+        transaction_type: TransactionType,
         threshold: Duration,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, sqlx::Error> {
@@ -1454,8 +1459,9 @@ impl PostgresDb {
             FROM transactions
             WHERE {} = 'parked'
               AND {} < NOW() - make_interval(secs => $1)
+              AND {} = $2
             ORDER BY {} ASC
-            LIMIT $2
+            LIMIT $3
             "#,
             transaction_cols::ID,
             transaction_cols::SIGNATURE,
@@ -1484,10 +1490,12 @@ impl PostgresDb {
             // Filters
             transaction_cols::STATUS,
             transaction_cols::UPDATED_AT,
+            transaction_cols::TRANSACTION_TYPE,
             // Ordering (FIFO over stale)
             transaction_cols::UPDATED_AT,
         ))
         .bind(threshold_secs)
+        .bind(transaction_type)
         .bind(limit)
         .fetch_all(&self.pool)
         .await
@@ -1793,15 +1801,17 @@ impl PostgresDb {
         Ok(())
     }
 
-    /// Drop release signatures whose parent transaction is no longer
-    /// `processing`. Returns the number of rows removed.
+    /// Only genuinely terminal rows are reclaimed; every non-terminal
+    /// status keeps its write-ahead journal. A demoted, quarantined, parked, or
+    /// pending-remint row can still be picked up or reminted, and the pre-mint
+    /// gate re-verifies those signatures before it would broadcast again, so
+    /// deleting them early would let a landed mint be re-issued.
     pub async fn gc_stale_release_signatures_internal(&self) -> Result<u64, sqlx::Error> {
         let result = sqlx::query(
             r#"
             DELETE FROM pending_release_signatures
-            WHERE transaction_id IN (
-                SELECT id FROM transactions WHERE status <> 'processing'
-            )
+            WHERE transaction_id IN (SELECT id FROM transactions
+                                     WHERE status IN ('completed', 'failed', 'failed_reminted'))
             "#,
         )
         .execute(&self.pool)

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -1028,39 +1028,156 @@ async fn release_signature_delete_removes_all_for_txn() -> Result<(), Box<dyn st
     Ok(())
 }
 
+/// The GC may only reclaim signatures of genuinely terminal rows
+/// (completed, failed, failed_reminted). Every non-terminal status retains its
+/// write-ahead journal: a row can still be picked up, demoted, re-armed from
+/// manual review, or reminted, and the pre-mint gate re-verifies those
+/// signatures before it would mint again.
 #[tokio::test(flavor = "multi_thread")]
-async fn release_signature_gc_only_drops_non_processing() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn release_signature_gc_retains_non_terminal() -> Result<(), Box<dyn std::error::Error>> {
     let (pool, storage, _pg) = start_postgres().await?;
 
-    let proc_txn = make_db_transaction("rel_gc_proc", TransactionType::Withdrawal);
-    let proc_id = storage.insert_db_transaction(&proc_txn).await?;
-    let done_txn = make_db_transaction("rel_gc_done", TransactionType::Withdrawal);
-    let done_id = storage.insert_db_transaction(&done_txn).await?;
+    // (label, status, must_survive)
+    let cases = [
+        ("processing", true),
+        ("pending", true),
+        ("manual_review", true),
+        ("parked", true),
+        ("pending_remint", true),
+        ("completed", false),
+        ("failed", false),
+        ("failed_reminted", false),
+    ];
 
-    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
-        .bind(proc_id)
+    let mut ids = Vec::new();
+    for (status, survive) in cases {
+        let ty = if status == "pending_remint" || status == "parked" {
+            TransactionType::Withdrawal
+        } else {
+            TransactionType::Deposit
+        };
+        let txn = make_db_transaction(&format!("rel_gc_{status}"), ty);
+        let id = storage.insert_db_transaction(&txn).await?;
+        sqlx::query(&format!(
+            "UPDATE transactions SET status = '{status}'::transaction_status WHERE id = $1"
+        ))
+        .bind(id)
         .execute(&pool)
         .await?;
-    sqlx::query("UPDATE transactions SET status = 'completed'::transaction_status WHERE id = $1")
-        .bind(done_id)
-        .execute(&pool)
-        .await?;
-
-    storage
-        .insert_release_signature(proc_id, "sig-proc".to_string(), 1)
-        .await?;
-    storage
-        .insert_release_signature(done_id, "sig-done".to_string(), 2)
-        .await?;
+        storage
+            .insert_release_signature(id, format!("sig-{status}"), 1)
+            .await?;
+        ids.push((status, id, survive));
+    }
 
     let removed = storage.gc_stale_release_signatures().await?;
+    let expected_removed = ids.iter().filter(|(_, _, s)| !s).count() as u64;
     assert_eq!(
-        removed, 1,
-        "GC must drop exactly the non-processing row's sig"
+        removed, expected_removed,
+        "GC must drop only the terminal rows' signatures"
     );
-    assert_eq!(storage.get_release_signatures(proc_id).await?.len(), 1);
-    assert!(storage.get_release_signatures(done_id).await?.is_empty());
+    for (status, id, survive) in ids {
+        let present = !storage.get_release_signatures(id).await?.is_empty();
+        assert_eq!(
+            present, survive,
+            "status '{status}' signature retention mismatch (survive={survive})"
+        );
+    }
+    Ok(())
+}
+
+// ── type-scoped stale queries ────────────────────────────────────────────────
+
+async fn backdate_updated_at(
+    pool: &PgPool,
+    id: i64,
+    age: chrono::Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    sqlx::query("ALTER TABLE transactions DISABLE TRIGGER update_transactions_updated_at")
+        .execute(pool)
+        .await?;
+    sqlx::query("UPDATE transactions SET updated_at = $1 WHERE id = $2")
+        .bind(Utc::now() - age)
+        .bind(id)
+        .execute(pool)
+        .await?;
+    sqlx::query("ALTER TABLE transactions ENABLE TRIGGER update_transactions_updated_at")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_processing_query_is_type_exclusive() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    let dep = make_db_transaction("stale_type_dep", TransactionType::Deposit);
+    let dep_id = storage.insert_db_transaction(&dep).await?;
+    let wd = make_db_transaction("stale_type_wd", TransactionType::Withdrawal);
+    let wd_id = storage.insert_db_transaction(&wd).await?;
+    for id in [dep_id, wd_id] {
+        sqlx::query(
+            "UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await?;
+        backdate_updated_at(&pool, id, chrono::Duration::minutes(10)).await?;
+    }
+
+    let threshold = std::time::Duration::from_secs(5 * 60);
+    let deposits = storage
+        .get_stale_processing_transactions(TransactionType::Deposit, threshold, 100)
+        .await?;
+    assert_eq!(
+        deposits.iter().map(|t| t.id).collect::<Vec<_>>(),
+        vec![dep_id],
+        "deposit scope must return exactly the deposit row"
+    );
+    let withdrawals = storage
+        .get_stale_processing_transactions(TransactionType::Withdrawal, threshold, 100)
+        .await?;
+    assert_eq!(
+        withdrawals.iter().map(|t| t.id).collect::<Vec<_>>(),
+        vec![wd_id],
+        "withdrawal scope must return exactly the withdrawal row"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_parked_query_is_type_exclusive() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    let dep = make_db_transaction("parked_type_dep", TransactionType::Deposit);
+    let dep_id = storage.insert_db_transaction(&dep).await?;
+    let wd = make_db_transaction("parked_type_wd", TransactionType::Withdrawal);
+    let wd_id = storage.insert_db_transaction(&wd).await?;
+    for id in [dep_id, wd_id] {
+        sqlx::query("UPDATE transactions SET status = 'parked'::transaction_status WHERE id = $1")
+            .bind(id)
+            .execute(&pool)
+            .await?;
+        backdate_updated_at(&pool, id, chrono::Duration::minutes(10)).await?;
+    }
+
+    let threshold = std::time::Duration::from_secs(5 * 60);
+    let withdrawals = storage
+        .get_stale_parked_transactions(TransactionType::Withdrawal, threshold, 100)
+        .await?;
+    assert_eq!(
+        withdrawals.iter().map(|t| t.id).collect::<Vec<_>>(),
+        vec![wd_id],
+        "withdrawal scope must return exactly the withdrawal row"
+    );
+    let deposits = storage
+        .get_stale_parked_transactions(TransactionType::Deposit, threshold, 100)
+        .await?;
+    assert_eq!(
+        deposits.iter().map(|t| t.id).collect::<Vec<_>>(),
+        vec![dep_id],
+        "deposit scope must return exactly the deposit row"
+    );
     Ok(())
 }
 

--- a/integration/tests/indexer/parked_withdrawal_recovery.rs
+++ b/integration/tests/indexer/parked_withdrawal_recovery.rs
@@ -277,7 +277,7 @@ async fn get_stale_parked_filters_and_orders() {
 
     // Stale parked only, oldest updated_at first.
     let stale = storage
-        .get_stale_parked_transactions(Duration::from_secs(5 * 60), 100)
+        .get_stale_parked_transactions(TransactionType::Withdrawal, Duration::from_secs(5 * 60), 100)
         .await
         .unwrap();
     let ids: Vec<i64> = stale.iter().map(|t| t.id).collect();
@@ -285,7 +285,7 @@ async fn get_stale_parked_filters_and_orders() {
 
     // Limit is honored (FIFO over stale → the oldest).
     let limited = storage
-        .get_stale_parked_transactions(Duration::from_secs(5 * 60), 1)
+        .get_stale_parked_transactions(TransactionType::Withdrawal, Duration::from_secs(5 * 60), 1)
         .await
         .unwrap();
     assert_eq!(limited.len(), 1);

--- a/integration/tests/indexer/parked_withdrawal_recovery.rs
+++ b/integration/tests/indexer/parked_withdrawal_recovery.rs
@@ -277,7 +277,11 @@ async fn get_stale_parked_filters_and_orders() {
 
     // Stale parked only, oldest updated_at first.
     let stale = storage
-        .get_stale_parked_transactions(TransactionType::Withdrawal, Duration::from_secs(5 * 60), 100)
+        .get_stale_parked_transactions(
+            TransactionType::Withdrawal,
+            Duration::from_secs(5 * 60),
+            100,
+        )
         .await
         .unwrap();
     let ids: Vec<i64> = stale.iter().map(|t| t.id).collect();

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1168,7 +1168,11 @@ async fn threshold_boundary_returns_only_strictly_older_rows() {
         .unwrap();
 
     let stale = db
-        .get_stale_processing_transactions_internal(Duration::from_secs(5 * 60), 100)
+        .get_stale_processing_transactions_internal(
+            TransactionType::Deposit,
+            Duration::from_secs(5 * 60),
+            100,
+        )
         .await
         .unwrap();
     // 4:59 excluded; 5:00 is timing-dependent (Postgres `<` is strict).
@@ -1484,4 +1488,192 @@ async fn demote_then_refetch_mints_exactly_once() {
         "only the owned incarnation persists a signature"
     );
     mock.shutdown().await;
+}
+
+// ── cross-operator recovery and the reopened-row gate ───────────────────────
+
+// The reported exploit end-to-end: a stale Processing deposit whose mint landed
+// on the channel is invisible to the withdraw operator's sweep (whose Solana
+// RPC would prove a coverage-backed false absence) and is completed, not
+// re-minted, by the escrow operator's own sweep.
+#[tokio::test(flavor = "multi_thread")]
+async fn cross_operator_recovery_does_not_replay_deposit_mint() {
+    let (db, url, _container) = start_pg("cross_op_recovery").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_deposit(
+        &Signature::new_unique().to_string(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        777,
+    );
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    let landed_sig = Signature::new_unique();
+    db.insert_release_signature_internal(tx_id, landed_sig.to_string(), 100)
+        .await
+        .unwrap();
+
+    // Solana mock: absent-but-covered (null status, expired blockhash, floor 0).
+    // Pre-fix, this coverage-proven wrong-chain Dead is what demoted the row.
+    let solana = MockRpcServer::start().await;
+    solana.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
+    );
+    solana.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    solana.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
+    let solana_client = test_client(solana.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    test_hooks::run_recovery_once(&storage, &solana_client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "processing",
+        "the withdraw sweep must not touch a deposit row"
+    );
+    assert_eq!(
+        solana.call_count("getSignatureStatuses"),
+        0,
+        "a deposit's mint signatures must never be classified on Solana"
+    );
+
+    // Escrow sweep against the channel: the landed mint completes the row.
+    let channel = MockRpcServer::start().await;
+    channel.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": {"slot": 200},
+            "value": [{
+                "slot": 100,
+                "confirmations": null,
+                "err": null,
+                "status": {"Ok": null},
+                "confirmationStatus": "finalized"
+            }]
+        })),
+    );
+    let channel_client = test_client(channel.url());
+    test_hooks::run_recovery_once(&storage, &channel_client, ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
+    assert_eq!(status_of(&pool, tx_id).await, "completed");
+    assert_eq!(
+        counterpart_sig_of(&pool, tx_id).await,
+        Some(landed_sig.to_string())
+    );
+    assert_eq!(channel.call_count("sendTransaction"), 0);
+    solana.shutdown().await;
+    channel.shutdown().await;
+}
+
+// A demoted deposit keeps its write-ahead signature (GC retention), and when the
+// row is re-locked the processor gate classifies it on the channel and completes
+// the row instead of dispatching a second mint: one broadcast total.
+#[tokio::test(flavor = "multi_thread")]
+async fn demoted_deposit_reopens_through_gate_without_second_mint() {
+    use private_channel_indexer::operator::{
+        processor::{process_deposit_funds, ProcessorState},
+        utils::instruction_util::TransactionBuilder,
+        MintCache,
+    };
+
+    let (db, url, _container) = start_pg("reopened_gate").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_deposit(
+        &Signature::new_unique().to_string(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        888,
+    );
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    let captured = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    // Write-ahead persist of the first (and only) mint broadcast.
+    let landed_sig = Signature::new_unique();
+    db.insert_release_signature_internal(tx_id, landed_sig.to_string(), 100)
+        .await
+        .unwrap();
+
+    // Recovery-style demote, then the GC pass that used to destroy the evidence.
+    assert!(storage.try_requeue_processing(tx_id, captured).await.unwrap());
+    storage.gc_stale_release_signatures().await.unwrap();
+    assert_eq!(
+        db.get_release_signatures_internal(tx_id).await.unwrap().len(),
+        1,
+        "a demoted row's write-ahead signature must survive the GC"
+    );
+
+    // The escrow fetcher re-locks the row; the gate must classify the retained
+    // signature on the channel before any mint is built.
+    let relocked = storage
+        .get_and_lock_pending_transactions(TransactionType::Deposit, 10)
+        .await
+        .unwrap();
+    let row = relocked
+        .into_iter()
+        .find(|r| r.id == tx_id)
+        .expect("row re-locked");
+
+    let channel = MockRpcServer::start().await;
+    channel.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": {"slot": 200},
+            "value": [{
+                "slot": 100,
+                "confirmations": null,
+                "err": null,
+                "status": {"Ok": null},
+                "confirmationStatus": "finalized"
+            }]
+        })),
+    );
+    let channel_client = Arc::new(test_client(channel.url()));
+
+    let mut ps = ProcessorState {
+        admin_pubkey: Pubkey::new_unique(),
+        release_funds_state: None,
+        mint_cache: MintCache::new(storage.clone()),
+    };
+    let (fetcher_tx, fetcher_rx) = tokio::sync::mpsc::channel(1);
+    let (sender_tx, mut sender_rx) = tokio::sync::mpsc::channel::<TransactionBuilder>(8);
+    let (storage_tx, _storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+    fetcher_tx.send(row).await.unwrap();
+    drop(fetcher_tx);
+
+    process_deposit_funds(
+        &mut ps,
+        fetcher_rx,
+        sender_tx,
+        storage_tx,
+        storage.clone(),
+        channel_client,
+        None,
+        ProgramType::Escrow,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        sender_rx.try_recv().is_err(),
+        "the gate must complete the row, never dispatch a second mint"
+    );
+    assert_eq!(status_of(&pool, tx_id).await, "completed");
+    assert_eq!(
+        counterpart_sig_of(&pool, tx_id).await,
+        Some(landed_sig.to_string())
+    );
+    assert_eq!(
+        channel.call_count("sendTransaction"),
+        0,
+        "exactly one mint broadcast total (the original write-ahead one)"
+    );
+    channel.shutdown().await;
 }

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1602,10 +1602,16 @@ async fn demoted_deposit_reopens_through_gate_without_second_mint() {
         .unwrap();
 
     // Recovery-style demote, then the GC pass that used to destroy the evidence.
-    assert!(storage.try_requeue_processing(tx_id, captured).await.unwrap());
+    assert!(storage
+        .try_requeue_processing(tx_id, captured)
+        .await
+        .unwrap());
     storage.gc_stale_release_signatures().await.unwrap();
     assert_eq!(
-        db.get_release_signatures_internal(tx_id).await.unwrap().len(),
+        db.get_release_signatures_internal(tx_id)
+            .await
+            .unwrap()
+            .len(),
         1,
         "a demoted row's write-ahead signature must survive the GC"
     );


### PR DESCRIPTION
## Summary

Closes cantina issue 130. This PR fixes a chain of recovery and garbage-collection bugs that could cause a successfully minted deposit to be demoted and minted a second time, creating unbacked channel supply. The fix has three parts: recovery is now scoped by `TransactionType` so each operator only processes its own rows; release-signature GC now retains signatures for **all non-terminal statuses**, preserving the broadcast journal for any row that may be retried; and reopened deposits pass through a pre-broadcast idempotency gate that checks existing signatures before minting.

Rather than performing a full on-chain history lookup, the gate reuses the persisted **pending signatures** as the source of truth. If any previous mint attempt already landed, the row is completed without broadcasting again. This keeps the hot path unchanged (new deposits perform no extra RPC calls), limits work to reopened rows, and relies on the journal that now survives across every non-terminal state, preserving the invariant that "no signatures" means "never broadcast."

The gate is fail-closed but avoids quarantining healthy rows. A `Landed` verdict completes the row, `NotLanded` proceeds to mint, while `Live` or `Uncertain` leave the row in `Processing` for the recovery worker to retry. Transient storage failures (journal reads or completion writes) are retried with bounded backoff; if retries are exhausted, the row simply remains `Processing` for recovery rather than risking a duplicate mint or incorrectly moving to `ManualReview`. No schema or configuration changes are required.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29489289878) |
| Indexer | 28,982 | 32,264 | 89.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29489289878) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29489289878) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29489289878) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,023 | 16,434 | 79.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29489289878) |
| **Total** | **55,601** | **64,236** | **86.6%** | |

> Last updated: 2026-07-16 10:53:02 UTC by E2E Integration