### PR TITLE
fix(indexer): never terminalize a persisted deposit mint on send error

### DIFF
--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -22,8 +22,6 @@ use chrono::Utc;
 use private_channel_escrow_program_client::errors::PrivateChannelEscrowProgramError;
 use private_channel_metrics::MetricLabel;
 use solana_keychain::SolanaSigner;
-use solana_rpc_client_api::client_error::ErrorKind;
-use solana_rpc_client_api::request::RpcError;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::signature::Signature;
 use tokio::sync::{mpsc, OwnedSemaphorePermit};
@@ -877,27 +875,6 @@ pub(super) async fn handle_success(
     }
 }
 
-/// Handle permanent transaction failure with deferred remint for withdrawals.
-///
-/// For withdrawal transactions: removes remint info from cache, runs cleanup
-/// (which removes the nonce from SMT and builder caches), then queues a deferred
-/// remint that will execute after the Solana finality window passes. This prevents
-/// double-spend if the original withdrawal lands on-chain after our polling window.
-///
-/// For non-withdrawal transactions: delegates to send_fatal_error.
-/// Whether a send failure came back as an explicit RPC rejection from the node
-/// (preflight simulation failure, blockhash errors, etc.). Such a response means the
-/// transaction was never submitted to the cluster, so failing fast is safe. A transport
-/// or IO error instead leaves the outcome ambiguous (the request may have reached the
-/// cluster), so a persisted mint defers to recovery rather than risk stranding a landed one.
-fn send_rejected_by_node(e: &TransactionError) -> bool {
-    matches!(
-        e,
-        TransactionError::Rpc(err)
-            if matches!(&err.kind, ErrorKind::RpcError(RpcError::RpcResponseError { .. }))
-    )
-}
-
 /// Leave a persisted transaction Processing after an uncertain terminal outcome.
 /// The broadcast may have landed, so a terminal Failed would strand a possibly-funded
 /// deposit and drop the signature recovery needs; recovery reconciles it next sweep.
@@ -963,6 +940,14 @@ pub(super) async fn requeue_prebroadcast_failure(
     }
 }
 
