### PR TITLE
fix(indexer): defer pre-broadcast remint failures instead of ManualReview

### DIFF
--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -1552,6 +1552,62 @@ mod tests {
         );
     }
 
+    /// The stored-signature lookup is the idempotency gate's first step. A
+    /// transient DB failure there is pre-broadcast: `attempt_remint` must defer
+    /// and retry the lookup on a later tick, never escalate or authorize a mint.
+    #[tokio::test]
+    async fn execute_deferred_remint_defers_when_signature_lookup_fails() {
+        ensure_test_signer();
+        let mut rpc_server = mockito::Server::new_async().await;
+        let (state, mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // No resend may be broadcast when the idempotency lookup cannot run.
+        let send = rpc_server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"sendTransaction""#.into(),
+            ))
+            .expect(0)
+            .create_async()
+            .await;
+
+        mock.set_should_fail("get_remint_signatures", true);
+
+        let entry = PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(730),
+                withdrawal_nonce: Some(73),
+                trace_id: Some("trace-730".to_string()),
+                deposit_claim_lease: None,
+            },
+            remint_info: make_remint_info(730),
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        };
+
+        let outcome = execute_deferred_remint(&state, entry, &storage_tx).await;
+
+        // Deferred, not resolved: the row stays PendingRemint for the next tick.
+        let DeferredRemintOutcome::Defer(_, reason) = outcome else {
+            panic!("lookup failure must defer, not resolve");
+        };
+        assert!(
+            reason.contains("stored remint-signature lookup failed"),
+            "defer reason must name the lookup failure: {reason}"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a lookup failure must not emit a status update"
+        );
+        send.assert_async().await;
+    }
+
     /// When the finality check returns null for a withdrawal signature
     /// (transaction was dropped), `execute_deferred_remint` is called. If the
     /// remint cannot even be built (source blockhash RPC unreachable), nothing
