### PR TITLE
fix(admin-vm): mirror account_keys() in loaded_transaction.accounts (issue-8)

### DIFF
--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -855,4 +855,110 @@ mod tests {
             "Live account must be returned to SVM"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Admin-mirror alignment: update_accounts must gate on is_writable(index)
+    // over an account_keys()-aligned mirror (the AdminVm output shape).
+    // -----------------------------------------------------------------------
+
+    /// Build an admin-shaped tx whose account_keys are
+    /// [payer(0, writable), mint(1, writable), spl_token(2, read-only)].
+    fn build_admin_shaped_tx() -> (SanitizedTransaction, Pubkey) {
+        use {
+            solana_sdk::{
+                instruction::{AccountMeta, Instruction},
+                message::Message,
+                signature::{Keypair, Signer},
+                transaction::Transaction,
+            },
+            std::collections::HashSet,
+        };
+        let payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let ix = Instruction {
+            program_id: spl_token::id(),
+            accounts: vec![
+                AccountMeta::new(mint, false),
+                AccountMeta::new(payer.pubkey(), true),
+            ],
+            data: vec![0u8; 35],
+        };
+        let msg = Message::new(&[ix], Some(&payer.pubkey()));
+        let tx = Transaction::new(&[&payer], msg, solana_sdk::hash::Hash::default());
+        let sanitized =
+            SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new()).unwrap();
+        (sanitized, mint)
+    }
+
+    /// Wrap a mirror account vec in a single-tx Executed SVM output.
+    fn executed_output_with_mirror(
+        accounts: Vec<(Pubkey, AccountSharedData)>,
+    ) -> LoadAndExecuteSanitizedTransactionsOutput {
+        use {
+            solana_svm::{
+                account_loader::LoadedTransaction,
+                transaction_error_metrics::TransactionErrorMetrics,
+                transaction_execution_result::{
+                    ExecutedTransaction, TransactionExecutionDetails,
+                },
+            },
+            solana_timings::ExecuteTimings,
+        };
+        let executed = ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                accounts,
+                ..Default::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status: Ok(()),
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: HashMap::new(),
+        };
+        LoadAndExecuteSanitizedTransactionsOutput {
+            error_metrics: TransactionErrorMetrics::default(),
+            execute_timings: ExecuteTimings::default(),
+            balance_collector: None,
+            processing_results: vec![Ok(ProcessedTransaction::Executed(Box::new(executed)))],
+        }
+    }
+
+    #[tokio::test]
+    async fn update_accounts_mirror_persists_writable_skips_readonly() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let (tx, mint) = build_admin_shaped_tx();
+
+        // Hand-build a mirror aligned to account_keys with a read-only spl_token slot.
+        let account_keys = tx.account_keys();
+        let mint_account = make_account(1, &[9u8; 82], &spl_token::id());
+        let program_account = make_account(1, &[1], &Pubkey::new_unique());
+        let mut accounts = Vec::new();
+        for i in 0..account_keys.len() {
+            let key = account_keys.get(i).copied().unwrap();
+            let acct = if key == mint {
+                mint_account.clone()
+            } else if key == spl_token::id() {
+                program_account.clone()
+            } else {
+                make_account(500, &[7], &Pubkey::default())
+            };
+            accounts.push((key, acct));
+        }
+
+        let output = executed_output_with_mirror(accounts);
+        bob.update_accounts(&output, std::slice::from_ref(&tx));
+
+        assert!(
+            bob.accounts.contains_key(&mint),
+            "writable mint slot must be inserted"
+        );
+        assert!(
+            !bob.accounts.contains_key(&spl_token::id()),
+            "read-only spl_token program slot must be skipped"
+        );
+    }
 }

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -898,9 +898,7 @@ mod tests {
             solana_svm::{
                 account_loader::LoadedTransaction,
                 transaction_error_metrics::TransactionErrorMetrics,
-                transaction_execution_result::{
-                    ExecutedTransaction, TransactionExecutionDetails,
-                },
+                transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
             },
             solana_timings::ExecuteTimings,
         };

--- a/core/src/accounts/utils.rs
+++ b/core/src/accounts/utils.rs
@@ -182,7 +182,8 @@ mod tests {
         };
         let msg = Message::new(&[ix], Some(&payer.pubkey()));
         let legacy = Transaction::new(&[&payer], msg, solana_sdk::hash::Hash::default());
-        let tx = SanitizedTransaction::try_from_legacy_transaction(legacy, &HashSet::new()).unwrap();
+        let tx =
+            SanitizedTransaction::try_from_legacy_transaction(legacy, &HashSet::new()).unwrap();
 
         // Full mirror: one slot per account key.
         let account_keys = tx.account_keys();

--- a/core/src/accounts/utils.rs
+++ b/core/src/accounts/utils.rs
@@ -146,4 +146,75 @@ mod tests {
         let base64 = encode_transaction_data(data, UiTransactionEncoding::Base64);
         assert_eq!(parsed, base64);
     }