+/// Handle permanent transaction failure with deferred remint for withdrawals.
+///
+/// For withdrawal transactions: removes remint info from cache, runs cleanup
+/// (which removes the nonce from SMT and builder caches), then queues a deferred
+/// remint that will execute after the Solana finality window passes. This prevents
+/// double-spend if the original withdrawal lands on-chain after our polling window.
+///
+/// For non-withdrawal transactions: delegates to send_fatal_error.
 pub(super) async fn handle_permanent_failure(
     state: &mut SenderState,
     ctx: &TransactionContext,
@@ -1367,15 +1352,16 @@ pub(super) async fn fire_and_store_task(
                 .with_label_values(&[pt, "rpc_send_error"])
                 .inc();
             error!("Failed to send transaction (fire-and-forget): {}", e);
-            // A node rejection (e.g. preflight) means the tx never reached the cluster, so
-            // fail fast. An ambiguous transport error on a persisted mint may have landed,
-            // so leave it Processing for recovery rather than strand a possibly-funded mint.
-            if persisted && !send_rejected_by_node(&e) {
+            // A persisted mint may already have landed, and even a preflight rejection can be
+            // a stale-node false negative, so a terminal Failed would strand a funded deposit
+            // and drop the signature recovery needs. Leave it Processing for recovery to
+            // reconcile against the persisted signature. Terminal sends mint no balance, so fail fast.
+            if persisted {
                 leave_processing_for_recovery(
                     pt,
                     ctx.transaction_id,
                     &signature,
-                    "ambiguous send error after write-ahead persist",
+                    "send error after write-ahead persist",
                 );
             } else {
                 send_fatal_error(&storage_tx, &ctx, &e.to_string()).await;
@@ -4455,12 +4441,11 @@ mod tests {
         );
     }
 
-    /// A send error (e.g. preflight rejection) means the broadcast never reached the
-    /// network, so even with the signature already persisted the mint is terminal Failed,
-    /// same as the withdrawal send path. (The broadcast-accepted-but-unconfirmed case is
-    /// the one route_poll_results leaves Processing; see the poll timeout test.)
+    /// A send error after the signature is persisted may still have landed on-chain, so the
+    /// mint is never terminalized in the sender: the signature is kept and no status update is
+    /// written (row left Processing for recovery to reconcile against the persisted signature).
     #[tokio::test]
-    async fn mint_send_error_after_persist_routes_to_failed() {
+    async fn mint_send_error_after_persist_left_for_recovery() {
         let mut server = mockito::Server::new_async().await;
         let _hash = mock_blockhash(&mut server);
         let _send = server
@@ -4507,12 +4492,147 @@ mod tests {
         };
         assert!(
             !mock.get_release_signatures(77).await.unwrap().is_empty(),
-            "signature must be persisted before the failing broadcast",
+            "signature must be preserved so recovery can reconcile it",
         );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update; row left Processing for recovery",
+        );
+        assert!(
+            state.in_flight.is_empty(),
+            "a failed broadcast stashes no in-flight entry",
+        );
+        assert_eq!(
+            state.semaphore.available_permits(),
+            before + 1,
+            "permit must be dropped on send error",
+        );
+    }
+
+    /// A preflight-style RPC rejection after the signature is persisted is deferred to
+    /// recovery too: even a "deterministic" program error can be a stale-node false negative,
+    /// so the sender never marks a persisted mint Failed and keeps the signature.
+    #[tokio::test]
+    async fn mint_preflight_failure_after_persist_left_for_recovery() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        // A preflight failure surfaces as a distinct RPC response error code (-32002); the
+        // sender's branch treats every persisted send error identically, so recovery decides.
+        let _send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {
+                        "code": -32002,
+                        "message": "Transaction simulation failed",
+                        "data": {
+                            "err": {"InstructionError": [0, {"Custom": 1}]},
+                            "logs": ["Program log: preflight failure"]
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create();
+
+        let state = make_sender_state_with_server(&server.url());
+        let t_lock = Utc::now();
+        seed_mock_deposit(&state, 77, TransactionStatus::Processing, t_lock);
+        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
+        let before = state.semaphore.available_permits();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            dummy_instruction(),
+            None,
+            mint_ctx(77),
+            RetryPolicy::None,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+            recoverable(t_lock),
+            permit,
+        )
+        .await;
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        assert!(
+            !mock.get_release_signatures(77).await.unwrap().is_empty(),
+            "signature must be preserved so recovery can reconcile it",
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a preflight rejection writes no status; row left Processing for recovery",
+        );
+        assert!(
+            state.in_flight.is_empty(),
+            "a failed broadcast stashes no in-flight entry",
+        );
+        assert_eq!(
+            state.semaphore.available_permits(),
+            before + 1,
+            "permit must be dropped on send error",
+        );
+    }
+
+    /// A Terminal (non-persisted) send error still fails fast: InitializeMint mints no
+    /// balance, so there is nothing to strand and the row is terminalized to Failed.
+    #[tokio::test]
+    async fn terminal_send_error_routes_to_failed() {
+        let mut server = mockito::Server::new_async().await;
+        let _hash = mock_blockhash(&mut server);
+        let _send = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "sendTransaction"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32600, "message": "Internal error"}
+                })
+                .to_string(),
+            )
+            .create();
+
+        let state = make_sender_state_with_server(&server.url());
+        let permit = state.semaphore.clone().try_acquire_owned().unwrap();
+        let before = state.semaphore.available_permits();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        fire_and_store_task(
+            state.rpc_client.clone(),
+            state.storage.clone(),
+            state.in_flight.clone(),
+            state.program_type,
+            dummy_instruction(),
+            None,
+            mint_ctx(909),
+            RetryPolicy::Idempotent,
+            ExtraErrorCheckPolicy::None,
+            storage_tx,
+            SendDurability::Terminal,
+            permit,
+        )
+        .await;
+
         let update = storage_rx
             .try_recv()
