### PR TITLE
fix(indexer): rescue transient-stranded withdrawals before sender handoff (issue-262)

### DIFF
--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -4,7 +4,9 @@ use crate::metrics;
 use crate::operator::instruction_util::{
     mint_idempotency_memo, MintToBuilder, SourceEventId, TransactionBuilder, WithdrawalRemintInfo,
 };
-use crate::operator::recovery::{classify_deposit_signatures, DepositOutcome};
+use crate::operator::recovery::{
+    classify_deposit_signatures, DepositOutcome, MAX_RECOVERY_REQUEUE_ATTEMPTS,
+};
 use crate::operator::sender::{FinalityRpc, TransactionStatusUpdate};
 use crate::operator::utils::storage_util::with_storage_backoff;
 use crate::operator::{
@@ -249,6 +251,82 @@ async fn halt_withdrawal_pipeline(
                 "quarantine_all_active_withdrawals failed: {}", e
             );
         }
+    }
+}
+
+/// CAS one owned, unsent withdrawal `Processing -> Pending` so the fetcher can
+/// re-claim it. Safe because a transient error before any send proves nothing
+/// was broadcast and no signature was recorded. Mirrors the sender's
+/// pre-broadcast requeue: `Ok(false)` (row moved) and `Err` (write failed) are
+/// logged and the row is left `Processing` for recovery to reconcile.
+async fn requeue_single_prebroadcast(storage: &Storage, pt_label: &str, transaction: &DbTransaction) {
+    match storage.try_requeue_prebroadcast(transaction.id).await {
+        Ok(true) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt_label, "prebroadcast_requeued"])
+                .inc();
+            info!(
+                txn_id = transaction.id,
+                trace_id = %transaction.trace_id,
+                "Requeued withdrawal to Pending after pre-broadcast transient error"
+            );
+        }
+        Ok(false) => warn!(
+            txn_id = transaction.id,
+            trace_id = %transaction.trace_id,
+            "Pre-broadcast requeue skipped: row no longer Processing"
+        ),
+        Err(e) => warn!(
+            txn_id = transaction.id,
+            trace_id = %transaction.trace_id,
+            "Pre-broadcast requeue failed, row left Processing for recovery: {e}"
+        ),
+    }
+}
+
+/// Rescue a transient-stranded withdrawal and its buffered siblings.
+///
+/// Called only from the transient arm before any rotation was dispatched, so
+/// nothing reached the sender. We requeue the current row plus every row still
+/// buffered in `fetcher_rx` (all flipped to `Processing` by the fetcher but
+/// never handed on) back to `Pending`, instead of dropping them stranded on
+/// `return Err`. Mirrors the drain in `halt_withdrawal_pipeline` but requeues
+/// rather than quarantines. No DB sweep: a blanket flip could hit an in-flight
+/// sender row whose signature is not yet persisted; only channel-buffered rows
+/// are provably safe.
+///
+/// The head row is capped on its durable requeue counter (carried on the fetched
+/// row, so no extra read): once it has already been requeued
+/// `MAX_RECOVERY_REQUEUE_ATTEMPTS` times without building, it is quarantined to
+/// ManualReview instead of requeued, so a deterministic error misclassified as
+/// transient cannot loop the operator in a restart storm. This mirrors the
+/// sender's pre-broadcast requeue cap. Buffered siblings never reached build, so
+/// they are rescued regardless of the head's fate; the nonce frontier holds them
+/// behind a quarantined head until an operator resolves it.
+async fn requeue_prebroadcast_pipeline(
+    storage: &Storage,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+    fetcher_rx: &mut mpsc::Receiver<DbTransaction>,
+    pt_label: &str,
+    transaction: &DbTransaction,
+    reason: String,
+) {
+    if transaction.recovery_requeue_attempts >= MAX_RECOVERY_REQUEUE_ATTEMPTS {
+        metrics::OPERATOR_TRANSACTION_ERRORS
+            .with_label_values(&[pt_label, "prebroadcast_requeue_cap"])
+            .inc();
+        warn!(
+            txn_id = transaction.id,
+            trace_id = %transaction.trace_id,
+            attempts = transaction.recovery_requeue_attempts,
+            "Withdrawal build failed after max pre-broadcast requeues; quarantining"
+        );
+        quarantine_single(storage_tx, transaction, reason).await;
+    } else {
+        requeue_single_prebroadcast(storage, pt_label, transaction).await;
+    }
+    while let Ok(buffered) = fetcher_rx.try_recv() {
+        requeue_single_prebroadcast(storage, pt_label, &buffered).await;
     }
 }
 