@@ -1646,11 +1702,17 @@ mod tests {
     async fn process_pending_remints_finalized_with_onchain_error_proceeds_to_remint() {
         ensure_test_signer();
         let mut rpc_server = mockito::Server::new_async().await;
-        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // The remint proceeds and defers on the (unmocked) blockhash, which
+        // persists the bumped counter, so the row must exist.
+        seed_pending_remint_row(&mock, 88, 0);
 
         let sig = Signature::new_unique();
 
+        // Finalized-failed: status present with an error. A finalized-failed sig
+        // is dead outright, so classification needs no block-height check.
         let _status_mock = mock_rpc(
             &mut rpc_server,
             "getSignatureStatuses",
@@ -1668,15 +1730,6 @@ mod tests {
                 },
                 "id": 0
             }"#,
-        )
-        .await;
-
-        // Block height ahead of the stored lvbh (0) so the finalized-failed sig
-        // counts as dead and the gate falls through to Case 3 (remint).
-        let _block_height_mock = mock_rpc(
-            &mut rpc_server,
-            "getBlockHeight",
-            r#"{"jsonrpc":"2.0","result":1000,"id":0}"#,
         )
         .await;
 
@@ -1699,15 +1752,14 @@ mod tests {
 
         process_pending_remints(&mut state, &storage_tx).await;
 
-        let update = storage_rx
-            .try_recv()
-            .expect("should receive a status update");
-        assert_ne!(
-            update.status,
-            TransactionStatus::Completed,
-            "finalized-with-error must NOT produce Completed — funds never left escrow"
+        // Not Completed: the gate reached Case 3 and attempted the remint, which
+        // defers on the unmocked blockhash rather than marking the withdrawal done.
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "finalized-with-error must NOT produce Completed — it proceeds to remint"
         );
-        assert_eq!(update.transaction_id, 88);
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
     }
 
     /// Regression: when every stored signature already has a status entry, the

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -55,8 +55,8 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
     {
         Ok(rows) => rows,
         Err(e) => {
-            return RemintAttempt::Failed(format!(
-                "stored remint-signature lookup failed for transaction {}: {}; refusing to remint",
+            return RemintAttempt::Defer(format!(
+                "stored remint-signature lookup failed for transaction {}: {}; will retry",
                 info.transaction_id, e
             ));
         }
@@ -127,10 +127,15 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
         .amount(info.amount)
         .idempotency_memo(memo);
 
+    // No transaction is broadcast until send_signed below, so instruction-build,
+    // blockhash and signing failures are pre-broadcast: defer and retry, never ManualReview.
     let instructions = match builder.instructions() {
         Ok(instructions) => instructions,
         Err(e) => {
-            return RemintAttempt::Failed(format!("Failed to build remint instructions: {}", e));
+            return RemintAttempt::Defer(format!(
+                "failed to build remint instructions for transaction {}: {}; will retry",
+                info.transaction_id, e
+            ));
         }
     };
 
@@ -146,9 +151,9 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
         match build_and_sign(&state.source_rpc_client, ix).await {
             Ok(signed) => signed,
             Err(e) => {
-                return RemintAttempt::Failed(format!(
-                    "Failed to build/sign remint transaction: {}",
-                    e
+                return RemintAttempt::Defer(format!(
+                    "failed to build/sign remint for transaction {}: {}; will retry",
+                    info.transaction_id, e
                 ));
             }
         };
@@ -1548,15 +1553,18 @@ mod tests {
     }
 
     /// When the finality check returns null for a withdrawal signature
-    /// (transaction was dropped), `execute_deferred_remint` is called.
-    /// If the remint itself also fails (RPC unreachable after the finality
-    /// check mock is consumed), the combined error must be sent as ManualReview.
+    /// (transaction was dropped), `execute_deferred_remint` is called. If the
+    /// remint cannot even be built (source blockhash RPC unreachable), nothing
+    /// was broadcast, so the entry must defer and requeue, never ManualReview.
     #[tokio::test]
-    async fn process_pending_remints_not_finalized_remint_fails_sends_manual_review() {
+    async fn process_pending_remints_not_finalized_remint_build_fails_defers() {
         ensure_test_signer();
         let mut rpc_server = mockito::Server::new_async().await;
-        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // The defer path persists the bumped counter, so the row must exist.
+        seed_pending_remint_row(&mock, 77, 0);
 
         let sig = Signature::new_unique();
 
@@ -1610,21 +1618,25 @@ mod tests {
 
         process_pending_remints(&mut state, &storage_tx).await;
 
-        let update = storage_rx.try_recv().expect("should receive ManualReview");
-        assert_eq!(update.transaction_id, 77);
-        assert_eq!(update.status, TransactionStatus::ManualReview);
-
-        let err = update.error_message.as_deref().unwrap();
         assert!(
-            err.contains("remint failed"),
-            "error should mention remint failure: {err}"
+            storage_rx.try_recv().is_err(),
+            "a pre-broadcast build failure must defer, not write ManualReview"
         );
-        assert!(
-            err.contains("release_funds failed"),
-            "error should include original withdrawal error: {err}"
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(
+            state.pending_remints[0].finality_check_attempts, 1,
+            "counter must be bumped after the deferral"
         );
 
-        assert!(state.pending_remints.is_empty());
+        // The row stays PendingRemint so restart recovery can retry the remint.
+        let persisted = mock
+            .pending_remint_transactions
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|t| t.id == 77)
+            .map(|t| t.finality_check_attempts);
+        assert_eq!(persisted, Some(1));
     }
 
     /// A withdrawal that reached finality but failed on-chain (err field is set)
@@ -1706,8 +1718,11 @@ mod tests {
     async fn process_pending_remints_skips_block_height_when_all_sigs_classifiable() {
         ensure_test_signer();
         let mut rpc_server = mockito::Server::new_async().await;
-        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // The defer path persists the bumped counter, so the row must exist.
+        seed_pending_remint_row(&mock, 89, 0);
 
         let sig = Signature::new_unique();
 
@@ -1732,9 +1747,16 @@ mod tests {
         )
         .await;
 
-        // Deliberately NOT mocking getBlockHeight: if the code reaches that
-        // call mockito returns 501, the call errors, and defer_or_escalate
-        // fires with "block height RPC failed" instead of execute_deferred_remint.
+        // getBlockHeight must NOT be called: every sig carries a status, so the
+        // classification is decided without it. expect(0) enforces the pre-check.
+        let block_height_never = rpc_server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getBlockHeight""#.into(),
+            ))
+            .expect(0)
+            .create_async()
+            .await;
 
         state.pending_remints.push(PendingRemint {
             ctx: TransactionContext {
@@ -1755,18 +1777,15 @@ mod tests {
 
         process_pending_remints(&mut state, &storage_tx).await;
 
-        let update = storage_rx
-            .try_recv()
-            .expect("should receive a status update");
-        assert_eq!(update.transaction_id, 89);
-        assert_eq!(update.status, TransactionStatus::ManualReview);
-        let err = update.error_message.as_deref().unwrap_or("");
+        // Reached execute_deferred_remint and deferred on the remint build (no
+        // blockhash mock), not on a spurious getBlockHeight call.
         assert!(
-            err.contains("remint failed"),
-            "must reach execute_deferred_remint; if this contains 'block height' \
-             the pre-check regressed: {err}"
+            storage_rx.try_recv().is_err(),
+            "classifiable-Dead then pre-broadcast build failure must defer"
         );
-        assert!(state.pending_remints.is_empty());
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
+        block_height_never.assert_async().await;
     }
 
     /// When a withdrawal was retried and produced multiple signatures, one of the
@@ -2494,8 +2513,11 @@ mod tests {
     async fn process_pending_remints_all_sigs_expired_proceeds_to_remint() {
         ensure_test_signer();
         let mut rpc_server = mockito::Server::new_async().await;
-        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        // The defer path persists the bumped counter, so the row must exist.
+        seed_pending_remint_row(&mock, 100, 0);
 
         let sig = Signature::new_unique();
 
@@ -2540,23 +2562,14 @@ mod tests {
 
         process_pending_remints(&mut state, &storage_tx).await;
 
-        // Reaching Case 3 triggers execute_deferred_remint, whose RPC calls
-        // have no matching mocks; the remint fails and writes ManualReview
-        // with "remint failed" in the error message.
-        let update = storage_rx
-            .try_recv()
-            .expect("should receive ManualReview from execute_deferred_remint");
-        assert_eq!(update.transaction_id, 100);
-        assert_eq!(update.status, TransactionStatus::ManualReview);
+        // Reaching Case 3 triggers execute_deferred_remint; the remint build has
+        // no blockhash mock, so it fails pre-broadcast and the entry defers.
         assert!(
-            update
-                .error_message
-                .as_deref()
-                .unwrap_or("")
-                .contains("remint failed"),
-            "reaching Case 3 means execute_deferred_remint ran"
+            storage_rx.try_recv().is_err(),
+            "pre-broadcast remint failure must defer, not ManualReview"
         );
-        assert!(state.pending_remints.is_empty());
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
     }
 
     /// Sig has no on-chain record but its blockhash is still within validity.

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -36,9 +36,15 @@ const MAX_FINALITY_CHECK_ATTEMPTS: u32 = 3;
 enum RemintAttempt {
     /// A remint landed on-chain (a prior attempt or the one just sent).
     Confirmed(Signature),
-    /// Not done yet; caller re-queues with an extended deadline.
-    Defer(String),
-    /// Cannot proceed safely; escalate to ManualReview.
+    /// Failed before any transaction could be broadcast, with no live signature
+    /// in play: nothing can land, so a bounded retry that ends in ManualReview is
+    /// safe. Caller re-queues via the capped escalation path.
+    DeferPreBroadcast(String),
+    /// A signature is persisted, or we cannot prove one isn't, so a transaction
+    /// may land. Reconcile it; never terminalize on a counter. Caller re-queues
+    /// without a cap so the entry keeps reclassifying until Landed/Dead.
+    DeferInFlight(String),
+    /// Cannot reconcile and cannot proceed safely; escalate to ManualReview.
     Failed(String),
 }
 
@@ -55,7 +61,11 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
     {
         Ok(rows) => rows,
         Err(e) => {
-            return RemintAttempt::Defer(format!(
+            // Lookup failed: we can't read whether a prior remint sig is persisted, so
+            // capping here could abandon an unread in-flight sig into a double-mint.
+            // Retry the lookup instead (no resend). Row stays PendingRemint, so recovery
+            // reloads it across restarts; in-process it retries until the DB recovers.
+            return RemintAttempt::DeferInFlight(format!(
                 "stored remint-signature lookup failed for transaction {}: {}; will retry",
                 info.transaction_id, e
             ));
@@ -95,7 +105,9 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
                 return RemintAttempt::Confirmed(signature);
             }
             SigFinality::Live(reason) => {
-                return RemintAttempt::Defer(format!(
+                // A persisted sig could still land. Reconcile until it resolves;
+                // blockhash expiry forces it to Landed or Dead, so this never spins.
+                return RemintAttempt::DeferInFlight(format!(
                     "prior remint attempt still in flight: {reason}"
                 ));
             }
@@ -132,7 +144,7 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
     let instructions = match builder.instructions() {
         Ok(instructions) => instructions,
         Err(e) => {
-            return RemintAttempt::Defer(format!(
+            return RemintAttempt::DeferPreBroadcast(format!(
                 "failed to build remint instructions for transaction {}: {}; will retry",
                 info.transaction_id, e
             ));
@@ -151,7 +163,7 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
         match build_and_sign(&state.source_rpc_client, ix).await {
             Ok(signed) => signed,
             Err(e) => {
-                return RemintAttempt::Defer(format!(
+                return RemintAttempt::DeferPreBroadcast(format!(
                     "failed to build/sign remint for transaction {}: {}; will retry",
                     info.transaction_id, e
                 ));
@@ -166,7 +178,7 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
         .insert_remint_signature(info.transaction_id, signature.to_string(), lvbh_i64)
         .await
     {
-        return RemintAttempt::Defer(format!(
+        return RemintAttempt::DeferPreBroadcast(format!(
             "pre-send remint persist failed for transaction {}: {}; will retry",
             info.transaction_id, e
         ));
@@ -174,7 +186,7 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
 
     if let Err(e) = send_signed(&state.source_rpc_client, &transaction, RetryPolicy::None).await {
         // Signature is durable; next attempt reclassifies it.
-        return RemintAttempt::Defer(format!(
+        return RemintAttempt::DeferInFlight(format!(
             "remint send failed for transaction {}: {}; will reclassify",
             info.transaction_id, e
         ));
@@ -191,7 +203,7 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
     {
         Ok(result) => result,
         Err(e) => {
-            return RemintAttempt::Defer(format!(
+            return RemintAttempt::DeferInFlight(format!(
                 "remint confirmation failed for transaction {}: {}; will reclassify",
                 info.transaction_id, e
             ));
@@ -203,17 +215,21 @@ async fn attempt_remint(state: &SenderState, info: &WithdrawalRemintInfo) -> Rem
             info!("Remint confirmed: {}", signature);
             RemintAttempt::Confirmed(signature)
         }
-        other => RemintAttempt::Defer(format!("remint not yet confirmed: {:?}", other)),
+        other => RemintAttempt::DeferInFlight(format!("remint not yet confirmed: {:?}", other)),
     }
 }
 
 /// Result of executing a matured PendingRemint entry.
+/// Boxed variants keep the enum small (PendingRemint is ~300 bytes).
 pub enum DeferredRemintOutcome {
     /// Terminal: a FailedReminted or ManualReview status was already emitted.
     Resolved,
-    /// Could not complete yet; caller re-queues the entry with the given reason.
-    /// Boxed to keep the enum small (PendingRemint is ~300 bytes).
-    Defer(Box<PendingRemint>, String),
+    /// Failed before broadcast with no live sig: caller re-queues via the capped
+    /// escalation path, which ends in ManualReview once the retry budget is spent.
+    DeferPreBroadcast(Box<PendingRemint>, String),
+    /// A sig is (or might be) persisted: caller re-queues without a cap so the
+    /// entry keeps reclassifying until it resolves. Never terminalized on a counter.
+    DeferInFlight(Box<PendingRemint>, String),
 }
 
 /// Execute the actual remint for a matured PendingRemint entry.
@@ -291,7 +307,12 @@ pub async fn execute_deferred_remint(
             }
             DeferredRemintOutcome::Resolved
         }
-        RemintAttempt::Defer(reason) => DeferredRemintOutcome::Defer(Box::new(entry), reason),
+        RemintAttempt::DeferPreBroadcast(reason) => {
+            DeferredRemintOutcome::DeferPreBroadcast(Box::new(entry), reason)
+        }
+        RemintAttempt::DeferInFlight(reason) => {
+            DeferredRemintOutcome::DeferInFlight(Box::new(entry), reason)
+        }
         RemintAttempt::Failed(remint_error) => {
             error!("Remint also failed: {}", remint_error);
             let combined = format!("{} | remint failed: {}", entry.original_error, remint_error);
@@ -622,24 +643,34 @@ pub async fn process_pending_remints(
                     "All withdrawal signatures for nonce {} are finalized-failed or expired; attempting remint",
                     nonce_label
                 );
-                if let DeferredRemintOutcome::Defer(entry, reason) =
-                    execute_deferred_remint(state, entry, storage_tx).await
-                {
-                    defer_or_escalate(
-                        &mut remaining,
-                        *entry,
-                        &nonce_label,
-                        &reason,
-                        &state.storage,
-                        storage_tx,
-                    )
-                    .await;
+                match execute_deferred_remint(state, entry, storage_tx).await {
+                    DeferredRemintOutcome::Resolved => {}
+                    // Nothing was broadcast: bounded retry, then ManualReview. Safe
+                    // because no signature can land.
+                    DeferredRemintOutcome::DeferPreBroadcast(entry, reason) => {
+                        defer_or_escalate(
+                            &mut remaining,
+                            *entry,
+                            &nonce_label,
+                            &reason,
+                            &state.storage,
+                            storage_tx,
+                        )
+                        .await;
+                    }
+                    // A signature is (or might be) persisted: re-queue without the
+                    // cap so it keeps reclassifying. Terminalizing here would abandon
+                    // a possibly-live sig and invite an operator double-mint.
+                    DeferredRemintOutcome::DeferInFlight(entry, reason) => {
+                        requeue_in_flight(&mut remaining, *entry, &nonce_label, &reason);
+                    }
                 }
             }
         }
     }
 
-    // `remaining` = entries not yet due + entries `defer_or_escalate` re-queued.
+    // `remaining` = entries not yet due + entries re-queued by `defer_or_escalate`
+    // or `requeue_in_flight`.
     state.pending_remints = remaining;
 }
 
@@ -684,8 +715,10 @@ async fn send_completed(
 }
 
 /// Bump the entry's deferral counter and either re-queue with an extended
-/// deadline or escalate to ManualReview when the cap is hit. Used by every
-/// "couldn't classify this entry as ready-to-remint" branch.
+/// deadline or escalate to ManualReview when the cap is hit. For the bounded
+/// paths only: dest-signature classification (Case 2) and pre-broadcast remint
+/// failures, where no signature can land so terminalizing at the cap is safe.
+/// In-flight remint defers use `requeue_in_flight` instead and never hit this cap.
 async fn defer_or_escalate(
     remaining: &mut Vec<PendingRemint>,
     entry: PendingRemint,
@@ -768,6 +801,26 @@ async fn defer_or_escalate(
     );
     remaining.push(PendingRemint {
         finality_check_attempts: attempt,
+        deadline: new_deadline,
+        ..entry
+    });
+}
+
+/// Re-queue an in-flight remint (a sig is, or might be, persisted). Never
+/// terminalizes and never bumps the counter: the classify gate resolves the sig
+/// on a later tick, and terminalizing a live sig would risk a double-mint.
+fn requeue_in_flight(
+    remaining: &mut Vec<PendingRemint>,
+    entry: PendingRemint,
+    nonce_label: &str,
+    reason: &str,
+) {
+    let new_deadline = Utc::now() + chrono::Duration::from_std(FINALITY_SAFETY_DELAY).unwrap();
+    warn!(
+        "Pending remint for nonce {} still in flight, re-queued (not terminalized): {}",
+        nonce_label, reason
+    );
+    remaining.push(PendingRemint {
         deadline: new_deadline,
         ..entry
     });
@@ -1552,9 +1605,10 @@ mod tests {
         );
     }
 
-    /// The stored-signature lookup is the idempotency gate's first step. A
-    /// transient DB failure there is pre-broadcast: `attempt_remint` must defer
-    /// and retry the lookup on a later tick, never escalate or authorize a mint.
+    /// The stored-signature lookup is the idempotency gate's first step. A DB
+    /// failure there means we can't read whether a prior sig is persisted, so
+    /// `attempt_remint` must defer in-flight: retry the lookup, never escalate or
+    /// authorize a mint. In-flight defers never bump the finality counter.
     #[tokio::test]
     async fn execute_deferred_remint_defers_when_signature_lookup_fails() {
         ensure_test_signer();
@@ -1593,10 +1647,16 @@ mod tests {
 
         let outcome = execute_deferred_remint(&state, entry, &storage_tx).await;
 
-        // Deferred, not resolved: the row stays PendingRemint for the next tick.
-        let DeferredRemintOutcome::Defer(_, reason) = outcome else {
-            panic!("lookup failure must defer, not resolve");
+        // Deferred in-flight, not resolved: the row stays PendingRemint for the
+        // next tick and no counter is bumped (a possibly-persisted sig we can't
+        // read must never be terminalized on a cap).
+        let DeferredRemintOutcome::DeferInFlight(entry, reason) = outcome else {
+            panic!("lookup failure must defer in-flight, not resolve");
         };
+        assert_eq!(
+            entry.finality_check_attempts, 0,
+            "in-flight defer must not bump the finality counter"
+        );
         assert!(
             reason.contains("stored remint-signature lookup failed"),
             "defer reason must name the lookup failure: {reason}"
@@ -2953,13 +3013,106 @@ mod tests {
 
         process_pending_remints(&mut state, &storage_tx).await;
 
-        // Deferred: re-queued with a bumped attempt, no terminal status emitted.
+        // Deferred in-flight: re-queued, no terminal status, and the counter is
+        // NOT bumped (a live sig must never be terminalized on the cap).
         assert!(
             storage_rx.try_recv().is_err(),
             "a live prior attempt must defer, not resolve"
         );
         assert_eq!(state.pending_remints.len(), 1);
-        assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
+        assert_eq!(
+            state.pending_remints[0].finality_check_attempts, 0,
+            "in-flight defer must not consume the finality budget"
+        );
+        // The write-ahead sig must survive: reclassification depends on it.
+        assert!(
+            mock.remint_signatures
+                .lock()
+                .unwrap()
+                .get(&901)
+                .is_some_and(|sigs| !sigs.is_empty()),
+            "the persisted remint signature must not be deleted"
+        );
+        src_send.assert_async().await;
+    }
+
+    /// An in-flight remint whose stored signature is still live must never be
+    /// escalated to ManualReview, even at the finality-check cap. It stays queued
+    /// with its persisted signature intact so reclassification can resolve it.
+    #[tokio::test]
+    async fn remint_at_cap_with_live_stored_attempt_requeues_not_manual_review() {
+        ensure_test_signer();
+        let txn_id = 903;
+        let mut dest = mockito::Server::new_async().await;
+        let mut source = mockito::Server::new_async().await;
+        // Release is dead, so the gate reaches the remint step.
+        let _dest_status = mock_release_dead(&mut dest).await;
+
+        // The stored attempt is on-chain but not yet finalized (still live).
+        let _src_status = mock_rpc(
+            &mut source,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{
+                "slot":100,"confirmations":10,"err":null,
+                "status":{"Ok":null},"confirmationStatus":"confirmed"}]},"id":0}"#,
+        )
+        .await;
+        // Must not broadcast a duplicate while the prior one may still land.
+        let src_send = source
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"sendTransaction""#.into(),
+            ))
+            .expect(0)
+            .create_async()
+            .await;
+
+        let (mut state, mock) = make_sender_state_split_rpc(&dest.url(), &source.url(), None);
+        let at_cap = MAX_FINALITY_CHECK_ATTEMPTS - 1;
+        seed_pending_remint_row(&mock, txn_id, at_cap as i32);
+        mock.remint_signatures
+            .lock()
+            .unwrap()
+            .insert(txn_id, vec![(Signature::new_unique().to_string(), 0)]);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(txn_id),
+                withdrawal_nonce: Some(9),
+                trace_id: Some(format!("trace-{txn_id}")),
+                deposit_claim_lease: None,
+            },
+            remint_info: make_remint_info(txn_id),
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            // One below the cap: a bounded defer would escalate on this tick.
+            finality_check_attempts: at_cap,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        // No ManualReview (no status at all): a live sig is never terminalized.
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a live sig at the cap must not be escalated to ManualReview"
+        );
+        // Still queued, counter unchanged: it keeps reclassifying.
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(state.pending_remints[0].finality_check_attempts, at_cap);
+        // The persisted sig survives so reclassification can resolve it.
+        assert!(
+            mock.remint_signatures
+                .lock()
+                .unwrap()
+                .get(&txn_id)
+                .is_some_and(|sigs| !sigs.is_empty()),
+            "the persisted remint signature must not be deleted"
+        );
         src_send.assert_async().await;
     }
 
@@ -3094,13 +3247,17 @@ mod tests {
 
         process_pending_remints(&mut state, &storage_tx).await;
 
-        // Broadcast happened, but confirmation is pending: defer, don't escalate.
+        // Broadcast happened, so the sig is durable and in-flight: defer without
+        // bumping the counter (reclassify next tick), don't escalate.
         assert!(
             storage_rx.try_recv().is_err(),
             "an unconfirmed remint must defer, not emit a status"
         );
         assert_eq!(state.pending_remints.len(), 1);
-        assert_eq!(state.pending_remints[0].finality_check_attempts, 1);
+        assert_eq!(
+            state.pending_remints[0].finality_check_attempts, 0,
+            "in-flight defer must not consume the finality budget"
+        );
         src_send.assert_async().await;
     }
 

--- a/integration/tests/indexer/remint_flow.rs
+++ b/integration/tests/indexer/remint_flow.rs
@@ -182,6 +182,33 @@ fn make_pending_remint_with_lvbh(
     }
 }
 
+/// A `getSignatureStatuses` reply for one finalized-failed signature. The
+/// release classifies as dead on this, so the gate proceeds to the remint.
+fn finalized_failed_status_reply() -> Reply {
+    Reply::result(json!({
+        "context": {"slot": 200},
+        "value": [{
+            "slot": 100,
+            "confirmations": null,
+            "err": {"InstructionError": [0, {"Custom": 1}]},
+            "status": {"Err": {"InstructionError": [0, {"Custom": 1}]}},
+            "confirmationStatus": "finalized"
+        }]
+    }))
+}
+
+/// `getLatestBlockhash` errors, enough to exhaust the RPC retry wrapper so
+/// build_and_sign fails pre-broadcast (nothing signed, nothing sent).
+fn blockhash_rpc_errors() -> Vec<Reply> {
+    vec![
+        Reply::error(-32000, "blockhash rpc down 1"),
+        Reply::error(-32000, "blockhash rpc down 2"),
+        Reply::error(-32000, "blockhash rpc down 3"),
+        Reply::error(-32000, "blockhash rpc down 4"),
+        Reply::error(-32000, "blockhash rpc down 5"),
+    ]
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // (a) Idempotency short-circuit — attempt_remint finds a landed prior remint.
 // ─────────────────────────────────────────────────────────────────────
@@ -665,9 +692,9 @@ async fn execute_deferred_remint_durably_records_landed_signature() {
 //
 // No stored attempt, then `sendTransaction` errors. The signature was
 // persisted write-ahead before the send, so the outcome is ambiguous
-// (the node may have broadcast it): `attempt_remint` returns `Defer` to
-// reclassify next tick rather than escalating. The caller gets
-// `DeferredRemintOutcome::Defer` and no status is emitted.
+// (the node may have broadcast it): `attempt_remint` returns `DeferInFlight`
+// to reclassify next tick rather than escalating. The caller gets
+// `DeferredRemintOutcome::DeferInFlight` and no status is emitted.
 #[tokio::test]
 async fn execute_deferred_remint_defers_when_send_fails() {
     let mock = MockRpcServer::start().await;
@@ -683,10 +710,13 @@ async fn execute_deferred_remint_defers_when_send_fails() {
     let outcome = test_hooks::execute_deferred_remint(&state, entry, &storage_tx).await;
 
     match outcome {
-        test_hooks::DeferredRemintOutcome::Defer(_, reason) => assert!(
+        test_hooks::DeferredRemintOutcome::DeferInFlight(_, reason) => assert!(
             reason.contains("send failed"),
             "defer reason must name the send failure; got {reason:?}"
         ),
+        test_hooks::DeferredRemintOutcome::DeferPreBroadcast(_, reason) => {
+            panic!("a persisted-then-send failure is in-flight, not pre-broadcast; got {reason:?}")
+        }
         test_hooks::DeferredRemintOutcome::Resolved => {
             panic!("a send failure must defer, not resolve terminally")
         }
@@ -695,5 +725,116 @@ async fn execute_deferred_remint_defers_when_send_fails() {
         storage_rx.try_recv().is_err(),
         "a deferred remint must not emit a status update"
     );
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// (g) Pre-broadcast remint failure gets a bounded retry, not immediate
+//     ManualReview.
+// ─────────────────────────────────────────────────────────────────────
+//
+// The release is finalized-failed, so the gate classifies it dead and
+// proceeds to remint. Source-chain blockhash retrieval then fails before
+// the transaction is signed or sent, so no remint could have landed and
+// retrying is safe. The first failure must not terminalize: the entry is
+// re-queued with a bumped attempt counter and its row stays PendingRemint,
+// the status startup recovery reloads, so it survives a restart. Escalation
+// to ManualReview only happens once the attempt cap is reached, see (h).
+#[tokio::test]
+async fn pre_broadcast_remint_failure_below_cap_defers() {
+    let mock = MockRpcServer::start().await;
+    let (mut state, mut storage_rx, storage_tx, storage_mock) = build_state(mock.url()).await;
+
+    let txn_id: i64 = 94;
+    seed_pending_remint_row(&storage_mock, txn_id, 0);
+    state.pending_remints.push(make_pending_remint(
+        txn_id,
+        6,
+        vec![Signature::new_unique()],
+        0,
+        make_remint_info(txn_id),
+    ));
+
+    // Release sig finalized-failed, so classification is dead and the gate
+    // proceeds to the remint.
+    mock.enqueue("getSignatureStatuses", finalized_failed_status_reply());
+    // Blockhash retrieval fails: build_and_sign errors before any broadcast.
+    mock.enqueue_sequence("getLatestBlockhash", blockhash_rpc_errors());
+
+    test_hooks::process_pending_remints(&mut state, &storage_tx).await;
+
+    // Nothing was broadcast, so no terminal status is emitted.
+    assert!(
+        storage_rx.try_recv().is_err(),
+        "a pre-broadcast failure below the cap must defer, not write a status"
+    );
+    // Re-queued in memory with the attempt counter bumped.
+    assert_eq!(state.pending_remints.len(), 1, "entry must be re-queued");
+    assert_eq!(
+        state.pending_remints[0].finality_check_attempts, 1,
+        "the deferral must bump the attempt counter"
+    );
+    // The row is still PendingRemint, so the restart sweep re-hydrates it.
+    let recoverable = storage_mock
+        .get_pending_remint_transactions()
+        .await
+        .unwrap();
+    assert!(
+        recoverable
+            .iter()
+            .any(|t| t.id == txn_id && t.status == TransactionStatus::PendingRemint),
+        "a pre-broadcast failure must leave the row recoverable across restarts"
+    );
+    assert_eq!(mock.call_count("sendTransaction"), 0, "no broadcast expected");
+    mock.shutdown().await;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// (h) Pre-broadcast remint failure at the cap escalates to ManualReview.
+// ─────────────────────────────────────────────────────────────────────
+//
+// The bounded retry from (g) is not infinite. An entry already at
+// MAX_FINALITY_CHECK_ATTEMPTS - 1 that fails pre-broadcast again trips the
+// cap: it is dropped from the queue and a ManualReview status is emitted
+// carrying both the original withdrawal error and the escalation reason.
+#[tokio::test]
+async fn pre_broadcast_remint_failure_at_cap_escalates_to_manual_review() {
+    let mock = MockRpcServer::start().await;
+    let (mut state, mut storage_rx, storage_tx, _mock) = build_state(mock.url()).await;
+
+    let txn_id: i64 = 95;
+    state.pending_remints.push(make_pending_remint(
+        txn_id,
+        7,
+        vec![Signature::new_unique()],
+        2, // MAX_FINALITY_CHECK_ATTEMPTS - 1
+        make_remint_info(txn_id),
+    ));
+
+    mock.enqueue("getSignatureStatuses", finalized_failed_status_reply());
+    mock.enqueue_sequence("getLatestBlockhash", blockhash_rpc_errors());
+
+    test_hooks::process_pending_remints(&mut state, &storage_tx).await;
+
+    let update = storage_rx
+        .recv()
+        .await
+        .expect("the cap must emit a ManualReview update");
+    assert_eq!(update.transaction_id, txn_id);
+    assert_eq!(update.status, TransactionStatus::ManualReview);
+    let msg = update.error_message.unwrap_or_default();
+    assert!(
+        msg.contains("escalated to ManualReview"),
+        "ManualReview at the cap must surface the escalation label; got {msg:?}"
+    );
+    assert!(
+        msg.contains("release_funds failed"),
+        "ManualReview must preserve the original withdrawal error; got {msg:?}"
+    );
+    assert!(
+        state.pending_remints.is_empty(),
+        "entry must not be re-queued past the cap"
+    );
+    assert_eq!(mock.call_count("sendTransaction"), 0, "no broadcast expected");
     mock.shutdown().await;
 }

--- a/integration/tests/indexer/remint_flow.rs
+++ b/integration/tests/indexer/remint_flow.rs
@@ -785,7 +785,11 @@ async fn pre_broadcast_remint_failure_below_cap_defers() {
             .any(|t| t.id == txn_id && t.status == TransactionStatus::PendingRemint),
         "a pre-broadcast failure must leave the row recoverable across restarts"
     );
-    assert_eq!(mock.call_count("sendTransaction"), 0, "no broadcast expected");
+    assert_eq!(
+        mock.call_count("sendTransaction"),
+        0,
+        "no broadcast expected"
+    );
     mock.shutdown().await;
 }
 
@@ -835,6 +839,10 @@ async fn pre_broadcast_remint_failure_at_cap_escalates_to_manual_review() {
         state.pending_remints.is_empty(),
         "entry must not be re-queued past the cap"
     );
-    assert_eq!(mock.call_count("sendTransaction"), 0, "no broadcast expected");
+    assert_eq!(
+        mock.call_count("sendTransaction"),
+        0,
+        "no broadcast expected"
+    );
     mock.shutdown().await;
 }


### PR DESCRIPTION
Fix: defer pre-broadcast remint failures instead of ManualReview (finding-283)

`execute_deferred_remint` sent every attempt_remint error to ManualReview, so a transient source-chain RPC/signer blip on a fresh compensation flipped the row off PendingRemint and hid it from recovery. Fix: reclassify pre-broadcast / nothing-sent failures from Failed → Defer so they flow through the existing bounded-retry path.

Recommendations:
  - Typed before/after-broadcast outcome — already modeled by RemintAttempt (Confirmed/Defer/Failed); corrected the routing.
  - Keep build/blockhash/signing failures in PendingRemint, bounded counter + requeue — done; these now Defer into defer_or_escalate (persists counter + deadline, requeues, row stays PendingRemint).
  - Defer + retry when the earlier-remint lookup is unavailable — done; get_remint_signatures failure now Defer.
  - Persist signature before broadcast, reconcile before retry — already implemented; also why Uncertain/unparseable cases stay Failed (fail-closed).

Tests updated for defer/requeue;
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,846 | 13,489 | 87.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29930273692) |
| Indexer | 29,463 | 32,733 | 90.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29930273692) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29930273692) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29930273692) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,100 | 16,565 | 79.1% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29930273692) |
| **Total** | **56,519** | **65,205** | **86.7%** | |

> Last updated: 2026-07-22 15:40:41 UTC by E2E Integration