### PR TITLE
fix(indexer): build the transaction identity index directly and never rebuild the obsolete two-part index (issue-265))

### DIFF
--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -139,56 +139,19 @@ impl PostgresDb {
         .execute(&self.pool)
         .await?;
 
-        // Durable identity for an indexed economic event is the pair
-        // (signature, instruction_index): one Solana transaction can carry several
-        // deposit or withdraw instructions, so each must persist as its own row.
-        // This runs right after the table is ensured, so the composite unique index
-        // exists before the table is exposed to any writer (init_schema completes
-        // before the pipeline starts). The column is added first so an in-place
-        // upgrade of a table that predates it does not reference a missing column,
-        // then the composite index is built while the old single-signature
-        // uniqueness is still in force, so signature is never left unprotected, and
-        // only then is the old single-signature constraint dropped. Existing rows
-        // backfill to instruction_index 0, and that old uniqueness guaranteed each
-        // signature mapped to one row, so every (signature, 0) pair is already
-        // unique and the build is clean. signature stays the leading column, so
-        // existing WHERE signature = $1 lookups remain index-served.
-        info!("Running instruction_index migration if needed...");
+        // Durable identity is the triple (signature, instruction_index, inner_index):
+        // a transaction can carry several instructions and each can emit more via CPI.
+        // Add the columns, then build the triple index directly (skipping the obsolete
+        // two-part index older schemas used) while any old single-signature uniqueness
+        // is still in force, so signature is never unprotected; backfilled rows stay
+        // unique so the build is clean. signature leads the index, so existing
+        // WHERE signature = $1 lookups remain index-served.
+        info!("Running transaction identity migration if needed...");
         sqlx::query(
             r#"
             DO $$ BEGIN
                 ALTER TABLE transactions
                 ADD COLUMN IF NOT EXISTS instruction_index INTEGER NOT NULL DEFAULT 0;
-            END $$;
-            "#,
-        )
-        .execute(&self.pool)
-        .await?;
-        sqlx::query(
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_signature_ix ON transactions (signature, instruction_index)",
-        )
-        .execute(&self.pool)
-        .await?;
-        sqlx::query(
-            r#"
-            DO $$ BEGIN
-                ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_signature_key;
-                DROP INDEX IF EXISTS idx_transactions_signature;
-            END $$;
-            "#,
-        )
-        .execute(&self.pool)
-        .await?;
-        info!("instruction_index migration complete");
-
-        // Extend the unique identity to (signature, instruction_index, inner_index)
-        // so a CPI deposit/withdraw gets its own row. Build-before-drop: add the
-        // nullable column, build the new index (NULL inner_index coalesced to -1
-        // since unique indexes treat NULLs as distinct), then drop the old one.
-        info!("Running inner_index migration if needed...");
-        sqlx::query(
-            r#"
-            DO $$ BEGIN
                 ALTER TABLE transactions
                 ADD COLUMN IF NOT EXISTS inner_index INTEGER;
             END $$;
@@ -202,10 +165,22 @@ impl PostgresDb {
         )
         .execute(&self.pool)
         .await?;
-        sqlx::query("DROP INDEX IF EXISTS idx_transactions_signature_ix")
-            .execute(&self.pool)
-            .await?;
-        info!("inner_index migration complete");
+        // Drop the old single-signature and two-part uniqueness now that the triple
+        // index is in force. The two-part index is cleaned up for older databases that
+        // carry it but is never rebuilt: valid CPI rows sharing (signature,
+        // instruction_index) would make a rebuild collide and abort startup.
+        sqlx::query(
+            r#"
+            DO $$ BEGIN
+                ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_signature_key;
+                DROP INDEX IF EXISTS idx_transactions_signature;
+                DROP INDEX IF EXISTS idx_transactions_signature_ix;
+            END $$;
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        info!("transaction identity migration complete");
 
         // Create indexes for transactions
         sqlx::query("CREATE INDEX IF NOT EXISTS idx_transactions_status ON transactions (status)")

--- a/integration/tests/indexer/db_migration_race.rs
+++ b/integration/tests/indexer/db_migration_race.rs
@@ -340,6 +340,88 @@ async fn cpi_inner_and_top_level_persist_as_distinct_rows() {
     );
 }
 
+// ── 1e. init_schema stays idempotent after CPI-colliding rows exist ─────────
+// Two valid CPI events under one wrapper instruction share (signature,
+// instruction_index=0) and differ only in inner_index. Once such rows are
+// durable, replaying init_schema must never rebuild the two-part index, which
+// would collide on those rows and brick every restart.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_init_schema_idempotent_after_cpi_colliding_rows() {
+    let (db, url, _container) = start_postgres("c1_cpi_collide_replay").await;
+    let storage = Storage::Postgres(db.clone());
+    // First init creates the three-part index (the final schema shape).
+    storage.init_schema().await.unwrap();
+
+    let signature = Signature::new_unique().to_string();
+    let mint = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+    let recipient = solana_sdk::pubkey::Pubkey::new_unique().to_string();
+
+    let build = |inner_index: Option<i32>, amount: u64| {
+        DbTransactionBuilder::new(signature.clone(), 1, mint.clone(), amount)
+            .initiator(recipient.clone())
+            .recipient(recipient.clone())
+            .transaction_type(TransactionType::Deposit)
+            .instruction_index(0)
+            .inner_index(inner_index)
+            .build()
+    };
+
+    // Two inner CPI events sharing (signature, instruction_index=0). This is the
+    // exact arming scenario: rows that collide under the two-part identity but
+    // are distinct under the three-part identity.
+    let batch = vec![build(Some(0), 100), build(Some(1), 200)];
+    let ids = storage
+        .insert_db_transactions_batch(&batch)
+        .await
+        .expect("batch insert ok");
+    assert_eq!(ids.len(), 2);
+    assert_ne!(ids[0], ids[1], "both CPI rows are distinct");
+
+    let pool = sqlx::PgPool::connect(&url).await.expect("sqlx connect");
+
+    // Replaying init_schema must not rebuild the two-part index against the
+    // colliding rows. Before the fix this fails with a duplicate-key error.
+    storage
+        .init_schema()
+        .await
+        .expect("init_schema must stay idempotent with colliding CPI rows present");
+
+    let assert_state = |pool: sqlx::PgPool, signature: String| async move {
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE signature = $1")
+                .bind(&signature)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 2, "both CPI rows survive the replay; got {count}");
+
+        let triple_index: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_transactions_signature_ix_inner'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(triple_index, 1, "triple unique index must remain");
+
+        let two_part_index: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_transactions_signature_ix'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(two_part_index, 0, "two-part index must stay dropped");
+    };
+
+    assert_state(pool.clone(), signature.clone()).await;
+
+    // A third replay proves durability across repeated restarts, not just one.
+    storage
+        .init_schema()
+        .await
+        .expect("init_schema must stay idempotent across repeated restarts");
+    assert_state(pool.clone(), signature.clone()).await;
+}
+
 // ── 2. Duplicate-key race in insert_transaction ────────────────────────────
 // Both rows default to instruction_index 0, so this also covers the
 // same-signature SAME-index collision: (sig, 0) is still unique and the race


### PR DESCRIPTION
## Summary

This PR fixes a startup issue 265 where valid CPI transactions could permanently prevent the indexer from restarting. On every startup, the database migration rebuilt an older two-part unique index before replacing it with the newer three-part transaction identity index. Once the database contained valid CPI events that shared the same `(signature, instruction_index)` but differed in `inner_index`, rebuilding the obsolete index failed with a duplicate-key error, causing every subsequent startup to fail in the same way.

The fix removes the obsolete two-part index from the migration entirely. The schema now builds the final three-part identity index directly, then removes the old indexes as cleanup. This avoids rebuilding an index that is incompatible with valid CPI data while ensuring transaction uniqueness is maintained throughout the migration. Existing databases recover automatically on the next restart without any manual intervention.

A new integration test verifies that repeated runs of `init_schema()` succeed after CPI rows already exist and that only the three-part index remains. 
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,846 | 13,489 | 87.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826949729) |
| Indexer | 29,240 | 32,525 | 89.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826949729) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826949729) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826949729) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,053 | 16,497 | 79.1% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29826949729) |
| **Total** | **56,249** | **64,929** | **86.6%** | |

> Last updated: 2026-07-21 12:20:03 UTC by E2E Integration