@@ -530,6 +608,11 @@ pub async fn process_release_funds(
     while let Some(transaction) = fetcher_rx.recv().await {
         let span = info_span!("process", trace_id = %transaction.trace_id, txn_id = transaction.id);
 
+        // Gates the transient rescue: once a boundary rotation is dispatched we
+        // must not requeue, or the reprocess could fire a second rotation and
+        // skip a tree generation. Read after the non-move async block completes.
+        let mut rotation_dispatched = false;
+
         let outcome: Result<(), OperatorError> = async {
             // Build the withdrawal first so (a) rotation + withdrawal dispatch
             // are atomic from the sender's perspective, and (b) row-data
@@ -584,6 +667,7 @@ pub async fn process_release_funds(
                         send_guaranteed(&sender_tx, rotation_tx, "reset smt root")
                             .await
                             .map_err(OperatorError::ChannelSend)?;
+                        rotation_dispatched = true;
                     } else {
                         info!(
                             nonce,
@@ -646,8 +730,21 @@ pub async fn process_release_funds(
                     return Ok(());
                 }
                 ErrorDisposition::Transient => {
-                    // Transient: surface the error so the supervisor can
-                    // restart us cleanly.
+                    // Nothing was sent before a rotation dispatch, so requeue
+                    // this row and its buffered siblings to Pending rather than
+                    // strand them Processing.
+                    if !rotation_dispatched {
+                        requeue_prebroadcast_pipeline(
+                            &storage,
+                            &storage_tx,
+                            &mut fetcher_rx,
+                            pt_label,
+                            &transaction,
+                            err.to_string(),
+                        )
+                        .await;
+                    }
+                    // Surface the error so the supervisor can restart us cleanly.
                     return Err(err);
                 }
                 ErrorDisposition::Fatal => {
@@ -1838,6 +1935,355 @@ mod tests {
 
         let update = storage_rx.recv().await.expect("quarantine update sent");
         assert_eq!(update.status, TransactionStatus::ManualReview);
+    }
+
+    // ── transient pre-broadcast requeue ─────────────────────────────────
+
+    /// Seed a Processing withdrawal into the mock's pending set. When
+    /// `mint_seeded` is false the mint is left out of `mock.mints`, so the
+    /// no-RPC MintCache surfaces the build-phase transient (RpcError) that the
+    /// fix rescues. Returns the row to feed through the fetcher channel.
+    fn seed_processing_withdrawal(
+        mock: &MockStorage,
+        id: i64,
+        nonce: i64,
+        mint: &Pubkey,
+        recipient: &Pubkey,
+        mint_seeded: bool,
+    ) -> DbTransaction {
+        if mint_seeded {
+            mock.mints.lock().unwrap().insert(
+                mint.to_string(),
+                DbMint {
+                    mint_address: mint.to_string(),
+                    decimals: 6,
+                    token_program: spl_token::id().to_string(),
+                    created_at: chrono::Utc::now(),
+                    status: "allowed".to_string(),
+                    is_pausable: Some(false),
+                    has_permanent_delegate: Some(false),
+                },
+            );
+        }
+        let txn = make_db_transaction(id, &mint.to_string(), &recipient.to_string(), Some(nonce), TransactionType::Withdrawal);
+        mock.pending_transactions.lock().unwrap().push(txn.clone());
+        txn
+    }
+
+    /// Core fix: a build-phase transient (unknown mint, no RPC) requeues the
+    /// current row Processing -> Pending instead of stranding it, and does not
+    /// quarantine it. The error still bubbles so the supervisor restarts.
+    #[tokio::test]
+    async fn process_release_funds_transient_requeues_row_to_pending() {
+        let mock = MockStorage::new();
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, false);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        assert!(
+            matches!(result, Err(OperatorError::RpcError(_))),
+            "expected a transient RpcError, got: {result:?}"
+        );
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Pending, "row must be requeued to Pending");
+        assert_eq!(after[0].recovery_requeue_attempts, 1, "requeue must bump the counter once");
+        drop(after);
+
+        assert!(sender_rx.try_recv().is_err(), "nothing was handed to the sender");
+        assert!(storage_rx.try_recv().is_err(), "row is rescued, not quarantined");
+    }
+
+    /// Durable cap: a row that has already been requeued the maximum number of
+    /// times is quarantined to ManualReview instead of requeued again, so a
+    /// deterministic error misclassified as transient cannot loop forever.
+    #[tokio::test]
+    async fn process_release_funds_transient_requeue_cap_quarantines() {
+        let mock = MockStorage::new();
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let mut txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, false);
+        // Fetched row already at the cap: the next transient must quarantine.
+        txn.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS;
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        assert!(matches!(result, Err(OperatorError::RpcError(_))), "got: {result:?}");
+
+        // A ManualReview update was emitted; the row was not requeued.
+        let update = storage_rx.try_recv().expect("expected a quarantine update");
+        assert_eq!(update.status, TransactionStatus::ManualReview);
+        assert_eq!(update.transaction_id, 1);
+        assert!(sender_rx.try_recv().is_err(), "nothing was handed to the sender");
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Processing, "quarantine rides the writer channel, not a direct requeue");
+    }
+
+    /// A transient on the head row also drains and requeues every row still
+    /// buffered behind it in the fetcher channel, so a stranded higher nonce
+    /// cannot wedge the tree frontier.
+    #[tokio::test]
+    async fn process_release_funds_transient_drains_and_requeues_buffered_rows() {
+        let mock = MockStorage::new();
+        let bad_mint = Pubkey::new_unique();
+        let good_mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        // Row 1 triggers the transient; 2 and 3 are valid but buffered behind it.
+        let t1 = seed_processing_withdrawal(&mock, 1, 5, &bad_mint, &recipient, false);
+        let t2 = seed_processing_withdrawal(&mock, 2, 6, &good_mint, &recipient, true);
+        let t3 = seed_processing_withdrawal(&mock, 3, 7, &good_mint, &recipient, true);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, _sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        fetcher_tx.send(t1).await.unwrap();
+        fetcher_tx.send(t2).await.unwrap();
+        fetcher_tx.send(t3).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        assert!(result.is_err());
+
+        let after = mock.pending_transactions.lock().unwrap();
+        for id in [1, 2, 3] {
+            let row = after.iter().find(|t| t.id == id).unwrap();
+            assert_eq!(row.status, TransactionStatus::Pending, "row {id} must be requeued");
+            assert_eq!(row.recovery_requeue_attempts, 1, "row {id} counter bumped once");
+        }
+    }
+
+    /// Fallback path: if the requeue CAS write itself fails, the row is left
+    /// Processing for the recovery sweep to reconcile (no counter bump).
+    #[tokio::test]
+    async fn process_release_funds_transient_requeue_write_failure_left_for_recovery() {
+        let mock = MockStorage::new();
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, false);
+        mock.set_should_fail("try_requeue_prebroadcast", true);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, _sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        assert!(result.is_err());
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Processing, "requeue write failed -> left for recovery");
+        assert_eq!(after[0].recovery_requeue_attempts, 0, "no counter bump on a failed requeue");
+    }
+
+    /// Once a boundary rotation is dispatched, a later transient (here a
+    /// preflight RPC blip) must NOT requeue, or the reprocess could re-fire the
+    /// rotation. The row is left Processing for recovery; the ResetSmtRoot still
+    /// went out.
+    #[tokio::test]
+    async fn process_release_funds_boundary_after_rotation_does_not_requeue() {
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+
+        let mock = MockStorage::new();
+        // Token-2022 with unresolved extension flags forces the preflight onto
+        // the RPC leg; the mocked getAccountInfo is an Instance account, so the
+        // mint parse fails transiently after the rotation was already sent.
+        mock.mints.lock().unwrap().insert(
+            mint_pubkey.to_string(),
+            DbMint {
+                mint_address: mint_pubkey.to_string(),
+                decimals: 6,
+                token_program: spl_token_2022::id().to_string(),
+                created_at: chrono::Utc::now(),
+                status: "allowed".to_string(),
+                is_pausable: None,
+                has_permanent_delegate: None,
+            },
+        );
+        let boundary = make_db_transaction(1, &mint_pubkey.to_string(), &recipient.to_string(), Some(MAX_TREE_LEAVES as i64), TransactionType::Withdrawal);
+        mock.pending_transactions.lock().unwrap().push(boundary.clone());
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+
+        // On-chain tree index 0 < target 1, so the rotation fires first.
+        let mut mocks = std::collections::HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, instance_account_response(0));
+        let rpc_client = RpcClientWithRetry::new_mocked(mocks);
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::with_rpc(storage.clone(), Arc::new(rpc_client)),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        fetcher_tx.send(boundary).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        assert!(result.is_err(), "preflight blip after rotation must surface as an error");
+
+        let msg = sender_rx.recv().await.unwrap();
+        assert!(
+            matches!(msg, TransactionBuilder::ResetSmtRoot(_)),
+            "the rotation must have been dispatched before the transient"
+        );
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Processing, "post-rotation row must not be requeued");
+        assert_eq!(after[0].recovery_requeue_attempts, 0);
+    }
+
+    /// Integration: transient-requeue a row to Pending, then heal the transient
+    /// (seed the mint) and feed the same row back Processing; it must now build
+    /// and reach the sender. Proves the rescued row is genuinely re-fetchable.
+    #[tokio::test]
+    async fn transient_then_recovery_end_to_end() {
+        let mock = MockStorage::new();
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, false);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        // Pass 1: unknown mint -> transient -> requeue to Pending.
+        let (ftx1, frx1) = mpsc::channel::<DbTransaction>(4);
+        let (stx1, _srx1) = mpsc::channel(10);
+        let (gtx1, _grx1) = mpsc::channel(10);
+        ftx1.send(txn).await.unwrap();
+        drop(ftx1);
+        let r1 = process_release_funds(&mut ps, frx1, stx1, gtx1, storage.clone(), ProgramType::Withdraw).await;
+        assert!(r1.is_err());
+
+        let requeued = {
+            let after = mock.pending_transactions.lock().unwrap();
+            assert_eq!(after[0].status, TransactionStatus::Pending);
+            after[0].clone()
+        };
+
+        // Heal the transient: the mint is now known in the DB.
+        mock.mints.lock().unwrap().insert(
+            mint_pubkey.to_string(),
+            DbMint {
+                mint_address: mint_pubkey.to_string(),
+                decimals: 6,
+                token_program: spl_token::id().to_string(),
+                created_at: chrono::Utc::now(),
+                status: "allowed".to_string(),
+                is_pausable: Some(false),
+                has_permanent_delegate: Some(false),
+            },
+        );
+
+        // Pass 2: the fetcher re-locks the row (Processing); it must now be sent.
+        let mut relocked = requeued;
+        relocked.status = TransactionStatus::Processing;
+        let (ftx2, frx2) = mpsc::channel::<DbTransaction>(4);
+        let (stx2, mut srx2) = mpsc::channel(10);
+        let (gtx2, _grx2) = mpsc::channel(10);
+        ftx2.send(relocked).await.unwrap();
+        drop(ftx2);
+        let r2 = process_release_funds(&mut ps, frx2, stx2, gtx2, storage.clone(), ProgramType::Withdraw).await;
+        assert!(r2.is_ok(), "healed row must process cleanly: {r2:?}");
+
+        let msg = srx2.recv().await.unwrap();
+        let TransactionBuilder::ReleaseFunds(b) = msg else {
+            panic!("expected ReleaseFunds after the transient healed");
+        };
+        assert_eq!(b.nonce, 5);
+        assert_eq!(b.transaction_id, 1);
+    }
+
+    /// Phase 2: a single transient DB blip on the metadata read is absorbed by
+    /// the read backoff, so the row is built and sent normally and never
+    /// requeued.
+    #[tokio::test]
+    async fn process_release_funds_single_db_blip_does_not_strand() {
+        let mock = MockStorage::new();
+        let mint_pubkey = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let txn = seed_processing_withdrawal(&mock, 1, 5, &mint_pubkey, &recipient, true);
+        // One transient blip on get_mint; the backoff rides it out.
+        mock.set_fail_times("get_mint", 1);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+
+        let mut ps = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage.clone()),
+        };
+
+        let (fetcher_tx, fetcher_rx) = mpsc::channel::<DbTransaction>(4);
+        let (sender_tx, mut sender_rx) = mpsc::channel(10);
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        fetcher_tx.send(txn).await.unwrap();
+        drop(fetcher_tx);
+
+        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        assert!(result.is_ok(), "backoff must absorb the single blip: {result:?}");
+
+        let msg = sender_rx.recv().await.unwrap();
+        let TransactionBuilder::ReleaseFunds(b) = msg else {
+            panic!("expected ReleaseFunds, blip should have been absorbed");
+        };
+        assert_eq!(b.nonce, 5);
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Processing, "row must not be requeued");
+        assert_eq!(after[0].recovery_requeue_attempts, 0);
     }
 
     // ── classify_processor_error ────────────────────────────────────────

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -257,9 +257,14 @@ async fn halt_withdrawal_pipeline(
 /// CAS one owned, unsent withdrawal `Processing -> Pending` so the fetcher can
 /// re-claim it. Safe because a transient error before any send proves nothing
 /// was broadcast and no signature was recorded. Mirrors the sender's
-/// pre-broadcast requeue: `Ok(false)` (row moved) and `Err` (write failed) are
-/// logged and the row is left `Processing` for recovery to reconcile.
-async fn requeue_single_prebroadcast(storage: &Storage, pt_label: &str, transaction: &DbTransaction) {
+/// pre-broadcast requeue: `Ok(false)` (CAS missed - row no longer `Processing`)
+/// and `Err` (write failed) are logged and the row is left `Processing` for
+/// recovery to reconcile.
+async fn requeue_single_prebroadcast(
+    storage: &Storage,
+    pt_label: &str,
+    transaction: &DbTransaction,
+) {
     match storage.try_requeue_prebroadcast(transaction.id).await {
         Ok(true) => {
             metrics::OPERATOR_TRANSACTION_ERRORS
@@ -284,29 +289,23 @@ async fn requeue_single_prebroadcast(storage: &Storage, pt_label: &str, transact
     }
 }
 
-/// Rescue a transient-stranded withdrawal and its buffered siblings.
+/// Rescue the head withdrawal after a transient error that occurred before its
+/// own rotation was dispatched, so nothing reached the sender. Requeue it
+/// `Processing -> Pending` for the fetcher to re-claim, instead of dropping it
+/// stranded on `return Err`. No DB sweep: a blanket flip could hit an in-flight
+/// sender row whose signature is not yet persisted; only this owned row and the
+/// channel-buffered rows are provably safe.
 ///
-/// Called only from the transient arm before any rotation was dispatched, so
-/// nothing reached the sender. We requeue the current row plus every row still
-/// buffered in `fetcher_rx` (all flipped to `Processing` by the fetcher but
-/// never handed on) back to `Pending`, instead of dropping them stranded on
-/// `return Err`. Mirrors the drain in `halt_withdrawal_pipeline` but requeues
-/// rather than quarantines. No DB sweep: a blanket flip could hit an in-flight
-/// sender row whose signature is not yet persisted; only channel-buffered rows
-/// are provably safe.
-///
-/// The head row is capped on its durable requeue counter (carried on the fetched
-/// row, so no extra read): once it has already been requeued
-/// `MAX_RECOVERY_REQUEUE_ATTEMPTS` times without building, it is quarantined to
-/// ManualReview instead of requeued, so a deterministic error misclassified as
-/// transient cannot loop the operator in a restart storm. This mirrors the
-/// sender's pre-broadcast requeue cap. Buffered siblings never reached build, so
-/// they are rescued regardless of the head's fate; the nonce frontier holds them
-/// behind a quarantined head until an operator resolves it.
-async fn requeue_prebroadcast_pipeline(
+/// Capped on the durable requeue counter (carried on the fetched row, so no
+/// extra read): once it has already been requeued `MAX_RECOVERY_REQUEUE_ATTEMPTS`
+/// times without building, it is quarantined to ManualReview instead of
+/// requeued, so a deterministic error misclassified as transient cannot loop the
+/// operator in a restart storm. This mirrors the sender's pre-broadcast requeue
+/// cap; the nonce frontier then holds later withdrawals behind the quarantined
+/// row until an operator resolves it.
+async fn requeue_or_quarantine_head(
     storage: &Storage,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
-    fetcher_rx: &mut mpsc::Receiver<DbTransaction>,
     pt_label: &str,
     transaction: &DbTransaction,
     reason: String,
@@ -325,6 +324,20 @@ async fn requeue_prebroadcast_pipeline(
     } else {
         requeue_single_prebroadcast(storage, pt_label, transaction).await;
     }
+}
+
+/// Drain rows still buffered in `fetcher_rx` and requeue each `Processing ->
+/// Pending`. They were flipped to `Processing` by the fetcher but never handed
+/// on, and no rotation was dispatched for them, so requeuing is always safe -
+/// even after a boundary rotation on the head, since their post-boundary nonces
+/// cannot re-fire it. Draining them prevents a stranded higher nonce from
+/// wedging the tree frontier. Mirrors the drain in `halt_withdrawal_pipeline`
+/// but requeues rather than quarantines.
+async fn drain_and_requeue_buffered(
+    storage: &Storage,
+    fetcher_rx: &mut mpsc::Receiver<DbTransaction>,
+    pt_label: &str,
+) {
     while let Ok(buffered) = fetcher_rx.try_recv() {
         requeue_single_prebroadcast(storage, pt_label, &buffered).await;
     }
@@ -730,20 +743,22 @@ pub async fn process_release_funds(
                     return Ok(());
                 }
                 ErrorDisposition::Transient => {
-                    // Nothing was sent before a rotation dispatch, so requeue
-                    // this row and its buffered siblings to Pending rather than
-                    // strand them Processing.
+                    // The head row is safe to rescue only before its own rotation
+                    // dispatch; after that a reprocess could re-fire an unconfirmed
+                    // rotation, so leave it for recovery. Buffered siblings never
+                    // had a rotation dispatched for them, so drain and requeue them
+                    // either way rather than strand them Processing.
                     if !rotation_dispatched {
-                        requeue_prebroadcast_pipeline(
+                        requeue_or_quarantine_head(
                             &storage,
                             &storage_tx,
-                            &mut fetcher_rx,
                             pt_label,
                             &transaction,
                             err.to_string(),
                         )
                         .await;
                     }
+                    drain_and_requeue_buffered(&storage, &mut fetcher_rx, pt_label).await;
                     // Surface the error so the supervisor can restart us cleanly.
                     return Err(err);
                 }
@@ -1965,7 +1980,13 @@ mod tests {
                 },
             );
         }
-        let txn = make_db_transaction(id, &mint.to_string(), &recipient.to_string(), Some(nonce), TransactionType::Withdrawal);
+        let txn = make_db_transaction(
+            id,
+            &mint.to_string(),
+            &recipient.to_string(),
+            Some(nonce),
+            TransactionType::Withdrawal,
+        );
         mock.pending_transactions.lock().unwrap().push(txn.clone());
         txn
     }
@@ -1994,19 +2015,40 @@ mod tests {
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
         assert!(
             matches!(result, Err(OperatorError::RpcError(_))),
             "expected a transient RpcError, got: {result:?}"
         );
 
         let after = mock.pending_transactions.lock().unwrap();
-        assert_eq!(after[0].status, TransactionStatus::Pending, "row must be requeued to Pending");
-        assert_eq!(after[0].recovery_requeue_attempts, 1, "requeue must bump the counter once");
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Pending,
+            "row must be requeued to Pending"
+        );
+        assert_eq!(
+            after[0].recovery_requeue_attempts, 1,
+            "requeue must bump the counter once"
+        );
         drop(after);
 
-        assert!(sender_rx.try_recv().is_err(), "nothing was handed to the sender");
-        assert!(storage_rx.try_recv().is_err(), "row is rescued, not quarantined");
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "nothing was handed to the sender"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "row is rescued, not quarantined"
+        );
     }
 
     /// Durable cap: a row that has already been requeued the maximum number of
@@ -2035,16 +2077,34 @@ mod tests {
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
-        assert!(matches!(result, Err(OperatorError::RpcError(_))), "got: {result:?}");
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(OperatorError::RpcError(_))),
+            "got: {result:?}"
+        );
 
         // A ManualReview update was emitted; the row was not requeued.
         let update = storage_rx.try_recv().expect("expected a quarantine update");
         assert_eq!(update.status, TransactionStatus::ManualReview);
         assert_eq!(update.transaction_id, 1);
-        assert!(sender_rx.try_recv().is_err(), "nothing was handed to the sender");
+        assert!(
+            sender_rx.try_recv().is_err(),
+            "nothing was handed to the sender"
+        );
         let after = mock.pending_transactions.lock().unwrap();
-        assert_eq!(after[0].status, TransactionStatus::Processing, "quarantine rides the writer channel, not a direct requeue");
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Processing,
+            "quarantine rides the writer channel, not a direct requeue"
+        );
     }
 
     /// A transient on the head row also drains and requeues every row still