-            .expect("send error must emit a terminal status");
-        assert_eq!(update.transaction_id, 77);
+            .expect("a terminal send error must emit a status update");
+        assert_eq!(update.transaction_id, 909);
         assert_eq!(update.status, TransactionStatus::Failed);
         assert!(
             state.in_flight.is_empty(),
@@ -5100,35 +5220,6 @@ mod tests {
         assert!(
             !mock.get_release_signatures(77).await.unwrap().is_empty(),
             "JIT retry must reuse the freed parent slot and journal its signature at saturation"
-        );
-    }
-
-    /// A node RPC rejection (preflight, blockhash, etc.) is definitive - the tx was never
-    /// submitted - so a persisted mint fails fast; a transport/IO error is ambiguous and a
-    /// persisted mint instead defers to recovery. This classifier draws that line.
-    #[test]
-    fn send_rejected_by_node_distinguishes_rejection_from_transport_error() {
-        use solana_rpc_client_api::client_error::{Error as ClientError, ErrorKind};
-        use solana_rpc_client_api::request::{RpcError, RpcResponseErrorData};
-
-        let node_rejection = TransactionError::Rpc(Box::new(ClientError::from(
-            ErrorKind::RpcError(RpcError::RpcResponseError {
-                code: -32002,
-                message: "preflight failure".to_string(),
-                data: RpcResponseErrorData::Empty,
-            }),
-        )));
-        assert!(
-            send_rejected_by_node(&node_rejection),
-            "an RPC response error is a definitive node rejection"
-        );
-
-        let transport_error = TransactionError::Rpc(Box::new(ClientError::from(
-            ErrorKind::Custom("connection reset".to_string()),
-        )));
-        assert!(
-            !send_rejected_by_node(&transport_error),
-            "a transport error is ambiguous, not a node rejection"
         );
     }
 

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -8,7 +8,8 @@
 //! 1. Single deposit mint: operator mints channel tokens for one pending deposit.
 //! 2. Issuance idempotency: duplicate deposit row does not trigger a double-mint.
 //! 3. Withdrawal nonce idempotency: duplicate withdrawal row releases funds only once.
-//! 4. Failure alerts: failed mint and failed withdrawal each fire a webhook POST.
+//! 4. Failure alerts: a failed withdrawal fires a webhook POST; a preflight-failed
+//!    mint is left Processing for recovery rather than terminalized.
 //! 5. Batch deposits: operator processes 5 deposits for distinct recipients in one sweep.
 //! 6. Idle operator: no phantom records created when the DB has no pending work.
 //! 7. Runtime reconciliation halt: channel supply over-issued beyond escrow custody
@@ -215,6 +216,36 @@ async fn wait_for_transaction_status(
     Err(format!(
         "Transaction {} did not reach status {} within {}s",
         signature, expected_status, timeout_secs
+    )
+    .into())
+}
+
+/// Poll until the deposit's write-ahead mint signature is journaled in
+/// `pending_release_signatures`. The journal is written right before broadcast,
+/// so a non-empty journal proves the mint reached the send step.
+async fn wait_for_release_signature_journaled(
+    pool: &sqlx::PgPool,
+    signature: &str,
+    timeout_secs: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = std::time::Instant::now();
+    while start.elapsed().as_secs() < timeout_secs {
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM pending_release_signatures prs \
+             JOIN transactions t ON t.id = prs.transaction_id \
+             WHERE t.signature = $1",
+        )
+        .bind(signature)
+        .fetch_one(pool)
+        .await?;
+        if count > 0 {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Err(format!(
+        "deposit {} did not journal a write-ahead mint signature within {}s",
+        signature, timeout_secs
     )
     .into())
 }
@@ -543,17 +574,22 @@ async fn test_withdrawal_operator_prevents_double_withdrawal(
     Ok(())
 }
 
-/// Triggers one failed mint (wrong-authority `mint_to`, rejected at preflight)
-/// and one bad withdrawal (mint not whitelisted on the instance, escalated to
-/// `ManualReview` because the burn never produced a verifiable signature) and
-/// asserts that the configured `alert_webhook_url` receives exactly two POST
-/// requests — `db_transaction_writer::send_webhook_alert` fires for both
-/// `Failed` and `ManualReview` dispositions.
+/// Triggers one preflight-failing mint (wrong-authority `mint_to`) and one bad
+/// withdrawal (mint not whitelisted on the instance, escalated to `ManualReview`
+/// because the burn never produced a verifiable signature).
+///
+/// A write-ahead-persisted mint is never terminalized in the sender: on a send
+/// error it is left Processing for recovery, so it journals its signature and
+/// stays Processing rather than reaching Failed, and fires no alert. Only the
+/// withdrawal's `ManualReview` disposition fires a webhook, so the configured
+/// `alert_webhook_url` receives exactly one POST via
+/// `db_transaction_writer::send_webhook_alert`.
 ///
 /// Uses a `mockito` HTTP server as the webhook endpoint so no external service
 /// is required.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_failed_withdrawals_and_mints_fire_alerts() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_failed_withdrawal_alerts_and_preflight_mint_defers_to_recovery(
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Operator Lifecycle: Alerts on Failure ===");
 
     let (test_validator, faucet_keypair) = start_test_validator_no_geyser().await;
@@ -587,11 +623,13 @@ async fn test_failed_withdrawals_and_mints_fire_alerts() -> Result<(), Box<dyn s
     TestEnvironment::setup_operator(&client, &faucet_keypair, env.instance).await?;
 
     let mut server = Server::new_async().await;
+    // Only the withdrawal's ManualReview disposition fires a webhook; the
+    // preflight-failed mint is deferred to recovery and writes no status.
     let alert_mock = server
         .mock("POST", "/")
         .match_header("content-type", "application/json")
         .with_status(200)
-        .expect(2)
+        .expect(1)
         .create_async()
         .await;
 
@@ -613,9 +651,9 @@ async fn test_failed_withdrawals_and_mints_fire_alerts() -> Result<(), Box<dyn s
     .await?;
 
     // Create a valid SPL mint with a *different* mint authority than the operator's
-    // admin key.  When the operator calls mint_to using the admin key, the SPL token
-    // program rejects it (wrong authority) → preflight fails → deposit reaches "failed"
-    // without going through the JIT initialization loop.
+    // admin key. When the operator calls mint_to using the admin key, the SPL token
+    // program rejects it (wrong authority), so the mint fails at preflight after the
+    // write-ahead signature is persisted.
     let admin = Keypair::try_from(&TEST_ADMIN_KEYPAIR[..])?;
     let bad_authority = Keypair::new(); // NOT the operator admin — intentionally wrong
     let bad_mint = Keypair::new();
@@ -646,7 +684,17 @@ async fn test_failed_withdrawals_and_mints_fire_alerts() -> Result<(), Box<dyn s
     .build();
     storage.insert_db_transaction(&bad_deposit).await?;
 
-    wait_for_transaction_status(&pool, &mint_fail_sig, "failed", 180).await?;
+    // A write-ahead-persisted mint is never terminalized in the sender: the send
+    // error leaves the row Processing for recovery to reconcile against the persisted
+    // signature. So the mint journals its signature and stays Processing, never Failed.
+    wait_for_release_signature_journaled(&pool, &mint_fail_sig, 180).await?;
+    let mint_row = db::get_transaction(&pool, &mint_fail_sig)
+        .await?
+        .expect("the deposit row must exist");
+    assert_eq!(
+        mint_row.status, "processing",
+        "a preflight-failed mint is deferred to recovery, not marked Failed"
+    );
 
     // Seed a separate mint that is NOT allowed on the instance to force withdrawal failure.
     let bad_withdraw_mint = Keypair::new();


### PR DESCRIPTION
This commit fixes issues 232. A deposit mint could be permanently stranded after a transient send error. Deposit mints first persist their transaction signature to the database before broadcasting so recovery can reconcile the transaction with the chain. However, if sending failed and the RPC error was classified as a node rejection, the sender immediately marked the deposit `Failed`. Because recovery only processes `Processing` rows, a transient RPC error could permanently strand a valid deposit, leaving user funds locked in escrow until manual intervention.

The fix removes this classification from the sender entirely. Once a deposit mint has been write-ahead persisted, **any** send error now leaves it in `Processing` for recovery. Recovery is already responsible for determining whether the transaction landed, should be retried, or should eventually be moved to `ManualReview` after exhausting the retry limit. This makes recovery the single source of truth for persisted deposits and eliminates the risk of incorrectly terminalizing a transaction that may have succeeded.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,486 | 13,120 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29603259832) |
| Indexer | 29,084 | 32,356 | 89.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29603259832) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29603259832) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29603259832) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,017 | 16,428 | 79.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29603259832) |
| **Total** | **55,697** | **64,322** | **86.6%** | |

> Last updated: 2026-07-17 18:57:41 UTC by E2E Integration