### PR TITLE
fix: gate InitializeMint2 as admin instruction

### DIFF
--- a/core/src/transactions.rs
+++ b/core/src/transactions.rs
@@ -3,10 +3,15 @@ use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 const SPL_INITIALIZE_MINT: u8 = 0;
+const SPL_INITIALIZE_MINT2: u8 = 20;
 
 /// A lazy-initialized static mapping from program_id (Pubkey) to a HashSet of admin instruction types (u8)
-pub static ADMIN_INSTRUCTIONS_MAP: LazyLock<HashMap<Pubkey, HashSet<u8>>> =
-    LazyLock::new(|| HashMap::from([(spl_token::id(), HashSet::from([SPL_INITIALIZE_MINT]))]));
+pub static ADMIN_INSTRUCTIONS_MAP: LazyLock<HashMap<Pubkey, HashSet<u8>>> = LazyLock::new(|| {
+    HashMap::from([(
+        spl_token::id(),
+        HashSet::from([SPL_INITIALIZE_MINT, SPL_INITIALIZE_MINT2]),
+    )])
+});
 
 /// Checks if an instruction is an admin-only instruction
 pub fn is_admin_instruction(program_id: &Pubkey, instruction_type: u8) -> bool {
@@ -29,6 +34,11 @@ mod tests {
     #[test]
     fn spl_initialize_mint_is_admin() {
         assert!(is_admin_instruction(&spl_token::id(), 0));
+    }
+
+    #[test]
+    fn spl_initialize_mint2_is_admin() {
+        assert!(is_admin_instruction(&spl_token::id(), 20));
     }
 
     #[test]

--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -28,6 +28,7 @@ const SPL_TOKEN_ID: Pubkey = spl_token::id();
 
 // SPL Token instruction types
 const INSTRUCTION_INITIALIZE_MINT: u8 = 0;
+const INSTRUCTION_INITIALIZE_MINT2: u8 = 20;
 
 /// This VM is used to execute admin transactions
 #[derive(Default)]
@@ -148,7 +149,10 @@ impl AdminVm {
                     };
 
                     match instruction_type {
-                        INSTRUCTION_INITIALIZE_MINT => {
+                        // InitializeMint2 shares InitializeMint's data layout;
+                        // only its account list differs (no rent sysvar), which
+                        // process_initialize_mint does not read.
+                        INSTRUCTION_INITIALIZE_MINT | INSTRUCTION_INITIALIZE_MINT2 => {
                             match Self::process_initialize_mint(callbacks, tx, instruction) {
                                 Ok((pubkey, account)) => accounts.push((pubkey, account)),
                                 Err(err) => {
@@ -520,6 +524,25 @@ mod tests {
     fn test_spl_valid_initialize_mint() {
         let authority = Pubkey::new_unique();
         let data = valid_init_mint_data(9, authority);
+        let tx = make_spl_tx(spl_token::id(), &[1], data);
+
+        let executed = assert_executed_with_status(run_admin_vm(&[tx]), Ok(()));
+
+        assert_eq!(executed.loaded_transaction.accounts.len(), 1);
+        let (_, account) = &executed.loaded_transaction.accounts[0];
+        let mint = Mint::unpack(account.data()).unwrap();
+        assert_eq!(mint.decimals, 9);
+        assert_eq!(mint.mint_authority, COption::Some(authority));
+    }
+
+    /// InitializeMint2 (type byte 20) shares InitializeMint's data layout and
+    /// routes to the same handler: a well-formed tx succeeds and produces a
+    /// Mint with the declared decimals and mint authority.
+    #[test]
+    fn test_spl_valid_initialize_mint2() {
+        let authority = Pubkey::new_unique();
+        let mut data = valid_init_mint_data(9, authority);
+        data[0] = INSTRUCTION_INITIALIZE_MINT2;
         let tx = make_spl_tx(spl_token::id(), &[1], data);
 
         let executed = assert_executed_with_status(run_admin_vm(&[tx]), Ok(()));

--- a/core/src/vm/admin.rs
+++ b/core/src/vm/admin.rs
@@ -642,8 +642,8 @@ mod tests {
         let account_keys = tx.account_keys();
         let accounts = &executed.loaded_transaction.accounts;
         assert_eq!(accounts.len(), account_keys.len());
-        for i in 0..account_keys.len() {
-            assert_eq!(accounts[i].0, account_keys.get(i).copied().unwrap());
+        for (index, (pubkey, _)) in accounts.iter().enumerate() {
+            assert_eq!(*pubkey, account_keys.get(index).copied().unwrap());
         }
     }
 
@@ -872,15 +872,21 @@ mod tests {
         let authority = Pubkey::new_unique();
         let mut data = valid_init_mint_data(9, authority);
         data[0] = INSTRUCTION_INITIALIZE_MINT2;
-        let tx = make_spl_tx(spl_token::id(), &[1], data);
+        let (tx, mint) = make_spl_tx_with_mint(spl_token::id(), data);
 
-        let executed = assert_executed_with_status(run_admin_vm(&[tx]), Ok(()));
+        let executed = assert_executed_with_status(run_admin_vm(std::slice::from_ref(&tx)), Ok(()));
 
-        assert_eq!(executed.loaded_transaction.accounts.len(), 1);
-        let (_, account) = &executed.loaded_transaction.accounts[0];
-        let mint = Mint::unpack(account.data()).unwrap();
-        assert_eq!(mint.decimals, 9);
-        assert_eq!(mint.mint_authority, COption::Some(authority));
+        // Accounts mirror account_keys, and the mint lands at its own index.
+        assert_eq!(
+            executed.loaded_transaction.accounts.len(),
+            tx.account_keys().len()
+        );
+        let mint_index = index_of(&tx, &mint);
+        let (pubkey, account) = &executed.loaded_transaction.accounts[mint_index];
+        assert_eq!(*pubkey, mint);
+        let mint_state = Mint::unpack(account.data()).unwrap();
+        assert_eq!(mint_state.decimals, 9);
+        assert_eq!(mint_state.mint_authority, COption::Some(authority));
     }
 
     // ─── Failure paths ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Gate InitializeMint2 as an admin instruction

**Finding (OtterSec offchain 1):** `ADMIN_INSTRUCTIONS_MAP` listed SPL-Token `InitializeMint`(discriminator 0) but not `InitializeMint2` (discriminator 20). Both create a mint; the only difference is that `InitializeMint2` omits the rent sysvar account. Since `InitializeMint2`  wasn't in the map, `is_admin_instruction` returned `false`, so `sigverify` never required the admin signer: any non-admin could create a mint in the channel.

**Fix:** Add `InitializeMint2` (20) to the admin set so both mint-creation variants require the admin signer.

These are the only two SPL-Token instructions that create a mint, so the gate is now exhaustive.

**Testing:** Added `spl_initialize_mint2_is_admin`
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,504 | 13,127 | 87.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30030601645) |
| Indexer | 22,947 | 26,047 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30030601645) |
| Gateway | 1,055 | 1,230 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30030601645) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30030601645) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,169 | 15,168 | 80.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30030601645) |
| **Total** | **48,460** | **56,475** | **85.8%** | |

> Last updated: 2026-07-23 18:05:22 UTC by E2E Integration