@@ -2077,14 +2137,29 @@ mod tests {
         fetcher_tx.send(t3).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
         assert!(result.is_err());
 
         let after = mock.pending_transactions.lock().unwrap();
         for id in [1, 2, 3] {
             let row = after.iter().find(|t| t.id == id).unwrap();
-            assert_eq!(row.status, TransactionStatus::Pending, "row {id} must be requeued");
-            assert_eq!(row.recovery_requeue_attempts, 1, "row {id} counter bumped once");
+            assert_eq!(
+                row.status,
+                TransactionStatus::Pending,
+                "row {id} must be requeued"
+            );
+            assert_eq!(
+                row.recovery_requeue_attempts, 1,
+                "row {id} counter bumped once"
+            );
         }
     }
 
@@ -2112,20 +2187,36 @@ mod tests {
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
         assert!(result.is_err());
 
         let after = mock.pending_transactions.lock().unwrap();
-        assert_eq!(after[0].status, TransactionStatus::Processing, "requeue write failed -> left for recovery");
-        assert_eq!(after[0].recovery_requeue_attempts, 0, "no counter bump on a failed requeue");
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Processing,
+            "requeue write failed -> left for recovery"
+        );
+        assert_eq!(
+            after[0].recovery_requeue_attempts, 0,
+            "no counter bump on a failed requeue"
+        );
     }
 
     /// Once a boundary rotation is dispatched, a later transient (here a
