### PR TITLE
fix(indexer): ownership-claim the JIT mint re-fire so a requeued deposit cannot double-mint

### DIFF
--- a/docs/runbooks/deposit_failed.md
+++ b/docs/runbooks/deposit_failed.md
@@ -116,10 +116,19 @@ landed mint).
 lost ownership of its row before broadcast: while the built mint was queued,
 the recovery worker demoted the row (or a re-fetch re-locked it), so the
 stale builder was dropped without broadcasting and without writing any
-status. The row's current owner or recovery mints it instead, so the
-one-deposit-one-mint invariant holds. No operator action; a sustained rate
-only signals the in-flight cap is stranding builders long enough for
-recovery to reclaim them (a throughput tuning signal, not a correctness bug).
+status. The same label also fires when a `MintNotInitialized` JIT re-fire
+loses its lease mid-retry (recovery demoted the row during the JIT window);
+the semantics are identical. The row's current owner or recovery mints it
+instead, so the one-deposit-one-mint invariant holds. No operator action; a
+sustained rate only signals the in-flight cap or the JIT window is stranding
+builders long enough for recovery to reclaim them (a throughput tuning
+signal, not a correctness bug).
+
+`OPERATOR_TRANSACTION_ERRORS{error_reason="jit_missing_claim_lease"}` is a
+defensive counter that should never fire: a JIT re-fire arrived without the
+ownership epoch its first claim stored. The re-fire is dropped without
+broadcast and the row stays Processing for recovery. A sustained rate is a
+code bug, not an operational condition.
 
 ## Post-incident artifacts
 

--- a/docs/runbooks/deposit_manual_review.md
+++ b/docs/runbooks/deposit_manual_review.md
@@ -169,6 +169,10 @@ in `manual_review` (not `failed`) specifically because JIT's structural
 check distinguished it from generic program errors — the on-chain mint
 state needs human investigation before any retry can succeed.
 
+Note: the JIT retry's journal is ownership-checked; a retry that loses
+its lease surfaces as `deposit_ownership_lost` (see
+[`deposit_failed.md`](deposit_failed.md)), not as manual review.
+
 #### Step 1 - verify on-chain
 
 Run [`_verify_onchain_mint.md`](_verify_onchain_mint.md). Like Paths

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -220,6 +220,8 @@ pub fn init_labels(program_type: &str) {
         "confirmation_timeout",
         "program_error",
         "confirmation_error",
+        "deposit_ownership_lost",
+        "jit_missing_claim_lease",
     ] {
         OPERATOR_TRANSACTION_ERRORS.with_label_values(&[program_type, error_reason]);
     }

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -158,9 +158,9 @@ pub mod test_hooks {
         .await
     }
 
-    /// Drives one `fire_and_store_task` for a deposit-mint first-fire. Acquires
-    /// a permit from the sender's semaphore, then builds, (claims +) persists,
-    /// and broadcasts. Lets tests pin the ownership-claim routing (abort vs
+    /// Drives one `fire_and_store_task` for a deposit-mint fire. Acquires a
+    /// permit from the sender's semaphore, then builds, claims + persists, and
+    /// broadcasts. Lets tests pin the ownership-claim routing (abort vs
     /// broadcast) without the sender loop. Returns `false` if the semaphore was
     /// already at capacity.
     #[allow(clippy::too_many_arguments)]
