### PR TITLE
fix: restrict the deferred remint queue to the Withdraw role (issue-273)

### DIFF
--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -4,6 +4,7 @@ use super::types::SenderState;
 use crate::operator::tree_constants::MAX_TREE_LEAVES;
 use crate::{
     channel_utils::send_guaranteed,
+    config::ProgramType,
     operator::{
         check_transaction_status, remint_idempotency_memo,
         sender::{
@@ -555,6 +556,11 @@ pub async fn process_pending_remints(
     state: &mut SenderState,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
 ) {
+    // Deferred remints are a Withdraw-only responsibility; skip for any other role.
+    if state.program_type != ProgramType::Withdraw {
+        return;
+    }
+
     let now = Utc::now();
 
     // Drain the queue and split: due now vs. wait longer.
@@ -822,7 +828,7 @@ mod tests {
             rotation_retry_queue: Vec::new(),
             ambiguous_retry_queue: Vec::new(),
             pending_rotation: None,
-            program_type: crate::config::ProgramType::Escrow,
+            program_type: crate::config::ProgramType::Withdraw,
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
@@ -887,6 +893,13 @@ mod tests {
     }
 
     fn make_sender_state_with_rpc(rpc_url: &str) -> (SenderState, MockStorage) {
+        make_sender_state_with_role(rpc_url, crate::config::ProgramType::Withdraw)
+    }
+
+    fn make_sender_state_with_role(
+        rpc_url: &str,
+        role: crate::config::ProgramType,
+    ) -> (SenderState, MockStorage) {
         let mock = MockStorage::new();
         let storage = Arc::new(Storage::Mock(mock.clone()));
         let rpc = Arc::new(crate::operator::RpcClientWithRetry::with_retry_config(
@@ -913,7 +926,7 @@ mod tests {
             rotation_retry_queue: Vec::new(),
             ambiguous_retry_queue: Vec::new(),
             pending_rotation: None,
-            program_type: crate::config::ProgramType::Escrow,
+            program_type: role,
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
@@ -985,7 +998,7 @@ mod tests {
             rotation_retry_queue: Vec::new(),
             ambiguous_retry_queue: Vec::new(),
             pending_rotation: None,
-            program_type: crate::config::ProgramType::Escrow,
+            program_type: crate::config::ProgramType::Withdraw,
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
@@ -1408,6 +1421,55 @@ mod tests {
         assert!(
             state.pending_remints.is_empty(),
             "entry should be removed from queue after Completed"
+        );
+    }
+
+    /// The deferred remint queue is a Withdraw-only responsibility. An Escrow
+    /// sender must never classify or remint a queued row: doing so would send
+    /// RPC on the wrong chain and could escalate the row to ManualReview.
+    #[tokio::test]
+    async fn process_pending_remints_noop_for_escrow_role() {
+        // No endpoints are mounted, so any RPC call would be an observable fault.
+        let mut rpc_server = mockito::Server::new_async().await;
+
+        // A catch-all set to expect zero hits: any request fails the assertion.
+        let no_calls = rpc_server
+            .mock("POST", "/")
+            .with_status(200)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let (mut state, _mock) =
+            make_sender_state_with_role(&rpc_server.url(), crate::config::ProgramType::Escrow);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(88),
+                withdrawal_nonce: Some(4),
+                trace_id: Some("trace-88".to_string()),
+                deposit_claim_lease: None,
+            },
+            remint_info: make_remint_info(88),
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        // No classify/send RPC reached the mock server.
+        no_calls.assert_async().await;
+
+        // No status update emitted for an Escrow sender.
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "Escrow must not emit any status update from the remint processor"
         );
     }
 

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -1,4 +1,5 @@
 use crate::channel_utils::send_guaranteed;
+use crate::config::ProgramType;
 use crate::error::account::AccountError;
 use crate::error::OperatorError;
 use crate::operator::sender::types::{PendingRemint, PendingSig, TransactionContext};
@@ -243,6 +244,11 @@ impl SenderState {
         &mut self,
         storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     ) -> Result<(), OperatorError> {
+        // Deferred remints are Withdraw-only; other roles must never claim a shared PendingRemint row.
+        if self.program_type != ProgramType::Withdraw {
+            return Ok(());
+        }
+
         let transactions = self.storage.get_pending_remint_transactions().await?;
 
         if transactions.is_empty() {
@@ -420,6 +426,13 @@ mod tests {
     use tokio::sync::mpsc;
 
     fn make_sender_state(mock: MockStorage) -> SenderState {
+        make_sender_state_with_role(mock, crate::config::ProgramType::Withdraw)
+    }
+
+    fn make_sender_state_with_role(
+        mock: MockStorage,
+        role: crate::config::ProgramType,
+    ) -> SenderState {
         let storage = Arc::new(Storage::Mock(mock));
         let rpc = Arc::new(RpcClientWithRetry::with_retry_config(
             "http://localhost:8899".to_string(),
@@ -441,7 +454,7 @@ mod tests {
             rotation_retry_queue: Vec::new(),
             ambiguous_retry_queue: Vec::new(),
             pending_rotation: None,
-            program_type: crate::config::ProgramType::Escrow,
+            program_type: role,
             remint_cache: HashMap::new(),
             pending_signatures: HashMap::new(),
             pending_remints: Vec::new(),
@@ -911,6 +924,44 @@ mod tests {
 
         // No ManualReview sent — missing deadline is handled gracefully.
         assert!(storage_rx.try_recv().is_err());
+    }
+
+    /// The deferred remint queue is a Withdraw-only responsibility. An Escrow
+    /// sender sharing the transactions DB must never claim a PendingRemint row:
+    /// it would classify the release signature on the wrong chain and could
+    /// flip the row to ManualReview, stranding it from the real Withdraw sender.
+    #[tokio::test]
+    async fn recover_pending_remints_noop_for_escrow_role() {
+        let mock = MockStorage::new();
+        let mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let sig = Signature::new_unique();
+        let deadline = Utc::now() - chrono::Duration::seconds(10);
+
+        // A matured PendingRemint withdrawal row is present in the shared DB.
+        mock.pending_remint_transactions
+            .lock()
+            .unwrap()
+            .push(make_pending_remint_row(70, &mint, &recipient, &sig, deadline));
+
+        let mut state =
+            make_sender_state_with_role(mock, crate::config::ProgramType::Escrow);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        state.recover_pending_remints(&storage_tx).await.unwrap();
+
+        // The Escrow sender must not hydrate the row into its queue.
+        assert!(
+            state.pending_remints.is_empty(),
+            "Escrow must not claim Withdraw remint rows"
+        );
+
+        // No status update emitted, especially no ManualReview: the row is left
+        // untouched for the real Withdraw sender.
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "Escrow must not emit any status update for a remint row"
+        );
     }
 
     // ── SenderState construction tests ───────────────────────────────

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -942,10 +942,11 @@ mod tests {
         mock.pending_remint_transactions
             .lock()
             .unwrap()
-            .push(make_pending_remint_row(70, &mint, &recipient, &sig, deadline));
+            .push(make_pending_remint_row(
+                70, &mint, &recipient, &sig, deadline,
+            ));
 
-        let mut state =
-            make_sender_state_with_role(mock, crate::config::ProgramType::Escrow);
+        let mut state = make_sender_state_with_role(mock, crate::config::ProgramType::Escrow);
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         state.recover_pending_remints(&storage_tx).await.unwrap();


### PR DESCRIPTION
## Summary

This PR fixes issue 273 where the Escrow and Withdraw operators could both process the deferred remint queue, even though remints are a Withdraw-only responsibility. Since the two operators use different RPC clients, an Escrow sender could incorrectly process a pending remint, check the release transaction on the wrong chain, and attempt to broadcast the remint to the wrong network. The transaction would then fail and be moved to `ManualReview`, preventing the correct Withdraw operator from ever processing it.

The fix adds a simple role check at the start of both `recover_pending_remints` and `process_pending_remints`. If the sender is running in the Escrow role, both functions return immediately without reading the database or processing the queue. This is a deliberate no-op rather than an error, since the Escrow operator should never have remint work. Placing the guard inside the shared functions ensures all current and future callers are protected.

New tests verify that the Escrow role ignores pending remints without making RPC calls or updating transaction status, while the existing Withdraw tests continue to validate the normal recovery, remint, and `ManualReview` paths. The change is intentionally limited to adding fail-closed role checks.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,846 | 13,489 | 87.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826026076) |
| Indexer | 29,337 | 32,625 | 89.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826026076) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826026076) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826026076) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,049 | 16,520 | 79.0% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826026076) |
| **Total** | **56,342** | **65,052** | **86.6%** | |

> Last updated: 2026-07-21 12:22:56 UTC by E2E Integration