-    /// preflight RPC blip) must NOT requeue, or the reprocess could re-fire the
-    /// rotation. The row is left Processing for recovery; the ResetSmtRoot still
-    /// went out.
+    /// preflight RPC blip) must NOT requeue the head, or the reprocess could
+    /// re-fire the rotation; it is left Processing for recovery. Buffered siblings
+    /// carry post-boundary nonces that cannot re-fire the rotation, so they are
+    /// still drained and requeued rather than stranded. The ResetSmtRoot goes out.
     #[tokio::test]
-    async fn process_release_funds_boundary_after_rotation_does_not_requeue() {
+    async fn process_release_funds_boundary_after_rotation_drains_siblings_not_head() {
         let mint_pubkey = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
 
@@ -2145,8 +2236,26 @@ mod tests {
                 has_permanent_delegate: None,
             },
         );
-        let boundary = make_db_transaction(1, &mint_pubkey.to_string(), &recipient.to_string(), Some(MAX_TREE_LEAVES as i64), TransactionType::Withdrawal);
-        mock.pending_transactions.lock().unwrap().push(boundary.clone());
+        let boundary = make_db_transaction(
+            1,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            Some(MAX_TREE_LEAVES as i64),
+            TransactionType::Withdrawal,
+        );
+        // A sibling buffered behind the boundary head (higher, post-boundary nonce).
+        let sibling = make_db_transaction(
+            2,
+            &mint_pubkey.to_string(),
+            &recipient.to_string(),
+            Some(MAX_TREE_LEAVES as i64 + 1),
+            TransactionType::Withdrawal,
+        );
+        {
+            let mut rows = mock.pending_transactions.lock().unwrap();
+            rows.push(boundary.clone());
+            rows.push(sibling.clone());
+        }
         let storage = Arc::new(Storage::Mock(mock.clone()));
 
         // On-chain tree index 0 < target 1, so the rotation fires first.
@@ -2165,10 +2274,22 @@ mod tests {
         let (storage_tx, _storage_rx) = mpsc::channel(10);
 
         fetcher_tx.send(boundary).await.unwrap();
+        fetcher_tx.send(sibling).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
-        assert!(result.is_err(), "preflight blip after rotation must surface as an error");
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "preflight blip after rotation must surface as an error"
+        );
 
         let msg = sender_rx.recv().await.unwrap();
         assert!(
@@ -2177,8 +2298,20 @@ mod tests {
         );
 
         let after = mock.pending_transactions.lock().unwrap();
-        assert_eq!(after[0].status, TransactionStatus::Processing, "post-rotation row must not be requeued");
-        assert_eq!(after[0].recovery_requeue_attempts, 0);
+        let head = after.iter().find(|t| t.id == 1).unwrap();
+        assert_eq!(
+            head.status,
+            TransactionStatus::Processing,
+            "post-rotation head must not be requeued"
+        );
+        assert_eq!(head.recovery_requeue_attempts, 0);
+        let sib = after.iter().find(|t| t.id == 2).unwrap();
+        assert_eq!(
+            sib.status,
+            TransactionStatus::Pending,
+            "buffered sibling must be drained and requeued, not stranded"
+        );
+        assert_eq!(sib.recovery_requeue_attempts, 1);
     }
 
     /// Integration: transient-requeue a row to Pending, then heal the transient
@@ -2204,7 +2337,15 @@ mod tests {
         let (gtx1, _grx1) = mpsc::channel(10);
         ftx1.send(txn).await.unwrap();
         drop(ftx1);
-        let r1 = process_release_funds(&mut ps, frx1, stx1, gtx1, storage.clone(), ProgramType::Withdraw).await;
+        let r1 = process_release_funds(
+            &mut ps,
+            frx1,
+            stx1,
+            gtx1,
+            storage.clone(),
+            ProgramType::Withdraw,
+        )
+        .await;
         assert!(r1.is_err());
 
         let requeued = {
@@ -2235,7 +2376,15 @@ mod tests {
         let (gtx2, _grx2) = mpsc::channel(10);
         ftx2.send(relocked).await.unwrap();
         drop(ftx2);
-        let r2 = process_release_funds(&mut ps, frx2, stx2, gtx2, storage.clone(), ProgramType::Withdraw).await;
+        let r2 = process_release_funds(
+            &mut ps,
+            frx2,
+            stx2,
+            gtx2,
+            storage.clone(),
+            ProgramType::Withdraw,
+        )
+        .await;
         assert!(r2.is_ok(), "healed row must process cleanly: {r2:?}");
 
         let msg = srx2.recv().await.unwrap();
@@ -2272,8 +2421,19 @@ mod tests {
         fetcher_tx.send(txn).await.unwrap();
         drop(fetcher_tx);
 
-        let result = process_release_funds(&mut ps, fetcher_rx, sender_tx, storage_tx, storage, ProgramType::Withdraw).await;
-        assert!(result.is_ok(), "backoff must absorb the single blip: {result:?}");
+        let result = process_release_funds(
+            &mut ps,
+            fetcher_rx,
+            sender_tx,
+            storage_tx,
+            storage,
+            ProgramType::Withdraw,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "backoff must absorb the single blip: {result:?}"
+        );
 
         let msg = sender_rx.recv().await.unwrap();
         let TransactionBuilder::ReleaseFunds(b) = msg else {
@@ -2282,7 +2442,11 @@ mod tests {
         assert_eq!(b.nonce, 5);
 
         let after = mock.pending_transactions.lock().unwrap();
-        assert_eq!(after[0].status, TransactionStatus::Processing, "row must not be requeued");
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Processing,
+            "row must not be requeued"
+        );
         assert_eq!(after[0].recovery_requeue_attempts, 0);
     }
 

--- a/indexer/src/operator/utils/mint_util.rs
+++ b/indexer/src/operator/utils/mint_util.rs
@@ -1,4 +1,5 @@
 use crate::error::{AccountError, OperatorError};
+use crate::operator::utils::storage_util::with_storage_backoff;
 use crate::operator::RpcClientWithRetry;
 use crate::storage::common::models::MintStatusAtSlot;
 use crate::storage::Storage;
@@ -99,7 +100,13 @@ impl MintCache {
             return Ok(metadata.clone());
         }
 
-        if let Some(m) = self.storage.get_mint(&mint_str).await? {
+        // Retry a transient DB blip before falling through to the RPC leg, so a
+        // brief outage does not surface as Transient and strand the withdrawal.
+        let db_mint = with_storage_backoff("mint metadata read", 0, || {
+            self.storage.get_mint(&mint_str)
+        })
+        .await?;
+        if let Some(m) = db_mint {
             let token_program =
                 Pubkey::from_str(&m.token_program).map_err(|e| OperatorError::InvalidPubkey {
                     pubkey: m.token_program.clone(),
@@ -141,7 +148,10 @@ impl MintCache {
             return Ok(*flags);
         }
 
-        let db_mint = self.storage.get_mint(&mint_str).await?;
+        let db_mint = with_storage_backoff("mint extension-flag read", 0, || {
+            self.storage.get_mint(&mint_str)
+        })
+        .await?;
         if let Some(ref m) = db_mint {
             if let (Some(p), Some(d)) = (m.is_pausable, m.has_permanent_delegate) {
                 self.extension_flags_cache.insert(mint_str, (p, d));
@@ -458,6 +468,33 @@ mod tests {
         let metadata2 = cache.get_mint_metadata(&mint).await.unwrap();
         assert_eq!(metadata2, metadata1);
         assert_eq!(cache.cache_size(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_mint_metadata_retries_transient_db_error() {
+        let mint = create_test_mint();
+        let mock = MockStorage::new();
+        mock.mints.lock().unwrap().insert(
+            mint.to_string(),
+            DbMint {
+                mint_address: mint.to_string(),
+                decimals: 6,
+                token_program: TOKEN_PROGRAM_ID.to_string(),
+                created_at: chrono::Utc::now(),
+                status: "allowed".to_string(),
+                is_pausable: Some(false),
+                has_permanent_delegate: Some(false),
+            },
+        );
+        // Two transient blips then success: the read backoff must ride them out.
+        mock.set_fail_times("get_mint", 2);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let mut cache = MintCache::new(storage);
+
+        let metadata = cache.get_mint_metadata(&mint).await.unwrap();
+        assert_eq!(metadata.token_program, TOKEN_PROGRAM_ID);
+        assert_eq!(metadata.decimals, 6);
+        assert_eq!(mock.calls("get_mint"), 3, "two failures + one success");
     }
 
     #[tokio::test]

--- a/indexer/src/operator/utils/mint_util.rs
+++ b/indexer/src/operator/utils/mint_util.rs
@@ -102,7 +102,8 @@ impl MintCache {
 
         // Retry a transient DB blip before falling through to the RPC leg, so a
         // brief outage does not surface as Transient and strand the withdrawal.
-        let db_mint = with_storage_backoff("mint metadata read", 0, || {
+        // transaction_id=-1: no per-call txn context here; retries log by op name.
+        let db_mint = with_storage_backoff("mint metadata read", -1, || {
             self.storage.get_mint(&mint_str)
         })
         .await?;
@@ -148,7 +149,8 @@ impl MintCache {
             return Ok(*flags);
         }
 
-        let db_mint = with_storage_backoff("mint extension-flag read", 0, || {
+        // transaction_id=-1: no per-call txn context here; retries log by op name.
+        let db_mint = with_storage_backoff("mint extension-flag read", -1, || {
             self.storage.get_mint(&mint_str)
         })
         .await?;

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -410,6 +410,9 @@ impl MockStorage {
     }
 
     pub async fn get_mint(&self, mint_address: &str) -> Result<Option<DbMint>, StorageError> {
+        // Inert unless a test opts in via set_fail_times/set_should_fail; lets
+        // the read-retry backoff around get_mint be unit-tested.
+        self.check_should_fail("get_mint")?;
         Ok(self.mints.lock().unwrap().get(mint_address).cloned())
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a issue 262 where withdrawals could become permanently stranded after a transient database or RPC error during transaction preparation. Before a withdrawal was handed to the sender, temporary failures while loading mint metadata left the row in `Processing` even though no transaction had been built or broadcast. Since the fetcher only processes `Pending` rows, these withdrawals were never retried automatically and eventually ended up in `ManualReview`. A brief outage could therefore strand an entire batch of withdrawals.

The fix rolls these withdrawals back from `Processing` to `Pending` whenever a transient error occurs **before** the sender is reached, allowing them to be retried after restart. This reuses the existing requeue mechanism already used by the sender for pre-broadcast failures, avoids any schema changes, and is guarded so it only runs when no transaction could have been sent. A retry limit also prevents endless requeue loops by moving repeatedly failing withdrawals to `ManualReview`, while transient database reads now benefit from the existing retry/backoff helper before being treated as failures.

The change is limited to the withdrawal preparation path and leaves deposits unchanged. Comprehensive tests verify successful requeueing, buffered-withdrawal handling, retry-limit behavior, rotation edge cases, end-to-end recovery after restart, database backoff, and that the normal successful flow is unaffected.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,846 | 13,489 | 87.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826702906) |
| Indexer | 29,719 | 33,035 | 90.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826702906) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826702906) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826702906) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,085 | 16,579 | 78.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826702906) |
| **Total** | **56,760** | **65,521** | **86.6%** | |

> Last updated: 2026-07-21 12:32:05 UTC by E2E Integration