### PR TITLE
fix(gateway): revalidate operator role against DB with TTL cache

### DIFF
--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -75,6 +75,13 @@ const ACCOUNT_GATED_METHODS: &[&str] = &[
     "getSignaturesForAddress",
 ];
 
+/// Whether `method` requires any auth check (operator-only or account-gated).
+/// Callers use this to skip JWT verification and the operator DB re-check for
+/// public methods.
+pub fn is_gated(method: &str) -> bool {
+    OPERATOR_ONLY_METHODS.contains(&method) || ACCOUNT_GATED_METHODS.contains(&method)
+}
+
 // ---------------------------------------------------------------------------
 // Token program IDs
 //
@@ -171,26 +178,25 @@ pub enum AuthDecision {
 // Auth entry point — called by enforce_auth
 // ---------------------------------------------------------------------------
 
-/// Checks whether the request is authorised to call `method` with `params`.
+/// Checks whether the request is authorised to call `method` with `params`,
+/// given the caller's already-verified `claims` (`None` if the JWT was missing,
+/// invalid, or expired).
 ///
-/// - If the method is not gated, returns `Proceed` immediately.
-/// - If the JWT is missing or invalid, returns `Reject(401)`.
-/// - If the caller is an Operator, returns `Proceed` (unrestricted access).
-/// - If the caller is a User, returns `NeedsAccountFetch` so the caller can
-///   fetch the raw account data and run the ownership check in
-///   `check_account_data_ownership`.
+/// `claims.role` is treated as the caller's effective role: the caller confirms
+/// an Operator claim against the DB first and passes `User` when it was revoked,
+/// so no DB lookup happens here for the role.
 ///
-/// No DB lookup is performed here. Users almost always query ATAs or other
-/// PDAs rather than their wallet pubkeys directly, so checking
-/// `verified_wallets` up-front would almost always be a wasted round-trip.
-/// `check_account_data_ownership` handles both token accounts (via owner/
-/// delegate byte inspection) and direct wallet pubkeys (fallback pubkey check).
-pub fn check_request_auth(
-    auth_header: Option<&str>,
-    decoding_key: &DecodingKey,
-    method: &str,
-    params: &Value,
-) -> AuthDecision {
+/// - Method not gated: `Proceed`.
+/// - No valid token on a gated method: `Reject(401)`.
+/// - Operator: `Proceed` (unrestricted read access).
+/// - User: `NeedsAccountFetch`, so the caller can fetch the raw account data and
+///   run the ownership check in `check_account_data_ownership`.
+///
+/// The User path defers the ownership DB lookup to `check_account_data_ownership`
+/// because users almost always query ATAs or PDAs rather than their wallet
+/// pubkeys directly, so checking `verified_wallets` up-front would usually be a
+/// wasted round-trip.
+pub fn check_request_auth(claims: Option<&Claims>, method: &str, params: &Value) -> AuthDecision {
     let is_operator_only = OPERATOR_ONLY_METHODS.contains(&method);
     let is_account_gated = ACCOUNT_GATED_METHODS.contains(&method);
 
@@ -198,7 +204,7 @@ pub fn check_request_auth(
         return AuthDecision::Proceed;
     }
 
-    let claims = match auth_header.and_then(|h| verify_bearer(h, decoding_key)) {
+    let claims = match claims {
         Some(c) => c,
         None => return AuthDecision::Reject(StatusCode::UNAUTHORIZED, unauthorized_body()),
     };
@@ -348,8 +354,8 @@ pub fn decode_account_data(encoded: &str) -> Option<Vec<u8>> {
 
 /// Extracts and verifies a Bearer token from the raw `Authorization` header value.
 /// Returns `Some(Claims)` on success, `None` if missing, malformed, or expired.
-fn verify_bearer(auth_header: &str, decoding_key: &DecodingKey) -> Option<Claims> {
-    let token = auth_header.strip_prefix("Bearer ")?;
+pub fn verify_bearer(auth_header: Option<&str>, decoding_key: &DecodingKey) -> Option<Claims> {
+    let token = auth_header?.strip_prefix("Bearer ")?;
     let mut validation = Validation::default();
     validation.set_issuer(&[JWT_ISSUER]);
     validation.set_audience(&[JWT_AUDIENCE]);
@@ -365,6 +371,7 @@ fn verify_bearer(auth_header: &str, decoding_key: &DecodingKey) -> Option<Claims
 //   -32001  Unauthorized — missing, invalid, or expired JWT
 //   -32002  Forbidden   — account not owned by the calling user
 //   -32003  Forbidden   — method requires operator role
+//   -32603  Internal    — a DB lookup (ownership or role) failed
 // ---------------------------------------------------------------------------
 
 fn unauthorized_body() -> Bytes {
@@ -412,6 +419,15 @@ fn db_error_body() -> Bytes {
     )
 }
 
+pub fn role_check_error_body() -> Bytes {
+    Bytes::from(
+        serde_json::json!({
+            "error": { "code": -32603, "message": "Internal error: could not verify caller role" }
+        })
+        .to_string(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -452,6 +468,16 @@ mod tests {
         .unwrap()
     }
 
+    /// Build verified `Claims` for the policy tests. `check_request_auth` treats
+    /// the role as already confirmed, so tests pass the effective role directly.
+    fn claims(role: Role) -> Claims {
+        Claims {
+            sub: Uuid::new_v4().to_string(),
+            role,
+            exp: (Utc::now().timestamp() + 3600) as usize,
+        }
+    }
+
     /// A lazy pool that never actually connects — safe to use in tests that
     /// return before hitting the DB (e.g. the mint-size rejection path).
     fn lazy_pool() -> PgPool {
@@ -460,48 +486,49 @@ mod tests {
             .unwrap()
     }
 
+    // ── verify_bearer ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn verify_bearer_accepts_valid_token() {
+        let token = forge_token(Role::Operator, 3600);
+        let parsed = verify_bearer(Some(&format!("Bearer {token}")), &decoding_key());
+        assert_eq!(parsed.map(|c| c.role), Some(Role::Operator));
+    }
+
+    #[test]
+    fn verify_bearer_rejects_expired_token() {
+        let token = forge_token(Role::Operator, -3600);
+        assert!(verify_bearer(Some(&format!("Bearer {token}")), &decoding_key()).is_none());
+    }
+
+    #[test]
+    fn verify_bearer_rejects_wrong_secret() {
+        let token = forge_token(Role::Operator, 3600);
+        let wrong_key = DecodingKey::from_secret(b"wrong-secret");
+        assert!(verify_bearer(Some(&format!("Bearer {token}")), &wrong_key).is_none());
+    }
+
+    #[test]
+    fn verify_bearer_rejects_missing_bearer_prefix() {
+        let token = forge_token(Role::Operator, 3600);
+        assert!(verify_bearer(Some(&token), &decoding_key()).is_none());
+    }
+
     // ── check_request_auth ────────────────────────────────────────────────────
+    //
+    // check_request_auth trusts claims.role as the caller's effective role;
+    // enforce_auth resolves it against the DB first. These tests pass Claims
+    // directly via the `claims` helper.
 
     #[test]
     fn ungated_method_proceeds_without_token() {
-        let decision = check_request_auth(None, &decoding_key(), "getSlot", &json!([]));
+        let decision = check_request_auth(None, "getSlot", &json!([]));
         assert!(matches!(decision, AuthDecision::Proceed));
     }
 
     #[test]
     fn operator_only_missing_token_is_401() {
-        let decision = check_request_auth(None, &decoding_key(), "getBlock", &json!([]));
-        assert!(matches!(
-            decision,
-            AuthDecision::Reject(StatusCode::UNAUTHORIZED, _)
-        ));
-    }
-
-    #[test]
-    fn operator_only_expired_token_is_401() {
-        let token = forge_token(Role::Operator, -3600);
-        let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
-            "getBlock",
-            &json!([]),
-        );
-        assert!(matches!(
-            decision,
-            AuthDecision::Reject(StatusCode::UNAUTHORIZED, _)
-        ));
-    }
-
-    #[test]
-    fn operator_only_wrong_secret_is_401() {
-        let token = forge_token(Role::Operator, 3600);
-        let wrong_key = DecodingKey::from_secret(b"wrong-secret");
-        let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &wrong_key,
-            "getBlock",
-            &json!([]),
-        );
+        let decision = check_request_auth(None, "getBlock", &json!([]));
         assert!(matches!(
             decision,
             AuthDecision::Reject(StatusCode::UNAUTHORIZED, _)
@@ -510,13 +537,7 @@ mod tests {
 
     #[test]
     fn operator_only_user_role_is_403() {
-        let token = forge_token(Role::User, 3600);
-        let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
-            "getBlock",
-            &json!([]),
-        );
+        let decision = check_request_auth(Some(&claims(Role::User)), "getBlock", &json!([]));
         assert!(matches!(
             decision,
             AuthDecision::Reject(StatusCode::FORBIDDEN, _)
@@ -525,25 +546,14 @@ mod tests {
 
     #[test]
     fn operator_only_operator_role_proceeds() {
-        let token = forge_token(Role::Operator, 3600);
-        let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
-            "getBlock",
-            &json!([]),
-        );
+        let decision = check_request_auth(Some(&claims(Role::Operator)), "getBlock", &json!([]));
         assert!(matches!(decision, AuthDecision::Proceed));
     }
 
     #[test]
     fn simulate_transaction_operator_only() {
-        let token = forge_token(Role::User, 3600);
-        let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
-            "simulateTransaction",
-            &json!([]),
-        );
+        let decision =
+            check_request_auth(Some(&claims(Role::User)), "simulateTransaction", &json!([]));
         assert!(matches!(
             decision,
             AuthDecision::Reject(StatusCode::FORBIDDEN, _)
@@ -552,12 +562,7 @@ mod tests {
 
     #[test]
     fn account_gated_no_token_is_401() {
-        let decision = check_request_auth(
-            None,
-            &decoding_key(),
-            "getAccountInfo",
-            &json!(["SomePubkey"]),
-        );
+        let decision = check_request_auth(None, "getAccountInfo", &json!(["SomePubkey"]));
         assert!(matches!(
             decision,
             AuthDecision::Reject(StatusCode::UNAUTHORIZED, _)
@@ -566,10 +571,8 @@ mod tests {
 
     #[test]
     fn account_gated_operator_role_proceeds() {
-        let token = forge_token(Role::Operator, 3600);
         let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
+            Some(&claims(Role::Operator)),
             "getAccountInfo",
             &json!(["SomePubkey"]),
         );
@@ -578,10 +581,8 @@ mod tests {
 
     #[test]
     fn account_gated_user_role_returns_needs_account_fetch() {
-        let token = forge_token(Role::User, 3600);
         let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
+            Some(&claims(Role::User)),
             "getAccountInfo",
             &json!(["SomePubkey"]),
         );
@@ -593,13 +594,7 @@ mod tests {
 
     #[test]
     fn account_gated_missing_pubkey_is_400() {
-        let token = forge_token(Role::User, 3600);
-        let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
-            "getAccountInfo",
-            &json!([]),
-        );
+        let decision = check_request_auth(Some(&claims(Role::User)), "getAccountInfo", &json!([]));
         assert!(matches!(
             decision,
             AuthDecision::Reject(StatusCode::BAD_REQUEST, _)
@@ -610,7 +605,6 @@ mod tests {
     fn get_signatures_for_address_no_token_is_401() {
         let decision = check_request_auth(
             None,
-            &decoding_key(),
             "getSignaturesForAddress",
             &json!(["So11111111111111111111111111111111111111112"]),
         );
@@ -622,10 +616,8 @@ mod tests {
 
     #[test]
     fn get_signatures_for_address_operator_proceeds() {
-        let token = forge_token(Role::Operator, 3600);
         let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
+            Some(&claims(Role::Operator)),
             "getSignaturesForAddress",
             &json!(["So11111111111111111111111111111111111111112"]),
         );
@@ -634,10 +626,8 @@ mod tests {
 
     #[test]
     fn get_signatures_for_address_user_role_returns_needs_account_fetch() {
-        let token = forge_token(Role::User, 3600);
         let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
+            Some(&claims(Role::User)),
             "getSignaturesForAddress",
             &json!(["So11111111111111111111111111111111111111112"]),
         );
@@ -649,10 +639,8 @@ mod tests {
 
     #[test]
     fn get_signatures_for_address_user_missing_pubkey_is_400() {
-        let token = forge_token(Role::User, 3600);
         let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
+            Some(&claims(Role::User)),
             "getSignaturesForAddress",
             &json!([]),
         );
@@ -664,10 +652,8 @@ mod tests {
 
     #[test]
     fn get_token_account_balance_gated_for_user() {
-        let token = forge_token(Role::User, 3600);
         let decision = check_request_auth(
-            Some(&format!("Bearer {token}")),
-            &decoding_key(),
+            Some(&claims(Role::User)),
             "getTokenAccountBalance",
             &json!(["SomePubkey"]),
         );

--- a/gateway/src/db.rs
+++ b/gateway/src/db.rs
@@ -1,6 +1,24 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
+use crate::auth::Role;
+
+/// Returns the role currently stored for `user_id`, or `None` if the user no
+/// longer exists. The gateway uses this to confirm that a JWT's Operator claim
+/// still matches the DB, since a token can outlive a demotion by up to 24h.
+pub async fn get_user_role(pool: &PgPool, user_id: Uuid) -> Result<Option<Role>, sqlx::Error> {
+    let row: Option<(String,)> =
+        sqlx::query_as(r#"SELECT role::text FROM private_channel_auth.users WHERE id = $1"#)
+            .bind(user_id)
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(row.map(|(role,)| match role.as_str() {
+        "operator" => Role::Operator,
+        _ => Role::User,
+    }))
+}
+
 /// Returns `true` if `pubkey` is registered in `private_channel_auth.verified_wallets`
 /// for the given `user_id`.
 ///

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -4,8 +4,9 @@ pub mod metrics;
 
 use crate::auth::{
     check_account_data_ownership, check_request_auth, decode_account_data, forbidden_body,
-    AuthDecision,
+    is_gated, role_check_error_body, verify_bearer, AuthDecision, Role,
 };
+use crate::db::get_user_role;
 use clap::Parser;
 use http_body_util::{BodyExt, Empty, Full, LengthLimitError, Limited};
 use hyper::body::{Bytes, Incoming};
@@ -20,12 +21,14 @@ use jsonwebtoken::DecodingKey;
 use serde_json::Value;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
+use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 /// Maximum allowed request body size (64 KB).
 const MAX_BODY_SIZE: usize = 64 * 1024;
@@ -111,6 +114,9 @@ pub struct Gateway {
     auth_db: Option<PgPool>,
     /// Cached result of the last upstream readiness probe, refreshed on demand.
     ready_cache: Arc<AsyncMutex<Option<ReadyCache>>>,
+    /// Cached auth-DB role confirmations, keyed by user id. Lets a token's
+    /// Operator claim be re-checked without a DB lookup on every request.
+    role_cache: Arc<Mutex<HashMap<Uuid, CachedRole>>>,
 }
 
 #[derive(Clone, Copy)]
@@ -119,8 +125,18 @@ struct ReadyCache {
     healthy: bool,
 }
 
+#[derive(Clone, Copy)]
+struct CachedRole {
+    is_operator: bool,
+    checked_at: Instant,
+}
+
 const READY_CACHE_TTL: Duration = Duration::from_secs(2);
 const READY_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// How long a DB role confirmation is trusted before re-checking. Bounds the
+/// window a demoted operator keeps access to at most this duration.
+const ROLE_CACHE_TTL: Duration = Duration::from_secs(30);
 
 /// A `JWT_SECRET` counts as "configured" only if non-empty after trimming, mirroring the
 /// auth service so a whitespace-only secret doesn't enable gateway RBAC while auth refuses
@@ -155,6 +171,7 @@ impl Gateway {
             jwt_secret,
             auth_db,
             ready_cache: Arc::new(AsyncMutex::new(None)),
+            role_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -290,10 +307,58 @@ impl Gateway {
         }
     }
 
+    /// Confirms whether `user_id` currently holds the Operator role in the auth
+    /// DB, caching the result for `ROLE_CACHE_TTL`. A JWT can outlive a demotion
+    /// by up to 24h, so an Operator claim is only honored when this returns
+    /// `true`.
+    ///
+    /// Returns `Err` if the DB is unreachable; the caller fails closed (denies
+    /// the operator elevation) rather than trusting a stale claim.
+    async fn confirm_operator(&self, auth_db: &PgPool, user_id: Uuid) -> Result<bool, sqlx::Error> {
+        // Fast path: a fresh cached confirmation avoids the DB round-trip.
+        // The lock is never held across the await below.
+        if let Some(entry) = self.role_cache.lock().unwrap().get(&user_id) {
+            if entry.checked_at.elapsed() < ROLE_CACHE_TTL {
+                return Ok(entry.is_operator);
+            }
+        }
+
+        let is_operator = matches!(get_user_role(auth_db, user_id).await?, Some(Role::Operator));
+
+        self.role_cache.lock().unwrap().insert(
+            user_id,
+            CachedRole {
+                is_operator,
+                checked_at: Instant::now(),
+            },
+        );
+        Ok(is_operator)
+    }
+
+    /// Records an auth-rejection metric and builds the error response.
+    fn reject_with_metrics(
+        &self,
+        method_label: &str,
+        status: StatusCode,
+        body: Bytes,
+        start: Instant,
+    ) -> Response<http_body_util::combinators::UnsyncBoxBody<Bytes, hyper::Error>> {
+        Self::record_metrics(
+            Some("auth_rejected"),
+            method_label,
+            "none",
+            &status.as_u16().to_string(),
+            start.elapsed().as_secs_f64(),
+        );
+        self.error_response(status, Some(body))
+    }
+
     /// Enforces RBAC on gated methods.
     ///
-    /// Returns `Some(response)` if the request must be rejected, `None` if it
-    /// may proceed. No-ops immediately when auth is not configured.
+    /// Returns `Some(response)` if the request must be rejected, `None` if it may
+    /// proceed. No-ops immediately when auth is not configured. Operator claims
+    /// are re-checked against the auth DB (cached), so a demoted operator loses
+    /// access within `ROLE_CACHE_TTL` rather than when their 24h token expires.
     async fn enforce_auth(
         &self,
         auth_header: Option<&str>,
@@ -307,7 +372,38 @@ impl Gateway {
             _ => return None,
         };
 
-        let decision = check_request_auth(auth_header, decoding_key, method, params);
+        // Public methods need neither a token nor a role check.
+        if !is_gated(method) {
+            return None;
+        }
+
+        let mut claims = verify_bearer(auth_header, decoding_key);
+
+        // Re-check an Operator claim against the DB and downgrade to User when
+        // the role was revoked. Fail closed if the DB can't be reached.
+        if let Some(caller) = claims.as_mut() {
+            if caller.role == Role::Operator {
+                let confirmed = match Uuid::parse_str(&caller.sub) {
+                    Ok(user_id) => self.confirm_operator(auth_db, user_id).await,
+                    // A malformed sub can't map to an operator row.
+                    Err(_) => Ok(false),
+                };
+                match confirmed {
+                    Ok(true) => {}                         // still an operator
+                    Ok(false) => caller.role = Role::User, // demoted -> effective User
+                    Err(_) => {
+                        return Some(self.reject_with_metrics(
+                            method_label,
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            role_check_error_body(),
+                            start,
+                        ));
+                    }
+                }
+            }
+        }
+
+        let decision = check_request_auth(claims.as_ref(), method, params);
 
         let (status, body) = match decision {
             AuthDecision::Proceed => return None,
@@ -334,14 +430,7 @@ impl Gateway {
             }
         };
 
-        Self::record_metrics(
-            Some("auth_rejected"),
-            method_label,
-            "none",
-            &status.as_u16().to_string(),
-            start.elapsed().as_secs_f64(),
-        );
-        Some(self.error_response(status, Some(body)))
+        Some(self.reject_with_metrics(method_label, status, body, start))
     }
 
     /// Build a JSON-RPC–style error body for 413 responses.

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -323,13 +323,20 @@ impl Gateway {
             }
         }
 
+        // Stamp the check time before the query so a slow lookup can't cache a
+        // stale role under a fresh timestamp; staleness stays bounded by the TTL
+        // even when concurrent requests race on the same user.
+        let checked_at = Instant::now();
         let is_operator = matches!(get_user_role(auth_db, user_id).await?, Some(Role::Operator));
 
-        self.role_cache.lock().unwrap().insert(
+        let mut cache = self.role_cache.lock().unwrap();
+        // Evict expired entries so the map stays bounded to recently-active operators.
+        cache.retain(|_, entry| entry.checked_at.elapsed() < ROLE_CACHE_TTL);
+        cache.insert(
             user_id,
             CachedRole {
                 is_operator,
-                checked_at: Instant::now(),
+                checked_at,
             },
         );
         Ok(is_operator)

--- a/gateway/tests/auth_integration.rs
+++ b/gateway/tests/auth_integration.rs
@@ -69,9 +69,9 @@ async fn start_postgres() -> (PgPool, String, testcontainers::ContainerAsync<Pos
 }
 
 /// Insert a bare-minimum user row with the given role and return its UUID.
-/// We only need the user to exist so verified_wallets can reference it —
-/// the gateway reads the role from the JWT, not from this row. But keeping
-/// the DB role consistent with the token makes tests easier to reason about.
+/// The gateway confirms Operator JWTs against this row, so operator tests keep
+/// the DB role matching the token. The revocation tests deliberately mismatch
+/// them (operator token, `user` row) to prove a demoted operator loses access.
 async fn insert_user(pool: &PgPool, role: &str) -> Uuid {
     let id = Uuid::new_v4();
     sqlx::query(
@@ -951,6 +951,79 @@ async fn test_operator_only_methods_enforce_role() {
             "{method}: expected 200 for operator role"
         );
     }
+}
+
+/// A JWT claiming Operator whose DB role has since been downgraded to `user`
+/// must lose operator access. The gateway re-checks the role against the auth
+/// DB instead of trusting the 24h token, so an operator-only method returns 403
+/// just as it would for any User-role caller.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_demoted_operator_loses_operator_access() {
+    let (pool, _url, _container) = start_postgres().await;
+    db::init_schema(&pool).await.unwrap();
+
+    // DB says `user`, but the token still claims `operator` (issued pre-demotion).
+    let user_id = insert_user(&pool, "user").await;
+    let stale_operator_token = generate_token(user_id, "operator");
+
+    let generic_response = json!({"jsonrpc":"2.0","id":1,"result":null}).to_string();
+    let backend = start_mock_backend_with_body(generic_response).await;
+    let addr = start_gateway(
+        pool,
+        "http://127.0.0.1:1".to_string(),
+        format!("http://{}", backend),
+    )
+    .await;
+
+    let res = Client::new()
+        .post(format!("http://{}", addr))
+        .bearer_auth(&stale_operator_token)
+        .json(&json!({ "jsonrpc": "2.0", "id": 1, "method": "getBlock", "params": [] }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 403);
+}
+
+/// The Operator bypass of the ownership check is revoked the same way: a stale
+/// operator token querying an account it does not own is subject to the normal
+/// ownership check and denied. Contrast with
+/// `test_get_account_info_operator_bypasses_ownership_check`, where a live
+/// operator is allowed through.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_demoted_operator_loses_ownership_bypass() {
+    let (pool, _url, _container) = start_postgres().await;
+    db::init_schema(&pool).await.unwrap();
+
+    // DB says `user` with no registered wallets; token still claims `operator`.
+    let user_id = insert_user(&pool, "user").await;
+    let stale_operator_token = generate_token(user_id, "operator");
+
+    // A System Program account triggers the pubkey-ownership fallback, which
+    // fails because the user has no verified wallets.
+    let backend = start_mock_backend_with_body(system_account_response()).await;
+    let addr = start_gateway(
+        pool,
+        "http://127.0.0.1:1".to_string(),
+        format!("http://{}", backend),
+    )
+    .await;
+
+    let res = Client::new()
+        .post(format!("http://{}", addr))
+        .bearer_auth(&stale_operator_token)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getAccountInfo",
+            "params": ["So11111111111111111111111111111111111111112"]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 403);
 }
 
 /// Public methods like `sendTransaction` and `getSlot` must pass through


### PR DESCRIPTION
## Summary

Closes the OtterSec JWT revocation finding: the gateway read the RBAC role straight from the JWT and never re-checked the DB, so an operator demoted via `set-role` kept full operator read access until their 24h token expired.

The gateway now re-checks any **Operator** claim against the auth DB (which it already connects to for ownership checks) and treats the caller as a plain `User` if the role was revoked. Results are cached with a 30s TTL, so a demoted operator loses access within 30s instead of up to 24h, at roughly one DB lookup per operator per 30s.

## Details

  - Only Operator claims are re-checked — a User token can never escalate, so no added DB load on user traffic.
  - **Fail closed**: if the auth DB is unreachable during the check, the request is rejected (500) rather than trusting the stale claim.
  - Downgrade reuses existing paths: operator-only methods return 403, account-gated methods fall through to the normal ownership check.
  - Gateway-only change; the auth service (source of truth) is untouched.

## Testing

  - 42 unit tests + 29 integration tests passing; `fmt` and `clippy -D warnings` clean.
  - Two new integration tests prove the fix: a stale operator token is denied on an operator-only method (403) and loses the ownership-check bypass (403).
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,149 | 12,761 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29969792308) |
| Indexer | 22,947 | 26,047 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29969792308) |
| Gateway | 1,055 | 1,230 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29969792308) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/29969792308) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **35,936** | **40,941** | **87.8%** | |

> Last updated: 2026-07-23 00:50:02 UTC by Auth