@@ -173,7 +173,6 @@ pub mod test_hooks {
         extra_error_checks_policy: crate::operator::utils::instruction_util::ExtraErrorCheckPolicy,
         storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
         durability: super::types::SendDurability,
-        deposit_expected_updated_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> bool {
         let Ok(permit) = Arc::clone(&state.semaphore).try_acquire_owned() else {
             return false;
@@ -190,7 +189,6 @@ pub mod test_hooks {
             extra_error_checks_policy,
             storage_tx.clone(),
             durability,
-            deposit_expected_updated_at,
             permit,
         )
         .await;
@@ -688,6 +686,7 @@ mod tests {
                 transaction_id: Some(txn_id),
                 withdrawal_nonce: None,
                 trace_id: None,
+                deposit_claim_lease: None,
             },
             instruction: InstructionWithSigners {
                 instructions: vec![],
@@ -873,6 +872,7 @@ mod tests {
                 transaction_id: Some(1),
                 withdrawal_nonce: Some(2),
                 trace_id: Some("t".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: WithdrawalRemintInfo {
                 transaction_id: 1,
@@ -965,6 +965,7 @@ mod tests {
                 transaction_id: Some(1),
                 withdrawal_nonce: Some(2),
                 trace_id: Some("t".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: WithdrawalRemintInfo {
                 transaction_id: 1,
@@ -1068,6 +1069,7 @@ mod tests {
                 transaction_id: Some(80),
                 withdrawal_nonce: Some(future_nonce),
                 trace_id: Some("trace-8".to_string()),
+                deposit_claim_lease: None,
             },
             ReleaseFundsBuilder::new(),
         ));
@@ -1113,6 +1115,7 @@ mod tests {
                 transaction_id: Some(20),
                 withdrawal_nonce: Some(stale_nonce),
                 trace_id: Some("trace-2".to_string()),
+                deposit_claim_lease: None,
             },
             ReleaseFundsBuilder::new(),
         ));
@@ -1159,6 +1162,7 @@ mod tests {
                 transaction_id: Some(20),
                 withdrawal_nonce: Some(stale_nonce),
                 trace_id: Some("trace-2".to_string()),
+                deposit_claim_lease: None,
             },
             ReleaseFundsBuilder::new(),
         ));
@@ -1167,6 +1171,7 @@ mod tests {
                 transaction_id: Some(200),
                 withdrawal_nonce: Some(future_nonce),
                 trace_id: Some("trace-future".to_string()),
+                deposit_claim_lease: None,
             },
             ReleaseFundsBuilder::new(),
         ));

--- a/indexer/src/operator/sender/proof.rs
+++ b/indexer/src/operator/sender/proof.rs
@@ -48,6 +48,7 @@ impl SenderSMTState {
             transaction_id: Some(transaction_id),
             withdrawal_nonce: Some(nonce),
             trace_id: Some(trace_id),
+            deposit_claim_lease: None,
         };
         self.nonce_to_builder.insert(nonce, (ctx, builder.clone()));
 
@@ -319,6 +320,7 @@ mod tests {
             transaction_id: Some(1),
             withdrawal_nonce: Some(0),
             trace_id: Some("t".to_string()),
+            deposit_claim_lease: None,
         };
         smt.nonce_to_builder
             .insert(0, (ctx, ReleaseFundsBuilder::new()));
@@ -348,6 +350,7 @@ mod tests {
             transaction_id: Some(1),
             withdrawal_nonce: Some(5),
             trace_id: Some("t".to_string()),
+            deposit_claim_lease: None,
         };
         smt.nonce_to_builder
             .insert(5, (ctx, ReleaseFundsBuilder::new()));
@@ -541,6 +544,7 @@ mod tests {
             transaction_id: Some(1),
             withdrawal_nonce: Some(0),
             trace_id: Some("t".to_string()),
+            deposit_claim_lease: None,
         };
         smt.nonce_to_builder.insert(0, (ctx, builder));
         state.smt_state = Some(smt);
@@ -571,6 +575,7 @@ mod tests {
             transaction_id: Some(1),
             withdrawal_nonce: Some(0),
             trace_id: Some("t".to_string()),
+            deposit_claim_lease: None,
         };
         smt.nonce_to_builder.insert(0, (ctx, builder));
         state.smt_state = Some(smt);

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -1058,6 +1058,7 @@ mod tests {
                 transaction_id: Some(555),
                 withdrawal_nonce: Some(5),
                 trace_id: Some("trace-555".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(555),
             signatures: vec![PendingSig {
@@ -1092,6 +1093,7 @@ mod tests {
                 transaction_id: Some(20),
                 withdrawal_nonce: Some(8),
                 trace_id: Some("trace-20".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(20),
             signatures: vec![PendingSig {
@@ -1144,6 +1146,7 @@ mod tests {
                 transaction_id: Some(30),
                 withdrawal_nonce: Some(9),
                 trace_id: Some("trace-30".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(30),
             signatures: vec![PendingSig {
@@ -1192,6 +1195,7 @@ mod tests {
                 transaction_id: Some(20),
                 withdrawal_nonce: Some(8),
                 trace_id: Some("trace-20".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(20),
             signatures: vec![PendingSig {
@@ -1258,6 +1262,7 @@ mod tests {
                 transaction_id: Some(10),
                 withdrawal_nonce: Some(1),
                 trace_id: Some("trace-10".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(10),
             signatures: vec![PendingSig {
@@ -1275,6 +1280,7 @@ mod tests {
                 transaction_id: Some(20),
                 withdrawal_nonce: Some(2),
                 trace_id: Some("trace-20".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(20),
             signatures: vec![PendingSig {
@@ -1371,6 +1377,7 @@ mod tests {
                 transaction_id: Some(99),
                 withdrawal_nonce: Some(7),
                 trace_id: Some("trace-99".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(99),
             signatures: vec![PendingSig {
@@ -1449,6 +1456,7 @@ mod tests {
                 transaction_id: Some(99),
                 withdrawal_nonce: Some(landed_nonce),
                 trace_id: Some("trace-99".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(99),
             signatures: vec![PendingSig {
@@ -1507,6 +1515,7 @@ mod tests {
                 transaction_id: Some(700),
                 withdrawal_nonce: Some(70),
                 trace_id: Some("trace-700".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(700),
             signatures: vec![PendingSig {
@@ -1587,6 +1596,7 @@ mod tests {
                 transaction_id: Some(77),
                 withdrawal_nonce: Some(11),
                 trace_id: Some("trace-77".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(77),
             signatures: vec![PendingSig {
@@ -1663,6 +1673,7 @@ mod tests {
                 transaction_id: Some(88),
                 withdrawal_nonce: Some(12),
                 trace_id: Some("trace-88".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(88),
             signatures: vec![PendingSig {
@@ -1730,6 +1741,7 @@ mod tests {
                 transaction_id: Some(89),
                 withdrawal_nonce: Some(13),
                 trace_id: Some("trace-89".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(89),
             signatures: vec![PendingSig {
@@ -1800,6 +1812,7 @@ mod tests {
                 transaction_id: Some(55),
                 withdrawal_nonce: Some(6),
                 trace_id: Some("trace-55".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(55),
             signatures: vec![
@@ -2513,6 +2526,7 @@ mod tests {
                 transaction_id: Some(100),
                 withdrawal_nonce: Some(20),
                 trace_id: Some("trace-100".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(100),
             signatures: vec![PendingSig {
@@ -2578,6 +2592,7 @@ mod tests {
                 transaction_id: Some(101),
                 withdrawal_nonce: Some(21),
                 trace_id: Some("trace-101".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(101),
             signatures: vec![PendingSig {
@@ -2633,6 +2648,7 @@ mod tests {
                 transaction_id: Some(102),
                 withdrawal_nonce: Some(22),
                 trace_id: Some("trace-102".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(102),
             signatures: vec![PendingSig {
@@ -2692,6 +2708,7 @@ mod tests {
                 transaction_id: Some(103),
                 withdrawal_nonce: Some(23),
                 trace_id: Some("trace-103".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(103),
             signatures: vec![PendingSig {
@@ -2763,6 +2780,7 @@ mod tests {
                 transaction_id: Some(105),
                 withdrawal_nonce: Some(25),
                 trace_id: Some("trace-105".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(105),
             signatures: vec![PendingSig {
@@ -2856,6 +2874,7 @@ mod tests {
                 transaction_id: Some(901),
                 withdrawal_nonce: Some(9),
                 trace_id: Some("trace-901".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(901),
             signatures: vec![PendingSig {
@@ -2923,6 +2942,7 @@ mod tests {
                 transaction_id: Some(902),
                 withdrawal_nonce: Some(9),
                 trace_id: Some("trace-902".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(902),
             signatures: vec![PendingSig {
@@ -2995,6 +3015,7 @@ mod tests {
                 transaction_id: Some(904),
                 withdrawal_nonce: Some(9),
                 trace_id: Some("trace-904".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(904),
             signatures: vec![PendingSig {
@@ -3138,6 +3159,7 @@ mod tests {
                 transaction_id: Some(906),
                 withdrawal_nonce: Some(9),
                 trace_id: Some("trace-906".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(906),
             signatures: vec![PendingSig {
@@ -3218,6 +3240,7 @@ mod tests {
                 transaction_id: Some(1500),
                 withdrawal_nonce: Some(15),
                 trace_id: Some("trace-1500".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(1500),
             signatures: vec![PendingSig {
@@ -3365,6 +3388,7 @@ mod tests {
                 transaction_id: Some(110),
                 withdrawal_nonce: Some(30),
                 trace_id: Some("trace-110".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(110),
             signatures: vec![PendingSig {
@@ -3442,6 +3466,7 @@ mod tests {
                 transaction_id: Some(710),
                 withdrawal_nonce: Some(71),
                 trace_id: Some("trace-710".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(710),
             signatures: vec![PendingSig {
@@ -3529,6 +3554,7 @@ mod tests {
                 transaction_id: Some(720),
                 withdrawal_nonce: Some(72),
                 trace_id: Some("trace-720".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: make_remint_info(720),
             signatures: vec![PendingSig {

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -339,6 +339,7 @@ impl SenderState {
                 // handle_permanent_failure before the row was written as PendingRemint.
                 withdrawal_nonce: tx.withdrawal_nonce.map(|n| n as u64),
                 trace_id: Some(tx.trace_id.clone()),
+                deposit_claim_lease: None,
             };
 
             let remint_info = WithdrawalRemintInfo {

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -177,6 +177,7 @@ pub async fn handle_transaction_submission(
         transaction_id: tx_builder.transaction_id(),
         withdrawal_nonce: tx_builder.withdrawal_nonce(),
         trace_id: tx_builder.trace_id(),
+        deposit_claim_lease: None,
     };
 
     // For a withdrawal, which tree does its nonce belong to? None for other txs.
@@ -234,14 +235,12 @@ pub async fn handle_transaction_submission(
                         // A user-fund Mint is Recoverable (persisted write-ahead, re-minted
                         // by recovery on failure); InitializeMint mints no balance and is
                         // on-chain idempotent, so it is Terminal.
-                        let durability = if matches!(tx_builder, TransactionBuilder::Mint(_)) {
-                            SendDurability::Recoverable
-                        } else {
-                            SendDurability::Terminal
+                        let durability = match &tx_builder {
+                            TransactionBuilder::Mint(b) => SendDurability::Recoverable {
+                                deposit_expected_updated_at: b.fetched_updated_at,
+                            },
+                            _ => SendDurability::Terminal,
                         };
-                        // Some only for a deposit Mint: the fetch-time token the
-                        // write-ahead persist proves ownership against.
-                        let deposit_expected_updated_at = tx_builder.fetched_updated_at();
                         spawn_fire_and_store(
                             state,
                             instruction,
@@ -251,7 +250,6 @@ pub async fn handle_transaction_submission(
                             extra_error_checks_policy,
                             storage_tx.clone(),
                             durability,
-                            deposit_expected_updated_at,
                         );
                     }
                     _ => {
@@ -307,6 +305,7 @@ pub(super) async fn route_builder_error(
                         transaction_id: Some(builder_with_nonce.transaction_id),
                         withdrawal_nonce: Some(builder_with_nonce.nonce),
                         trace_id: Some(builder_with_nonce.trace_id),
+                        deposit_claim_lease: None,
                     },
                     builder_with_nonce.builder,
                 ));
@@ -644,7 +643,17 @@ pub(super) fn handle_confirmation_result<'a>(
                 );
                 match try_jit_mint_initialization(state, txn_id, instruction.clone()).await {
                     JitOutcome::Retry(new_instruction) => {
-                        // Journal the signature before broadcast
+                        let Some(lease) = ctx.deposit_claim_lease else {
+                            metrics::OPERATOR_TRANSACTION_ERRORS
+                                .with_label_values(&[pt, "jit_missing_claim_lease"])
+                                .inc();
+                            warn!(
+                                transaction_id = txn_id,
+                                "JIT retry missing deposit claim lease; leaving row Processing for recovery",
+                            );
+                            return;
+                        };
+                        // Journal the retry signature through the ownership claim before broadcast.
                         // Awaited inline since this rare retry is already off the hot path.
                         match Arc::clone(&state.semaphore).try_acquire_owned() {
                             Ok(permit) => {
@@ -663,9 +672,9 @@ pub(super) fn handle_confirmation_result<'a>(
                                     retry_policy,
                                     mint_extra_error_checks_policy(),
                                     storage_tx.clone(),
-                                    SendDurability::Recoverable,
-                                    // Plain persist: already owned by the bounded first claim.
-                                    None,
+                                    SendDurability::Recoverable {
+                                        deposit_expected_updated_at: lease,
+                                    },
                                     permit,
                                 )
                                 .await;
@@ -1170,10 +1179,7 @@ pub(super) fn spawn_fire_and_store(
     retry_policy: RetryPolicy,
     extra_error_checks_policy: ExtraErrorCheckPolicy,
     storage_tx: mpsc::Sender<TransactionStatusUpdate>,
-    // Recoverable only for a real user-fund Mint
     durability: SendDurability,
-    // Deposit first-fire ownership token; `None` for the JIT re-fire and InitializeMint.
-    deposit_expected_updated_at: Option<chrono::DateTime<chrono::Utc>>,
 ) -> bool {
     let permit = match Arc::clone(&state.semaphore).try_acquire_owned() {
         Ok(p) => p,
@@ -1207,7 +1213,6 @@ pub(super) fn spawn_fire_and_store(
         extra_error_checks_policy,
         storage_tx,
         durability,
-        deposit_expected_updated_at,
         permit,
     ));
 
@@ -1231,14 +1236,9 @@ pub(super) async fn fire_and_store_task(
     extra_error_checks_policy: ExtraErrorCheckPolicy,
     storage_tx: mpsc::Sender<TransactionStatusUpdate>,
     durability: SendDurability,
-    // For a deposit's first mint attempt, this is the row's `updated_at` from
-    // fetch time. Before broadcasting we check the row still has it; if it
-    // changed, recovery requeued the row and we drop the mint instead of sending
-    // a duplicate. `None` skips the check (the JIT retry, which claimed the row
-    // moments earlier).
-    deposit_expected_updated_at: Option<chrono::DateTime<chrono::Utc>>,
     permit: OwnedSemaphorePermit,
 ) {
+    let mut ctx = ctx;
     let pt = program_type.as_label();
     let send_start = std::time::Instant::now();
 
@@ -1264,7 +1264,7 @@ pub(super) async fn fire_and_store_task(
             // sees no signature and re-mints it. Terminal sends (InitializeMint) mint
             // no balance, so fail fast.
             match durability {
-                SendDurability::Recoverable => {
+                SendDurability::Recoverable { .. } => {
                     metrics::OPERATOR_TRANSACTION_ERRORS
                         .with_label_values(&[pt, "left_processing_for_recovery"])
                         .inc();
@@ -1283,79 +1283,59 @@ pub(super) async fn fire_and_store_task(
         }
     };
 
-    let persisted = if durability == SendDurability::Recoverable {
-        let Some(txid) = ctx.transaction_id else {
-            // Persist required but no transaction_id to key on: abort before broadcasting an unrecoverable mint.
-            drop(permit);
-            metrics::OPERATOR_TRANSACTION_ERRORS
-                .with_label_values(&[pt, "pre_send_persist_error"])
-                .inc();
-            error!("Persist required but transaction has no id; aborting before broadcast");
-            return;
-        };
-        match deposit_expected_updated_at {
-            // Deposit first-fire: the persist doubles as an ownership claim,
-            // since the builder may have waited behind the cap long enough for
-            // recovery to demote the row. A lost claim drops it without broadcast.
-            Some(expected) => {
-                match storage
-                    .claim_and_persist_deposit_signature(
-                        txid,
-                        expected,
-                        signature.to_string(),
-                        last_valid_block_height as i64,
-                    )
-                    .await
-                {
-                    Ok(true) => true,
-                    Ok(false) => {
-                        drop(permit);
-                        metrics::OPERATOR_TRANSACTION_ERRORS
-                            .with_label_values(&[pt, "deposit_ownership_lost"])
-                            .inc();
-                        warn!(
-                            transaction_id = txid,
-                            signature = %signature,
-                            "Deposit ownership lost before broadcast; dropping stale builder without minting",
-                        );
-                        return;
-                    }
-                    Err(e) => {
-                        drop(permit);
-                        metrics::OPERATOR_TRANSACTION_ERRORS
-                            .with_label_values(&[pt, "pre_send_persist_error"])
-                            .inc();
-                        error!(
-                            transaction_id = txid,
-                            signature = %signature,
-                            "Aborting before broadcast, leaving row Processing for recovery: {e}",
-                        );
-                        return;
-                    }
-                }
-            }
-            // JIT re-fire: plain write-ahead insert. It runs only after a
-            // successful first claim, within a window far shorter than the
-            // recovery staleness threshold, so the row is provably still ours.
-            None => {
-                if persist_signature_or_abort(
-                    &storage,
-                    pt,
+    let persisted = match durability {
+        SendDurability::Recoverable {
+            deposit_expected_updated_at,
+        } => {
+            let Some(txid) = ctx.transaction_id else {
+                // Persist required but no transaction_id to key on: abort before broadcasting an unrecoverable mint.
+                drop(permit);
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[pt, "pre_send_persist_error"])
+                    .inc();
+                error!("Persist required but transaction has no id; aborting before broadcast");
+                return;
+            };
+            match storage
+                .claim_and_persist_deposit_signature(
                     txid,
-                    &signature,
-                    last_valid_block_height,
+                    deposit_expected_updated_at,
+                    signature.to_string(),
+                    last_valid_block_height as i64,
                 )
                 .await
-                .is_err()
-                {
+            {
+                Ok(Some(lease)) => {
+                    ctx.deposit_claim_lease = Some(lease);
+                    true
+                }
+                Ok(None) => {
                     drop(permit);
+                    metrics::OPERATOR_TRANSACTION_ERRORS
+                        .with_label_values(&[pt, "deposit_ownership_lost"])
+                        .inc();
+                    warn!(
+                        transaction_id = txid,
+                        signature = %signature,
+                        "Deposit ownership lost before broadcast; dropping stale builder without minting",
+                    );
                     return;
                 }
-                true
+                Err(e) => {
+                    drop(permit);
+                    metrics::OPERATOR_TRANSACTION_ERRORS
+                        .with_label_values(&[pt, "pre_send_persist_error"])
+                        .inc();
+                    error!(
+                        transaction_id = txid,
+                        signature = %signature,
+                        "Aborting before broadcast, leaving row Processing for recovery: {e}",
+                    );
+                    return;
+                }
             }
         }
-    } else {
-        false
+        SendDurability::Terminal => false,
     };
 
     match send_signed(&rpc_client, &transaction, retry_policy).await {
@@ -1902,6 +1882,7 @@ mod tests {
             transaction_id: Some(42),
             withdrawal_nonce: None, // not a withdrawal
             trace_id: Some("trace-42".to_string()),
+            deposit_claim_lease: None,
         };
 
         handle_permanent_failure(&mut state, &ctx, &storage_tx, "some error").await;
@@ -1923,6 +1904,7 @@ mod tests {
             transaction_id: Some(7),
             withdrawal_nonce: Some(99),
             trace_id: Some("trace-7".to_string()),
+            deposit_claim_lease: None,
         };
 
         handle_permanent_failure(&mut state, &ctx, &storage_tx, "max retries").await;
@@ -1953,6 +1935,7 @@ mod tests {
             transaction_id: Some(10),
             withdrawal_nonce: Some(5),
             trace_id: Some("trace-10".to_string()),
+            deposit_claim_lease: None,
         };
 
         handle_permanent_failure(&mut state, &ctx, &storage_tx, "release_funds failed").await;
@@ -1991,6 +1974,7 @@ mod tests {
             transaction_id: Some(10),
             withdrawal_nonce: Some(5),
             trace_id: Some("trace-10".to_string()),
+            deposit_claim_lease: None,
         };
 
         handle_permanent_failure(&mut state, &ctx, &storage_tx, "rpc send error").await;
@@ -2131,6 +2115,7 @@ mod tests {
             transaction_id: Some(50),
             withdrawal_nonce: Some(3),
             trace_id: Some("trace-50".to_string()),
+            deposit_claim_lease: None,
         };
         smt.nonce_to_builder
             .insert(3, (ctx.clone(), ReleaseFundsBuilder::new()));
@@ -2207,6 +2192,7 @@ mod tests {
             transaction_id: Some(txn_id),
             withdrawal_nonce: Some(nonce),
             trace_id: Some(format!("trace-{txn_id}")),
+            deposit_claim_lease: None,
         }
     }
 
@@ -2775,6 +2761,7 @@ mod tests {
             transaction_id: Some(10),
             withdrawal_nonce: Some(5),
             trace_id: Some("trace-10".to_string()),
+            deposit_claim_lease: None,
         };
 
         let before = Utc::now();
@@ -2878,6 +2865,7 @@ mod tests {
             transaction_id: Some(10),
             withdrawal_nonce: Some(5),
             trace_id: Some("trace-10".to_string()),
+            deposit_claim_lease: None,
         };
 
         handle_permanent_failure(&mut state, &ctx, &storage_tx, "release_funds failed").await;
@@ -2905,6 +2893,7 @@ mod tests {
             transaction_id: Some(42),
             withdrawal_nonce: None,
             trace_id: Some("trace-1".to_string()),
+            deposit_claim_lease: None,
         };
 
         send_fatal_error(&tx, &ctx, "test error").await;
@@ -2925,6 +2914,7 @@ mod tests {
             transaction_id: None,
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         send_fatal_error(&tx, &ctx, "test error").await;
@@ -2943,6 +2933,7 @@ mod tests {
             transaction_id: Some(7),
             withdrawal_nonce: None,
             trace_id: Some("trace-mint".to_string()),
+            deposit_claim_lease: None,
         };
         let sig = Signature::new_unique();
 
@@ -2974,6 +2965,7 @@ mod tests {
             transaction_id: None,
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
         let sig = Signature::new_unique();
 
@@ -3004,6 +2996,7 @@ mod tests {
             transaction_id: Some(99),
             withdrawal_nonce: Some(5),
             trace_id: Some("trace-wd".to_string()),
+            deposit_claim_lease: None,
         };
         let sig = Signature::new_unique();
 
@@ -3031,6 +3024,7 @@ mod tests {
             transaction_id: Some(10),
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         handle_confirmation_result(
@@ -3068,6 +3062,7 @@ mod tests {
             transaction_id: Some(11),
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         handle_confirmation_result(
@@ -3140,6 +3135,7 @@ mod tests {
             transaction_id: None,
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         handle_confirmation_result(
@@ -3207,6 +3203,7 @@ mod tests {
             transaction_id: None,
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         handle_confirmation_result(
@@ -3243,6 +3240,7 @@ mod tests {
             transaction_id: Some(12),
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         handle_confirmation_result(
@@ -3278,6 +3276,7 @@ mod tests {
             transaction_id: Some(13),
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         let rpc_err = Box::new(
@@ -3326,6 +3325,7 @@ mod tests {
             transaction_id: Some(14),
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         handle_confirmation_result(
@@ -3358,6 +3358,7 @@ mod tests {
             transaction_id: None,
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         handle_confirmation_result(
@@ -3392,6 +3393,7 @@ mod tests {
             transaction_id: Some(20),
             withdrawal_nonce: Some(5),
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         send_and_confirm(
@@ -3429,6 +3431,7 @@ mod tests {
             transaction_id: Some(30),
             withdrawal_nonce: Some(2),
             trace_id: Some("trace-confirmed".to_string()),
+            deposit_claim_lease: None,
         };
         let sig = Signature::new_unique();
 
@@ -3464,6 +3467,7 @@ mod tests {
             transaction_id: Some(15),
             withdrawal_nonce: None, // No nonce → rebuild_with_regenerated_proof returns None
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         handle_confirmation_result(
@@ -3581,6 +3585,7 @@ mod tests {
             transaction_id: Some(42),
             withdrawal_nonce: None,
             trace_id: Some("trace-fire".to_string()),
+            deposit_claim_lease: None,
         };
 
         fire_and_store(
@@ -3706,6 +3711,7 @@ mod tests {
             transaction_id: Some(55),
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         fire_and_store(
@@ -3746,6 +3752,7 @@ mod tests {
                 transaction_id: Some(txn_id),
                 withdrawal_nonce: None,
                 trace_id: Some(format!("trace-{txn_id}")),
+                deposit_claim_lease: None,
             },
             instruction: dummy_instruction(),
             compute_unit_price: None,
@@ -4371,70 +4378,24 @@ mod tests {
             transaction_id: Some(txn_id),
             withdrawal_nonce: None,
             trace_id: Some(format!("trace-{txn_id}")),
+            deposit_claim_lease: None,
         }
     }
 
-    /// A persisting (Mint) fire-and-store run writes the signed transaction's signature
-    /// via `insert_release_signature` and then broadcasts that same signature.
-    #[tokio::test]
-    async fn mint_persists_signature_before_send() {
-        let mut server = mockito::Server::new_async().await;
-        let _hash = mock_blockhash(&mut server);
-        let send = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "method": "sendTransaction"
-            })))
-            .with_status(200)
-            .with_body(
-                serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": Signature::default().to_string()
-                })
-                .to_string(),
-            )
-            .expect(1)
-            .create();
+    fn mint_ctx_with_lease(
+        txn_id: i64,
+        lease: chrono::DateTime<chrono::Utc>,
+    ) -> TransactionContext {
+        TransactionContext {
+            deposit_claim_lease: Some(lease),
+            ..mint_ctx(txn_id)
+        }
+    }
 
-        let state = make_sender_state_with_server(&server.url());
-        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
-        let (storage_tx, _rx) = mpsc::channel(10);
-
-        fire_and_store_task(
-            state.rpc_client.clone(),
-            state.storage.clone(),
-            state.in_flight.clone(),
-            state.program_type,
-            dummy_instruction(),
-            None,
-            mint_ctx(77),
-            RetryPolicy::None,
-            ExtraErrorCheckPolicy::None,
-            storage_tx,
-            SendDurability::Recoverable,
-            None,
-            permit,
-        )
-        .await;
-
-        send.assert();
-        let Storage::Mock(ref mock) = *state.storage else {
-            panic!("expected mock storage");
-        };
-        let stored = mock.get_release_signatures(77).await.unwrap();
-        assert_eq!(stored.len(), 1, "exactly one mint signature persisted");
-        assert_eq!(
-            stored[0].0,
-            Signature::default().to_string(),
-            "persisted signature must be the broadcast signature"
-        );
-        assert_eq!(stored[0].1, 100, "persisted lvbh must match the blockhash");
-        assert_eq!(
-            state.in_flight.len(),
-            1,
-            "successful broadcast stashes the in-flight tx"
-        );
+    fn recoverable(lease: chrono::DateTime<chrono::Utc>) -> SendDurability {
+        SendDurability::Recoverable {
+            deposit_expected_updated_at: lease,
+        }
     }
 
     /// A failed write-ahead persist on the mint path must NOT broadcast, must stash no
@@ -4455,6 +4416,8 @@ mod tests {
         let Storage::Mock(ref mock) = *state.storage else {
             panic!("expected mock storage");
         };
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Processing, t_lock);
         mock.set_should_fail("insert_release_signature", true);
         let permit = state.semaphore.clone().try_acquire_owned().unwrap();
         let before = state.semaphore.available_permits();
@@ -4471,8 +4434,7 @@ mod tests {
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
             storage_tx,
-            SendDurability::Recoverable,
-            None,
+            recoverable(t_lock),
             permit,
         )
         .await;
@@ -4518,6 +4480,8 @@ mod tests {
             .create();
 
         let state = make_sender_state_with_server(&server.url());
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Processing, t_lock);
         let permit = state.semaphore.clone().try_acquire_owned().unwrap();
         let before = state.semaphore.available_permits();
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
@@ -4533,8 +4497,7 @@ mod tests {
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
             storage_tx,
-            SendDurability::Recoverable,
-            None,
+            recoverable(t_lock),
             permit,
         )
         .await;
@@ -4602,8 +4565,7 @@ mod tests {
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
             storage_tx,
-            SendDurability::Recoverable,
-            None,
+            recoverable(Utc::now()),
             permit,
         )
         .await;
@@ -4738,7 +4700,9 @@ mod tests {
 
         let mut state = make_sender_state_with_server(&server.url());
         seed_mint_builder(&mut state, 77, Pubkey::new_unique());
-        let ctx = mint_ctx(77);
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Processing, t_lock);
+        let ctx = mint_ctx_with_lease(77, t_lock);
         let (storage_tx, _rx) = mpsc::channel(10);
 
         handle_confirmation_result(
@@ -4775,6 +4739,13 @@ mod tests {
             state.in_flight.entries.lock().unwrap()[0].persisted,
             "the stashed JIT-retry tx must be marked persisted"
         );
+        let stashed_lease = state.in_flight.entries.lock().unwrap()[0]
+            .ctx
+            .deposit_claim_lease;
+        assert!(
+            stashed_lease.is_some_and(|lease| lease != t_lock),
+            "the stashed JIT-retry ctx must carry the advanced claim lease"
+        );
     }
 
     /// A failed write-ahead persist on the JIT retry must abort before
@@ -4802,9 +4773,11 @@ mod tests {
         let Storage::Mock(ref mock) = *state.storage else {
             panic!("expected mock storage");
         };
-        mock.set_should_fail("insert_release_signature", true);
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Processing, t_lock);
+        mock.set_should_fail("claim_and_persist_deposit_signature", true);
         let before = state.semaphore.available_permits();
-        let ctx = mint_ctx(77);
+        let ctx = mint_ctx_with_lease(77, t_lock);
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         handle_confirmation_result(
@@ -4836,6 +4809,135 @@ mod tests {
         );
     }
 
+    /// A JIT retry with no carried ownership lease must fail closed: no
+    /// signature, no broadcast, no status update, and the row remains for
+    /// recovery. This is defensive; normal deposit mints get the lease from the
+    /// first successful claim.
+    #[tokio::test]
+    async fn jit_refire_missing_lease_fails_closed() {
+        use crate::operator::SignerUtil;
+
+        ensure_test_signer();
+        let mut server = mockito::Server::new_async().await;
+        let admin = SignerUtil::admin_signer().pubkey();
+        let _acct = mock_get_account_info_mint(&mut server, admin);
+        let send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .expect(0)
+            .create();
+
+        let mut state = make_sender_state_with_server(&server.url());
+        seed_mint_builder(&mut state, 77, Pubkey::new_unique());
+        let metric = metrics::OPERATOR_TRANSACTION_ERRORS
+            .with_label_values(&[state.program_type.as_label(), "jit_missing_claim_lease"]);
+        let before_metric = metric.get();
+        let ctx = mint_ctx(77);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        handle_confirmation_result(
+            &mut state,
+            Ok(ConfirmationResult::MintNotInitialized),
+            Signature::new_unique(),
+            None,
+            &ctx,
+            dummy_instruction(),
+            RetryPolicy::None,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        send.assert();
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        assert!(
+            mock.get_release_signatures(77).await.unwrap().is_empty(),
+            "missing lease path must journal nothing"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "missing lease path must leave the row Processing"
+        );
+        assert!(state.in_flight.is_empty(), "missing lease stashes nothing");
+        assert_eq!(
+            metric.get(),
+            before_metric + 1.0,
+            "missing lease increments jit_missing_claim_lease"
+        );
+    }
+
+    /// A stale JIT retry lease means recovery or a new incarnation owns the row.
+    /// The re-fire must drop without journaling or broadcasting.
+    #[tokio::test]
+    async fn jit_refire_aborts_when_ownership_lost() {
+        use crate::operator::SignerUtil;
+
+        ensure_test_signer();
+        let mut server = mockito::Server::new_async().await;
+        let admin = SignerUtil::admin_signer().pubkey();
+        let _acct = mock_get_account_info_mint(&mut server, admin);
+        let _hash = mock_blockhash(&mut server);
+        let send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .expect(0)
+            .create();
+
+        let mut state = make_sender_state_with_server(&server.url());
+        seed_mint_builder(&mut state, 77, Pubkey::new_unique());
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Pending, t_lock);
+        let metric = metrics::OPERATOR_TRANSACTION_ERRORS
+            .with_label_values(&[state.program_type.as_label(), "deposit_ownership_lost"]);
+        let before_metric = metric.get();
+        let before_permits = state.semaphore.available_permits();
+        let ctx = mint_ctx_with_lease(77, t_lock);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        handle_confirmation_result(
+            &mut state,
+            Ok(ConfirmationResult::MintNotInitialized),
+            Signature::new_unique(),
+            None,
+            &ctx,
+            dummy_instruction(),
+            RetryPolicy::None,
+            &ExtraErrorCheckPolicy::None,
+            &storage_tx,
+        )
+        .await;
+
+        send.assert();
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        assert!(
+            mock.get_release_signatures(77).await.unwrap().is_empty(),
+            "lost JIT claim must persist no retry signature"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "lost JIT claim writes no status"
+        );
+        assert!(state.in_flight.is_empty(), "lost JIT claim stashes nothing");
+        assert_eq!(
+            state.semaphore.available_permits(),
+            before_permits,
+            "the acquired JIT permit must be released on lost claim"
+        );
+        assert_eq!(
+            metric.get(),
+            before_metric + 1.0,
+            "lost JIT claim increments deposit_ownership_lost"
+        );
+    }
+
     /// When the in-flight cap is reached, the JIT retry must not broadcast
     /// (nothing journaled, no status update, nothing stashed) so the row is left
     /// Processing for recovery.
@@ -4858,6 +4960,8 @@ mod tests {
 
         let mut state = make_sender_state_with_server(&server.url());
         seed_mint_builder(&mut state, 77, Pubkey::new_unique());
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Processing, t_lock);
 
         // Drain every permit and hold them so the JIT retry can't acquire one.
         let _held: Vec<_> = (0..MAX_IN_FLIGHT)
@@ -4865,7 +4969,7 @@ mod tests {
             .collect();
         assert_eq!(state.semaphore.available_permits(), 0);
 
-        let ctx = mint_ctx(77);
+        let ctx = mint_ctx_with_lease(77, t_lock);
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         handle_confirmation_result(
@@ -4961,12 +5065,14 @@ mod tests {
 
         let mut state = make_sender_state_with_server(&server.url());
         seed_mint_builder(&mut state, 77, Pubkey::new_unique());
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Processing, t_lock);
 
         // Parent in-flight tx holds a permit drawn from the state semaphore and carries
         // the mint policy so route_poll_results classifies MintNotInitialized.
         let parent = super::super::types::InFlightTx {
             signature: sig,
-            ctx: mint_ctx(77),
+            ctx: mint_ctx_with_lease(77, t_lock),
             instruction: dummy_instruction(),
             compute_unit_price: None,
             retry_policy: RetryPolicy::None,
@@ -5059,6 +5165,7 @@ mod tests {
             transaction_id: Some(909),
             withdrawal_nonce: None,
             trace_id: Some("trace-init".to_string()),
+            deposit_claim_lease: None,
         };
 
         fire_and_store_task(
@@ -5073,7 +5180,6 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             storage_tx,
             SendDurability::Terminal,
-            None,
             permit,
         )
         .await;
@@ -5174,8 +5280,7 @@ mod tests {
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
             storage_tx,
-            SendDurability::Recoverable,
-            Some(t_lock),
+            recoverable(t_lock),
             permit,
         )
         .await;
@@ -5250,8 +5355,7 @@ mod tests {
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
             storage_tx,
-            SendDurability::Recoverable,
-            Some(t_lock),
+            recoverable(t_lock),
             permit,
         )
         .await;
@@ -5270,6 +5374,13 @@ mod tests {
         );
         let after = mock.pending_transactions.lock().unwrap()[0].updated_at;
         assert_ne!(after, t_lock, "a successful claim bumps updated_at");
+        assert_eq!(
+            state.in_flight.entries.lock().unwrap()[0]
+                .ctx
+                .deposit_claim_lease,
+            Some(after),
+            "the in-flight context carries the next ownership lease"
+        );
     }
 
     // ── spawn_fire_and_store: cap enforcement ─────────────────────────
@@ -5293,6 +5404,7 @@ mod tests {
             transaction_id: Some(9999),
             withdrawal_nonce: None,
             trace_id: None,
+            deposit_claim_lease: None,
         };
 
         let result = spawn_fire_and_store(
@@ -5304,7 +5416,6 @@ mod tests {
             ExtraErrorCheckPolicy::None,
             storage_tx,
             SendDurability::Terminal,
-            None,
         );
 
         assert!(!result, "must return false when at capacity");
@@ -5333,12 +5444,12 @@ mod tests {
                 transaction_id: Some(1),
                 withdrawal_nonce: None,
                 trace_id: None,
+                deposit_claim_lease: None,
             },
             RetryPolicy::None,
             ExtraErrorCheckPolicy::None,
             storage_tx,
             SendDurability::Terminal,
-            None,
         );
 
         assert!(result, "must return true when capacity is available");
@@ -5498,6 +5609,7 @@ mod tests {
                 transaction_id: Some(1),
                 withdrawal_nonce: Some(nonce),
                 trace_id: Some("t".to_string()),
+                deposit_claim_lease: None,
             },
             remint_info: WithdrawalRemintInfo {
                 transaction_id: 1,

--- a/indexer/src/operator/sender/types.rs
+++ b/indexer/src/operator/sender/types.rs
@@ -81,18 +81,28 @@ pub struct TransactionContext {
     pub transaction_id: Option<i64>,
     pub withdrawal_nonce: Option<u64>,
     pub trace_id: Option<String>,
+    /// Ownership lease from this deposit's most recent successful claim (the
+    /// row's post-claim `updated_at`). A JIT re-fire must present it to the
+    /// next claim before broadcasting again.
+    pub deposit_claim_lease: Option<DateTime<Utc>>,
 }
 
 /// How a fire-and-store send is handled, decided by whether it carries user value.
 ///
-/// `Recoverable` (value-bearing user `Mint`): journal the signature before broadcast, and
-/// on a pre-broadcast build/sign failure leave the row Processing for recovery.
+/// `Recoverable` (a user `Mint`, which moves value): before broadcasting, the
+/// signature is recorded by an atomic claim that also proves the sender still
+/// owns the row. If build or sign fails before broadcast, the row is left
+/// Processing so recovery re-mints it. If another writer changed the row first,
+/// the claim fails and the send is skipped; that only delays the mint until
+/// recovery retries, it never double-mints.
 ///
 /// `Terminal` (`InitializeMint`): mints no balance and is on-chain idempotent, so no
 /// journal, and a build/sign failure fails fast.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SendDurability {
-    Recoverable,
+    Recoverable {
+        deposit_expected_updated_at: DateTime<Utc>,
+    },
     Terminal,
 }
 

--- a/indexer/src/operator/utils/instruction_util.rs
+++ b/indexer/src/operator/utils/instruction_util.rs
@@ -196,16 +196,6 @@ impl TransactionBuilder {
         }
     }
 
-    /// The fetch-time ownership token, present only for a deposit `Mint`. The
-    /// sender CASes on it at the write-ahead persist; other variants have no
-    /// such token so they take the plain-insert path.
-    pub fn fetched_updated_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
-        match self {
-            Self::Mint(b) => Some(b.fetched_updated_at),
-            Self::ReleaseFunds(_) | Self::InitializeMint(_) | Self::ResetSmtRoot(_) => None,
-        }
-    }
-
     pub fn withdrawal_nonce(&self) -> Option<u64> {
         match self {
             Self::ReleaseFunds(builder) => Some(builder.nonce),
@@ -648,15 +638,6 @@ mod tests {
             Some("trace-mint".to_string())
         );
         assert_eq!(make_reset_smt_builder().trace_id(), None);
-    }
-
-    #[test]
-    fn fetched_updated_at_some_only_for_mint() {
-        // Only a deposit Mint carries the ownership token the sender CASes on.
-        assert!(make_mint_builder().fetched_updated_at().is_some());
-        assert!(make_release_funds_builder().fetched_updated_at().is_none());
-        assert!(make_init_mint_builder().fetched_updated_at().is_none());
-        assert!(make_reset_smt_builder().fetched_updated_at().is_none());
     }
 
     #[test]

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -490,16 +490,18 @@ impl Storage {
     }
 
     /// Atomically claim a `Processing` deposit (CAS on `updated_at`) and persist
-    /// its broadcast signature in one transaction. `Ok(true)` means the sender
-    /// still owns the row and may broadcast; `Ok(false)` means it was demoted or
-    /// re-locked, so the builder must be dropped without broadcasting.
+    /// its broadcast signature in one transaction. `Ok(Some(lease))` means the
+    /// sender still owns the row and may broadcast; the returned lease is the
+    /// row's new `updated_at`, which a later re-claim must present. `Ok(None)`
+    /// means the row was demoted or re-locked, so the builder must be dropped
+    /// without broadcasting.
     pub async fn claim_and_persist_deposit_signature(
         &self,
         transaction_id: i64,
         expected_updated_at: chrono::DateTime<chrono::Utc>,
         signature: String,
         last_valid_block_height: i64,
-    ) -> Result<bool, StorageError> {
+    ) -> Result<Option<chrono::DateTime<chrono::Utc>>, StorageError> {
         claim_and_persist_deposit_signature::claim_and_persist_deposit_signature(
             self,
             transaction_id,
@@ -743,18 +745,19 @@ mod tests {
     }
 
     /// Owned row (Processing, matching token): claim succeeds, the signature is
-    /// persisted, and `updated_at` advances (the D3 bump).
+    /// persisted, and `updated_at` advances. The returned lease must equal the
+    /// row's new `updated_at`, making it usable as the next CAS token.
     #[tokio::test]
     async fn claim_succeeds_when_owned() {
         let (storage, mock) = make_mock_storage();
         let t0 = Utc::now();
         seed_claim_row(&mock, 1, TransactionStatus::Processing, t0);
 
-        let claimed = storage
+        let lease = storage
             .claim_and_persist_deposit_signature(1, t0, "sig-owned".to_string(), 100)
             .await
-            .unwrap();
-        assert!(claimed, "owning the Processing incarnation must claim");
+            .unwrap()
+            .expect("owning the Processing incarnation must claim");
 
         let sigs = storage.get_release_signatures(1).await.unwrap();
         assert_eq!(sigs.len(), 1, "the broadcast signature must be persisted");
@@ -762,6 +765,10 @@ mod tests {
 
         let after = mock.pending_transactions.lock().unwrap()[0].updated_at;
         assert_ne!(after, t0, "a successful claim must bump updated_at");
+        assert_eq!(
+            lease, after,
+            "the returned lease must equal the row's new updated_at"
+        );
     }
 
     /// Recovery already demoted the row to Pending: the claim must abort and
@@ -776,7 +783,7 @@ mod tests {
             .claim_and_persist_deposit_signature(1, t0, "sig-demoted".to_string(), 100)
             .await
             .unwrap();
-        assert!(!claimed, "a demoted row must not be claimable");
+        assert!(claimed.is_none(), "a demoted row must not be claimable");
         assert!(
             storage.get_release_signatures(1).await.unwrap().is_empty(),
             "no signature may be persisted on a lost claim"
@@ -797,7 +804,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            !claimed,
+            claimed.is_none(),
             "a stale token must not claim the re-locked incarnation"
         );
         assert!(storage.get_release_signatures(1).await.unwrap().is_empty());
@@ -814,7 +821,7 @@ mod tests {
             .claim_and_persist_deposit_signature(1, t0, "sig-terminal".to_string(), 100)
             .await
             .unwrap();
-        assert!(!claimed, "a terminal row must not be claimable");
+        assert!(claimed.is_none(), "a terminal row must not be claimable");
         assert!(storage.get_release_signatures(1).await.unwrap().is_empty());
     }
 

--- a/indexer/src/storage/common/storage/claim_and_persist_deposit_signature.rs
+++ b/indexer/src/storage/common/storage/claim_and_persist_deposit_signature.rs
@@ -1,16 +1,17 @@
 use crate::{error::StorageError, storage::common::storage::Storage};
 
 /// Atomic ownership claim + write-ahead signature persist for a deposit mint.
-/// `Ok(true)` means the sender still owns the `Processing` incarnation it was
-/// handed and may broadcast; `Ok(false)` means the row was demoted or re-locked
-/// so the builder must be dropped without broadcasting.
+/// `Ok(Some(lease))` means the sender still owns the `Processing` incarnation
+/// it was handed and may broadcast; the returned lease is the row's new
+/// `updated_at`, which a later re-claim must present. `Ok(None)` means the row
+/// was demoted or re-locked so the builder must be dropped without broadcasting.
 pub async fn claim_and_persist_deposit_signature(
     storage: &Storage,
     transaction_id: i64,
     expected_updated_at: chrono::DateTime<chrono::Utc>,
     signature: String,
     last_valid_block_height: i64,
-) -> Result<bool, StorageError> {
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
             .claim_and_persist_deposit_signature_internal(

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -919,38 +919,48 @@ impl MockStorage {
     /// Mirror `claim_and_persist_deposit_signature_internal`: CAS the row on
     /// `(id, Processing, updated_at)`; on a hit bump `updated_at`, persist the
     /// signature (mirroring the `ON CONFLICT (signature)` dedup) and return
-    /// `Ok(true)`; on a miss return `Ok(false)` and persist nothing.
+    /// `Ok(Some(new_updated_at))`; on a miss return `Ok(None)` and persist
+    /// nothing.
     pub async fn claim_and_persist_deposit_signature(
         &self,
         transaction_id: i64,
         expected_updated_at: DateTime<Utc>,
         signature: String,
         last_valid_block_height: i64,
-    ) -> Result<bool, StorageError> {
+    ) -> Result<Option<DateTime<Utc>>, StorageError> {
         self.check_should_fail("claim_and_persist_deposit_signature")?;
         // Scope the guard so it is released before the await below.
-        let claimed = {
+        let lease = {
             let mut pending = self.pending_transactions.lock().unwrap();
-            match pending.iter_mut().find(|t| {
+            let owned = pending.iter().any(|t| {
                 t.id == transaction_id
                     && t.status == TransactionStatus::Processing
                     && t.updated_at == expected_updated_at
-            }) {
-                Some(txn) => {
-                    txn.updated_at = Utc::now();
-                    true
-                }
-                None => false,
+            });
+            // CAS miss: Postgres updates no row and never reaches the insert.
+            if !owned {
+                return Ok(None);
             }
+            // A simulated insert failure rolls the whole transaction back in
+            // Postgres, so it must abort here with no bump once the row is owned.
+            self.check_should_fail("insert_release_signature")?;
+            let lease = Utc::now();
+            let txn = pending
+                .iter_mut()
+                .find(|t| {
+                    t.id == transaction_id
+                        && t.status == TransactionStatus::Processing
+                        && t.updated_at == expected_updated_at
+                })
+                .expect("row present: ownership checked under the same lock");
+            txn.updated_at = lease;
+            lease
         };
-        if !claimed {
-            return Ok(false);
-        }
 
         // Reuse the write-ahead insert (mirrors the ON CONFLICT (signature) dedup).
         self.insert_release_signature(transaction_id, signature, last_valid_block_height)
             .await?;
-        Ok(true)
+        Ok(Some(lease))
     }
 
     pub async fn get_release_signatures(

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1715,35 +1715,40 @@ impl PostgresDb {
     /// Atomically claim a `Processing` deposit and persist its broadcast
     /// signature in one transaction. The CAS on `updated_at` bumps the row so a
     /// racing recovery demote (also a CAS on that column) loses; sharing one
-    /// transaction leaves no bumped-but-unsigned window. `Ok(false)` means the
-    /// row was demoted or re-locked, so the caller must not broadcast.
+    /// transaction leaves no bumped-but-unsigned window. `Ok(Some(lease))`
+    /// returns the committed post-claim `updated_at`, valid as the next CAS
+    /// token; `Ok(None)` means the row was demoted or re-locked, so the caller
+    /// must not broadcast.
     pub async fn claim_and_persist_deposit_signature_internal(
         &self,
         transaction_id: i64,
         expected_updated_at: chrono::DateTime<chrono::Utc>,
         signature: String,
         last_valid_block_height: i64,
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<Option<chrono::DateTime<chrono::Utc>>, sqlx::Error> {
         let mut tx = self.pool.begin().await?;
 
-        let claimed = sqlx::query(
+        // RETURNING yields the post-trigger committed value, so the lease handed
+        // back is exactly the token a subsequent CAS must present.
+        let claimed = sqlx::query_scalar::<_, chrono::DateTime<chrono::Utc>>(
             r#"
             UPDATE transactions
             SET updated_at = NOW()
             WHERE id = $1
               AND status = 'processing'
               AND updated_at = $2
+            RETURNING updated_at
             "#,
         )
         .bind(transaction_id)
         .bind(expected_updated_at)
-        .execute(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await?;
 
-        if claimed.rows_affected() != 1 {
+        let Some(lease) = claimed else {
             tx.rollback().await?;
-            return Ok(false);
-        }
+            return Ok(None);
+        };
 
         sqlx::query(
             r#"
@@ -1760,7 +1765,7 @@ impl PostgresDb {
         .await?;
 
         tx.commit().await?;
-        Ok(true)
+        Ok(Some(lease))
     }
 
     /// Return a transaction's release signatures as (signature, lvbh).

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -1263,22 +1263,26 @@ async fn claim_is_atomic() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     let token = updated_at_of(&pool, id).await;
 
-    let claimed = storage
+    let epoch = storage
         .claim_and_persist_deposit_signature(id, token, "sig-claim".to_string(), 555)
-        .await?;
-    assert!(claimed, "owning the Processing incarnation must claim");
+        .await?
+        .expect("owning the Processing incarnation must claim");
     let sigs = storage.get_release_signatures(id).await?;
     assert_eq!(sigs.len(), 1, "a successful claim persists exactly one sig");
     assert_eq!(sigs[0], ("sig-claim".to_string(), 555));
     let bumped = updated_at_of(&pool, id).await;
     assert_ne!(bumped, token, "a successful claim bumps updated_at");
+    assert_eq!(
+        epoch, bumped,
+        "the returned epoch must equal the committed post-claim updated_at"
+    );
 
     // A stale token must abort atomically: no new sig, no timestamp change.
     let stale = bumped - chrono::Duration::seconds(60);
     let failed = storage
         .claim_and_persist_deposit_signature(id, stale, "sig-fail".to_string(), 1)
         .await?;
-    assert!(!failed, "a stale token must not claim");
+    assert!(failed.is_none(), "a stale token must not claim");
     assert_eq!(
         storage.get_release_signatures(id).await?.len(),
         1,
@@ -1308,19 +1312,17 @@ async fn claim_dedups_signature_on_conflict() -> Result<(), Box<dyn std::error::
         .await?;
 
     let token1 = updated_at_of(&pool, id).await;
-    assert!(
-        storage
-            .claim_and_persist_deposit_signature(id, token1, "dup-sig".to_string(), 1)
-            .await?
-    );
-    // The first claim bumped updated_at; the second claim owns the new token but
-    // re-inserts the same signature, which must be deduped.
-    let token2 = updated_at_of(&pool, id).await;
-    assert!(
-        storage
-            .claim_and_persist_deposit_signature(id, token2, "dup-sig".to_string(), 999)
-            .await?
-    );
+    let token2 = storage
+        .claim_and_persist_deposit_signature(id, token1, "dup-sig".to_string(), 1)
+        .await?
+        .expect("the first claim must own the fetch-time token");
+    // The first claim's returned epoch is presented directly as the second
+    // claim's token, pinning that a returned epoch is a valid next CAS token.
+    // The re-inserted duplicate signature must be deduped.
+    assert!(storage
+        .claim_and_persist_deposit_signature(id, token2, "dup-sig".to_string(), 999)
+        .await?
+        .is_some());
     assert_eq!(
         storage.get_release_signatures(id).await?.len(),
         1,

--- a/integration/tests/indexer/sender_fixtures.rs
+++ b/integration/tests/indexer/sender_fixtures.rs
@@ -40,6 +40,10 @@ use {
     solana_keychain::SolanaSigner,
     solana_sdk::{commitment_config::CommitmentLevel, pubkey::Pubkey, signature::Keypair},
     spl_associated_token_account::get_associated_token_address_with_program_id,
+    spl_token::{
+        solana_program::{program_option::COption, program_pack::Pack},
+        state::Mint,
+    },
     std::sync::{Arc, Once},
     test_utils::mock_rpc::{MockRpcServer, Reply},
     tokio::sync::mpsc,
@@ -162,7 +166,49 @@ pub fn deposit_ctx(transaction_id: i64) -> TransactionContext {
         transaction_id: Some(transaction_id),
         withdrawal_nonce: None,
         trace_id: Some(format!("trace-{transaction_id}")),
+        deposit_claim_lease: None,
     }
+}
+
+/// `deposit_ctx` carrying the ownership epoch a prior claim returned, so
+/// JIT re-fire tests can present a valid or stale lease token.
+pub fn deposit_ctx_with_lease(
+    transaction_id: i64,
+    epoch: chrono::DateTime<chrono::Utc>,
+) -> TransactionContext {
+    TransactionContext {
+        deposit_claim_lease: Some(epoch),
+        ..deposit_ctx(transaction_id)
+    }
+}
+
+/// Packed SPL `Mint` bytes, initialized, with the supplied mint authority.
+pub fn pack_mint_with_authority(authority: COption<Pubkey>) -> Vec<u8> {
+    let mint = Mint {
+        mint_authority: authority,
+        supply: 0,
+        decimals: 6,
+        is_initialized: true,
+        freeze_authority: COption::None,
+    };
+    let mut data = vec![0u8; Mint::LEN];
+    Mint::pack(mint, &mut data).expect("pack mint");
+    data
+}
+
+/// `getAccountInfo` reply wrapping raw account bytes as an SPL-token-owned account.
+pub fn account_info_reply_bytes(data: &[u8]) -> Reply {
+    Reply::result(json!({
+        "context": { "slot": 100 },
+        "value": {
+            "data": [STANDARD.encode(data), "base64"],
+            "executable": false,
+            "lamports": 1_461_600u64,
+            "owner": spl_token::id().to_string(),
+            "rentEpoch": 0u64,
+            "space": data.len(),
+        }
+    }))
 }
 
 /// Withdrawal-side `TransactionContext`: both fields set, drives the
@@ -173,6 +219,7 @@ pub fn withdrawal_ctx(transaction_id: i64, nonce: u64) -> TransactionContext {
         transaction_id: Some(transaction_id),
         withdrawal_nonce: Some(nonce),
         trace_id: Some(format!("trace-{transaction_id}")),
+        deposit_claim_lease: None,
     }
 }
 

--- a/integration/tests/indexer/sender_fixtures.rs
+++ b/integration/tests/indexer/sender_fixtures.rs
@@ -170,14 +170,14 @@ pub fn deposit_ctx(transaction_id: i64) -> TransactionContext {
     }
 }
 
-/// `deposit_ctx` carrying the ownership epoch a prior claim returned, so
+/// `deposit_ctx` carrying the ownership lease a prior claim returned, so
 /// JIT re-fire tests can present a valid or stale lease token.
 pub fn deposit_ctx_with_lease(
     transaction_id: i64,
-    epoch: chrono::DateTime<chrono::Utc>,
+    lease: chrono::DateTime<chrono::Utc>,
 ) -> TransactionContext {
     TransactionContext {
-        deposit_claim_lease: Some(epoch),
+        deposit_claim_lease: Some(lease),
         ..deposit_ctx(transaction_id)
     }
 }

--- a/integration/tests/indexer/sender_onchain_error_arms.rs
+++ b/integration/tests/indexer/sender_onchain_error_arms.rs
@@ -23,7 +23,6 @@
 mod sender_fixtures;
 
 use {
-    base64::{engine::general_purpose::STANDARD, Engine as _},
     private_channel_escrow_program_client::errors::PrivateChannelEscrowProgramError,
     private_channel_indexer::{
         config::ProgramType,
@@ -42,10 +41,10 @@ use {
         },
     },
     sender_fixtures::{
-        blockhash_reply, build_default_sender_state, confirmed_status_reply, deposit_ctx,
-        ensure_admin_signer_env, make_config, make_instruction, send_transaction_echo_reply,
+        account_info_reply_bytes, blockhash_reply, build_default_sender_state,
+        confirmed_status_reply, deposit_ctx, deposit_ctx_with_lease, ensure_admin_signer_env,
+        make_config, make_instruction, pack_mint_with_authority, send_transaction_echo_reply,
     },
-    serde_json::json,
     solana_keychain::SolanaSigner,
     solana_sdk::{commitment_config::CommitmentLevel, pubkey::Pubkey, signature::Signature},
     spl_token::{
@@ -293,6 +292,26 @@ async fn build_state_for_jit_caller_arm(
     (state, storage_rx, storage_tx, mock, mint)
 }
 
+/// Seed a Processing deposit row in the mock store so JIT re-fire tests have a target.
+fn seed_processing_deposit(
+    storage: &MockStorage,
+    id: i64,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) {
+    use private_channel_indexer::storage::common::models::DbTransactionBuilder;
+    let owner = Pubkey::new_unique().to_string();
+    let mut tx =
+        DbTransactionBuilder::new(format!("sig-{id}"), 1, Pubkey::new_unique().to_string(), 1)
+            .initiator(owner.clone())
+            .recipient(owner)
+            .transaction_type(private_channel_indexer::storage::TransactionType::Deposit)
+            .build();
+    tx.id = id;
+    tx.status = TransactionStatus::Processing;
+    tx.updated_at = updated_at;
+    storage.pending_transactions.lock().unwrap().push(tx);
+}
+
 fn make_mint_builder_for_caller_arm(mint: Pubkey) -> MintToBuilder {
     let mut builder = MintToBuilder::new();
     let admin = SignerUtil::admin_signer().pubkey();
@@ -308,46 +327,24 @@ fn make_mint_builder_for_caller_arm(mint: Pubkey) -> MintToBuilder {
     builder
 }
 
-fn pack_mint_with_authority(authority: COption<Pubkey>) -> Vec<u8> {
-    let mint = Mint {
-        mint_authority: authority,
-        supply: 0,
-        decimals: 6,
-        is_initialized: true,
-        freeze_authority: COption::None,
-    };
-    let mut data = vec![0u8; Mint::LEN];
-    Mint::pack(mint, &mut data).expect("pack mint");
-    data
-}
-
-fn account_info_reply_bytes(data: &[u8]) -> test_utils::mock_rpc::Reply {
-    test_utils::mock_rpc::Reply::result(json!({
-        "context": { "slot": 100 },
-        "value": {
-            "data": [STANDARD.encode(data), "base64"],
-            "executable": false,
-            "lamports": 1_461_600u64,
-            "owner": spl_token::id().to_string(),
-            "rentEpoch": 0u64,
-            "space": data.len(),
-        }
-    }))
-}
-
 /// Drive the caller arm with `Ok(MintNotInitialized)` after seeding the
 /// mint_builders entry. Pulled out so each test reads as a wire-script
-/// + assertions block.
+/// + assertions block. `claim_epoch` is the ownership token the JIT
+/// re-fire presents; only the Retry outcome needs one.
 async fn drive_caller_arm_with_jit_setup(
     state: &mut private_channel_indexer::operator::sender::types::SenderState,
     txn_id: i64,
     mint: Pubkey,
+    claim_epoch: Option<chrono::DateTime<chrono::Utc>>,
     storage_tx: &tokio::sync::mpsc::Sender<TransactionStatusUpdate>,
 ) {
     state
         .mint_builders
         .insert(txn_id, make_mint_builder_for_caller_arm(mint));
-    let ctx = deposit_ctx(txn_id);
+    let ctx = match claim_epoch {
+        Some(epoch) => deposit_ctx_with_lease(txn_id, epoch),
+        None => deposit_ctx(txn_id),
+    };
     test_hooks::handle_confirmation_result(
         state,
         Ok(ConfirmationResult::MintNotInitialized),
@@ -372,6 +369,11 @@ async fn drive_caller_arm_with_jit_setup(
 async fn mint_not_initialized_jit_retry_completes() {
     let (mut state, mut storage_rx, storage_tx, mock, mint) =
         build_state_for_jit_caller_arm(true).await;
+    // Seed a Processing row the re-fire's claim owns via the same t0 the ctx carries.
+    let t0 = chrono::Utc::now();
+    if let Storage::Mock(mock_storage) = &*state.storage {
+        seed_processing_deposit(mock_storage, 5001, t0);
+    }
 
     // JIT pre-check sees admin-owned init, so Retry without sending init.
     let admin_bytes = pack_mint_with_authority(COption::Some(SignerUtil::admin_signer().pubkey()));
@@ -383,7 +385,19 @@ async fn mint_not_initialized_jit_retry_completes() {
     // The subsequent poll cycle confirms the stashed retry.
     mock.enqueue("getSignatureStatuses", confirmed_status_reply());
 
-    drive_caller_arm_with_jit_setup(&mut state, 5001, mint, &storage_tx).await;
+    drive_caller_arm_with_jit_setup(&mut state, 5001, mint, Some(t0), &storage_tx).await;
+
+    if let Storage::Mock(mock_storage) = &*state.storage {
+        assert_eq!(
+            mock_storage
+                .get_release_signatures(5001)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "the owned JIT re-fire journals exactly one retry signature"
+        );
+    }
 
     // The retry is stashed in-flight, not confirmed inline; drive one poll cycle.
     test_hooks::poll_in_flight(&mut state, &storage_tx).await;
@@ -415,7 +429,7 @@ async fn mint_not_initialized_jit_manual_review_authority_mismatch() {
     mock.enqueue("getAccountInfo", account_info_reply_bytes(&foreign_bytes));
 
     let txn_id: i64 = 5002;
-    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, &storage_tx).await;
+    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, None, &storage_tx).await;
 
     let update = storage_rx
         .recv()
@@ -457,7 +471,7 @@ async fn mint_not_initialized_jit_manual_review_corrupt_state() {
     mock.enqueue("getAccountInfo", account_info_reply_bytes(&data));
 
     let txn_id: i64 = 5003;
-    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, &storage_tx).await;
+    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, None, &storage_tx).await;
 
     let update = storage_rx
         .recv()
@@ -489,7 +503,7 @@ async fn mint_not_initialized_jit_permanent_failure() {
     );
 
     let txn_id: i64 = 5004;
-    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, &storage_tx).await;
+    drive_caller_arm_with_jit_setup(&mut state, txn_id, mint, None, &storage_tx).await;
 
     let update = storage_rx
         .recv()
@@ -520,6 +534,7 @@ async fn mint_not_initialized_no_txn_id_routes_to_failed() {
         transaction_id: None,
         withdrawal_nonce: None,
         trace_id: None,
+        deposit_claim_lease: None,
     };
 
     test_hooks::handle_confirmation_result(

--- a/integration/tests/indexer/sender_onchain_error_arms.rs
+++ b/integration/tests/indexer/sender_onchain_error_arms.rs
@@ -328,21 +328,21 @@ fn make_mint_builder_for_caller_arm(mint: Pubkey) -> MintToBuilder {
 }
 
 /// Drive the caller arm with `Ok(MintNotInitialized)` after seeding the
-/// mint_builders entry. Pulled out so each test reads as a wire-script
-/// + assertions block. `claim_epoch` is the ownership token the JIT
-/// re-fire presents; only the Retry outcome needs one.
+/// mint_builders entry. Pulled out so each test reads as a wire-script plus
+/// assertions block. `claim_lease` is the ownership lease the JIT re-fire
+/// presents; only the Retry outcome needs one.
 async fn drive_caller_arm_with_jit_setup(
     state: &mut private_channel_indexer::operator::sender::types::SenderState,
     txn_id: i64,
     mint: Pubkey,
-    claim_epoch: Option<chrono::DateTime<chrono::Utc>>,
+    claim_lease: Option<chrono::DateTime<chrono::Utc>>,
     storage_tx: &tokio::sync::mpsc::Sender<TransactionStatusUpdate>,
 ) {
     state
         .mint_builders
         .insert(txn_id, make_mint_builder_for_caller_arm(mint));
-    let ctx = match claim_epoch {
-        Some(epoch) => deposit_ctx_with_lease(txn_id, epoch),
+    let ctx = match claim_lease {
+        Some(lease) => deposit_ctx_with_lease(txn_id, lease),
         None => deposit_ctx(txn_id),
     };
     test_hooks::handle_confirmation_result(

--- a/integration/tests/indexer/sender_poll_rpc_error.rs
+++ b/integration/tests/indexer/sender_poll_rpc_error.rs
@@ -70,6 +70,7 @@ fn make_in_flight_tx(
             transaction_id: Some(txn_id),
             withdrawal_nonce: None,
             trace_id: Some(format!("trace-{txn_id}")),
+            deposit_claim_lease: None,
         },
         instruction: make_instruction(),
         compute_unit_price: None,

--- a/integration/tests/indexer/sender_rotation_retry.rs
+++ b/integration/tests/indexer/sender_rotation_retry.rs
@@ -73,6 +73,7 @@ async fn rotation_drain_matched_submits() {
             transaction_id: Some(20),
             withdrawal_nonce: Some(nonce),
             trace_id: Some("trace-2".to_string()),
+            deposit_claim_lease: None,
         },
         make_release_funds_builder(nonce),
     ));

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -11,17 +11,20 @@ use {
         operator::{
             recovery::test_hooks,
             sender::{test_hooks as sender_hooks, types::SendDurability, types::SenderState},
-            utils::instruction_util::{ExtraErrorCheckPolicy, RetryPolicy},
+            utils::instruction_util::{ExtraErrorCheckPolicy, MintToBuilder, RetryPolicy},
             utils::rpc_util::{RetryConfig, RpcClientWithRetry},
-            TransactionStatusUpdate,
+            utils::transaction_util::ConfirmationResult,
+            SignerUtil, TransactionStatusUpdate,
         },
         storage::{common::models::DbTransactionBuilder, PostgresDb, Storage, TransactionType},
         PostgresConfig,
     },
     sender_fixtures::{
-        blockhash_reply, deposit_ctx, make_config, make_instruction, send_transaction_echo_reply,
+        account_info_reply_bytes, blockhash_reply, deposit_ctx, deposit_ctx_with_lease,
+        make_config, make_instruction, pack_mint_with_authority, send_transaction_echo_reply,
     },
     serde_json::json,
+    solana_keychain::SolanaSigner,
     solana_sdk::{
         commitment_config::{CommitmentConfig, CommitmentLevel},
         pubkey::Pubkey,
@@ -1229,8 +1232,9 @@ async fn drive_first_fire(
         RetryPolicy::None,
         ExtraErrorCheckPolicy::None,
         storage_tx,
-        SendDurability::Recoverable,
-        Some(token),
+        SendDurability::Recoverable {
+            deposit_expected_updated_at: token,
+        },
     )
     .await;
 }
@@ -1296,16 +1300,14 @@ async fn stale_owned_builder_does_not_double_mint() {
     mock.shutdown().await;
 }
 
-// Bug oracle: the unguarded write-ahead persist (a plain insert with no ownership
-// check) broadcasts a stale mint on a demoted row. This reproduces the reported
-// bug through production code: the mint lands on a Pending row, so its Completed
-// write no-ops (it9) and the row is re-fetched for a second mint (it3). IT1 is the
-// exact contrast: with its ownership token the first-fire broadcasts nothing on the
-// same setup. The JIT re-fire still uses this token-less path but is kept off a
-// demoted row by the bounded confirmation window.
+// The mid-JIT double-mint window, closed: a first mint claims and broadcasts,
+// recovery demotes the row while the JIT verdict is pending, and the JIT
+// re-fire then presents the epoch of its own (now superseded) claim. The
+// re-claim must lose, so nothing new is journaled or broadcast and the row
+// stays with its current owner.
 #[tokio::test(flavor = "multi_thread")]
-async fn unguarded_first_fire_would_broadcast_on_demoted_row() {
-    let (db, url, _container) = start_pg("it_oracle_unguarded").await;
+async fn stale_jit_refire_does_not_double_mint() {
+    let (db, url, _container) = start_pg("it_stale_jit_refire").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -1317,46 +1319,91 @@ async fn unguarded_first_fire_would_broadcast_on_demoted_row() {
         100,
     );
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
-    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    let t_lock = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
 
     let mock = MockRpcServer::start().await;
+    // First fire: build/sign, claim the row, journal one signature, broadcast.
     mock.enqueue("getLatestBlockhash", blockhash_reply());
     mock.enqueue("sendTransaction", send_transaction_echo_reply());
-    let recovery_client = test_client(mock.url());
-    let state = build_pg_sender_state(storage.clone(), mock.url()).await;
+    let mut state = build_pg_sender_state(storage.clone(), mock.url()).await;
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    // Same setup as IT1: recovery demotes the stale row to Pending.
+    drive_first_fire(&state, tx_id, t_lock, &storage_tx).await;
+    assert_eq!(
+        mint_broadcast_count(&mock),
+        1,
+        "the owned first fire broadcasts exactly once"
+    );
+    // The row's committed post-claim updated_at is the epoch the first claim
+    // returned; the JIT re-fire below carries it as its ownership token.
+    let claim_epoch = updated_at_of(&pool, tx_id).await;
+    assert_ne!(claim_epoch, t_lock, "the first claim advances the token");
+
+    // Recovery demotes mid-JIT: age the row past the staleness threshold and
+    // classify the journaled signature dead (null status, expired blockhash,
+    // covered attempt window), so the deposit is requeued to Pending.
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
+    );
+    mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    mock.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
+    let recovery_client = test_client(mock.url());
     test_hooks::run_recovery_once(&storage, &recovery_client, ProgramType::Escrow, &storage_tx)
         .await
         .unwrap();
     assert_eq!(status_of(&pool, tx_id).await, "pending");
+    let sigs_after_demote = db.get_release_signatures_internal(tx_id).await.unwrap();
 
-    // Drive the persist with no ownership token: the token-less (unguarded) path.
-    sender_hooks::run_fire_and_store_task(
-        &state,
+    // The JIT re-fire: MintNotInitialized verdict, pre-check reads an
+    // admin-authority initialized mint (Retry), build/sign gets a blockhash,
+    // then the re-claim runs with the stale epoch and must abort.
+    let mut builder = MintToBuilder::new();
+    builder.mint(Pubkey::new_unique());
+    state.mint_builders.insert(tx_id, builder);
+    let admin_bytes =
+        pack_mint_with_authority(spl_token::solana_program::program_option::COption::Some(
+            SignerUtil::admin_signer().pubkey(),
+        ));
+    mock.enqueue("getAccountInfo", account_info_reply_bytes(&admin_bytes));
+    mock.enqueue("getLatestBlockhash", blockhash_reply());
+
+    let metric = OPERATOR_TRANSACTION_ERRORS.with_label_values(&["escrow", OWNERSHIP_LOST_REASON]);
+    let metric_before = metric.get();
+    let ctx = deposit_ctx_with_lease(tx_id, claim_epoch);
+
+    sender_hooks::handle_confirmation_result(
+        &mut state,
+        Ok(ConfirmationResult::MintNotInitialized),
+        Signature::new_unique(),
+        None,
+        &ctx,
         make_instruction(),
-        None,
-        deposit_ctx(tx_id),
         RetryPolicy::None,
-        ExtraErrorCheckPolicy::None,
+        &ExtraErrorCheckPolicy::None,
         &storage_tx,
-        SendDurability::Recoverable,
-        None,
     )
     .await;
 
     assert_eq!(
         mint_broadcast_count(&mock),
         1,
-        "the token-less path broadcasts a stale mint on a demoted (Pending) row"
+        "the stale JIT re-fire must not broadcast a second mint"
+    );
+    assert_eq!(
+        db.get_release_signatures_internal(tx_id).await.unwrap(),
+        sigs_after_demote,
+        "a lost JIT claim journals no new signature"
+    );
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "pending",
+        "the lost claim leaves the row to its current owner"
     );
     assert!(
-        !db.get_release_signatures_internal(tx_id)
-            .await
-            .unwrap()
-            .is_empty(),
-        "the token-less path persists a signature against a Pending row"
+        metric.get() > metric_before,
+        "a lost JIT claim increments deposit_ownership_lost"
     );
     mock.shutdown().await;
 }

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1302,7 +1302,7 @@ async fn stale_owned_builder_does_not_double_mint() {
 
 // The mid-JIT double-mint window, closed: a first mint claims and broadcasts,
 // recovery demotes the row while the JIT verdict is pending, and the JIT
-// re-fire then presents the epoch of its own (now superseded) claim. The
+// re-fire then presents the lease of its own (now superseded) claim. The
 // re-claim must lose, so nothing new is journaled or broadcast and the row
 // stays with its current owner.
 #[tokio::test(flavor = "multi_thread")]
@@ -1334,10 +1334,10 @@ async fn stale_jit_refire_does_not_double_mint() {
         1,
         "the owned first fire broadcasts exactly once"
     );
-    // The row's committed post-claim updated_at is the epoch the first claim
+    // The row's committed post-claim updated_at is the lease the first claim
     // returned; the JIT re-fire below carries it as its ownership token.
-    let claim_epoch = updated_at_of(&pool, tx_id).await;
-    assert_ne!(claim_epoch, t_lock, "the first claim advances the token");
+    let claim_lease = updated_at_of(&pool, tx_id).await;
+    assert_ne!(claim_lease, t_lock, "the first claim advances the token");
 
     // Recovery demotes mid-JIT: age the row past the staleness threshold and
     // classify the journaled signature dead (null status, expired blockhash,
@@ -1358,7 +1358,7 @@ async fn stale_jit_refire_does_not_double_mint() {
 
     // The JIT re-fire: MintNotInitialized verdict, pre-check reads an
     // admin-authority initialized mint (Retry), build/sign gets a blockhash,
-    // then the re-claim runs with the stale epoch and must abort.
+    // then the re-claim runs with the stale lease and must abort.
     let mut builder = MintToBuilder::new();
     builder.mint(Pubkey::new_unique());
     state.mint_builders.insert(tx_id, builder);
@@ -1371,7 +1371,7 @@ async fn stale_jit_refire_does_not_double_mint() {
 
     let metric = OPERATOR_TRANSACTION_ERRORS.with_label_values(&["escrow", OWNERSHIP_LOST_REASON]);
     let metric_before = metric.get();
-    let ctx = deposit_ctx_with_lease(tx_id, claim_epoch);
+    let ctx = deposit_ctx_with_lease(tx_id, claim_lease);
 
     sender_hooks::handle_confirmation_result(
         &mut state,


### PR DESCRIPTION
## Summary

Closes cantina issue 113. The previous ownership-claim fix protected a deposit mint's first broadcast but left the `MintNotInitialized` JIT retry unguarded. If recovery requeued the row while the sender was waiting to retry, the stale JIT builder could still broadcast a second mint, creating unbacked channel supply. This PR closes that gap by requiring **every** value-bearing deposit broadcast, including JIT retries, to successfully reclaim ownership before sending.

The ownership token is now part of `SendDurability::Recoverable`, making a recoverable deposit send impossible to construct without it. The atomic claim returns the newly written lease (`updated_at`), which is carried on the in-flight `TransactionContext` and presented again by the JIT retry. If recovery has already taken ownership, the claim fails and the stale retry exits before broadcasting, using the same ownership protocol as the initial send.

The implementation is fail-closed throughout. A missing lease or lost ownership never results in a broadcast; the sender exits and leaves the row for recovery. Transient storage  A transient storage failure during the claim is fail-closed on the first attempt: the sender aborts before broadcast and leaves the row Processing, so the recovery worker re-processes it later rather than risking a duplicate mint.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29412493826) |
| Indexer | 27,929 | 31,257 | 89.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29412493826) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29412493826) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29412493826) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,863 | 16,252 | 79.1% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29412493826) |
| **Total** | **54,388** | **63,047** | **86.3%** | |

> Last updated: 2026-07-15 12:33:35 UTC by E2E Integration