+
+    /// An admin-shaped mirror (accounts aligned to account_keys) produces
+    /// stored-meta balance arrays whose length equals account_keys().len(),
+    /// guarding the get_stored_transaction consumer.
+    #[test]
+    fn test_stored_transaction_admin_mirror_balances_aligned() {
+        use {
+            solana_sdk::{
+                account::AccountSharedData,
+                instruction::{AccountMeta, Instruction},
+                message::Message,
+                pubkey::Pubkey,
+                signature::{Keypair, Signer},
+                transaction::Transaction,
+            },
+            solana_svm::{
+                account_loader::LoadedTransaction,
+                transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
+            },
+            solana_svm_transaction::svm_message::SVMMessage,
+            std::collections::{HashMap, HashSet},
+        };
+
+        // Admin-shaped tx: account_keys = [payer, mint, spl_token].
+        let payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let ix = Instruction {
+            program_id: spl_token::id(),
+            accounts: vec![
+                AccountMeta::new(mint, false),
+                AccountMeta::new(payer.pubkey(), true),
+            ],
+            data: vec![0u8; 35],
+        };
+        let msg = Message::new(&[ix], Some(&payer.pubkey()));
+        let legacy = Transaction::new(&[&payer], msg, solana_sdk::hash::Hash::default());
+        let tx = SanitizedTransaction::try_from_legacy_transaction(legacy, &HashSet::new()).unwrap();
+
+        // Full mirror: one slot per account key.
+        let account_keys = tx.account_keys();
+        let accounts: Vec<(Pubkey, AccountSharedData)> = (0..account_keys.len())
+            .map(|i| {
+                (
+                    account_keys.get(i).copied().unwrap(),
+                    AccountSharedData::new(1, 0, &Pubkey::default()),
+                )
+            })
+            .collect();
+
+        let executed = ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                accounts,
+                ..Default::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status: Ok(()),
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: HashMap::new(),
+        };
+        let processed = ProcessedTransaction::Executed(Box::new(executed));
+
+        let stored = get_stored_transaction(&tx, 1, 0, &processed);
+        let expected = account_keys.len();
+        assert_eq!(stored.meta.pre_balances.len(), expected);
+        assert_eq!(stored.meta.post_balances.len(), expected);
+    }
 }

