### PR TITLE
fix(indexer): close the reconnect residual tail gap with an in-band checkpoint gate (issue-251)

### DIFF
--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -590,6 +590,9 @@ mod tests {
                     ProcessorMessage::Instruction(_) => {
                         panic!("Expected no Instruction messages for empty blocks");
                     }
+                    ProcessorMessage::Regate { .. } => {
+                        panic!("Expected no Regate messages from backfill");
+                    }
                 }
             }
         }
@@ -933,6 +936,7 @@ mod tests {
                 .map(|m| match m {
                     ProcessorMessage::SlotComplete { slot, .. } => *slot,
                     ProcessorMessage::Instruction(_) => panic!("unexpected Instruction message"),
+                    ProcessorMessage::Regate { .. } => panic!("unexpected Regate message"),
                 })
                 .collect();
             assert_eq!(slots, vec![101, 102, 103]);

--- a/indexer/src/indexer/checkpoint.rs
+++ b/indexer/src/indexer/checkpoint.rs
@@ -46,7 +46,8 @@ struct CheckpointState {
     frontier: u64,
     // Processed-but-not-yet-contiguous slots in `(frontier, target]`, awaiting the fold.
     completed: HashSet<u64>,
-    // Backfill target `T0` while gated; `None` once handed off / ungated (plain max).
+    // Backfill/reconnect target while gated; `None` only when never gated. After the
+    // frontier reaches the target it stays `Some` but is inert (the plain-max path).
     gate: Option<u64>,
     // True when `frontier` advanced since the last successful flush (so flush has work).
     dirty: bool,
@@ -487,7 +488,11 @@ mod tests {
         // A later reconnect resumes LOWER; the target follows it down.
         state.regate(FROM, T0 + 5);
         let rest: Vec<u64> = (T0 + 1..=T0 + 5).collect();
-        assert_eq!(drive(&mut state, &rest), T0 + 5, "hands off at the latest target");
+        assert_eq!(
+            drive(&mut state, &rest),
+            T0 + 5,
+            "hands off at the latest target"
+        );
         assert_eq!(drive(&mut state, &[T0 + 500]), T0 + 500, "then plain max");
     }
 
@@ -499,10 +504,20 @@ mod tests {
         let mut state = CheckpointState::ungated();
         assert_eq!(state.frontier, 0);
         state.regate(5000, 5001);
-        assert_eq!(state.frontier, 5000, "fresh state anchors at the durable checkpoint");
-        assert_eq!(drive(&mut state, &[5001]), 5001, "folds to the target and hands off");
+        assert_eq!(
+            state.frontier, 5000,
+            "fresh state anchors at the durable checkpoint"
+        );
+        assert_eq!(
+            drive(&mut state, &[5001]),
+            5001,
+            "folds to the target and hands off"
+        );
         state.regate(10, 6000);
-        assert_eq!(state.frontier, 5001, "a lower from never rewinds the frontier");
+        assert_eq!(
+            state.frontier, 5001,
+            "a lower from never rewinds the frontier"
+        );
     }
 
     /// A target at or below the frontier is inert: the gap is already covered, so

--- a/indexer/src/indexer/checkpoint.rs
+++ b/indexer/src/indexer/checkpoint.rs
@@ -20,6 +20,19 @@ pub struct CheckpointUpdate {
     pub slot: u64,
 }
 
+/// In-band message on the checkpoint channel. `Slot` advances the durable frontier;
+/// `Regate` re-arms the per-program gate on reconnect. Both ride one FIFO channel so
+/// a re-arm always applies before the slot it precedes (no cross-channel race).
+#[derive(Debug, Clone)]
+pub enum CheckpointMsg {
+    Slot(CheckpointUpdate),
+    Regate {
+        program_type: ProgramType,
+        from: u64,
+        target: u64,
+    },
+}
+
 /// Per-program-type checkpoint progress.
 ///
 /// `frontier` is the contiguous, fully-processed prefix and equals the value
@@ -110,6 +123,15 @@ impl CheckpointState {
         }
     }
 
+    /// Re-arm the gate to hold the checkpoint until slots `(from, target]` are filled.
+    /// `from` is the durable checkpoint: pulling the frontier up to it stops a brand-new
+    /// state from gating at 0 and never folding. The frontier never moves backward, and
+    /// the newest reconnect sets the target so a lower resume slot can still hand off.
+    fn regate(&mut self, from: u64, target: u64) {
+        self.frontier = self.frontier.max(from);
+        self.gate = Some(target);
+    }
+
     /// Slots left to fill while gated (`target - frontier`), saturating to 0 post-handoff.
     fn lag(&self) -> u64 {
         match self.gate {
@@ -163,7 +185,7 @@ impl CheckpointWriter {
 
     /// Start the checkpoint writer service
     /// Spawns a background task that listens for checkpoint updates and batches writes to DB
-    pub fn start(self, mut rx: mpsc::Receiver<CheckpointUpdate>) -> JoinHandle<()> {
+    pub fn start(self, mut rx: mpsc::Receiver<CheckpointMsg>) -> JoinHandle<()> {
         tokio::spawn(async move {
             info!(
                 "Starting CheckpointWriter service (batch interval: {}s, max batch size: {}, gated: {})",
@@ -182,7 +204,12 @@ impl CheckpointWriter {
                 tokio::select! {
                     update = rx.recv() => {
                         match update {
-                            Some(update) => {
+                            // A Regate is a control signal, not slot progress: re-arm the
+                            // gate and do not count it toward a batch flush.
+                            Some(CheckpointMsg::Regate { program_type, from, target }) => {
+                                self.record_regate(&mut states, program_type, from, target);
+                            }
+                            Some(CheckpointMsg::Slot(update)) => {
                                 self.record_update(&mut states, update);
 
                                 update_count += 1;
@@ -223,6 +250,25 @@ impl CheckpointWriter {
         state.apply(update.slot);
         metrics::INDEXER_CHECKPOINT_FRONTIER_LAG
             .with_label_values(&[update.program_type.as_label()])
+            .set(state.lag() as f64);
+    }
+
+    /// Handle a reconnect Regate for one program: re-arm its gate over `(from, target]`
+    /// and refresh the lag gauge. Just in-memory state, no DB write. The gate then holds
+    /// the checkpoint until the backfill fills every slot in that window.
+    fn record_regate(
+        &self,
+        states: &mut HashMap<ProgramType, CheckpointState>,
+        program_type: ProgramType,
+        from: u64,
+        target: u64,
+    ) {
+        let state = states
+            .entry(program_type)
+            .or_insert_with(|| self.new_state());
+        state.regate(from, target);
+        metrics::INDEXER_CHECKPOINT_FRONTIER_LAG
+            .with_label_values(&[program_type.as_label()])
             .set(state.lag() as f64);
     }
 
@@ -400,6 +446,116 @@ mod tests {
     }
 
     // ============================================================================
+    // Regate (reconnect re-arm) Tests
+    // ============================================================================
+
+    /// After a hand-off, a reconnect re-arms the gate to a new target; a hole plus
+    /// a live tip must not leapfrog the frontier, and once the residual window fills
+    /// contiguously it folds up to the new target and hands off again.
+    #[test]
+    fn regate_rearms_after_handoff_and_blocks_leapfrog() {
+        let mut state = CheckpointState::gated(FROM, T0);
+        let full: Vec<u64> = (FROM + 1..=T0).collect();
+        assert_eq!(drive(&mut state, &full), T0);
+        // Hand off to plain-max with a live slot above T0.
+        assert_eq!(drive(&mut state, &[T0 + 50]), T0 + 50);
+
+        // Reconnect observes a later resume slot and re-arms the gate.
+        state.regate(T0 + 50, T0 + 100);
+
+        // A hole (T0+51 skipped) plus a live tip cannot move the durable frontier.
+        assert_eq!(drive(&mut state, &[T0 + 52, 9_000_000]), T0 + 50);
+
+        // Filling the residual window contiguously folds to the new target.
+        let residual: Vec<u64> = (T0 + 51..=T0 + 100).collect();
+        assert_eq!(drive(&mut state, &residual), T0 + 100);
+
+        // Handed off again: a later live tip advances via plain max.
+        assert_eq!(drive(&mut state, &[9_000_001]), 9_000_001);
+    }
+
+    /// The gate target tracks the latest reconnect: a lower resume slot after a higher
+    /// one lowers the target so the fold can hand off, instead of stalling above what the
+    /// source will emit.
+    #[test]
+    fn regate_latest_target_wins() {
+        let mut state = CheckpointState::gated(FROM, T0);
+        // A first reconnect raises the target above T0.
+        state.regate(FROM, T0 + 20);
+        let upto_t0: Vec<u64> = (FROM + 1..=T0).collect();
+        assert_eq!(drive(&mut state, &upto_t0), T0, "still gated below T0+20");
+        // A later reconnect resumes LOWER; the target follows it down.
+        state.regate(FROM, T0 + 5);
+        let rest: Vec<u64> = (T0 + 1..=T0 + 5).collect();
+        assert_eq!(drive(&mut state, &rest), T0 + 5, "hands off at the latest target");
+        assert_eq!(drive(&mut state, &[T0 + 500]), T0 + 500, "then plain max");
+    }
+
+    /// A reconnect on a fresh state seeds the frontier to the durable checkpoint, so a
+    /// Regate arriving before any Slot cannot freeze the fold at 0; a later lower `from`
+    /// never rewinds it.
+    #[test]
+    fn regate_seeds_frontier_from_durable_checkpoint() {
+        let mut state = CheckpointState::ungated();
+        assert_eq!(state.frontier, 0);
+        state.regate(5000, 5001);
+        assert_eq!(state.frontier, 5000, "fresh state anchors at the durable checkpoint");
+        assert_eq!(drive(&mut state, &[5001]), 5001, "folds to the target and hands off");
+        state.regate(10, 6000);
+        assert_eq!(state.frontier, 5001, "a lower from never rewinds the frontier");
+    }
+
+    /// A target at or below the frontier is inert: the gap is already covered, so
+    /// plain-max progress continues with no stall.
+    #[test]
+    fn regate_below_frontier_is_inert() {
+        let mut state = CheckpointState::ungated();
+        assert_eq!(drive(&mut state, &[500]), 500);
+        state.regate(400, 400);
+        assert_eq!(drive(&mut state, &[600]), 600);
+        assert_eq!(state.lag(), 0);
+    }
+
+    /// The writer's Regate handling re-gates the correct per-program state: after
+    /// record_regate the gated frontier stays put and lag reflects the new target.
+    #[test]
+    fn record_regate_arms_gate_for_program() {
+        let storage: Arc<Storage> = Arc::new(Storage::Mock(MockStorage::new()));
+        let writer = CheckpointWriter::new(storage);
+        let mut states: HashMap<ProgramType, CheckpointState> = HashMap::new();
+
+        // Seed the program at frontier 100 the way the writer loop would.
+        writer.record_update(
+            &mut states,
+            CheckpointUpdate {
+                program_type: ProgramType::Escrow,
+                slot: 100,
+            },
+        );
+        writer.record_regate(&mut states, ProgramType::Escrow, 100, 110);
+
+        // A live tip and an in-gap slot must not move the gated frontier.
+        writer.record_update(
+            &mut states,
+            CheckpointUpdate {
+                program_type: ProgramType::Escrow,
+                slot: 105,
+            },
+        );
+        writer.record_update(
+            &mut states,
+            CheckpointUpdate {
+                program_type: ProgramType::Escrow,
+                slot: 2_000_000,
+            },
+        );
+
+        let state = states.get(&ProgramType::Escrow).unwrap();
+        assert_eq!(state.frontier, 100);
+        assert_eq!(state.lag(), 10);
+    }
+
+    // ============================================================================
     // Builder Tests
     // ============================================================================
 
@@ -567,10 +723,10 @@ mod tests {
         let (tx, rx) = mpsc::channel(16);
         let handle = writer.start(rx);
 
-        tx.send(CheckpointUpdate {
+        tx.send(CheckpointMsg::Slot(CheckpointUpdate {
             program_type: ProgramType::Escrow,
             slot: 500,
-        })
+        }))
         .await
         .unwrap();
 
@@ -597,16 +753,16 @@ mod tests {
         let handle = writer.start(rx);
 
         // Send 2 updates to trigger batch flush
-        tx.send(CheckpointUpdate {
+        tx.send(CheckpointMsg::Slot(CheckpointUpdate {
             program_type: ProgramType::Escrow,
             slot: 100,
-        })
+        }))
         .await
         .unwrap();
-        tx.send(CheckpointUpdate {
+        tx.send(CheckpointMsg::Slot(CheckpointUpdate {
             program_type: ProgramType::Escrow,
             slot: 200,
-        })
+        }))
         .await
         .unwrap();
 
@@ -633,16 +789,16 @@ mod tests {
         let handle = writer.start(rx);
 
         // Send updates with decreasing slots - highest should win
-        tx.send(CheckpointUpdate {
+        tx.send(CheckpointMsg::Slot(CheckpointUpdate {
             program_type: ProgramType::Escrow,
             slot: 300,
-        })
+        }))
         .await
         .unwrap();
-        tx.send(CheckpointUpdate {
+        tx.send(CheckpointMsg::Slot(CheckpointUpdate {
             program_type: ProgramType::Escrow,
             slot: 100, // lower slot, should be ignored
-        })
+        }))
         .await
         .unwrap();
 
@@ -664,10 +820,10 @@ mod tests {
         let (tx, rx) = mpsc::channel(16);
         let handle = writer.start(rx);
 
-        tx.send(CheckpointUpdate {
+        tx.send(CheckpointMsg::Slot(CheckpointUpdate {
             program_type: ProgramType::Withdraw,
             slot: 42,
-        })
+        }))
         .await
         .unwrap();
 

--- a/indexer/src/indexer/datasource/common/types.rs
+++ b/indexer/src/indexer/datasource/common/types.rs
@@ -69,6 +69,14 @@ pub enum ProcessorMessage {
         slot: u64,
         program_type: ProgramType,
     },
+    /// Re-arm the checkpoint gate on reconnect over the durable range `(from, target]`.
+    /// Rides the same FIFO pipeline as the slots it protects, so the gate is set before
+    /// the first live slot at `target` can leapfrog the unfilled residual window.
+    Regate {
+        program_type: ProgramType,
+        from: u64,
+        target: u64,
+    },
 }
 
 // Channel types for sending/receiving messages to transaction processor

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -257,6 +257,10 @@ struct ReconnectGapCtx {
 /// the fold at the durable checkpoint, then spawn a bounded backfill (one in-flight; any
 /// prior is aborted). Sent before the first live block so the gate wins the FIFO race.
 #[cfg(feature = "datasource-rpc")]
+/// Returns whether it is safe to forward the block that triggered this arm. `false`
+/// means cancellation interrupted the checkpoint read before the gate was armed, so the
+/// caller must NOT forward the block: its SlotComplete would advance the checkpoint over
+/// the still-unfilled gap. `true` means the gate is armed, or a fresh system needs none.
 async fn arm_reconnect_gap(
     t_sub: u64,
     ctx: &ReconnectGapCtx,
@@ -264,10 +268,10 @@ async fn arm_reconnect_gap(
     cancel: &CancellationToken,
     backoff: Duration,
     prev: &mut Option<tokio::task::JoinHandle<()>>,
-) -> Result<(), DataSourceRpcError> {
+) -> Result<bool, DataSourceRpcError> {
     // Resolve the anchor before arming: the gate must seed the frontier to the durable
-    // checkpoint, so a wrong/zero `from` would freeze it. Retry a failed read (fail
-    // closed: the first block is not forwarded yet) until cancellation.
+    // checkpoint, so a wrong/zero `from` would freeze it. Retry a failed read until it
+    // succeeds or cancellation ends it (returning false so the block is not forwarded).
     let checkpoint = loop {
         match get_last_checkpoint(&ctx.storage, ctx.program_type).await {
             Ok(slot) => break slot,
@@ -275,7 +279,7 @@ async fn arm_reconnect_gap(
                 warn!("Reconnect gap: checkpoint read failed, retrying: {}", e);
                 record_gap_fill_error(ctx.program_type);
                 if backoff_cancelled(cancel, backoff).await {
-                    return Ok(());
+                    return Ok(false);
                 }
             }
         }
@@ -284,7 +288,7 @@ async fn arm_reconnect_gap(
     // Fresh system: startup backfill owns initial catch-up and there is no residual
     // window; arming would freeze the frontier on a range the fill never emits.
     if checkpoint == 0 {
-        return Ok(());
+        return Ok(true);
     }
 
     send_guaranteed(
@@ -331,7 +335,7 @@ async fn arm_reconnect_gap(
         .await;
     });
     *prev = Some(handle);
-    Ok(())
+    Ok(true)
 }
 
 /// Waits one backoff period; true means cancellation fired first.
@@ -612,7 +616,7 @@ async fn connect_and_stream(
                     if let Some(ctx) = gap_ctx {
                         if !armed {
                             armed = true;
-                            arm_reconnect_gap(
+                            let safe_to_forward = arm_reconnect_gap(
                                 block.slot,
                                 ctx,
                                 &tx,
@@ -622,6 +626,12 @@ async fn connect_and_stream(
                             )
                             .await
                             .map_err(DataSourceError::Rpc)?;
+                            // Cancelled mid-arm before the gate was set: stop instead of
+                            // forwarding this block, whose SlotComplete would leapfrog the
+                            // unfilled gap. Shutdown proceeds; a restart replays the slot.
+                            if !safe_to_forward {
+                                break;
+                            }
                         }
                     }
 
@@ -1124,6 +1134,47 @@ mod tests {
         assert!(
             rx.recv().await.is_none(),
             "a fresh system must emit no Regate and no SlotComplete"
+        );
+        no_blocks.assert_async().await;
+    }
+
+    /// Cancellation while the checkpoint read is failing reports the block unsafe to
+    /// forward, so its SlotComplete cannot leapfrog the still-unfilled gap on shutdown.
+    #[tokio::test]
+    async fn arm_reconnect_gap_cancelled_during_read_withholds_block() {
+        use crate::storage::common::storage::mock::MockStorage;
+        let mut server = Server::new_async().await;
+        let no_blocks = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "getBlock"})))
+            .expect(0)
+            .create_async()
+            .await;
+
+        // The checkpoint read fails, so arm loops; a pre-cancelled token ends it at once.
+        let mock = MockStorage::new();
+        mock.set_checkpoint("escrow", 100);
+        mock.set_should_fail("get_committed_checkpoint", true);
+        let ctx = test_gap_ctx(&server, Arc::new(Storage::Mock(mock)), 1000);
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let mut prev: Option<tokio::task::JoinHandle<()>> = None;
+
+        let safe = arm_reconnect_gap(103, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+            .await
+            .unwrap();
+        drop(tx);
+
+        assert!(
+            !safe,
+            "cancellation before arming must report the block unsafe to forward"
+        );
+        assert!(prev.is_none(), "no backfill is spawned on a cancelled arm");
+        assert!(
+            rx.recv().await.is_none(),
+            "no Regate is emitted on a cancelled arm"
         );
         no_blocks.assert_async().await;
     }

--- a/indexer/src/indexer/datasource/yellowstone/source.rs
+++ b/indexer/src/indexer/datasource/yellowstone/source.rs
@@ -121,12 +121,14 @@ enum GapFillOutcome {
     Cancelled,
 }
 
-/// Repairs the reconnect gap (checkpoint, tip], returning Resolved only once every
-/// slot is indexed or proven empty; failures retry in place with backoff so the
-/// caller can never resubscribe over an open gap. Cancellation wins every wait.
+/// Repairs the reconnect gap (checkpoint, target] up to the fixed observed resume slot,
+/// returning Resolved only once every slot is indexed or proven empty; failures retry in
+/// place with backoff. The gate keeps the checkpoint frozen until this completes (an
+/// un-fillable slot fails closed). Cancellation wins every wait.
 #[cfg(feature = "datasource-rpc")]
 #[allow(clippy::too_many_arguments)]
-async fn ensure_reconnect_gap_filled<F, Fut>(
+async fn fill_reconnect_gap_to<F, Fut>(
+    target: u64,
     get_checkpoint: F,
     rpc_poller: &RpcPoller,
     max_gap_slots: u64,
@@ -167,23 +169,11 @@ where
             return GapFillOutcome::Resolved;
         }
 
-        let current_slot = match rpc_poller.get_latest_slot().await {
-            Ok(slot) => slot,
-            Err(e) => {
-                warn!("Reconnect gap-fill: tip fetch failed, retrying: {}", e);
-                record_gap_fill_error(program_type);
-                if backoff_cancelled(cancel, backoff).await {
-                    return GapFillOutcome::Cancelled;
-                }
-                continue;
-            }
-        };
-
-        let gap = match validate_gap(current_slot, checkpoint, max_gap_slots) {
+        let gap = match validate_gap(target, checkpoint, max_gap_slots) {
             Ok(None) => {
                 info!(
-                    "No gap detected on reconnect. Current slot: {}, checkpoint: {}",
-                    current_slot, checkpoint
+                    "No reconnect gap to fill. Target: {}, checkpoint: {}",
+                    target, checkpoint
                 );
                 return GapFillOutcome::Resolved;
             }
@@ -217,14 +207,14 @@ where
         // from checkpoint-1 to include it; inserts are idempotent.
         let replay_anchor = checkpoint.saturating_sub(1);
         info!(
-            "Gap detected on reconnect: {} slots (replaying from {} to {}). Backfilling...",
-            gap, replay_anchor, current_slot
+            "Reconnect gap: {} slots (replaying from {} to {}). Backfilling...",
+            gap, replay_anchor, target
         );
 
         match fill_slot_range(
             rpc_poller,
             replay_anchor,
-            current_slot,
+            target,
             batch_size,
             program_type,
             escrow_instance_id,
@@ -249,6 +239,99 @@ where
             return GapFillOutcome::Cancelled;
         }
     }
+}
+
+/// Context threaded to `connect_and_stream` so it can, on the first live block of a
+/// reconnect, observe the resume slot and arm the gate + concurrent backfill.
+#[cfg(feature = "datasource-rpc")]
+struct ReconnectGapCtx {
+    poller: Arc<RpcPoller>,
+    storage: Arc<Storage>,
+    max_gap_slots: u64,
+    batch_size: usize,
+    program_type: ProgramType,
+    escrow_instance_id: Option<Pubkey>,
+}
+
+/// Arm the reconnect gate over `(checkpoint, t_sub]` carrying `from` so the writer anchors
+/// the fold at the durable checkpoint, then spawn a bounded backfill (one in-flight; any
+/// prior is aborted). Sent before the first live block so the gate wins the FIFO race.
+#[cfg(feature = "datasource-rpc")]
+async fn arm_reconnect_gap(
+    t_sub: u64,
+    ctx: &ReconnectGapCtx,
+    tx: &InstructionSender,
+    cancel: &CancellationToken,
+    backoff: Duration,
+    prev: &mut Option<tokio::task::JoinHandle<()>>,
+) -> Result<(), DataSourceRpcError> {
+    // Resolve the anchor before arming: the gate must seed the frontier to the durable
+    // checkpoint, so a wrong/zero `from` would freeze it. Retry a failed read (fail
+    // closed: the first block is not forwarded yet) until cancellation.
+    let checkpoint = loop {
+        match get_last_checkpoint(&ctx.storage, ctx.program_type).await {
+            Ok(slot) => break slot,
+            Err(e) => {
+                warn!("Reconnect gap: checkpoint read failed, retrying: {}", e);
+                record_gap_fill_error(ctx.program_type);
+                if backoff_cancelled(cancel, backoff).await {
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    // Fresh system: startup backfill owns initial catch-up and there is no residual
+    // window; arming would freeze the frontier on a range the fill never emits.
+    if checkpoint == 0 {
+        return Ok(());
+    }
+
+    send_guaranteed(
+        tx,
+        ProcessorMessage::Regate {
+            program_type: ctx.program_type,
+            from: checkpoint,
+            target: t_sub,
+        },
+        "Regate (yellowstone)",
+    )
+    .await
+    .map_err(|e| DataSourceRpcError::Protocol {
+        reason: format!("Regate send failed: {e}"),
+    })?;
+
+    // Supersede any prior in-flight backfill; the new one covers the superset range.
+    if let Some(handle) = prev.take() {
+        handle.abort();
+    }
+
+    let poller = ctx.poller.clone();
+    let storage = ctx.storage.clone();
+    let program_type = ctx.program_type;
+    let escrow_instance_id = ctx.escrow_instance_id;
+    let max_gap_slots = ctx.max_gap_slots;
+    let batch_size = ctx.batch_size;
+    let tx = tx.clone();
+    let cancel = cancel.clone();
+
+    let handle = tokio::spawn(async move {
+        fill_reconnect_gap_to(
+            t_sub,
+            || get_last_checkpoint(&storage, program_type),
+            &poller,
+            max_gap_slots,
+            batch_size,
+            program_type,
+            escrow_instance_id,
+            &tx,
+            &cancel,
+            backoff,
+        )
+        .await;
+    });
+    *prev = Some(handle);
+    Ok(())
 }
 
 /// Waits one backoff period; true means cancellation fired first.
@@ -305,11 +388,42 @@ impl DataSource for YellowstoneSource {
         let storage = self.storage.clone();
 
         let handle = tokio::spawn(async move {
+            // Reconnect gate context, built once; None disables reconnect gating.
+            #[cfg(feature = "datasource-rpc")]
+            let gap_ctx_opt = match (rpc_poller, storage) {
+                (Some(poller), Some(storage)) => Some(ReconnectGapCtx {
+                    poller,
+                    storage,
+                    max_gap_slots,
+                    batch_size,
+                    program_type,
+                    escrow_instance_id,
+                }),
+                _ => None,
+            };
+            // One in-flight reconnect backfill, owned here and superseded on each reconnect.
+            #[cfg(feature = "datasource-rpc")]
+            let mut backfill_handle: Option<tokio::task::JoinHandle<()>> = None;
+            // True once some connection has subscribed. Only later connections arm the
+            // reconnect gate; the first stream is a cold start that startup backfill
+            // already covers. A connect that fails before subscribing does not count.
+            #[cfg(feature = "datasource-rpc")]
+            let mut ever_streamed = false;
+
             loop {
                 if cancellation_token.is_cancelled() {
                     info!("Yellowstone source received cancellation signal, stopping...");
                     break;
                 }
+
+                #[cfg(feature = "datasource-rpc")]
+                let gap_ctx = if ever_streamed {
+                    gap_ctx_opt.as_ref()
+                } else {
+                    None
+                };
+                #[cfg(feature = "datasource-rpc")]
+                let mut subscribed = false;
 
                 match connect_and_stream(
                     &endpoint,
@@ -319,6 +433,12 @@ impl DataSource for YellowstoneSource {
                     tx.clone(),
                     cancellation_token.clone(),
                     health.as_ref(),
+                    #[cfg(feature = "datasource-rpc")]
+                    gap_ctx,
+                    #[cfg(feature = "datasource-rpc")]
+                    &mut backfill_handle,
+                    #[cfg(feature = "datasource-rpc")]
+                    &mut subscribed,
                 )
                 .await
                 {
@@ -340,33 +460,17 @@ impl DataSource for YellowstoneSource {
                         metrics::INDEXER_DATASOURCE_RECONNECTS
                             .with_label_values(&[program_type.as_label()])
                             .inc();
-                        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                        // Cancellation-aware backoff so shutdown does not wait out the 5s.
+                        tokio::select! {
+                            _ = cancellation_token.cancelled() => {}
+                            _ = tokio::time::sleep(tokio::time::Duration::from_secs(5)) => {}
+                        }
                     }
                 }
 
                 #[cfg(feature = "datasource-rpc")]
-                {
-                    // Repairing the gap is a hard precondition for resubscribing: a live
-                    // SlotComplete at the tip would advance the durable checkpoint past
-                    // the unfilled range, so the loop must not fall through on failure.
-                    if let (Some(poller), Some(storage)) = (&rpc_poller, &storage) {
-                        match ensure_reconnect_gap_filled(
-                            || get_last_checkpoint(storage, program_type),
-                            poller,
-                            max_gap_slots,
-                            batch_size,
-                            program_type,
-                            escrow_instance_id,
-                            &tx,
-                            &cancellation_token,
-                            RECONNECT_GAP_RETRY_BACKOFF,
-                        )
-                        .await
-                        {
-                            GapFillOutcome::Resolved => {}
-                            GapFillOutcome::Cancelled => break,
-                        }
-                    }
+                if subscribed {
+                    ever_streamed = true;
                 }
             }
 
@@ -382,6 +486,7 @@ impl DataSource for YellowstoneSource {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn connect_and_stream(
     endpoint: &str,
     x_token: Option<String>,
@@ -390,6 +495,13 @@ async fn connect_and_stream(
     tx: InstructionSender,
     cancellation_token: CancellationToken,
     health: Option<&Arc<private_channel_metrics::HealthState>>,
+    // Present only on reconnects (after the first connection). When set, the first
+    // live block arms the gate + backfill so the residual window cannot be leapfrogged.
+    #[cfg(feature = "datasource-rpc")] gap_ctx: Option<&ReconnectGapCtx>,
+    #[cfg(feature = "datasource-rpc")] backfill_handle: &mut Option<tokio::task::JoinHandle<()>>,
+    // Set true once this connection subscribes, so the caller can tell a real streaming
+    // session apart from a connect failure that never reached the reconnect-gating state.
+    #[cfg(feature = "datasource-rpc")] subscribed: &mut bool,
 ) -> Result<(), DataSourceError> {
     let mut client = GeyserGrpcClient::build_from_shared(endpoint.to_string())
         .map_err(|e| DataSourceRpcError::Protocol {
@@ -452,6 +564,16 @@ async fn connect_and_stream(
             reason: e.to_string(),
         })?;
 
+    // A subscribe handshake succeeded; from here the next connection is a reconnect.
+    #[cfg(feature = "datasource-rpc")]
+    {
+        *subscribed = true;
+    }
+
+    // Arm the reconnect gate on the first live block of this connection only.
+    #[cfg(feature = "datasource-rpc")]
+    let mut armed = false;
+
     loop {
         tokio::select! {
             _ = cancellation_token.cancelled() => {
@@ -482,6 +604,26 @@ async fn connect_and_stream(
                         block.slot,
                         block.transactions.len()
                     );
+
+                    // First live block after a reconnect: observe the resume slot and
+                    // arm the gate + concurrent backfill BEFORE forwarding this block,
+                    // so its SlotComplete cannot leapfrog the still-unfilled window.
+                    #[cfg(feature = "datasource-rpc")]
+                    if let Some(ctx) = gap_ctx {
+                        if !armed {
+                            armed = true;
+                            arm_reconnect_gap(
+                                block.slot,
+                                ctx,
+                                &tx,
+                                &cancellation_token,
+                                RECONNECT_GAP_RETRY_BACKOFF,
+                                backfill_handle,
+                            )
+                            .await
+                            .map_err(DataSourceError::Rpc)?;
+                        }
+                    }
 
                     // Fail-closed: any parse/send failure returns Err (reconnect + gap-fill
                     // replays the slot) and no SlotComplete is emitted for it.
@@ -540,42 +682,6 @@ mod tests {
         })
     }
 
-    fn mock_get_slot(server: &mut Server, slot: u64) -> mockito::Mock {
-        server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(json!({
-                "method": "getSlot"
-            })))
-            .with_status(200)
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "result": slot,
-                    "id": 1
-                })
-                .to_string(),
-            )
-            .create()
-    }
-
-    fn mock_get_slot_error(server: &mut Server) -> mockito::Mock {
-        server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(json!({
-                "method": "getSlot"
-            })))
-            .with_status(200)
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "error": { "code": -32600, "message": "Invalid request" },
-                    "id": 1
-                })
-                .to_string(),
-            )
-            .create()
-    }
-
     fn mock_get_block_success(server: &mut Server, slot: u64) -> mockito::Mock {
         server
             .mock("POST", "/")
@@ -610,11 +716,31 @@ mod tests {
         move || std::future::ready(Ok(slot))
     }
 
-    /// no gap on reconnect resolves immediately without fetching any block.
+    /// Mock storage seeded with an escrow checkpoint, backing arm_reconnect_gap's
+    /// checkpoint read (get_last_checkpoint on program "escrow").
+    fn storage_with_checkpoint(slot: u64) -> Arc<Storage> {
+        use crate::storage::common::storage::mock::MockStorage;
+        let mock = MockStorage::new();
+        mock.set_checkpoint("escrow", slot);
+        Arc::new(Storage::Mock(mock))
+    }
+
+    /// Escrow reconnect-gap context over the mock RPC server and storage.
+    fn test_gap_ctx(server: &Server, storage: Arc<Storage>, max_gap_slots: u64) -> ReconnectGapCtx {
+        ReconnectGapCtx {
+            poller: Arc::new(test_poller(server)),
+            storage,
+            max_gap_slots,
+            batch_size: 10,
+            program_type: ProgramType::Escrow,
+            escrow_instance_id: None,
+        }
+    }
+
+    /// No gap up to the target resolves immediately without fetching any block.
     #[tokio::test]
     async fn gap_fill_no_gap_resolves_without_fetching_blocks() {
         let mut server = Server::new_async().await;
-        let _m = mock_get_slot(&mut server, 100);
         let no_blocks = server
             .mock("POST", "/")
             .match_body(mockito::Matcher::PartialJson(json!({"method": "getBlock"})))
@@ -626,7 +752,8 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(64);
         let cancel = CancellationToken::new();
 
-        let outcome = ensure_reconnect_gap_filled(
+        let outcome = fill_reconnect_gap_to(
+            100,
             checkpoint_ok(100),
             &poller,
             1000,
@@ -648,12 +775,11 @@ mod tests {
         );
     }
 
-    /// Checkpoint 100, tip 103; the fill replays the boundary slot (anchor 99)
+    /// Checkpoint 100, target 103; the fill replays the boundary slot (anchor 99)
     /// and emits SlotComplete for exactly 100..=103.
     #[tokio::test]
     async fn gap_fill_fills_gap_and_replays_boundary_slot() {
         let mut server = Server::new_async().await;
-        let _m_slot = mock_get_slot(&mut server, 103);
         let _blocks: Vec<_> = (100..=103)
             .map(|s| mock_get_block_success(&mut server, s))
             .collect();
@@ -662,7 +788,8 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(64);
         let cancel = CancellationToken::new();
 
-        let outcome = ensure_reconnect_gap_filled(
+        let outcome = fill_reconnect_gap_to(
+            103,
             checkpoint_ok(100),
             &poller,
             1000,
@@ -688,7 +815,7 @@ mod tests {
     }
 
     /// Checkpoint 0 is a fresh system; startup backfill owns catch-up, so the
-    /// wrapper resolves without a single RPC call.
+    /// fill resolves without a single RPC call.
     #[tokio::test]
     async fn gap_fill_fresh_system_resolves_without_rpc() {
         let mut server = Server::new_async().await;
@@ -698,7 +825,8 @@ mod tests {
         let (tx, _rx) = mpsc::channel(64);
         let cancel = CancellationToken::new();
 
-        let outcome = ensure_reconnect_gap_filled(
+        let outcome = fill_reconnect_gap_to(
+            100,
             checkpoint_ok(0),
             &poller,
             1000,
@@ -720,8 +848,7 @@ mod tests {
     async fn gap_fill_retries_checkpoint_read_failures() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        let mut server = Server::new_async().await;
-        let _m = mock_get_slot(&mut server, 100);
+        let server = Server::new_async().await;
 
         let calls = Arc::new(AtomicUsize::new(0));
         let calls_in = calls.clone();
@@ -740,7 +867,9 @@ mod tests {
         let (tx, _rx) = mpsc::channel(64);
         let cancel = CancellationToken::new();
 
-        let outcome = ensure_reconnect_gap_filled(
+        // target == checkpoint => no gap once the read heals.
+        let outcome = fill_reconnect_gap_to(
+            100,
             get_checkpoint,
             &poller,
             1000,
@@ -757,71 +886,11 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 3);
     }
 
-    /// A failing tip fetch retries in place and resolves once the endpoint heals.
-    #[tokio::test]
-    async fn gap_fill_retries_tip_fetch_failures() {
-        let mut server = Server::new_async().await;
-        let err_mock = server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::PartialJson(json!({"method": "getSlot"})))
-            .with_status(200)
-            .with_body(
-                json!({
-                    "jsonrpc": "2.0",
-                    "error": { "code": -32600, "message": "Invalid request" },
-                    "id": 1
-                })
-                .to_string(),
-            )
-            .expect_at_least(1)
-            .create_async()
-            .await;
-
-        let poller = test_poller(&server);
-        let (tx, _rx) = mpsc::channel(64);
-        let cancel = CancellationToken::new();
-        let cancel_task = cancel.clone();
-
-        let handle = tokio::spawn(async move {
-            ensure_reconnect_gap_filled(
-                checkpoint_ok(100),
-                &poller,
-                1000,
-                10,
-                ProgramType::Escrow,
-                None,
-                &tx,
-                &cancel_task,
-                TEST_BACKOFF,
-            )
-            .await
-        });
-
-        // Observe at least one failed attempt before healing the endpoint.
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while !err_mock.matched_async().await {
-                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-            }
-        })
-        .await
-        .expect("tip fetch error was never observed");
-
-        // mockito matches the newest-registered mock first, so this overrides the error.
-        let _ok = mock_get_slot(&mut server, 100);
-
-        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), handle)
-            .await
-            .expect("must resolve after the tip fetch heals")
-            .unwrap();
-        assert_eq!(outcome, GapFillOutcome::Resolved);
-    }
-
     /// An unavailable (pruned) slot stalls the loop with repeated attempts;
     /// no SlotComplete ever leaks and cancellation ends the stall.
     #[tokio::test]
     async fn gap_fill_unavailable_slot_stalls_without_slot_complete() {
         let mut server = Server::new_async().await;
-        let _m_slot = mock_get_slot(&mut server, 103);
         // Slot 100 is absent below the floor (100 < 500) => Unavailable.
         let absent = server
             .mock("POST", "/")
@@ -852,7 +921,8 @@ mod tests {
         let cancel_task = cancel.clone();
 
         let mut handle = tokio::spawn(async move {
-            ensure_reconnect_gap_filled(
+            fill_reconnect_gap_to(
+                103,
                 checkpoint_ok(100),
                 &poller,
                 1000,
@@ -896,12 +966,11 @@ mod tests {
         assert_eq!(outcome, GapFillOutcome::Cancelled);
     }
 
-    /// An oversized gap stalls loudly with no fill attempt at all, because
-    /// validate_gap rejects it before any block fetch.
+    /// An oversized gap to the target stalls loudly with no fill attempt at all,
+    /// because validate_gap rejects it before any block fetch.
     #[tokio::test]
     async fn gap_fill_too_large_stalls_without_fill() {
         let mut server = Server::new_async().await;
-        let _m_slot = mock_get_slot(&mut server, 200);
         let no_blocks = server
             .mock("POST", "/")
             .match_body(mockito::Matcher::PartialJson(json!({"method": "getBlock"})))
@@ -915,7 +984,8 @@ mod tests {
         let cancel_task = cancel.clone();
 
         let mut handle = tokio::spawn(async move {
-            ensure_reconnect_gap_filled(
+            fill_reconnect_gap_to(
+                200,
                 checkpoint_ok(100),
                 &poller,
                 10,
@@ -951,17 +1021,21 @@ mod tests {
     /// out the full production backoff.
     #[tokio::test]
     async fn gap_fill_cancellation_interrupts_backoff_promptly() {
-        let mut server = Server::new_async().await;
-        let _err = mock_get_slot_error(&mut server);
+        let server = Server::new_async().await;
 
         let poller = test_poller(&server);
         let (tx, _rx) = mpsc::channel(64);
         let cancel = CancellationToken::new();
         let cancel_task = cancel.clone();
 
+        // A checkpoint read that always errors forces the loop into its backoff.
+        let get_checkpoint =
+            || std::future::ready(Err(CheckpointError::InvalidCheckpoint { slot: 0, last: 0 }));
+
         let handle = tokio::spawn(async move {
-            ensure_reconnect_gap_filled(
-                checkpoint_ok(100),
+            fill_reconnect_gap_to(
+                103,
+                get_checkpoint,
                 &poller,
                 1000,
                 10,
@@ -983,6 +1057,119 @@ mod tests {
             .expect("cancellation must interrupt the backoff, not wait it out")
             .unwrap();
         assert_eq!(outcome, GapFillOutcome::Cancelled);
+    }
+
+    /// arm_reconnect_gap emits the gate re-arm first, then backfills up to the
+    /// observed resume slot (boundary replay from checkpoint-1).
+    #[tokio::test]
+    async fn arm_reconnect_gap_emits_regate_then_fills_to_target() {
+        let mut server = Server::new_async().await;
+        let _blocks: Vec<_> = (100..=103)
+            .map(|s| mock_get_block_success(&mut server, s))
+            .collect();
+
+        let ctx = test_gap_ctx(&server, storage_with_checkpoint(100), 1000);
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let mut prev: Option<tokio::task::JoinHandle<()>> = None;
+
+        arm_reconnect_gap(103, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+            .await
+            .unwrap();
+        drop(tx);
+
+        let mut msgs = vec![];
+        while let Some(m) = rx.recv().await {
+            msgs.push(m);
+        }
+        prev.unwrap().await.unwrap();
+
+        assert!(
+            matches!(msgs[0], ProcessorMessage::Regate { target: 103, .. }),
+            "the gate re-arm must be emitted first"
+        );
+        let slots: Vec<u64> = msgs
+            .iter()
+            .filter_map(|m| match m {
+                ProcessorMessage::SlotComplete { slot, .. } => Some(*slot),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(slots, vec![100, 101, 102, 103]);
+    }
+
+    /// A fresh system (checkpoint 0) arms no gate and spawns no fill: startup
+    /// backfill owns catch-up, and arming would freeze the frontier forever.
+    #[tokio::test]
+    async fn arm_reconnect_gap_fresh_system_does_not_arm() {
+        let mut server = Server::new_async().await;
+        let no_blocks = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "getBlock"})))
+            .expect(0)
+            .create_async()
+            .await;
+
+        let ctx = test_gap_ctx(&server, storage_with_checkpoint(0), 1000);
+        let (tx, mut rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let mut prev: Option<tokio::task::JoinHandle<()>> = None;
+
+        arm_reconnect_gap(103, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+            .await
+            .unwrap();
+        drop(tx);
+
+        assert!(prev.is_none(), "a fresh system must not spawn a backfill");
+        assert!(
+            rx.recv().await.is_none(),
+            "a fresh system must emit no Regate and no SlotComplete"
+        );
+        no_blocks.assert_async().await;
+    }
+
+    /// A second arm aborts the prior backfill and leaves exactly one in flight,
+    /// bounding concurrent reconnect backfills to one.
+    #[tokio::test]
+    async fn arm_reconnect_gap_aborts_prior_backfill() {
+        let mut server = Server::new_async().await;
+        let _ = mock_get_block_success(&mut server, 100);
+
+        // max_gap_slots = 10 with target 1000 => GapTooLarge => the fill loops
+        // forever, keeping the first backfill in flight so it can be aborted.
+        let ctx = test_gap_ctx(&server, storage_with_checkpoint(100), 10);
+        let (tx, _rx) = mpsc::channel(64);
+        let cancel = CancellationToken::new();
+        let mut prev: Option<tokio::task::JoinHandle<()>> = None;
+
+        arm_reconnect_gap(1000, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+            .await
+            .unwrap();
+        let first = prev.as_ref().unwrap().abort_handle();
+        assert!(!first.is_finished(), "first backfill is still in flight");
+
+        arm_reconnect_gap(1000, &ctx, &tx, &cancel, TEST_BACKOFF, &mut prev)
+            .await
+            .unwrap();
+
+        // The prior backfill was aborted; only the replacement remains in flight.
+        for _ in 0..100 {
+            if first.is_finished() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(first.is_finished(), "the prior backfill must be aborted");
+        let second = prev.as_ref().unwrap().abort_handle();
+        assert!(
+            !second.is_finished(),
+            "the replacement backfill stays in flight"
+        );
+
+        cancel.cancel();
+        if let Some(h) = prev.take() {
+            let _ = h.await;
+        }
     }
 
     /// Borsh-encoded WithdrawFunds payload (discriminator 0, amount, None destination)
@@ -1607,6 +1794,7 @@ mod tests {
                     assert_eq!(slot, 1100);
                     completed = true;
                 }
+                ProcessorMessage::Regate { .. } => panic!("no Regate expected here"),
             }
         }
         assert_eq!(instructions, 0, "a failed tx must not be indexed");

--- a/indexer/src/indexer/mod.rs
+++ b/indexer/src/indexer/mod.rs
@@ -9,5 +9,5 @@ pub mod reconciliation;
 pub mod resync;
 pub mod transaction_processor;
 
-pub use checkpoint::CheckpointUpdate;
+pub use checkpoint::{CheckpointMsg, CheckpointUpdate};
 pub use indexer::run;

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -208,7 +208,10 @@ impl TransactionProcessor {
                     .await
                     .is_err()
                     {
-                        error!("Regate send failed for {:?} target {}", program_type, target);
+                        error!(
+                            "Regate send failed for {:?} target {}",
+                            program_type, target
+                        );
                         return Err(IndexerError::CheckpointChannelClosed);
                     }
                 }

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -4,7 +4,7 @@ use crate::{
     config::ProgramType,
     error::{IndexerError, StorageError},
     indexer::{
-        checkpoint::CheckpointUpdate,
+        checkpoint::{CheckpointMsg, CheckpointUpdate},
         datasource::common::{
             parser::{escrow_instance_of, EscrowInstruction, WithdrawInstruction},
             types::{InstructionWithMetadata, ProcessorMessage, ProgramInstruction},
@@ -69,7 +69,7 @@ impl WriteRetryPolicy {
 /// Current implementation: Sequential slot processing with batch inserts per slot (Option 3)
 pub struct TransactionProcessor {
     storage: Arc<Storage>,
-    checkpoint_tx: mpsc::Sender<CheckpointUpdate>,
+    checkpoint_tx: mpsc::Sender<CheckpointMsg>,
 
     // Per-slot instruction buffers, so a foreign SlotComplete finalizes only its own slot's rows.
     slot_buffers: HashMap<u64, Vec<InstructionWithMetadata>>,
@@ -90,7 +90,7 @@ pub struct TransactionProcessor {
 }
 
 impl TransactionProcessor {
-    pub fn new(storage: Arc<Storage>, checkpoint_tx: mpsc::Sender<CheckpointUpdate>) -> Self {
+    pub fn new(storage: Arc<Storage>, checkpoint_tx: mpsc::Sender<CheckpointMsg>) -> Self {
         Self {
             storage,
             checkpoint_tx,
@@ -186,6 +186,30 @@ impl TransactionProcessor {
                         .observe(start.elapsed().as_secs_f64());
                     if let Some(h) = &self.health {
                         h.record_progress();
+                    }
+                }
+                ProcessorMessage::Regate {
+                    program_type,
+                    from,
+                    target,
+                } => {
+                    // Forward the gate re-arm in-band, ahead of the slot it precedes. No
+                    // DB write and no health bump: it is a control signal, not slot
+                    // progress. A send failure means the writer is gone, so exit.
+                    if send_guaranteed(
+                        &self.checkpoint_tx,
+                        CheckpointMsg::Regate {
+                            program_type,
+                            from,
+                            target,
+                        },
+                        "regate",
+                    )
+                    .await
+                    .is_err()
+                    {
+                        error!("Regate send failed for {:?} target {}", program_type, target);
+                        return Err(IndexerError::CheckpointChannelClosed);
                     }
                 }
             }
@@ -286,7 +310,7 @@ impl TransactionProcessor {
         // pipeline instead of retrying a closed channel.
         match send_guaranteed(
             &self.checkpoint_tx,
-            CheckpointUpdate { program_type, slot },
+            CheckpointMsg::Slot(CheckpointUpdate { program_type, slot }),
             "checkpoint",
         )
         .await
@@ -935,11 +959,34 @@ mod tests {
         }
     }
 
+    /// Unwrap the next message as a slot checkpoint, panicking on a Regate; keeps
+    /// the slot-oriented recv sites terse now that the channel carries CheckpointMsg.
+    async fn recv_slot(rx: &mut mpsc::Receiver<CheckpointMsg>) -> CheckpointUpdate {
+        match rx.recv().await.expect("expected a checkpoint message") {
+            CheckpointMsg::Slot(update) => update,
+            CheckpointMsg::Regate { target, .. } => {
+                panic!("expected a Slot checkpoint, got Regate(target={target})")
+            }
+        }
+    }
+
+    /// Poll the committed checkpoint until it reaches `want`, so a test can await a
+    /// durable flush without racing the writer's batch timer.
+    async fn wait_for_checkpoint(mock: &MockStorage, program: &str, want: u64) {
+        for _ in 0..200 {
+            if mock.get_committed_checkpoint(program).await.unwrap() == Some(want) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("checkpoint for {program} never reached {want}");
+    }
+
     fn make_processor_and_rx(
         escrow_instance_id: Pubkey,
     ) -> (
         TransactionProcessor,
-        tokio::sync::mpsc::Receiver<CheckpointUpdate>,
+        tokio::sync::mpsc::Receiver<CheckpointMsg>,
     ) {
         let mock = MockStorage::new();
         let storage = Arc::new(Storage::Mock(mock));
@@ -954,7 +1001,7 @@ mod tests {
         escrow_instance_id: Pubkey,
     ) -> (
         TransactionProcessor,
-        tokio::sync::mpsc::Receiver<CheckpointUpdate>,
+        tokio::sync::mpsc::Receiver<CheckpointMsg>,
         MockStorage,
     ) {
         let mock = MockStorage::new();
@@ -973,7 +1020,7 @@ mod tests {
             .finalize_and_checkpoint(42, ProgramType::Escrow)
             .await
             .unwrap();
-        let cp = checkpoint_rx.recv().await.unwrap();
+        let cp = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(cp.slot, 42);
         assert_eq!(cp.program_type, ProgramType::Escrow);
         assert!(processor.slot_buffers.is_empty());
@@ -994,7 +1041,7 @@ mod tests {
             assert_eq!(inserted[0].len(), 1);
         }
 
-        let cp = checkpoint_rx.recv().await.unwrap();
+        let cp = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(cp.slot, 100);
     }
 
@@ -1014,7 +1061,7 @@ mod tests {
             assert!(mints.contains_key(&make_pubkey(2).to_string()));
         }
 
-        let cp = checkpoint_rx.recv().await.unwrap();
+        let cp = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(cp.slot, 200);
     }
 
@@ -1040,7 +1087,7 @@ mod tests {
             assert_eq!(rows[0].signature, "sig-allow-1");
         }
 
-        let cp = checkpoint_rx.recv().await.unwrap();
+        let cp = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(cp.slot, 200);
     }
 
@@ -1080,7 +1127,7 @@ mod tests {
             );
         }
 
-        let cp = checkpoint_rx.recv().await.unwrap();
+        let cp = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(cp.slot, 250);
     }
 
@@ -1107,7 +1154,7 @@ mod tests {
             assert_eq!(inserted.len(), 1, "row lands once after the retry");
             assert_eq!(inserted[0][0].slot, 401);
         }
-        let cp = checkpoint_rx.recv().await.unwrap();
+        let cp = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(cp.slot, 401);
         // Exactly one checkpoint - the failed attempt did not also send one.
         assert!(checkpoint_rx.try_recv().is_err());
@@ -1214,8 +1261,61 @@ mod tests {
             assert_eq!(inserted.len(), 1);
         }
 
-        let cp = checkpoint_rx.recv().await.unwrap();
+        let cp = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(cp.slot, 500);
+    }
+
+    /// The processor forwards a Regate in-band ahead of the slot it precedes and
+    /// does no DB write for it, locking the FIFO ordering the gate re-arm depends on.
+    #[tokio::test]
+    async fn processor_forwards_regate_before_slot_in_order() {
+        let (processor, mut checkpoint_rx, mock) = make_processor_with_mock(deposit_instance());
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
+
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            500,
+            Some("s5".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::Regate {
+            program_type: ProgramType::Escrow,
+            from: 100,
+            target: 110,
+        })
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: 500,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+
+        processor.start(rx).await.unwrap();
+
+        // Regate is forwarded first, ahead of slot 500's checkpoint.
+        match checkpoint_rx.recv().await.unwrap() {
+            CheckpointMsg::Regate {
+                program_type,
+                from,
+                target,
+            } => {
+                assert_eq!(program_type, ProgramType::Escrow);
+                assert_eq!(from, 100);
+                assert_eq!(target, 110);
+            }
+            other => panic!("expected Regate first, got {other:?}"),
+        }
+        let cp = recv_slot(&mut checkpoint_rx).await;
+        assert_eq!(cp.slot, 500);
+
+        // No DB write for the Regate: only slot 500's deposit row landed.
+        let inserted = mock.inserted_transactions.lock().unwrap();
+        assert_eq!(inserted.len(), 1);
+        assert_eq!(inserted[0][0].slot, 500);
     }
 
     /// Finalizing slot A inserts only A's rows and leaves B buffered until B's own SlotComplete.
@@ -1266,8 +1366,8 @@ mod tests {
             assert_eq!(batches[1][0].slot, SLOT_B as i64);
         }
 
-        let first = checkpoint_rx.recv().await.unwrap();
-        let second = checkpoint_rx.recv().await.unwrap();
+        let first = recv_slot(&mut checkpoint_rx).await;
+        let second = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(first.slot, SLOT_A);
         assert_eq!(second.slot, SLOT_B);
     }
@@ -1320,8 +1420,10 @@ mod tests {
         );
 
         let mut checkpointed = Vec::new();
-        while let Ok(cp) = checkpoint_rx.try_recv() {
-            checkpointed.push(cp.slot);
+        while let Ok(msg) = checkpoint_rx.try_recv() {
+            if let CheckpointMsg::Slot(cp) = msg {
+                checkpointed.push(cp.slot);
+            }
         }
         assert_eq!(
             checkpointed,
@@ -1349,7 +1451,7 @@ mod tests {
         consumed: ConsumedSet,
     ) -> (
         TransactionProcessor,
-        tokio::sync::mpsc::Receiver<CheckpointUpdate>,
+        tokio::sync::mpsc::Receiver<CheckpointMsg>,
         MockStorage,
     ) {
         let mock = MockStorage::new();
@@ -1617,8 +1719,8 @@ mod tests {
         let result = processor.start(rx).await;
         assert!(result.is_ok(), "retry self-heal keeps the loop running");
 
-        let first = checkpoint_rx.recv().await.unwrap();
-        let second = checkpoint_rx.recv().await.unwrap();
+        let first = recv_slot(&mut checkpoint_rx).await;
+        let second = recv_slot(&mut checkpoint_rx).await;
         assert_eq!(first.slot, N);
         assert_eq!(second.slot, N_NEXT);
     }
@@ -1721,6 +1823,115 @@ mod tests {
         assert_eq!(inserted.len(), 1);
         assert_eq!(inserted[0][0].slot, DEPOSIT_SLOT as i64);
         assert!(committed >= DEPOSIT_SLOT);
+    }
+
+    /// The exact issue #251 reproduction, end-to-end through the real pipeline: the
+    /// reconnect residual window (T_gf, T_sub] must be indexed, never leapfrogged by
+    /// the live tip that resumes above it. Removing the writer's Regate arm makes
+    /// this drive the checkpoint straight to the tip and skip the window, so it is
+    /// the authoritative guard that value-bearing events there are never lost.
+    #[tokio::test]
+    async fn reconnect_residual_gap_is_not_leapfrogged() {
+        const T_GF: u64 = 100; // stale tip the old gap-fill stopped at
+        const T_SUB: u64 = 110; // real live resume slot observed on reconnect
+        const RESIDUAL_DEPOSIT: u64 = 105; // a value-bearing event inside the window
+        const LIVE_TIP: u64 = 9_000_000;
+        let (tx, processor_handle, checkpoint_handle, mock) =
+            spawn_pipeline(deposit_instance(), None);
+
+        // Steady state before the reconnect: durable checkpoint and in-memory
+        // frontier both sit at T_gf.
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: T_GF,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        wait_for_checkpoint(&mock, "escrow", T_GF).await;
+
+        // Reconnect: arm the gate to the observed resume slot, then the live tip and
+        // the live resume slot arrive BEFORE the residual (100, 110] is backfilled.
+        tx.send(ProcessorMessage::Regate {
+            program_type: ProgramType::Escrow,
+            from: T_GF,
+            target: T_SUB,
+        })
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: LIVE_TIP,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: T_SUB,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+
+        // The durable checkpoint must stay frozen at T_gf even though slot 9_000_000
+        // was processed - this is the leapfrog the ungated code commits.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let committed = mock
+            .get_committed_checkpoint("escrow")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            committed, T_GF,
+            "checkpoint must not leapfrog the unfilled residual window"
+        );
+
+        // Backfill closes (100, 110] contiguously, including a real deposit at 105.
+        for slot in (T_GF + 1)..=T_SUB {
+            if slot == RESIDUAL_DEPOSIT {
+                tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+                    RESIDUAL_DEPOSIT,
+                    Some("dep-105".to_string()),
+                    None,
+                )))
+                .await
+                .unwrap();
+            }
+            tx.send(ProcessorMessage::SlotComplete {
+                slot,
+                program_type: ProgramType::Escrow,
+            })
+            .await
+            .unwrap();
+        }
+        // A later live slot advances the checkpoint past the now-contiguous window.
+        tx.send(ProcessorMessage::SlotComplete {
+            slot: LIVE_TIP + 1,
+            program_type: ProgramType::Escrow,
+        })
+        .await
+        .unwrap();
+
+        drop(tx);
+        processor_handle.await.unwrap();
+        checkpoint_handle.await.unwrap();
+
+        let committed = mock
+            .get_committed_checkpoint("escrow")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            committed > T_SUB,
+            "checkpoint advances past the window once it is contiguous"
+        );
+        // The residual-window deposit was indexed, not silently lost.
+        let inserted = mock.inserted_transactions.lock().unwrap();
+        assert!(
+            inserted
+                .iter()
+                .flatten()
+                .any(|t| t.slot == RESIDUAL_DEPOSIT as i64),
+            "the residual-window deposit must be indexed"
+        );
     }
 
     /// A crash mid-backfill persists the contiguous frontier, not the tip, so resume re-backfills with no tail skipped.

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -1828,11 +1828,11 @@ mod tests {
         assert!(committed >= DEPOSIT_SLOT);
     }
 
-    /// The exact issue #251 reproduction, end-to-end through the real pipeline: the
-    /// reconnect residual window (T_gf, T_sub] must be indexed, never leapfrogged by
-    /// the live tip that resumes above it. Removing the writer's Regate arm makes
-    /// this drive the checkpoint straight to the tip and skip the window, so it is
-    /// the authoritative guard that value-bearing events there are never lost.
+    /// The exact reconnect residual-gap reproduction, end-to-end through the real
+    /// pipeline: the residual window (T_gf, T_sub] must be indexed, never leapfrogged by
+    /// the live tip that resumes above it. Removing the writer's Regate arm makes this
+    /// drive the checkpoint straight to the tip and skip the window, so it is the
+    /// authoritative guard that value-bearing events there are never lost.
     #[tokio::test]
     async fn reconnect_residual_gap_is_not_leapfrogged() {
         const T_GF: u64 = 100; // stale tip the old gap-fill stopped at

--- a/indexer/src/shutdown_utils.rs
+++ b/indexer/src/shutdown_utils.rs
@@ -8,7 +8,7 @@
 //! - Buffer time before storage closure
 
 use crate::error::IndexerError;
-use crate::indexer::checkpoint::CheckpointUpdate;
+use crate::indexer::checkpoint::CheckpointMsg;
 use crate::indexer::datasource::common::datasource::DataSource;
 use crate::indexer::datasource::common::types::ProcessorMessage;
 use crate::storage::Storage;
@@ -105,7 +105,7 @@ pub async fn shutdown_indexer(
     datasource: Box<dyn DataSource>,
     datasource_handle: tokio::task::JoinHandle<()>,
     instruction_tx: mpsc::Sender<ProcessorMessage>,
-    checkpoint_tx: mpsc::Sender<CheckpointUpdate>,
+    checkpoint_tx: mpsc::Sender<CheckpointMsg>,
     checkpoint_handle: tokio::task::JoinHandle<()>,
     processor_handle: tokio::task::JoinHandle<Result<(), IndexerError>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -171,7 +171,7 @@ async fn perform_indexer_shutdown_stages(
     mut datasource: Box<dyn DataSource>,
     datasource_handle: tokio::task::JoinHandle<()>,
     instruction_tx: mpsc::Sender<ProcessorMessage>,
-    checkpoint_tx: mpsc::Sender<CheckpointUpdate>,
+    checkpoint_tx: mpsc::Sender<CheckpointMsg>,
     checkpoint_handle: tokio::task::JoinHandle<()>,
     processor_handle: tokio::task::JoinHandle<Result<(), IndexerError>>,
     config: &ShutdownConfig,
@@ -528,7 +528,7 @@ async fn perform_operator_shutdown_stages(
 /// Graceful cleanup after backfill completion
 pub async fn cleanup_after_backfill(
     checkpoint_handle: tokio::task::JoinHandle<()>,
-    checkpoint_tx: mpsc::Sender<CheckpointUpdate>,
+    checkpoint_tx: mpsc::Sender<CheckpointMsg>,
     storage: Arc<Storage>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!("Cleaning up after backfill completion...");
@@ -673,7 +673,7 @@ mod tests {
     async fn cleanup_after_backfill_ok() {
         let mock = MockStorage::new();
         let storage = Arc::new(Storage::Mock(mock));
-        let (checkpoint_tx, checkpoint_rx) = mpsc::channel::<CheckpointUpdate>(10);
+        let (checkpoint_tx, checkpoint_rx) = mpsc::channel::<CheckpointMsg>(10);
 
         // Start a simple checkpoint writer that just drains
         let checkpoint_handle = tokio::spawn(async move {

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -289,6 +289,7 @@ impl MockStorage {
         &self,
         program_type: &str,
     ) -> Result<Option<u64>, StorageError> {
+        self.check_should_fail("get_committed_checkpoint")?;
         Ok(self
             .committed_checkpoints
             .lock()

--- a/integration/tests/indexer/checkpoint_partial_flush.rs
+++ b/integration/tests/indexer/checkpoint_partial_flush.rs
@@ -14,7 +14,7 @@
 use {
     private_channel_indexer::{
         config::ProgramType,
-        indexer::checkpoint::{CheckpointUpdate, CheckpointWriter},
+        indexer::checkpoint::{CheckpointMsg, CheckpointUpdate, CheckpointWriter},
         storage::{common::storage::mock::MockStorage, Storage},
     },
     std::{sync::Arc, time::Duration},
@@ -28,7 +28,7 @@ async fn run_with_updates(
     updates: Vec<CheckpointUpdate>,
     hold_for: Duration,
 ) {
-    let (tx, rx) = mpsc::channel::<CheckpointUpdate>(16);
+    let (tx, rx) = mpsc::channel::<CheckpointMsg>(16);
     // batch_interval=1s forces the ticker branch to fire within `hold_for`.
     let handle = CheckpointWriter::new(storage)
         .with_batch_interval(1)
@@ -36,7 +36,7 @@ async fn run_with_updates(
         .start(rx);
 
     for u in updates {
-        tx.send(u).await.expect("channel open");
+        tx.send(CheckpointMsg::Slot(u)).await.expect("channel open");
     }
 
     tokio::time::sleep(hold_for).await;

--- a/integration/tests/indexer/multi_instruction_pipeline.rs
+++ b/integration/tests/indexer/multi_instruction_pipeline.rs
@@ -21,7 +21,7 @@ use {
     private_channel_indexer::{
         config::ProgramType,
         indexer::{
-            checkpoint::CheckpointUpdate,
+            checkpoint::CheckpointMsg,
             datasource::common::{
                 parser::{
                     DepositAccounts, DepositData, DepositEvent, EscrowInstruction,
@@ -150,7 +150,7 @@ fn withdraw_meta(
 /// Drive the processor over one slot's worth of messages, then close the input
 /// so `start()` returns. Returns once the processor task has fully drained.
 async fn run_slot(storage: Arc<Storage>, instance: Pubkey, messages: Vec<ProcessorMessage>) {
-    let (checkpoint_tx, _checkpoint_rx) = mpsc::channel::<CheckpointUpdate>(16);
+    let (checkpoint_tx, _checkpoint_rx) = mpsc::channel::<CheckpointMsg>(16);
     let (instr_tx, instr_rx) = mpsc::channel::<ProcessorMessage>(16);
 
     let processor =

--- a/integration/tests/indexer/reconnect_gap_fill_fail_closed.rs
+++ b/integration/tests/indexer/reconnect_gap_fill_fail_closed.rs
@@ -1,6 +1,9 @@
-//! Fail-closed reconnect gap-fill for `YellowstoneSource`: after a stream drop the
-//! source must not resubscribe until the gap `(checkpoint, tip]` is repaired, so no
-//! live `SlotComplete` can advance the durable checkpoint over the missing range.
+//! Reconnect gap gating for `YellowstoneSource`: after a stream drop the source
+//! resubscribes immediately, but on the first live block it arms the checkpoint gate
+//! to the observed resume slot before forwarding that block. A concurrent RPC backfill
+//! closes the residual window `(checkpoint, resume]`, and until it does the gate holds
+//! the durable checkpoint, so no live `SlotComplete` can advance it over the still
+//! missing range. An un-fillable boundary keeps the checkpoint frozen (fail-closed).
 
 use mockito::{Matcher, Server as MockitoServer};
 use private_channel_indexer::config::ProgramType;
@@ -21,6 +24,7 @@ use test_utils::mock_yellowstone::{MockYellowstoneServer, Update, UpdateMatcher}
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 #[path = "yellowstone_helpers.rs"]
@@ -68,17 +72,6 @@ fn empty_block_json() -> serde_json::Value {
         "parentSlot": 0,
         "transactions": []
     })
-}
-
-async fn mock_get_slot(server: &mut MockitoServer, slot: u64) -> mockito::Mock {
-    server
-        .mock("POST", "/")
-        .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
-        .with_status(200)
-        .with_body(json!({"jsonrpc": "2.0", "result": slot, "id": 1}).to_string())
-        .expect_at_least(1)
-        .create_async()
-        .await
 }
 
 async fn mock_block_ok(server: &mut MockitoServer, slot: u64) -> mockito::Mock {
@@ -157,6 +150,26 @@ async fn wait_until_matched(mock: &mockito::Mock, secs: u64, what: &str) {
     .unwrap_or_else(|_| panic!("timed out waiting for: {what}"));
 }
 
+/// Poll the durable checkpoint until it reaches `want`, so a test can await a
+/// gate hand-off without racing the writer's batch timer.
+async fn wait_for_checkpoint(storage: &Arc<Storage>, program: &str, want: u64, secs: u64) {
+    tokio::time::timeout(Duration::from_secs(secs), async {
+        loop {
+            if storage
+                .get_committed_checkpoint(program)
+                .await
+                .expect("read checkpoint")
+                == Some(want)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("checkpoint for {program} never reached {want}"));
+}
+
 fn poller(server: &MockitoServer) -> Arc<RpcPoller> {
     Arc::new(RpcPoller::new(
         server.url(),
@@ -165,109 +178,102 @@ fn poller(server: &MockitoServer) -> Arc<RpcPoller> {
     ))
 }
 
-/// While the fill fails the source stalls fail-closed (no resubscribe, no
-/// SlotComplete, checkpoint frozen); once the RPC heals, the gap slots land
-/// first and only then does live delivery resume on subscribe #2.
+/// Wire the real processor + checkpoint writer over `storage`. The durable
+/// checkpoint is the observable: the gate holding the frontier is what keeps it
+/// from advancing over an unfilled window.
+fn spawn_pipeline(
+    storage: Arc<Storage>,
+) -> (mpsc::Sender<ProcessorMessage>, JoinHandle<()>, JoinHandle<()>) {
+    let (checkpoint_tx, checkpoint_rx) = mpsc::channel(256);
+    let writer_handle = CheckpointWriter::new(storage.clone())
+        .with_batch_interval(1)
+        .start(checkpoint_rx);
+    let (tx, instruction_rx) = mpsc::channel::<ProcessorMessage>(256);
+    let processor = TransactionProcessor::new(storage, checkpoint_tx);
+    let processor_handle = tokio::spawn(async move {
+        let _ = processor.start(instruction_rx).await;
+    });
+    (tx, processor_handle, writer_handle)
+}
+
+fn make_source(ys_url: String, rpc: &MockitoServer, storage: Arc<Storage>) -> YellowstoneSource {
+    YellowstoneSource::new(ys_url, None, "confirmed".to_string(), ProgramType::Escrow, None)
+        .with_gap_detection(poller(rpc), 1_000, 16)
+        .with_storage(storage)
+}
+
+/// While the boundary slot stays pruned the gate holds the durable checkpoint at the
+/// seed even though the source resubscribed and delivered the live resume slot; once
+/// the RPC heals, the residual window fills and the checkpoint advances.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn stalls_while_gap_fill_fails_then_recovers_in_order() {
+async fn stalled_gap_fill_gates_checkpoint_then_recovers() {
     init_tracing();
     let (_pg, storage) = start_postgres().await;
-    storage
-        .update_committed_checkpoint("escrow", CHECKPOINT)
-        .await
-        .expect("seed checkpoint");
 
     let mut rpc = MockitoServer::new_async().await;
-    let _slot = mock_get_slot(&mut rpc, TIP).await;
     for s in (CHECKPOINT + 1)..=TIP {
         let _m = mock_block_ok(&mut rpc, s).await;
     }
-    // The boundary slot is the blocker: expect the initial attempt plus at
-    // least one retry, proving the loop retries instead of falling through.
+    // The boundary slot blocks: expect the initial attempt plus at least one retry,
+    // proving the fill loops instead of resolving over the gap.
     let pruned = mock_block_pruned(&mut rpc, CHECKPOINT, 2).await;
     let _floor = mock_retention_floor(&mut rpc, 500).await;
 
     let ys = MockYellowstoneServer::start().await;
-    let (tx, mut rx) = mpsc::channel::<ProcessorMessage>(256);
+    let (tx, processor_handle, writer_handle) = spawn_pipeline(storage.clone());
     let cancel = CancellationToken::new();
-
-    let mut source = YellowstoneSource::new(
-        ys.url(),
-        None,
-        "confirmed".to_string(),
-        ProgramType::Escrow,
-        None,
-    )
-    .with_gap_detection(poller(&rpc), 1_000, 16)
-    .with_storage(storage.clone());
-
+    let mut source = make_source(ys.url(), &rpc, storage.clone());
     let handle = source
-        .start(tx, cancel.clone())
+        .start(tx.clone(), cancel.clone())
         .await
         .expect("yellowstone source start");
 
+    // Steady state: a live slot brings the writer frontier and durable checkpoint to
+    // CHECKPOINT before the drop, so the gate has a real anchor to hold.
     wait_for_subscribes(&ys, 1, 10).await;
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(CHECKPOINT)));
+    wait_for_checkpoint(&storage, "escrow", CHECKPOINT, 15).await;
+
     ys.drop_stream();
+    // Resume slot delivered on subscribe #2 becomes the gate target; the fill of
+    // (CHECKPOINT, TIP] stalls on the pruned boundary.
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP)));
 
-    // Failing phase: two attempts on the pruned slot means one full 5s backoff
-    // elapsed with the gap still open.
-    wait_until_matched(&pruned, 20, "two gap-fill attempts on the pruned slot").await;
-
-    assert_eq!(
-        ys.call_count("subscribe"),
-        1,
-        "must not resubscribe while the gap is open"
-    );
-    while let Ok(msg) = rx.try_recv() {
-        assert!(
-            !matches!(msg, ProcessorMessage::SlotComplete { .. }),
-            "no SlotComplete may be emitted while the gap-fill is failing"
-        );
-    }
-    assert_eq!(
-        storage
-            .get_committed_checkpoint("escrow")
-            .await
-            .expect("read checkpoint"),
-        Some(CHECKPOINT),
-        "durable checkpoint must stay frozen during the stall"
-    );
-
-    // Heal: mockito matches the newest-registered mock first, so slot 100 now
-    // serves an empty block. Queue a live slot for the post-repair stream.
-    let _healed = mock_block_ok(&mut rpc, CHECKPOINT).await;
-    ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP + 1)));
-
-    let mut slots = vec![];
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
-    while slots.len() < 5 {
-        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-        if remaining.is_zero() {
-            panic!("timed out waiting for recovery; slots so far: {slots:?}");
-        }
-        if let Ok(Some(ProcessorMessage::SlotComplete { slot, .. })) =
-            tokio::time::timeout(remaining, rx.recv()).await
-        {
-            slots.push(slot);
-        }
-    }
-    assert_eq!(
-        slots,
-        vec![100, 101, 102, 103, 104],
-        "gap slots must land before the first live slot of subscribe #2"
-    );
+    wait_until_matched(&pruned, 20, "gap-fill retries on the pruned boundary").await;
     assert!(
         ys.call_count("subscribe") >= 2,
-        "the source must resubscribe only after the gap is repaired"
+        "the source resubscribes immediately under the gate; got {}",
+        ys.call_count("subscribe")
     );
+
+    // The gate holds the durable checkpoint at the seed while the window is unfilled,
+    // even though the live resume slot TIP was delivered and processed.
+    for _ in 0..6 {
+        assert_eq!(
+            storage
+                .get_committed_checkpoint("escrow")
+                .await
+                .expect("read checkpoint"),
+            Some(CHECKPOINT),
+            "gate must hold the checkpoint while the residual window is unfilled"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+
+    // Heal the boundary; the fill closes (CHECKPOINT, TIP] and the checkpoint advances.
+    let _healed = mock_block_ok(&mut rpc, CHECKPOINT).await;
+    wait_for_checkpoint(&storage, "escrow", TIP, 30).await;
 
     cancel.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    drop(tx);
+    let _ = tokio::time::timeout(Duration::from_secs(3), processor_handle).await;
+    let _ = tokio::time::timeout(Duration::from_secs(3), writer_handle).await;
     ys.shutdown().await;
 }
 
-/// Cancellation during a stalled gap-fill joins the source task promptly
-/// and stops all RPC traffic.
+/// Cancellation during a stalled gap-fill joins the source task promptly and stops
+/// all RPC traffic, even though the fill runs as a spawned task under the gate.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn shutdown_while_gap_fill_stalled_joins_promptly() {
     init_tracing();
@@ -278,7 +284,6 @@ async fn shutdown_while_gap_fill_stalled_joins_promptly() {
         .expect("seed checkpoint");
 
     let mut rpc = MockitoServer::new_async().await;
-    let _slot = mock_get_slot(&mut rpc, TIP).await;
     for s in (CHECKPOINT + 1)..=TIP {
         let _m = mock_block_ok(&mut rpc, s).await;
     }
@@ -286,19 +291,10 @@ async fn shutdown_while_gap_fill_stalled_joins_promptly() {
     let _floor = mock_retention_floor(&mut rpc, 500).await;
 
     let ys = MockYellowstoneServer::start().await;
+    // Keep the receiver alive so the source's sends never fail on a closed channel.
     let (tx, _rx) = mpsc::channel::<ProcessorMessage>(256);
     let cancel = CancellationToken::new();
-
-    let mut source = YellowstoneSource::new(
-        ys.url(),
-        None,
-        "confirmed".to_string(),
-        ProgramType::Escrow,
-        None,
-    )
-    .with_gap_detection(poller(&rpc), 1_000, 16)
-    .with_storage(storage.clone());
-
+    let mut source = make_source(ys.url(), &rpc, storage.clone());
     let handle = source
         .start(tx, cancel.clone())
         .await
@@ -306,18 +302,21 @@ async fn shutdown_while_gap_fill_stalled_joins_promptly() {
 
     wait_for_subscribes(&ys, 1, 10).await;
     ys.drop_stream();
+    // The first live block on subscribe #2 arms the gate and spawns the fill, which
+    // then stalls on the pruned boundary.
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP)));
     wait_until_matched(&pruned, 20, "a failed gap-fill attempt").await;
 
-    // Cancel mid-stall; the select! on the backoff must wake immediately, far
-    // inside the 5s production backoff.
+    // Cancel mid-stall; the select! on the backoff must wake immediately, far inside
+    // the 5s production backoff.
     cancel.cancel();
     tokio::time::timeout(Duration::from_secs(3), handle)
         .await
         .expect("source must join promptly when cancelled during a stall")
         .expect("source task must not panic");
 
-    // Newest-registered mock matches first: any RPC call after the join would
-    // land here and fail the zero-hit expectation.
+    // Newest-registered mock matches first: any RPC call after the join would land
+    // here and fail the zero-hit expectation.
     let quiet = rpc.mock("POST", "/").expect(0).create_async().await;
     tokio::time::sleep(Duration::from_millis(500)).await;
     quiet.assert_async().await;
@@ -325,24 +324,17 @@ async fn shutdown_while_gap_fill_stalled_joins_promptly() {
     ys.shutdown().await;
 }
 
-/// The exact bug (#21) end-to-end: a live tip beyond the gap must never advance
-/// the durable checkpoint while the gap is unfilled. This wires the real
-/// processor and the ungated plain-max checkpoint writer, the component that
-/// corrupted the checkpoint in the bug, so the DB value is the observable. The
-/// boundary slot stays pruned for the whole test, so gap-fill can never resolve;
-/// a live block past the tip is queued but only a resubscribe would deliver it,
-/// and a fail-open regression would resubscribe and leap the checkpoint to it.
+/// The exact bug end-to-end: a live tip beyond the gap must never advance the durable
+/// checkpoint while the gap is unfilled. This wires the real processor and writer, the
+/// component that corrupted the checkpoint in the bug. The boundary stays pruned for
+/// the whole test, so the fill can never resolve; the source resubscribes and delivers
+/// the live resume slot and a tip beyond it, yet the gate keeps the checkpoint frozen.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stalled_gap_fill_never_advances_checkpoint_over_live_tip() {
     init_tracing();
     let (_pg, storage) = start_postgres().await;
-    storage
-        .update_committed_checkpoint("escrow", CHECKPOINT)
-        .await
-        .expect("seed checkpoint");
 
     let mut rpc = MockitoServer::new_async().await;
-    let _slot = mock_get_slot(&mut rpc, TIP).await;
     for s in (CHECKPOINT + 1)..=TIP {
         let _m = mock_block_ok(&mut rpc, s).await;
     }
@@ -350,45 +342,30 @@ async fn stalled_gap_fill_never_advances_checkpoint_over_live_tip() {
     let pruned = mock_block_pruned(&mut rpc, CHECKPOINT, 1).await;
     let _floor = mock_retention_floor(&mut rpc, 500).await;
 
-    // Real pipeline: the processor finalizes slots and the ungated writer
-    // plain-maxes each SlotComplete into the durable checkpoint.
-    let (checkpoint_tx, checkpoint_rx) = mpsc::channel(64);
-    let writer_handle = CheckpointWriter::new(storage.clone())
-        .with_batch_interval(1)
-        .start(checkpoint_rx);
-    let (tx, instruction_rx) = mpsc::channel::<ProcessorMessage>(256);
-    let processor = TransactionProcessor::new(storage.clone(), checkpoint_tx);
-    let processor_handle = tokio::spawn(processor.start(instruction_rx));
-
     let ys = MockYellowstoneServer::start().await;
+    let (tx, processor_handle, writer_handle) = spawn_pipeline(storage.clone());
     let cancel = CancellationToken::new();
-
-    let mut source = YellowstoneSource::new(
-        ys.url(),
-        None,
-        "confirmed".to_string(),
-        ProgramType::Escrow,
-        None,
-    )
-    .with_gap_detection(poller(&rpc), 1_000, 16)
-    .with_storage(storage.clone());
-
+    let mut source = make_source(ys.url(), &rpc, storage.clone());
     let handle = source
         .start(tx.clone(), cancel.clone())
         .await
         .expect("yellowstone source start");
 
+    // Bring the frontier and durable checkpoint to CHECKPOINT before the drop.
     wait_for_subscribes(&ys, 1, 10).await;
-    ys.drop_stream();
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(CHECKPOINT)));
+    wait_for_checkpoint(&storage, "escrow", CHECKPOINT, 15).await;
 
-    // Queued after the drop, so only a resubscribe (subscribe #2) could deliver
-    // it. Under the fix that never happens; under the old fail-open it would land
-    // and push the checkpoint to TIP + 1.
+    ys.drop_stream();
+    // Subscribe #2 resumes at TIP (the gate target); a later live tip beyond the
+    // target is delivered too. Under the fix both are gated; a fail-open regression
+    // would plain-max the checkpoint to one of them.
+    ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP)));
     ys.enqueue(UpdateMatcher, Update::ok(empty_block(TIP + 1)));
     wait_until_matched(&pruned, 20, "a gap-fill attempt on the pruned slot").await;
 
-    // Hold well past the 5s backoff so a regressed fail-open would have
-    // resubscribed and advanced the checkpoint by now; it must stay at the seed.
+    // Hold well past the 5s backoff so a regressed fail-open would have advanced the
+    // checkpoint by now; the gate must keep it at the seed.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     while tokio::time::Instant::now() < deadline {
         assert_eq!(
@@ -399,13 +376,12 @@ async fn stalled_gap_fill_never_advances_checkpoint_over_live_tip() {
             Some(CHECKPOINT),
             "checkpoint must never advance past the unfilled gap"
         );
-        assert_eq!(
-            ys.call_count("subscribe"),
-            1,
-            "the source must not resubscribe while the gap is open"
-        );
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
+    assert!(
+        ys.call_count("subscribe") >= 2,
+        "the source resubscribes; the gate, not a blocked resubscribe, is the guard"
+    );
 
     cancel.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;

--- a/integration/tests/indexer/reconnect_gap_fill_fail_closed.rs
+++ b/integration/tests/indexer/reconnect_gap_fill_fail_closed.rs
@@ -183,7 +183,11 @@ fn poller(server: &MockitoServer) -> Arc<RpcPoller> {
 /// from advancing over an unfilled window.
 fn spawn_pipeline(
     storage: Arc<Storage>,
-) -> (mpsc::Sender<ProcessorMessage>, JoinHandle<()>, JoinHandle<()>) {
+) -> (
+    mpsc::Sender<ProcessorMessage>,
+    JoinHandle<()>,
+    JoinHandle<()>,
+) {
     let (checkpoint_tx, checkpoint_rx) = mpsc::channel(256);
     let writer_handle = CheckpointWriter::new(storage.clone())
         .with_batch_interval(1)
@@ -197,9 +201,15 @@ fn spawn_pipeline(
 }
 
 fn make_source(ys_url: String, rpc: &MockitoServer, storage: Arc<Storage>) -> YellowstoneSource {
-    YellowstoneSource::new(ys_url, None, "confirmed".to_string(), ProgramType::Escrow, None)
-        .with_gap_detection(poller(rpc), 1_000, 16)
-        .with_storage(storage)
+    YellowstoneSource::new(
+        ys_url,
+        None,
+        "confirmed".to_string(),
+        ProgramType::Escrow,
+        None,
+    )
+    .with_gap_detection(poller(rpc), 1_000, 16)
+    .with_storage(storage)
 }
 
 /// While the boundary slot stays pruned the gate holds the durable checkpoint at the

--- a/integration/tests/indexer/yellowstone_inner_and_unknown.rs
+++ b/integration/tests/indexer/yellowstone_inner_and_unknown.rs
@@ -102,6 +102,8 @@ async fn yellowstone_handles_inner_instructions_and_unknown_discriminator() {
                     other_instructions += 1;
                 }
             },
+            // No reconnect in this test, so no gate re-arm is expected.
+            Ok(Some(ProcessorMessage::Regate { .. })) => {}
             Ok(None) | Err(_) => break,
         }
     }

--- a/integration/tests/indexer/yellowstone_reconnect_gap.rs
+++ b/integration/tests/indexer/yellowstone_reconnect_gap.rs
@@ -47,17 +47,9 @@ async fn gap_fill_runs_after_drop_stream() {
     // In-process mockito RPC backend for the RpcPoller backfill path.
     let mut rpc_mock = MockitoServer::new_async().await;
 
-    // Chain tip = 106. Anchor = checkpoint-1 = 100 → backfill 101..=106.
-    let _slot_mock = rpc_mock
-        .mock("POST", "/")
-        .match_body(Matcher::PartialJson(json!({"method": "getSlot"})))
-        .with_status(200)
-        .with_body(json!({"jsonrpc": "2.0", "result": 106, "id": 1}).to_string())
-        .expect_at_least(1)
-        .create_async()
-        .await;
-
-    // Empty blocks → only SlotComplete markers. Slot 101 was also streamed;
+    // The fill targets the observed resume slot (106 below), not a tip probe, so
+    // no getSlot mock is needed. Anchor = checkpoint-1 = 100 => backfill 101..=106.
+    // Empty blocks => only SlotComplete markers. Slot 101 was also streamed;
     // replay is harmless thanks to idempotent inserts in prod.
     let mut block_mocks = Vec::new();
     for slot in 101u64..=106u64 {
@@ -131,10 +123,13 @@ async fn gap_fill_runs_after_drop_stream() {
         }
     }
 
-    // Phase 2: drop the stream → source reads checkpoint and backfills 101..=106.
+    // Phase 2: drop the stream. On resubscribe the first live block (106) becomes the
+    // gate target, and the concurrent backfill fills 101..=106.
     server.drop_stream();
 
-    // Phase 3: queue 107,108 to prove streaming resumes post-backfill.
+    // Phase 3: queue 106,107,108. The 106 resume slot sets the fill target; 107,108
+    // prove streaming continues past the backfilled window.
+    server.enqueue(UpdateMatcher, Update::ok(empty_block(106)));
     server.enqueue(UpdateMatcher, Update::ok(empty_block(107)));
     server.enqueue(UpdateMatcher, Update::ok(empty_block(108)));
 

--- a/integration/tests/indexer/yellowstone_wiring.rs
+++ b/integration/tests/indexer/yellowstone_wiring.rs
@@ -91,6 +91,8 @@ async fn block_stream_delivers_deposit_and_completes() {
                     assert_eq!(meta.slot, 101);
                 }
             }
+            // No reconnect in this test, so no gate re-arm is expected.
+            ProcessorMessage::Regate { .. } => {}
         }
     }
 


### PR DESCRIPTION
## Summary

Closses issue 251. On a Yellowstone reconnect, the datasource previously backfilled up to a snapshot of the current tip and only then resubscribed. Any blocks produced between the snapshot and the new subscription were processed by neither path. Because the checkpoint advanced normally once live streaming resumed, it could permanently skip this "residual tail" window, silently missing deposits or withdrawals that occurred during it. The longer the outage, the larger this unindexed window could become.

This PR closes that gap by subscribing first, observing the actual resume slot, and then gating checkpoint advancement until the residual range has been backfilled. On the first live block after reconnect, the datasource emits an in-band `Regate` message ahead of the block on the existing processing pipeline and concurrently backfills the missing slots. Because the gate and the protected block travel through the same FIFO pipeline, the checkpoint cannot advance past the reconnect boundary before the backfill completes, while live streaming continues uninterrupted.

The existing backfill logic is unchanged; only the reconnect flow is updated. After successfully reconnecting, the checkpoint is temporarily held at its last durable value while a single backfill catches up to the new resume point. Once the missing slots are filled, the checkpoint continues advancing normally.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,846 | 13,489 | 87.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29995472226) |
| Indexer | 29,813 | 33,150 | 89.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29995472226) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29995472226) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29995472226) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,223 | 16,700 | 79.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29995472226) |
| **Total** | **56,992** | **65,757** | **86.7%** | |

> Last updated: 2026-07-23 10:21:40 UTC by E2E Integration