--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -151,6 +151,17 @@ impl AdminVm {
                         INSTRUCTION_INITIALIZE_MINT => {
                             match Self::process_initialize_mint(callbacks, tx, instruction) {
                                 Ok((mint_index, pubkey, account)) => {
+                                    // Reject a second init of the same mint in one tx,
+                                    // like real SVM, instead of overwriting the first.
+                                    if created_mints.iter().any(|(i, _, _)| *i == mint_index) {
+                                        break 'tx Self::create_executed_transaction(
+                                            Err(TransactionError::InstructionError(
+                                                ix_idx_u8,
+                                                InstructionError::AccountAlreadyInitialized,
+                                            )),
+                                            vec![],
+                                        );
+                                    }
                                     created_mints.push((mint_index, pubkey, account))
                                 }
                                 Err(err) => {
@@ -187,10 +198,13 @@ impl AdminVm {
                             .get(i)
                             .copied()
                             .expect("index is within account_keys length");
-                        (
-                            key,
-                            callbacks.get_account_shared_data(&key).unwrap_or_default(),
-                        )
+                        // Mint slots are overwritten below
+                        let account = if created_mints.iter().any(|(mi, _, _)| *mi == i) {
+                            AccountSharedData::default()
+                        } else {
+                            callbacks.get_account_shared_data(&key).unwrap_or_default()
+                        };
+                        (key, account)
                     })
                     .collect();
                 for (mint_index, pubkey, account) in created_mints {
@@ -524,7 +538,11 @@ mod tests {
     fn make_two_instruction_spl_tx(
         ix1_data: Vec<u8>,
         ix2_data: Vec<u8>,
-    ) -> (solana_sdk::transaction::SanitizedTransaction, Pubkey, Pubkey) {
+    ) -> (
+        solana_sdk::transaction::SanitizedTransaction,
+        Pubkey,
+        Pubkey,
+    ) {
         use solana_sdk::{
             instruction::{AccountMeta, Instruction},
             message::Message,
@@ -678,7 +696,10 @@ mod tests {
         let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
 
         let account_keys = tx.account_keys();
-        assert_eq!(executed.loaded_transaction.accounts.len(), account_keys.len());
+        assert_eq!(
+            executed.loaded_transaction.accounts.len(),
+            account_keys.len()
+        );
 
         let idx_a = index_of(&tx, &mint_a);
         let idx_b = index_of(&tx, &mint_b);
@@ -702,6 +723,54 @@ mod tests {
         assert!(persisted.iter().any(|(k, _)| *k == mint_b));
     }
 
+    /// Two InitializeMint instructions on the SAME mint in one tx: the second
+    /// is rejected with AccountAlreadyInitialized, matching real SVM, and no
+    /// accounts persist.
+    #[test]
+    fn test_admin_duplicate_mint_same_tx_rejected() {
+        use solana_sdk::{
+            instruction::{AccountMeta, Instruction},
+            message::Message,
+            signature::{Keypair, Signer},
+            transaction::Transaction,
+        };
+        use std::collections::HashSet;
+
+        let authority = Pubkey::new_unique();
+        let payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let ix = |data: Vec<u8>| Instruction {
+            program_id: spl_token::id(),
+            accounts: vec![
+                AccountMeta::new(mint, false),
+                AccountMeta::new(payer.pubkey(), true),
+            ],
+            data,
+        };
+        let msg = Message::new(
+            &[
+                ix(valid_init_mint_data(6, authority)),
+                ix(valid_init_mint_data(6, authority)),
+            ],
+            Some(&payer.pubkey()),
+        );
+        let legacy = Transaction::new(&[&payer], msg, solana_sdk::hash::Hash::default());
+        let tx = solana_sdk::transaction::SanitizedTransaction::try_from_legacy_transaction(
+            legacy,
+            &HashSet::new(),
+        )
+        .unwrap();
+
+        let executed = assert_executed_with_status(
+            run_admin_vm(std::slice::from_ref(&tx)),
+            Err(TransactionError::InstructionError(
+                1,
+                InstructionError::AccountAlreadyInitialized,
+            )),
+        );
+        assert!(executed.loaded_transaction.accounts.is_empty());
+    }
+
     /// A non-mint slot (the fee payer) is filled from the callback: the mirror
     /// carries the exact account the callback returned, and it is persisted
     /// unchanged (proves slots are filled from the callback, not defaulted).
@@ -721,12 +790,17 @@ mod tests {
             account: payer_account.clone(),
         };
 
-        let executed =
-            assert_executed_with_status(run_admin_vm_with_cb(std::slice::from_ref(&tx), &cb), Ok(()));
+        let executed = assert_executed_with_status(
+            run_admin_vm_with_cb(std::slice::from_ref(&tx), &cb),
+            Ok(()),
+        );
 
         let (pubkey, account) = &executed.loaded_transaction.accounts[0];
         assert_eq!(*pubkey, fee_payer);
-        assert_eq!(*account, payer_account, "fee-payer slot must carry callback account");
+        assert_eq!(
+            *account, payer_account,
+            "fee-payer slot must carry callback account"
+        );
 
         let persisted = persisted_by_consumer(&executed, &tx);
         assert!(
@@ -885,8 +959,10 @@ mod tests {
         let (tx, mint_pubkey) = make_spl_tx_with_mint(spl_token::id(), data);
         let cb = StubCbWithUninitialized { mint: mint_pubkey };
 
-        let executed =
-            assert_executed_with_status(run_admin_vm_with_cb(std::slice::from_ref(&tx), &cb), Ok(()));
+        let executed = assert_executed_with_status(
+            run_admin_vm_with_cb(std::slice::from_ref(&tx), &cb),
+            Ok(()),
+        );
         assert_eq!(
             executed.loaded_transaction.accounts.len(),
             tx.account_keys().len()

--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -117,7 +117,7 @@ impl AdminVm {
     ) -> LoadAndExecuteSanitizedTransactionsOutput {
         let mut processing_results: Vec<TransactionProcessingResult> = vec![];
         for tx in sanitized_txs {
-            let mut accounts = vec![];
+            let mut created_mints: Vec<(usize, Pubkey, AccountSharedData)> = vec![];
             let executed: ExecutedTransaction = 'tx: {
                 for (ix_index, (program_id, instruction)) in
                     tx.program_instructions_iter().enumerate()
@@ -150,7 +150,9 @@ impl AdminVm {
                     match instruction_type {
                         INSTRUCTION_INITIALIZE_MINT => {
                             match Self::process_initialize_mint(callbacks, tx, instruction) {
-                                Ok((pubkey, account)) => accounts.push((pubkey, account)),
+                                Ok((mint_index, pubkey, account)) => {
+                                    created_mints.push((mint_index, pubkey, account))
+                                }
                                 Err(err) => {
                                     break 'tx Self::create_executed_transaction(
                                         Err(TransactionError::InstructionError(ix_idx_u8, err)),
@@ -174,7 +176,27 @@ impl AdminVm {
                         }
                     }
                 }
-                Self::create_executed_transaction(Ok(()), accounts)
+                // Mirror account_keys() in order so downstream is_writable(index)
+                // lines up. Fill slots from the callback, then place the mint(s).
+                let account_keys = tx.account_keys();
+                let mut mirror: Vec<(Pubkey, AccountSharedData)> = (0..account_keys.len())
+                    .map(|i| {
+                        // i is always in range; expect so a future refactor panics
+                        // instead of silently seating a zero pubkey at a writable slot.
+                        let key = account_keys
+                            .get(i)
+                            .copied()
+                            .expect("index is within account_keys length");
+                        (
+                            key,
+                            callbacks.get_account_shared_data(&key).unwrap_or_default(),
+                        )
+                    })
+                    .collect();
+                for (mint_index, pubkey, account) in created_mints {
+                    mirror[mint_index] = (pubkey, account);
+                }
+                Self::create_executed_transaction(Ok(()), mirror)
             };
             processing_results.push(Ok(ProcessedTransaction::Executed(Box::new(executed))));
         }
@@ -193,8 +215,9 @@ impl AdminVm {
     }
 
     /// Validate and process a single SPL Token `InitializeMint` instruction.
-    /// Returns the (pubkey, Mint account) on success, or the
-    /// appropriate `InstructionError` on any validation failure.
+    /// Returns the (account_keys index, pubkey, Mint account) on success, so the
+    /// caller can place the mint at its true slot in the account_keys mirror, or
+    /// the appropriate `InstructionError` on any validation failure.
     ///
     /// SPL Token `InitializeMint` wire layout
     /// (see `spl_token::instruction::TokenInstruction::pack`):
@@ -212,7 +235,7 @@ impl AdminVm {
         callbacks: &CB,
         tx: &impl SVMTransaction,
         instruction: solana_svm_transaction::instruction::SVMInstruction,
-    ) -> Result<(Pubkey, AccountSharedData), InstructionError> {
+    ) -> Result<(usize, Pubkey, AccountSharedData), InstructionError> {
         // Minimum payload: instruction must reference the mint as an account,
         // and data must span discriminator + decimals + mint_authority + the
         // freeze_authority COption tag at byte 34. `TokenInstruction::pack`
@@ -262,7 +285,7 @@ impl AdminVm {
         let decimals = instruction.data[1];
         let mint_authority = &instruction.data[2..34];
         let mint_account = Self::create_mint_account(decimals, mint_authority, freeze_authority);
-        Ok((mint_pubkey, mint_account))
+        Ok((mint_index, mint_pubkey, mint_account))
     }
 }
 
@@ -270,8 +293,34 @@ impl AdminVm {
 mod tests {
     use super::*;
     use solana_sdk::account::ReadableAccount;
+    use solana_svm_transaction::svm_message::SVMMessage;
     use spl_token::solana_program::program_pack::Pack;
     use spl_token::state::Mint;
+
+    /// Replicates the downstream consumer gate: keep only the account slots the
+    /// transaction marks writable at their positional index (see bob.rs and
+    /// settle.rs, which both persist exactly `accounts[i]` where `is_writable(i)`).
+    fn persisted_by_consumer(
+        executed: &ExecutedTransaction,
+        tx: &solana_sdk::transaction::SanitizedTransaction,
+    ) -> Vec<(Pubkey, AccountSharedData)> {
+        executed
+            .loaded_transaction
+            .accounts
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| tx.is_writable(*i))
+            .map(|(_, kv)| kv.clone())
+            .collect()
+    }
+
+    /// Positional index of `key` inside the transaction's account_keys.
+    fn index_of(tx: &solana_sdk::transaction::SanitizedTransaction, key: &Pubkey) -> usize {
+        let account_keys = tx.account_keys();
+        (0..account_keys.len())
+            .find(|i| account_keys.get(*i).copied() == Some(*key))
+            .expect("key present in account_keys")
+    }
 
     /// `create_mint_account` packs a Mint with the given decimals + authority
     /// and no freeze authority; the packed bytes round-trip through
@@ -475,7 +524,7 @@ mod tests {
     fn make_two_instruction_spl_tx(
         ix1_data: Vec<u8>,
         ix2_data: Vec<u8>,
-    ) -> solana_sdk::transaction::SanitizedTransaction {
+    ) -> (solana_sdk::transaction::SanitizedTransaction, Pubkey, Pubkey) {
         use solana_sdk::{
             instruction::{AccountMeta, Instruction},
             message::Message,
@@ -505,11 +554,12 @@ mod tests {
         };
         let msg = Message::new(&[ix1, ix2], Some(&payer.pubkey()));
         let tx = Transaction::new(&[&payer], msg, solana_sdk::hash::Hash::default());
-        solana_sdk::transaction::SanitizedTransaction::try_from_legacy_transaction(
+        let sanitized = solana_sdk::transaction::SanitizedTransaction::try_from_legacy_transaction(
             tx,
             &HashSet::new(),
         )
-        .unwrap()
+        .unwrap();
+        (sanitized, mint_a, mint_b)
     }
 
     // ─── Happy path ─────────────────────────────────────────────────────────
@@ -520,15 +570,220 @@ mod tests {
     fn test_spl_valid_initialize_mint() {
         let authority = Pubkey::new_unique();
         let data = valid_init_mint_data(9, authority);
-        let tx = make_spl_tx(spl_token::id(), &[1], data);
+        let (tx, mint) = make_spl_tx_with_mint(spl_token::id(), data);
 
-        let executed = assert_executed_with_status(run_admin_vm(&[tx]), Ok(()));
+        let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
 
-        assert_eq!(executed.loaded_transaction.accounts.len(), 1);
-        let (_, account) = &executed.loaded_transaction.accounts[0];
-        let mint = Mint::unpack(account.data()).unwrap();
-        assert_eq!(mint.decimals, 9);
-        assert_eq!(mint.mint_authority, COption::Some(authority));
+        // Accounts mirror account_keys, and the mint lands at its own index.
+        assert_eq!(
+            executed.loaded_transaction.accounts.len(),
+            tx.account_keys().len()
+        );
+        let mint_index = index_of(&tx, &mint);
+        let (pubkey, account) = &executed.loaded_transaction.accounts[mint_index];
+        assert_eq!(*pubkey, mint);
+        let mint_state = Mint::unpack(account.data()).unwrap();
+        assert_eq!(mint_state.decimals, 9);
+        assert_eq!(mint_state.mint_authority, COption::Some(authority));
+    }
+
+    /// Returns the configured account for the configured pubkey, None otherwise.
+    /// Used to prove non-mint mirror slots are filled from the callback.
+    struct StubCbForPubkey {
+        key: Pubkey,
+        account: AccountSharedData,
+    }
+    impl solana_svm_callback::TransactionProcessingCallback for StubCbForPubkey {
+        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+            if *pubkey == self.key {
+                Some(self.account.clone())
+            } else {
+                None
+            }
+        }
+        fn account_matches_owners(&self, _account: &Pubkey, _owners: &[Pubkey]) -> Option<usize> {
+            None
+        }
+    }
+    impl solana_svm_callback::InvokeContextCallback for StubCbForPubkey {}
+
+    /// On the happy path `accounts` is a positional mirror of `account_keys()`:
+    /// same length and same pubkey at every index.
+    #[test]
+    fn test_admin_accounts_mirror_account_keys() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(6, authority);
+        let (tx, _mint) = make_spl_tx_with_mint(spl_token::id(), data);
+
+        let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
+
+        let account_keys = tx.account_keys();
+        let accounts = &executed.loaded_transaction.accounts;
+        assert_eq!(accounts.len(), account_keys.len());
+        for i in 0..account_keys.len() {
+            assert_eq!(accounts[i].0, account_keys.get(i).copied().unwrap());
+        }
+    }
+
+    /// The created mint sits at the same index its pubkey occupies in
+    /// `account_keys()`, that slot is writable, and it unpacks to the declared
+    /// decimals and authority.
+    #[test]
+    fn test_admin_mint_at_account_keys_index() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(4, authority);
+        let (tx, mint) = make_spl_tx_with_mint(spl_token::id(), data);
+
+        let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
+
+        let mint_index = index_of(&tx, &mint);
+        assert!(tx.is_writable(mint_index), "mint slot must be writable");
+        let (pubkey, account) = &executed.loaded_transaction.accounts[mint_index];
+        assert_eq!(*pubkey, mint);
+        let mint_state = Mint::unpack(account.data()).unwrap();
+        assert_eq!(mint_state.decimals, 4);
+        assert_eq!(mint_state.mint_authority, COption::Some(authority));
+    }
+
+    /// Consumer writable-gate persists the mint and skips the read-only spl_token slot.
+    #[test]
+    fn test_admin_writable_gate_persists_only_mint_not_program() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(6, authority);
+        let (tx, mint) = make_spl_tx_with_mint(spl_token::id(), data);
+
+        let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
+
+        let persisted = persisted_by_consumer(&executed, &tx);
+        assert!(
+            persisted.iter().any(|(k, _)| *k == mint),
+            "writable mint must be persisted"
+        );
+        assert!(
+            !persisted.iter().any(|(k, _)| *k == spl_token::id()),
+            "read-only spl_token program must NOT be persisted"
+        );
+    }
+
+    /// Two InitializeMint instructions in one tx: each mint lands at its own
+    /// account_keys index, the mirror stays aligned, and the consumer gate
+    /// persists both mints.
+    #[test]
+    fn test_admin_multi_mint_each_at_correct_index() {
+        let authority = Pubkey::new_unique();
+        let ix1 = valid_init_mint_data(2, authority);
+        let ix2 = valid_init_mint_data(8, authority);
+        let (tx, mint_a, mint_b) = make_two_instruction_spl_tx(ix1, ix2);
+
+        let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
+
+        let account_keys = tx.account_keys();
+        assert_eq!(executed.loaded_transaction.accounts.len(), account_keys.len());
+
+        let idx_a = index_of(&tx, &mint_a);
+        let idx_b = index_of(&tx, &mint_b);
+        assert_eq!(executed.loaded_transaction.accounts[idx_a].0, mint_a);
+        assert_eq!(executed.loaded_transaction.accounts[idx_b].0, mint_b);
+        assert_eq!(
+            Mint::unpack(executed.loaded_transaction.accounts[idx_a].1.data())
+                .unwrap()
+                .decimals,
+            2
+        );
+        assert_eq!(
+            Mint::unpack(executed.loaded_transaction.accounts[idx_b].1.data())
+                .unwrap()
+                .decimals,
+            8
+        );
+
+        let persisted = persisted_by_consumer(&executed, &tx);
+        assert!(persisted.iter().any(|(k, _)| *k == mint_a));
+        assert!(persisted.iter().any(|(k, _)| *k == mint_b));
+    }
+
+    /// A non-mint slot (the fee payer) is filled from the callback: the mirror
+    /// carries the exact account the callback returned, and it is persisted
+    /// unchanged (proves slots are filled from the callback, not defaulted).
+    #[test]
+    fn test_admin_non_mint_slot_filled_from_callback() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(6, authority);
+        let (tx, _mint) = make_spl_tx_with_mint(spl_token::id(), data);
+
+        // The fee payer is account_keys[0]; stub the callback to return a
+        // populated account for it.
+        let fee_payer = tx.account_keys().get(0).copied().unwrap();
+        let mut payer_account = AccountSharedData::new(777, 3, &Pubkey::new_unique());
+        payer_account.set_data_from_slice(&[1, 2, 3]);
+        let cb = StubCbForPubkey {
+            key: fee_payer,
+            account: payer_account.clone(),
+        };
+
+        let executed =
+            assert_executed_with_status(run_admin_vm_with_cb(std::slice::from_ref(&tx), &cb), Ok(()));
+
+        let (pubkey, account) = &executed.loaded_transaction.accounts[0];
+        assert_eq!(*pubkey, fee_payer);
+        assert_eq!(*account, payer_account, "fee-payer slot must carry callback account");
+
+        let persisted = persisted_by_consumer(&executed, &tx);
+        assert!(
+            persisted
+                .iter()
+                .any(|(k, a)| *k == fee_payer && *a == payer_account),
+            "fee-payer must be persisted unchanged"
+        );
+    }
+
+    /// With an all-None callback, the read-only program slot defaults and is
+    /// never persisted; no live account is tombstoned by the gate.
+    #[test]
+    fn test_admin_absent_non_mint_slot_defaults() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(6, authority);
+        let (tx, _mint) = make_spl_tx_with_mint(spl_token::id(), data);
+
+        let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
+
+        let program_index = index_of(&tx, &spl_token::id());
+        assert_eq!(
+            executed.loaded_transaction.accounts[program_index].1,
+            AccountSharedData::default(),
+            "absent read-only slot must default"
+        );
+        assert!(
+            !tx.is_writable(program_index),
+            "spl_token program slot is read-only"
+        );
+        let persisted = persisted_by_consumer(&executed, &tx);
+        assert!(
+            !persisted.iter().any(|(k, _)| *k == spl_token::id()),
+            "defaulted read-only slot must never be persisted"
+        );
+    }
+
+    /// Documents the accepted admin side effect: when the fee payer is absent
+    /// from the callback its writable slot defaults, so the consumer would
+    /// tombstone it. This is a no-op in practice because every account key is
+    /// preloaded before execution, so an absent key is absent in the DB too;
+    /// the delete targets nothing and GC reaps the tombstone.
+    #[test]
+    fn test_admin_absent_fee_payer_slot_would_tombstone() {
+        let authority = Pubkey::new_unique();
+        let data = valid_init_mint_data(6, authority);
+        let (tx, _mint) = make_spl_tx_with_mint(spl_token::id(), data);
+
+        // All-None callback: the writable fee payer at index 0 has no state.
+        let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
+
+        let fee_payer = tx.account_keys().get(0).copied().unwrap();
+        assert!(tx.is_writable(0), "fee payer slot is writable");
+        let (pubkey, account) = &executed.loaded_transaction.accounts[0];
+        assert_eq!(*pubkey, fee_payer);
+        // lamports == 0 and empty data is exactly how the consumer detects a delete.
+        assert!(account.lamports() == 0 && account.data().is_empty());
     }
 
     // ─── Failure paths ──────────────────────────────────────────────────────
@@ -630,8 +885,17 @@ mod tests {
         let (tx, mint_pubkey) = make_spl_tx_with_mint(spl_token::id(), data);
         let cb = StubCbWithUninitialized { mint: mint_pubkey };
 
-        let executed = assert_executed_with_status(run_admin_vm_with_cb(&[tx], &cb), Ok(()));
-        assert_eq!(executed.loaded_transaction.accounts.len(), 1);
+        let executed =
+            assert_executed_with_status(run_admin_vm_with_cb(std::slice::from_ref(&tx), &cb), Ok(()));
+        assert_eq!(
+            executed.loaded_transaction.accounts.len(),
+            tx.account_keys().len()
+        );
+        let mint_index = index_of(&tx, &mint_pubkey);
+        assert_eq!(
+            executed.loaded_transaction.accounts[mint_index].0,
+            mint_pubkey
+        );
     }
 
     /// InitializeMint data with the freeze-authority COption tag set to 1
@@ -667,7 +931,7 @@ mod tests {
         // Second instruction: unsupported SPL Token type 3 (Transfer).
         let bad = vec![3u8; 10];
 
-        let tx = make_two_instruction_spl_tx(valid, bad);
+        let (tx, _mint_a, _mint_b) = make_two_instruction_spl_tx(valid, bad);
         let executed = assert_executed_with_status(
             run_admin_vm(&[tx]),
             Err(TransactionError::InstructionError(
@@ -689,7 +953,7 @@ mod tests {
         let bad = vec![3u8; 10];
         let valid = valid_init_mint_data(6, authority);
 
-        let tx = make_two_instruction_spl_tx(bad, valid);
+        let (tx, _mint_a, _mint_b) = make_two_instruction_spl_tx(bad, valid);
         let executed = assert_executed_with_status(
             run_admin_vm(&[tx]),
             Err(TransactionError::InstructionError(

--- a/integration/tests/private-channel/integration.rs
+++ b/integration/tests/private-channel/integration.rs
@@ -390,6 +390,9 @@ async fn test_suite(private_channel_ctx: &PrivateChannelContext, solana_ctx: &So
     // admin-vm malformed InitializeMint coverage.
     run_admin_vm_initialize_mint_malformed_test(private_channel_ctx).await;
 
+    // admin-vm InitializeMint persistence + account_keys mirror coverage.
+    run_admin_vm_initialize_mint_persists_test(private_channel_ctx).await;
+
     // parallel-SVM SnapshotCallback coverage (20-tx burst).
     run_parallel_svm_burst_test(private_channel_ctx).await;
 

--- a/integration/tests/private-channel/rpc/mod.rs
+++ b/integration/tests/private-channel/rpc/mod.rs
@@ -35,6 +35,9 @@ mod test_simulate_transaction_preflight;
 // admin-vm malformed InitializeMint coverage.
 mod test_admin_vm_initialize_mint_malformed;
 
+// admin-vm InitializeMint persistence + account_keys mirror coverage.
+mod test_admin_vm_initialize_mint_persists;
+
 // parallel-SVM SnapshotCallback coverage.
 mod test_parallel_svm_burst;
 
@@ -71,4 +74,5 @@ pub use test_simulate_transaction_account_writes::run_simulate_transaction_accou
 pub use test_simulate_transaction_preflight::run_simulate_transaction_preflight_test;
 
 pub use test_admin_vm_initialize_mint_malformed::run_admin_vm_initialize_mint_malformed_test;
+pub use test_admin_vm_initialize_mint_persists::run_admin_vm_initialize_mint_persists_test;
 pub use test_parallel_svm_burst::run_parallel_svm_burst_test;

--- a/integration/tests/private-channel/rpc/test_admin_vm_initialize_mint_persists.rs
+++ b/integration/tests/private-channel/rpc/test_admin_vm_initialize_mint_persists.rs
@@ -69,7 +69,11 @@ fn assert_balances_aligned(tx_json: &serde_json::Value, label: &str) {
 }
 
 /// Fetch and unpack the on-chain Mint at `pubkey`, asserting its decimals.
-async fn assert_mint_decimals(ctx: &PrivateChannelContext, pubkey: &solana_sdk::pubkey::Pubkey, label: &str) {
+async fn assert_mint_decimals(
+    ctx: &PrivateChannelContext,
+    pubkey: &solana_sdk::pubkey::Pubkey,
+    label: &str,
+) {
     let account = ctx
         .read_client
         .get_account(pubkey)
@@ -104,7 +108,10 @@ async fn case_single_mint_persists(ctx: &PrivateChannelContext) {
         blockhash,
     );
     let sig = ctx
-        .send_and_check(&init_tx, Duration::from_secs(SEND_AND_CHECK_DURATION_SECONDS))
+        .send_and_check(
+            &init_tx,
+            Duration::from_secs(SEND_AND_CHECK_DURATION_SECONDS),
+        )
         .await
         .expect("send_and_check should not error")
         .expect("InitializeMint should land");

--- a/integration/tests/private-channel/rpc/test_admin_vm_initialize_mint_persists.rs
+++ b/integration/tests/private-channel/rpc/test_admin_vm_initialize_mint_persists.rs
@@ -1,0 +1,199 @@
+//! `test_admin_vm_initialize_mint_persists`
+//!
+//! Target file: `core/src/vm/admin.rs` — verifies that the AdminVm returns a
+//! full `account_keys()` mirror so a well-formed `InitializeMint` persists the
+//! mint and produces length-aligned stored-meta balance arrays.
+//! Binary: `private_channel_integration` (existing).
+//! Fixture: reuses `PrivateChannelContext`.
+//!
+//! Cases:
+//!   1. A single well-formed admin InitializeMint lands successfully, its
+//!      stored-meta balance arrays are length-aligned to accountKeys, the mint
+//!      exists with the declared decimals/authority, and the spl_token program
+//!      account is not clobbered.
+//!   2. One admin tx with two InitializeMint instructions - both mints persist.
+
+use {
+    super::{
+        test_context::PrivateChannelContext,
+        utils::{MINT_DECIMALS, SEND_AND_CHECK_DURATION_SECONDS},
+    },
+    crate::setup,
+    solana_sdk::{
+        account::ReadableAccount,
+        program_pack::Pack,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    spl_token::state::Mint,
+    std::time::Duration,
+};
+
+pub async fn run_admin_vm_initialize_mint_persists_test(ctx: &PrivateChannelContext) {
+    println!("\n=== AdminVm InitializeMint Persistence Coverage ===");
+
+    case_single_mint_persists(ctx).await;
+    case_two_mints_persist(ctx).await;
+
+    println!("✓ AdminVm mint-persistence tests passed");
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Assert the getTransaction meta balance arrays are aligned to accountKeys,
+/// which is exactly the invariant the AdminVm account_keys mirror restores.
+fn assert_balances_aligned(tx_json: &serde_json::Value, label: &str) {
+    let keys_len = tx_json
+        .pointer("/transaction/message/accountKeys")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or_else(|| panic!("{label}: accountKeys missing (full response: {tx_json})"));
+    let pre_len = tx_json
+        .pointer("/meta/preBalances")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len());
+    let post_len = tx_json
+        .pointer("/meta/postBalances")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len());
+    assert_eq!(
+        pre_len,
+        Some(keys_len),
+        "{label}: preBalances must equal accountKeys len (full response: {tx_json})"
+    );
+    assert_eq!(
+        post_len,
+        Some(keys_len),
+        "{label}: postBalances must equal accountKeys len (full response: {tx_json})"
+    );
+}
+
+/// Fetch and unpack the on-chain Mint at `pubkey`, asserting its decimals.
+async fn assert_mint_decimals(ctx: &PrivateChannelContext, pubkey: &solana_sdk::pubkey::Pubkey, label: &str) {
+    let account = ctx
+        .read_client
+        .get_account(pubkey)
+        .await
+        .unwrap_or_else(|e| panic!("{label}: mint {pubkey} must exist after settle: {e:?}"));
+    let mint = Mint::unpack(account.data())
+        .unwrap_or_else(|e| panic!("{label}: mint {pubkey} must unpack as SPL Mint: {e:?}"));
+    assert!(mint.is_initialized, "{label}: mint must be initialized");
+    assert_eq!(
+        mint.decimals, MINT_DECIMALS,
+        "{label}: mint decimals must match declared value"
+    );
+}
+
+// ── Cases ───────────────────────────────────────────────────────────────────
+
+/// A well-formed single InitializeMint lands, has length-aligned balance meta,
+/// persists the mint, and leaves the spl_token program account untouched.
+async fn case_single_mint_persists(ctx: &PrivateChannelContext) {
+    let mint = Keypair::new();
+
+    // Baseline of the spl_token program account so we can prove it is not
+    // clobbered by the mint write (best-effort: skipped if the RPC lacks it).
+    let program_before = ctx.read_client.get_account(&spl_token::id()).await.ok();
+
+    let blockhash = ctx.get_blockhash().await.unwrap();
+    let init_tx = setup::create_mint_account_transaction(
+        &ctx.operator_key,
+        &mint,
+        &ctx.operator_key.pubkey(),
+        MINT_DECIMALS,
+        blockhash,
+    );
+    let sig = ctx
+        .send_and_check(&init_tx, Duration::from_secs(SEND_AND_CHECK_DURATION_SECONDS))
+        .await
+        .expect("send_and_check should not error")
+        .expect("InitializeMint should land");
+
+    let response = ctx
+        .get_transaction(&sig)
+        .await
+        .expect("get_transaction should not error")
+        .expect("InitializeMint must be retrievable");
+
+    let err = response
+        .pointer("/meta/err")
+        .unwrap_or(&serde_json::Value::Null);
+    assert!(
+        err.is_null(),
+        "case 1: InitializeMint must succeed, got err: {err} (full: {response})"
+    );
+    assert_balances_aligned(&response, "case 1 (single mint)");
+
+    assert_mint_decimals(ctx, &mint.pubkey(), "case 1").await;
+
+    if let Some(before) = program_before {
+        let after = ctx
+            .read_client
+            .get_account(&spl_token::id())
+            .await
+            .expect("spl_token program must still exist after mint write");
+        assert_eq!(
+            before.data(),
+            after.data(),
+            "case 1: spl_token program account must not be clobbered"
+        );
+    }
+    println!("  ✓ case 1: single InitializeMint persists mint, balances aligned");
+}
+
+/// One admin tx carrying two InitializeMint instructions: both mints succeed
+/// and persist at the correct state.
+async fn case_two_mints_persist(ctx: &PrivateChannelContext) {
+    let mint_a = Keypair::new();
+    let mint_b = Keypair::new();
+    let operator = ctx.operator_key.pubkey();
+
+    let ix_a = spl_token::instruction::initialize_mint(
+        &spl_token::id(),
+        &mint_a.pubkey(),
+        &operator,
+        None,
+        MINT_DECIMALS,
+    )
+    .unwrap();
+    let ix_b = spl_token::instruction::initialize_mint(
+        &spl_token::id(),
+        &mint_b.pubkey(),
+        &operator,
+        None,
+        MINT_DECIMALS,
+    )
+    .unwrap();
+
+    let blockhash = ctx.get_blockhash().await.unwrap();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix_a, ix_b],
+        Some(&operator),
+        &[&ctx.operator_key],
+        blockhash,
+    );
+
+    let sig = ctx
+        .send_and_check(&tx, Duration::from_secs(SEND_AND_CHECK_DURATION_SECONDS))
+        .await
+        .expect("send_and_check should not error")
+        .expect("two-mint InitializeMint should land");
+
+    let response = ctx
+        .get_transaction(&sig)
+        .await
+        .expect("get_transaction should not error")
+        .expect("two-mint tx must be retrievable");
+    let err = response
+        .pointer("/meta/err")
+        .unwrap_or(&serde_json::Value::Null);
+    assert!(
+        err.is_null(),
+        "case 2: two-mint tx must succeed, got err: {err} (full: {response})"
+    );
+    assert_balances_aligned(&response, "case 2 (two mints)");
+
+    assert_mint_decimals(ctx, &mint_a.pubkey(), "case 2 mint_a").await;
+    assert_mint_decimals(ctx, &mint_b.pubkey(), "case 2 mint_b").await;
+    println!("  ✓ case 2: two InitializeMint instructions both persist");
+}


### PR DESCRIPTION
## Summary

The AdminVm returned `loaded_transaction.accounts` as a compact list containing only the created mint(s), whereas the real SVM returns a positional mirror of `account_keys()`. Downstream code assumes this one-to-one mapping when checking account writability and building transaction metadata, so the compact representation could misalign writable checks and produce incorrectly shaped balance arrays.

This change makes the AdminVm mirror the real SVM by returning one entry per `account_keys()` element and placing created mint(s) at their correct indices. Non-mint accounts are populated from the callback, making the output match the regular SVM while leaving the failure path unchanged. The change is isolated to `core/src/vm/admin.rs`; shared consumers require no modifications.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,480 | 13,103 | 87.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29935114388) |
| Indexer | 22,956 | 26,047 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29935114388) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29935114388) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29935114388) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,171 | 15,163 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29935114388) |
| **Total** | **48,427** | **56,411** | **85.8%** | |

> Last updated: 2026-07-22 16:12:26 UTC by E2E Integration