### PR TITLE
fix: distinguish missing accounts from load errors (issue-11-ottersec)

### DIFF
--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -29,7 +29,7 @@
 /// evict less frequently accessed accounts.
 use {
     crate::{
-        accounts::{precompiles::PRECOMPILES, AccountsDB},
+        accounts::{get_accounts::AccountLoadError, precompiles::PRECOMPILES, AccountsDB},
         stages::AccountSettlement,
     },
     solana_sdk::{
@@ -103,14 +103,21 @@ impl BOB {
 
     /// Preloads accounts into BOB from the database.
     ///
-    /// Returns `(fetched, cached)` where:
-    /// - `fetched` = accounts that were missing from BOB and loaded from the DB.
-    /// - `cached`  = accounts that were already warm in BOB (no DB round-trip needed).
+    /// Returns `(fetched, cached)`: `fetched` accounts were loaded from the DB,
+    /// `cached` were already warm in BOB. An account that is not in the DB is
+    /// simply left uncached so the SVM sees it as absent. Any load failure
+    /// returns `Err`: the caller must treat it as fatal rather than persist over
+    /// live state, because a masked failure would let the SVM see a real account
+    /// as absent, and a corrupt account is an integrity fault that cannot be
+    /// safely executed against.
     ///
     /// Only queries the database for accounts that are actual cache misses
     /// (not in BOB's HashMap and not a precompile). Once the working set is
     /// warm, most batches will skip the DB entirely.
-    pub async fn preload_accounts(&mut self, pubkeys: &[Pubkey]) -> (usize, usize) {
+    pub async fn preload_accounts(
+        &mut self,
+        pubkeys: &[Pubkey],
+    ) -> Result<(usize, usize), AccountLoadError> {
         // Drain settled_accounts channel to keep dirty/clean tracking current.
         // The expensive eviction sweep only runs every GC_EVICTION_INTERVAL batches.
         self.garbage_collect();
@@ -133,18 +140,21 @@ impl BOB {
 
         // If everything is warm, skip the DB round-trip entirely.
         if miss_keys.is_empty() {
-            return (0, already_cached);
+            return Ok((0, already_cached));
         }
 
-        // Only fetch the cache-miss keys from the database.
-        let accounts = self.accounts_db.get_accounts(&miss_keys).await;
+        // Only fetch the cache-miss keys. A transient outage or a corrupt row
+        // propagates as Err and is handled as fatal by the caller.
+        let loads = self.accounts_db.load_accounts(&miss_keys).await?;
         let mut fetched = 0usize;
-        for (index, account_opt) in accounts.iter().enumerate() {
-            if let Some(account) = account_opt {
+        for (index, load) in loads.into_iter().enumerate() {
+            // A None means the account is not in the DB: leave it uncached so the
+            // SVM sees it as absent. Only found accounts are cached.
+            if let Some(account) = load {
                 self.accounts.insert(
                     miss_keys[index],
                     AccountWithMeta {
-                        account: account.clone(),
+                        account,
                         synced_since: None,
                         deleted: false,
                     },
@@ -153,7 +163,7 @@ impl BOB {
             }
         }
 
-        (fetched, already_cached)
+        Ok((fetched, already_cached))
     }
 
     // TODO: Merge this implementation with the one in the settlement stage
@@ -957,6 +967,99 @@ mod tests {
         assert!(
             !bob.accounts.contains_key(&spl_token::id()),
             "read-only spl_token program slot must be skipped"
+        );
+    }
+
+    // ── preload_accounts against a real backing store ──
+
+    /// Overwrite the `data` column for `pubkey` with bytes that cannot
+    /// deserialize into an AccountSharedData.
+    async fn insert_corrupt_pg(db: &AccountsDB, pubkey: Pubkey) {
+        if let AccountsDB::Postgres(pg) = db {
+            sqlx::query(
+                "INSERT INTO accounts (pubkey, data) VALUES ($1, $2)
+                 ON CONFLICT (pubkey) DO UPDATE SET data = EXCLUDED.data",
+            )
+            .bind(pubkey.to_bytes().to_vec())
+            .bind(vec![0xAAu8; 5])
+            .execute(pg.pool.as_ref())
+            .await
+            .unwrap();
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preload_found_caches_account() {
+        let (db, _pg) = crate::test_helpers::start_test_postgres().await;
+        let mut writer = db.clone();
+        let pk = Pubkey::new_unique();
+        writer
+            .set_account(pk, make_account(7, &[1], &Pubkey::default()))
+            .await;
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut bob = BOB::new(db, rx).await;
+        let (fetched, _cached) = bob.preload_accounts(&[pk]).await.unwrap();
+
+        assert_eq!(fetched, 1);
+        assert!(
+            TransactionProcessingCallback::get_account_shared_data(&bob, &pk).is_some(),
+            "Found account must be cached"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preload_missing_is_noop() {
+        let (db, _pg) = crate::test_helpers::start_test_postgres().await;
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut bob = BOB::new(db, rx).await;
+        let pk = Pubkey::new_unique();
+
+        let (fetched, _cached) = bob.preload_accounts(&[pk]).await.unwrap();
+
+        assert_eq!(fetched, 0);
+        assert!(
+            TransactionProcessingCallback::get_account_shared_data(&bob, &pk).is_none(),
+            "Missing account must not be cached"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preload_corrupt_is_fatal() {
+        let (db, _pg) = crate::test_helpers::start_test_postgres().await;
+        let bad = Pubkey::new_unique();
+        insert_corrupt_pg(&db, bad).await;
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut bob = BOB::new(db, rx).await;
+        let result = bob.preload_accounts(&[bad]).await;
+
+        // A corrupt account is an integrity fault, not a cache miss.
+        assert!(
+            matches!(result, Err(AccountLoadError::Corrupt(k)) if k == bad),
+            "corrupt account must propagate as a fatal error"
+        );
+        assert!(
+            TransactionProcessingCallback::get_account_shared_data(&bob, &bad).is_none(),
+            "corrupt account must not be cached"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial_test::serial]
+    async fn preload_transient_error_propagates() {
+        // Dead backend: preload must propagate Err (fatal), not report success.
+        let db = crate::test_helpers::dead_postgres_db();
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut bob = BOB::new(db, rx).await;
+
+        crate::accounts::get_accounts::set_test_retry(2, 1);
+        let result = bob.preload_accounts(&[Pubkey::new_unique()]).await;
+        crate::accounts::get_accounts::reset_test_retry();
+
+        assert!(
+            matches!(result, Err(AccountLoadError::Backend(_))),
+            "a dead backend must propagate as a fatal error"
         );
     }
 }

--- a/core/src/accounts/get_accounts.rs
+++ b/core/src/accounts/get_accounts.rs
@@ -4,74 +4,456 @@ use {
     redis::{AsyncCommands, RedisResult},
     solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
     sqlx::Row,
-    std::sync::Arc,
+    std::{fmt::Display, future::Future, sync::Arc, time::Duration},
 };
 
-pub async fn get_accounts(db: &AccountsDB, accounts: &[Pubkey]) -> Vec<Option<AccountSharedData>> {
-    match db {
-        AccountsDB::Postgres(postgres_db) => get_accounts_postgres(postgres_db, accounts).await,
-        AccountsDB::Redis(redis_db) => get_accounts_redis(redis_db, accounts).await,
+/// A load failure the caller must treat as fatal, kept separate from a genuinely
+/// absent account so a failure is never mistaken for a missing account. A loaded
+/// account is a plain `Some`, and not-in-the-DB is a plain `None`.
+#[derive(Debug, Clone)]
+pub enum AccountLoadError {
+    /// The query failed and did not recover after retries (transient outage).
+    Backend(String),
+    /// A stored account could not be deserialized. Retrying cannot fix bad bytes,
+    /// so this is an integrity problem that halts the batch.
+    Corrupt(Pubkey),
+}
+
+impl Display for AccountLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AccountLoadError::Backend(msg) => {
+                write!(f, "account store read failed after retries: {}", msg)
+            }
+            AccountLoadError::Corrupt(pubkey) => {
+                write!(f, "account {} is corrupt in the store", pubkey)
+            }
+        }
     }
 }
 
-async fn get_accounts_postgres(
+impl std::error::Error for AccountLoadError {}
+
+/// Bounded-retry parameters for transient whole-query failures. Only the query
+/// itself is retried; a corrupt row is never retried.
+const LOAD_MAX_ATTEMPTS: u32 = 4;
+const LOAD_BACKOFF_BASE_MS: u64 = 20;
+const LOAD_BACKOFF_CAP_MS: u64 = 500;
+
+#[cfg(not(test))]
+fn retry_params() -> (u32, u64) {
+    (LOAD_MAX_ATTEMPTS, LOAD_BACKOFF_BASE_MS)
+}
+
+// Tests shrink the retry schedule so the transient-fatal path returns fast.
+#[cfg(test)]
+static TEST_MAX_ATTEMPTS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(LOAD_MAX_ATTEMPTS);
+#[cfg(test)]
+static TEST_BASE_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(LOAD_BACKOFF_BASE_MS);
+
+#[cfg(test)]
+fn retry_params() -> (u32, u64) {
+    use std::sync::atomic::Ordering::Relaxed;
+    (TEST_MAX_ATTEMPTS.load(Relaxed), TEST_BASE_MS.load(Relaxed))
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_retry(attempts: u32, base_ms: u64) {
+    use std::sync::atomic::Ordering::Relaxed;
+    TEST_MAX_ATTEMPTS.store(attempts, Relaxed);
+    TEST_BASE_MS.store(base_ms, Relaxed);
+}
+
+#[cfg(test)]
+pub(crate) fn reset_test_retry() {
+    set_test_retry(LOAD_MAX_ATTEMPTS, LOAD_BACKOFF_BASE_MS);
+}
+
+/// Exponential backoff for `attempt` (1-based), capped at `LOAD_BACKOFF_CAP_MS`.
+fn backoff_delay(attempt: u32, base_ms: u64) -> Duration {
+    let shift = attempt.saturating_sub(1).min(20);
+    let ms = base_ms
+        .saturating_mul(1u64 << shift)
+        .min(LOAD_BACKOFF_CAP_MS);
+    Duration::from_millis(ms)
+}
+
+/// Retry `op` up to `attempts` times with capped exponential backoff, awaiting
+/// `sleep` between tries. Split from `with_retry` so unit tests can inject a
+/// fake sleeper and observe the requested delays without wall-clock waits.
+async fn with_retry_using_sleep<T, E, F, Fut, S, SFut>(
+    attempts: u32,
+    base_ms: u64,
+    mut op: F,
+    mut sleep: S,
+) -> Result<T, E>
+where
+    E: Display,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    S: FnMut(Duration) -> SFut,
+    SFut: Future<Output = ()>,
+{
+    let max = attempts.max(1);
+    let mut attempt = 1u32;
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(e) => {
+                if attempt >= max {
+                    return Err(e);
+                }
+                let delay = backoff_delay(attempt, base_ms);
+                tracing::warn!(
+                    "account load attempt {}/{} failed: {}; retrying in {:?}",
+                    attempt,
+                    max,
+                    e,
+                    delay
+                );
+                sleep(delay).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+/// Production wrapper over `with_retry_using_sleep` using the configured
+/// schedule and a real tokio sleep.
+async fn with_retry<T, E, F, Fut>(op: F) -> Result<T, E>
+where
+    E: Display,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+{
+    let (attempts, base_ms) = retry_params();
+    with_retry_using_sleep(attempts, base_ms, op, |d| tokio::time::sleep(d)).await
+}
+
+/// Deserialize a stored row. `Err` means the bytes are corrupt, which the caller
+/// turns into a fatal error rather than retrying.
+fn classify_row(data: &[u8]) -> Result<AccountSharedData, ()> {
+    bincode::deserialize::<AccountSharedData>(data).map_err(|_| ())
+}
+
+/// Load used by preload: `Some` per found account, `None` for an absent one, and
+/// a typed `Err` for either fatal case (transient outage or a corrupt row).
+pub async fn load_accounts(
+    db: &AccountsDB,
+    accounts: &[Pubkey],
+) -> Result<Vec<Option<AccountSharedData>>, AccountLoadError> {
+    match db {
+        AccountsDB::Postgres(postgres_db) => load_accounts_postgres(postgres_db, accounts).await,
+        AccountsDB::Redis(redis_db) => load_accounts_redis(redis_db, accounts).await,
+    }
+}
+
+/// Returns an account when found, or `None` for any other case: not in the DB,
+/// corrupt, or a read error. Use when the caller only needs the account value.
+pub async fn get_accounts(db: &AccountsDB, accounts: &[Pubkey]) -> Vec<Option<AccountSharedData>> {
+    load_accounts(db, accounts)
+        .await
+        .unwrap_or_else(|_| vec![None; accounts.len()])
+}
+
+async fn load_accounts_postgres(
     postgres_db: &PostgresAccountsDB,
     accounts: &[Pubkey],
-) -> Vec<Option<AccountSharedData>> {
+) -> Result<Vec<Option<AccountSharedData>>, AccountLoadError> {
     let pool = Arc::clone(&postgres_db.pool);
     let pubkey_bytes: Vec<Vec<u8>> = accounts.iter().map(|key| key.to_bytes().to_vec()).collect();
 
-    match sqlx::query("SELECT pubkey, data FROM accounts WHERE pubkey = ANY($1)")
-        .bind(&pubkey_bytes)
-        .fetch_all(pool.as_ref())
-        .await
-    {
-        Ok(rows) => {
-            // Initialize result vector with None for all accounts
-            let mut result = vec![None; accounts.len()];
+    // Only the whole query is retried; a corrupt row is fatal, handled below.
+    let rows = with_retry(|| async {
+        sqlx::query("SELECT pubkey, data FROM accounts WHERE pubkey = ANY($1)")
+            .bind(&pubkey_bytes)
+            .fetch_all(pool.as_ref())
+            .await
+    })
+    .await
+    .map_err(|e| AccountLoadError::Backend(e.to_string()))?;
 
-            for row in rows {
-                let pubkey_bytes: Vec<u8> = row.get("pubkey");
-                let data: Vec<u8> = row.get("data");
+    // Absent keys stay None; a present row that will not deserialize is fatal.
+    let mut result = vec![None; accounts.len()];
+    for row in rows {
+        let row_pubkey: Vec<u8> = row.get("pubkey");
+        let data: Vec<u8> = row.get("data");
 
-                // Find the index of this pubkey in the original input
-                if let Some(index) = accounts
-                    .iter()
-                    .position(|&key| key.to_bytes().as_slice() == pubkey_bytes)
-                {
-                    match bincode::deserialize::<AccountSharedData>(&data) {
-                        Ok(account) => result[index] = Some(account),
-                        Err(e) => {
-                            tracing::error!("Failed to deserialize account data: {}", e);
-                        }
-                    }
-                }
+        if let Some(index) = accounts
+            .iter()
+            .position(|&key| key.to_bytes().as_slice() == row_pubkey)
+        {
+            match classify_row(&data) {
+                Ok(account) => result[index] = Some(account),
+                Err(()) => return Err(AccountLoadError::Corrupt(accounts[index])),
             }
-            result
-        }
-        Err(e) => {
-            tracing::error!("Failed to fetch accounts: {}", e);
-            vec![None; accounts.len()]
         }
     }
+    Ok(result)
 }
 
-async fn get_accounts_redis(
+async fn load_accounts_redis(
     redis_db: &RedisAccountsDB,
     accounts: &[Pubkey],
-) -> Vec<Option<AccountSharedData>> {
-    let mut conn = redis_db.connection.clone();
+) -> Result<Vec<Option<AccountSharedData>>, AccountLoadError> {
     let keys = accounts
         .iter()
         .map(|key| format!("account:{}", key))
         .collect::<Vec<_>>();
-    let data: RedisResult<Vec<Option<Vec<u8>>>> = conn.mget(keys).await;
 
-    match data {
-        Ok(results) => results
-            .into_iter()
-            .map(|opt| opt.and_then(|bytes| bincode::deserialize(&bytes).ok()))
-            .collect(),
-        Err(_) => vec![None; accounts.len()],
+    let data: Vec<Option<Vec<u8>>> = with_retry(|| async {
+        let mut conn = redis_db.connection.clone();
+        let out: RedisResult<Vec<Option<Vec<u8>>>> = conn.mget(&keys).await;
+        out
+    })
+    .await
+    .map_err(|e| AccountLoadError::Backend(e.to_string()))?;
+
+    let mut result = vec![None; accounts.len()];
+    for (index, opt) in data.into_iter().enumerate() {
+        if let Some(bytes) = opt {
+            match classify_row(&bytes) {
+                Ok(account) => result[index] = Some(account),
+                Err(()) => return Err(AccountLoadError::Corrupt(accounts[index])),
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::test_helpers::{start_test_postgres, start_test_redis},
+        solana_sdk::account::ReadableAccount,
+        std::sync::atomic::{AtomicU32, Ordering},
+    };
+
+    // ── with_retry unit tests (no wall-clock sleep) ──
+
+    /// A no-op sleeper that records every requested delay so tests can assert on
+    /// the backoff schedule without actually waiting.
+    fn recording_sleep(
+        log: std::rc::Rc<std::cell::RefCell<Vec<Duration>>>,
+    ) -> impl FnMut(Duration) -> std::future::Ready<()> {
+        move |d: Duration| {
+            log.borrow_mut().push(d);
+            std::future::ready(())
+        }
+    }
+
+    #[tokio::test]
+    async fn with_retry_succeeds_after_n_failures() {
+        let calls = AtomicU32::new(0);
+        // Fail twice, succeed on the third call.
+        let result: Result<u32, String> = with_retry_using_sleep(
+            5,
+            1,
+            || {
+                let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    if n < 3 {
+                        Err(format!("transient {n}"))
+                    } else {
+                        Ok(n)
+                    }
+                }
+            },
+            |_d| std::future::ready(()),
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), 3);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "must stop as soon as it succeeds"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_retry_exhausts_and_returns_err() {
+        let calls = AtomicU32::new(0);
+        let result: Result<u32, String> = with_retry_using_sleep(
+            4,
+            1,
+            || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async move { Err::<u32, _>("always fails".to_string()) }
+            },
+            |_d| std::future::ready(()),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            4,
+            "must invoke exactly LOAD_MAX_ATTEMPTS times, no more, no fewer"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_retry_backoff_is_bounded() {
+        let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let result: Result<u32, String> = with_retry_using_sleep(
+            6,
+            1000, // large base so every delay would exceed the cap if uncapped
+            || async { Err::<u32, _>("boom".to_string()) },
+            recording_sleep(log.clone()),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let delays = log.borrow();
+        // One sleep between each of the 6 attempts → 5 sleeps.
+        assert_eq!(delays.len(), 5);
+        for d in delays.iter() {
+            assert!(
+                *d <= Duration::from_millis(LOAD_BACKOFF_CAP_MS),
+                "no single backoff may exceed the cap: {:?}",
+                d
+            );
+        }
+        // Backoff must be non-decreasing (exponential until the cap).
+        for pair in delays.windows(2) {
+            assert!(pair[1] >= pair[0], "backoff must not shrink");
+        }
+    }
+
+    // ── classify_row unit tests ──
+
+    #[test]
+    fn classify_row_valid_is_found() {
+        let account = AccountSharedData::new(7, 0, &Pubkey::new_unique());
+        let bytes = bincode::serialize(&account).unwrap();
+        let loaded = classify_row(&bytes).expect("valid bytes must deserialize");
+        assert_eq!(loaded.lamports(), 7);
+    }
+
+    #[test]
+    fn classify_row_garbage_is_corrupt() {
+        let garbage = vec![0xffu8; 3];
+        assert!(classify_row(&garbage).is_err());
+    }
+
+    // ── Postgres integration: load_accounts ──
+
+    /// Overwrite the `data` column for `pubkey` with bytes that cannot
+    /// deserialize into an AccountSharedData.
+    async fn insert_corrupt_account_pg(db: &AccountsDB, pubkey: Pubkey) {
+        let AccountsDB::Postgres(pg) = db else {
+            panic!("expected Postgres");
+        };
+        sqlx::query(
+            "INSERT INTO accounts (pubkey, data) VALUES ($1, $2)
+             ON CONFLICT (pubkey) DO UPDATE SET data = EXCLUDED.data",
+        )
+        .bind(pubkey.to_bytes().to_vec())
+        .bind(vec![0xAAu8; 5])
+        .execute(pg.pool.as_ref())
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn load_accounts_found_missing_mix() {
+        let (mut db, _pg) = start_test_postgres().await;
+        let stored = Pubkey::new_unique();
+        let absent = Pubkey::new_unique();
+        db.set_account(stored, AccountSharedData::new(9, 0, &Pubkey::new_unique()))
+            .await;
+
+        let loads = load_accounts(&db, &[stored, absent]).await.unwrap();
+        assert!(loads[0].is_some());
+        assert!(loads[1].is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn load_accounts_corrupt_row_is_fatal() {
+        let (db, _pg) = start_test_postgres().await;
+        let bad = Pubkey::new_unique();
+        insert_corrupt_account_pg(&db, bad).await;
+
+        // A corrupt row is an integrity fault: the whole load fails fatally.
+        let result = load_accounts(&db, &[bad]).await;
+        assert!(matches!(result, Err(AccountLoadError::Corrupt(k)) if k == bad));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial_test::serial]
+    async fn load_accounts_transient_error_is_fatal() {
+        // Dead backend + shrunk retries: the read must surface a typed fatal
+        // error, never a `None`. Serial so the global retry override does not
+        // race other transient tests.
+        let db = crate::test_helpers::dead_postgres_db();
+        set_test_retry(2, 1);
+        let result = load_accounts(&db, &[Pubkey::new_unique()]).await;
+        reset_test_retry();
+
+        assert!(
+            matches!(result, Err(AccountLoadError::Backend(_))),
+            "a dead backend must surface a typed fatal error, never None"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn public_get_accounts_adapter_found_and_missing() {
+        let (mut db, _pg) = start_test_postgres().await;
+        let found = Pubkey::new_unique();
+        let missing = Pubkey::new_unique();
+        db.set_account(found, AccountSharedData::new(3, 0, &Pubkey::new_unique()))
+            .await;
+
+        let results = db.get_accounts(&[found, missing]).await;
+        assert!(results[0].is_some(), "found surfaces as Some");
+        assert!(results[1].is_none(), "missing surfaces as None");
+    }
+
+    // ── Redis integration: load_accounts ──
+
+    async fn insert_corrupt_account_redis(db: &mut RedisAccountsDB, pubkey: Pubkey) {
+        use redis::AsyncCommands;
+        let key = format!("account:{}", pubkey);
+        let _: RedisResult<()> = db.connection.set(key, vec![0xAAu8; 5]).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn load_accounts_redis_found_and_missing() {
+        let (mut raw, _redis) = start_test_redis().await;
+        let found = Pubkey::new_unique();
+        let missing = Pubkey::new_unique();
+        raw.set_account(found, AccountSharedData::new(4, 0, &Pubkey::new_unique()))
+            .await;
+
+        let db = AccountsDB::Redis(raw);
+        let loads = load_accounts(&db, &[found, missing]).await.unwrap();
+        assert!(loads[0].is_some());
+        assert!(loads[1].is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn load_accounts_redis_corrupt_row_is_fatal() {
+        let (mut raw, _redis) = start_test_redis().await;
+        let corrupt = Pubkey::new_unique();
+        insert_corrupt_account_redis(&mut raw, corrupt).await;
+
+        let db = AccountsDB::Redis(raw);
+        let result = load_accounts(&db, &[corrupt]).await;
+        assert!(matches!(result, Err(AccountLoadError::Corrupt(k)) if k == corrupt));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial_test::serial]
+    async fn load_accounts_redis_transient_error_is_fatal() {
+        let db = AccountsDB::Redis(crate::test_helpers::dead_redis_db().await);
+        set_test_retry(2, 1);
+        let result = load_accounts(&db, &[Pubkey::new_unique()]).await;
+        reset_test_retry();
+
+        assert!(matches!(result, Err(AccountLoadError::Backend(_))));
     }
 }

--- a/core/src/accounts/traits.rs
+++ b/core/src/accounts/traits.rs
@@ -132,6 +132,15 @@ impl AccountsDB {
         super::get_accounts::get_accounts(self, accounts).await
     }
 
+    /// Load used by preload: `Some` per found account, `None` for an absent one,
+    /// and a typed `Err` for a fatal failure (transient outage or a corrupt row).
+    pub async fn load_accounts(
+        &self,
+        accounts: &[Pubkey],
+    ) -> Result<Vec<Option<AccountSharedData>>, super::get_accounts::AccountLoadError> {
+        super::get_accounts::load_accounts(self, accounts).await
+    }
+
     pub async fn store_performance_sample(
         &mut self,
         sample: solana_rpc_client_types::response::RpcPerfSample,

--- a/core/src/rpc/simulate_transaction_impl.rs
+++ b/core/src/rpc/simulate_transaction_impl.rs
@@ -150,7 +150,14 @@ pub async fn simulate_transaction(
     )
     .await;
     let noop: SharedMetrics = std::sync::Arc::new(NoopMetrics);
-    let execution_result = execute_batch(batch, &mut execution_deps, &noop).await;
+    let execution_result = execute_batch(batch, &mut execution_deps, &noop)
+        .await
+        .map_err(|e| {
+            custom_error(
+                JSON_RPC_SERVER_ERROR,
+                format!("Failed to load accounts for simulation: {}", e),
+            )
+        })?;
 
     let result = if let Some(regular_results) = execution_result.regular_results {
         regular_results

--- a/core/src/stage_metrics.rs
+++ b/core/src/stage_metrics.rs
@@ -25,6 +25,8 @@ pub trait StageMetrics: Send + Sync {
     fn executor_results_send_failed(&self, kind: &'static str);
     fn executor_missing_results(&self, kind: &'static str);
     fn executor_dropped_expired_blockhash(&self, count: usize);
+    fn executor_preload_fatal(&self);
+    fn executor_corrupt_account(&self);
 
     // Executor — latency histograms (durations in milliseconds)
     fn executor_batch_duration_ms(&self, ms: f64);
@@ -93,6 +95,12 @@ impl StageMetrics for NoopMetrics {
     }
     fn executor_dropped_expired_blockhash(&self, count: usize) {
         debug!("executor: dropped {} expired blockhash txs", count);
+    }
+    fn executor_preload_fatal(&self) {
+        debug!("executor: fatal preload error");
+    }
+    fn executor_corrupt_account(&self) {
+        debug!("executor: aborted batch on corrupt account");
     }
     fn executor_batch_duration_ms(&self, ms: f64) {
         debug!("executor: batch_duration={:.3}ms", ms);
@@ -218,6 +226,18 @@ counter_vec!(
     EXECUTOR_DROPPED_EXPIRED_BH,
     "private_channel_executor_dropped_expired_bh_total",
     "Transactions dropped at execution due to expired blockhash",
+    &[]
+);
+counter_vec!(
+    EXECUTOR_PRELOAD_FATAL,
+    "private_channel_executor_preload_fatal_total",
+    "Fatal account preload errors that aborted the executor",
+    &[]
+);
+counter_vec!(
+    EXECUTOR_CORRUPT_ACCOUNT,
+    "private_channel_executor_corrupt_account_total",
+    "Batches aborted because a referenced account was corrupt in the store",
     &[]
 );
 counter_vec!(
@@ -359,6 +379,16 @@ impl StageMetrics for PrometheusMetrics {
             .with_label_values(&[] as &[&str])
             .inc_by(count as f64);
     }
+    fn executor_preload_fatal(&self) {
+        EXECUTOR_PRELOAD_FATAL
+            .with_label_values(&[] as &[&str])
+            .inc();
+    }
+    fn executor_corrupt_account(&self) {
+        EXECUTOR_CORRUPT_ACCOUNT
+            .with_label_values(&[] as &[&str])
+            .inc();
+    }
     fn executor_batch_duration_ms(&self, ms: f64) {
         EXECUTOR_BATCH_DURATION
             .with_label_values(&[] as &[&str])
@@ -440,6 +470,8 @@ pub fn init_prometheus_metrics() {
         EXECUTOR_RESULTS_SEND_FAILED,
         EXECUTOR_MISSING_RESULTS,
         EXECUTOR_DROPPED_EXPIRED_BH,
+        EXECUTOR_PRELOAD_FATAL,
+        EXECUTOR_CORRUPT_ACCOUNT,
         SETTLER_TXS_SETTLED,
         // Executor latency histograms
         EXECUTOR_BATCH_DURATION,

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -145,6 +145,12 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                             ).await {
                                 Ok(result) => result,
                                 Err(e) => {
+                                    // Fatal on purpose. Breaking ends the executor task, which the
+                                    // node supervisor (wait_for_any_worker_quit) turns into a clean
+                                    // full shutdown and a non-zero process exit for the supervisor to
+                                    // restart. Nothing in this batch was settled, and restart rebuilds
+                                    // the dedup cache from settled blocks only, so the dropped txs are
+                                    // not deduped and remain resubmittable.
                                     error!("Fatal account load error, aborting executor: {:?}", e);
                                     break;
                                 }

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts::{bob::BOB, AccountsDB},
+        accounts::{bob::BOB, get_accounts::AccountLoadError, AccountsDB},
         nodes::node::WorkerHandle,
         processor::{
             create_transaction_batch_processor, get_transaction_check_results,
@@ -135,11 +135,20 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                             let batch_size = batch.transactions.len();
                             debug!("Executor received batch with {} transactions", batch_size);
 
-                            let execution_result = execute_batch(
+                            // A fatal preload error (transient DB failure that
+                            // survived retries) aborts the loop without settling:
+                            // nothing is recorded, so the txs stay resubmittable.
+                            let execution_result = match execute_batch(
                                 batch,
                                 &mut execution_deps,
                                 &metrics,
-                            ).await;
+                            ).await {
+                                Ok(result) => result,
+                                Err(e) => {
+                                    error!("Fatal account load error, aborting executor: {:?}", e);
+                                    break;
+                                }
+                            };
 
                             let num_transactions_executed = execution_result.admin_transactions.len() + execution_result.regular_transactions.len();
                             heartbeat.record_progress();
@@ -428,7 +437,7 @@ pub async fn execute_batch(
     batch: ConflictFreeBatch,
     execution_deps: &mut ExecutionDeps,
     metrics: &SharedMetrics,
-) -> ExecutionResult {
+) -> Result<ExecutionResult, AccountLoadError> {
     let t_batch = Instant::now();
     let batch_size = batch.transactions.len();
     debug!("Executing batch with {} transactions", batch_size);
@@ -517,10 +526,30 @@ pub async fn execute_batch(
     // Preload accounts
     let accounts_to_preload = accounts_to_preload.into_iter().collect::<Vec<_>>();
     let t_op = Instant::now();
-    let (preload_fetched, preload_cached) = execution_deps
+    // Both fatal cases abort the batch without settling, so nothing is recorded
+    // and the txs stay resubmittable. A transient outage would otherwise record
+    // default state over a live account; a corrupt account is an integrity fault
+    // that must not be executed against.
+    let (preload_fetched, preload_cached) = match execution_deps
         .bob
         .preload_accounts(&accounts_to_preload)
-        .await;
+        .await
+    {
+        Ok(counts) => counts,
+        Err(e) => {
+            match &e {
+                AccountLoadError::Corrupt(pubkey) => {
+                    metrics.executor_corrupt_account();
+                    error!("aborting batch: account {} is corrupt in the store", pubkey);
+                }
+                AccountLoadError::Backend(msg) => {
+                    metrics.executor_preload_fatal();
+                    error!("aborting batch: account load failed after retries: {}", msg);
+                }
+            }
+            return Err(e);
+        }
+    };
     let t_preload = t_op.elapsed();
     debug!(
         "preload: {} accounts ({} fetched, {} cached) in {:?}",
@@ -701,12 +730,12 @@ pub async fn execute_batch(
     );
     metrics.executor_batch_duration_ms(t_total.as_secs_f64() * 1000.0);
 
-    ExecutionResult {
+    Ok(ExecutionResult {
         admin_transactions,
         regular_transactions,
         admin_results,
         regular_results,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -808,7 +837,9 @@ mod tests {
                 index: i,
             })
             .collect();
-        execute_batch(ConflictFreeBatch { transactions }, deps, metrics).await
+        execute_batch(ConflictFreeBatch { transactions }, deps, metrics)
+            .await
+            .expect("execute_batch should not fail in this test")
     }
 
     fn regular_result(
@@ -1189,7 +1220,7 @@ mod tests {
         let batch = ConflictFreeBatch { transactions };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
 
         assert_eq!(result.regular_transactions.len(), n);
         assert!(result.admin_transactions.is_empty());
@@ -1220,7 +1251,7 @@ mod tests {
         let batch = ConflictFreeBatch { transactions };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
 
         let results = result.regular_results.unwrap();
         assert_eq!(results.processing_results.len(), n);
@@ -1292,7 +1323,7 @@ mod tests {
         };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(empty_batch, &mut deps, &noop).await;
+        let result = execute_batch(empty_batch, &mut deps, &noop).await.unwrap();
         assert!(result.admin_transactions.is_empty());
         assert!(result.regular_transactions.is_empty());
         assert!(result.admin_results.is_none());
@@ -1314,7 +1345,7 @@ mod tests {
         };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
         assert!(!result.regular_transactions.is_empty());
         assert!(result.admin_transactions.is_empty());
         assert!(
@@ -1349,7 +1380,7 @@ mod tests {
         };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
         assert_eq!(result.regular_transactions.len(), 2);
         assert!(result.admin_transactions.is_empty());
         let results = result.regular_results.unwrap();
@@ -1393,7 +1424,7 @@ mod tests {
         };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
 
         assert_eq!(
             result.regular_transactions.len(),
@@ -1439,7 +1470,9 @@ mod tests {
         };
 
         // Pass 1: bh is in the live window — all 3 must execute.
-        let r1 = execute_batch(batch_with(&Keypair::new()), &mut deps, &noop).await;
+        let r1 = execute_batch(batch_with(&Keypair::new()), &mut deps, &noop)
+            .await
+            .unwrap();
         assert_eq!(
             r1.regular_transactions.len(),
             3,
@@ -1450,7 +1483,9 @@ mod tests {
         live.write().unwrap().clear();
 
         // Pass 2: same blockhash, now expired — all 3 must be filtered.
-        let r2 = execute_batch(batch_with(&Keypair::new()), &mut deps, &noop).await;
+        let r2 = execute_batch(batch_with(&Keypair::new()), &mut deps, &noop)
+            .await
+            .unwrap();
         assert_eq!(
             r2.regular_transactions.len(),
             0,
@@ -1534,7 +1569,7 @@ mod tests {
         let batch = ConflictFreeBatch { transactions };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
 
         let output_signatures: Vec<_> = result
             .regular_transactions
@@ -1585,7 +1620,7 @@ mod tests {
         let batch = ConflictFreeBatch { transactions };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
 
         let output_signatures: Vec<_> = result
             .regular_transactions
@@ -1639,7 +1674,7 @@ mod tests {
         let batch = ConflictFreeBatch { transactions };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
 
         let output_signatures: Vec<_> = result
             .regular_transactions
@@ -1844,7 +1879,7 @@ mod tests {
         };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
         assert_eq!(result.admin_transactions.len(), 1);
         assert!(result.regular_transactions.is_empty());
         assert!(result.admin_results.is_some());
@@ -1870,7 +1905,7 @@ mod tests {
         };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
         assert!(
             result.admin_transactions.is_empty(),
             "mixed tx must not be admin-routed"
@@ -1904,7 +1939,7 @@ mod tests {
         };
 
         let noop: SharedMetrics = Arc::new(NoopMetrics);
-        let result = execute_batch(batch, &mut deps, &noop).await;
+        let result = execute_batch(batch, &mut deps, &noop).await.unwrap();
         assert_eq!(result.admin_transactions.len(), 1);
         assert_eq!(result.regular_transactions.len(), 1);
         assert!(result.admin_results.is_some());
@@ -2012,5 +2047,99 @@ mod tests {
             "executor must exit promptly even with a full results channel"
         );
         drop(execution_results_rx);
+    }
+
+    // ─── Corrupt-account handling ───
+
+    /// Overwrite the `data` column for `pubkey` with bytes that cannot
+    /// deserialize into an AccountSharedData.
+    async fn insert_corrupt_pg(db: &AccountsDB, pubkey: Pubkey) {
+        if let AccountsDB::Postgres(pg) = db {
+            sqlx::query(
+                "INSERT INTO accounts (pubkey, data) VALUES ($1, $2)
+                 ON CONFLICT (pubkey) DO UPDATE SET data = EXCLUDED.data",
+            )
+            .bind(pubkey.to_bytes().to_vec())
+            .bind(vec![0xAAu8; 5])
+            .execute(pg.pool.as_ref())
+            .await
+            .unwrap();
+        }
+    }
+
+    /// A corrupt account is a fatal integrity fault: execute_batch aborts the
+    /// whole batch so nothing is settled, rather than failing single txs.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn corrupt_account_aborts_batch() {
+        let (accounts_db, _pg) = start_test_postgres().await;
+        let corrupt = Pubkey::new_unique();
+        insert_corrupt_pg(&accounts_db, corrupt).await;
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
+        let noop: SharedMetrics = Arc::new(NoopMetrics);
+
+        let batch = ConflictFreeBatch {
+            transactions: vec![crate::scheduler::TransactionWithIndex {
+                transaction: Arc::new(transfer(&Keypair::new(), &corrupt, 10)),
+                index: 0,
+            }],
+        };
+        let result = execute_batch(batch, &mut deps, &noop).await;
+
+        assert!(
+            matches!(result, Err(AccountLoadError::Corrupt(k)) if k == corrupt),
+            "a referenced corrupt account must abort the batch fatally"
+        );
+    }
+
+    /// A corrupt account referenced by no transaction has no effect: it is never
+    /// loaded, so the batch executes normally.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unreferenced_corrupt_account_has_no_effect() {
+        let (accounts_db, _pg) = start_test_postgres().await;
+        let unref = Pubkey::new_unique();
+        insert_corrupt_pg(&accounts_db, unref).await;
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
+        let metrics: SharedMetrics = Arc::new(NoopMetrics);
+
+        let result = run_batch(
+            &mut deps,
+            &metrics,
+            vec![transfer(&Keypair::new(), &Pubkey::new_unique(), 10)],
+        )
+        .await;
+
+        assert_eq!(result.regular_transactions.len(), 1);
+        assert!(is_executed(regular_result(&result, 0)));
+    }
+
+    /// A transient preload failure that survives retries is fatal: execute_batch
+    /// returns Err and produces nothing to settle.
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial_test::serial]
+    async fn preload_fatal_aborts_batch() {
+        let accounts_db = crate::test_helpers::dead_postgres_db();
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
+        let noop: SharedMetrics = Arc::new(NoopMetrics);
+
+        // Dead backend; shrink retries so the fatal error returns fast.
+        crate::accounts::get_accounts::set_test_retry(2, 1);
+        let batch = ConflictFreeBatch {
+            transactions: vec![crate::scheduler::TransactionWithIndex {
+                transaction: Arc::new(transfer(&Keypair::new(), &Pubkey::new_unique(), 10)),
+                index: 0,
+            }],
+        };
+        let result = execute_batch(batch, &mut deps, &noop).await;
+        crate::accounts::get_accounts::reset_test_retry();
+
+        assert!(
+            result.is_err(),
+            "a dead backend must abort the batch fatally"
+        );
     }
 }

--- a/core/src/test_helpers.rs
+++ b/core/src/test_helpers.rs
@@ -170,6 +170,53 @@ pub(crate) async fn start_test_redis() -> (
     (db, container)
 }
 
+/// A Postgres-backed AccountsDB whose pool points at a closed port with a short
+/// acquire timeout, so any query fails fast. Used to exercise the transient
+/// (fatal) load path without a 30s wait.
+#[cfg(test)]
+pub(crate) fn dead_postgres_db() -> crate::accounts::AccountsDB {
+    use crate::accounts::{AccountsDB, PostgresAccountsDB};
+    use sqlx::postgres::PgPoolOptions;
+    use std::sync::Arc;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(std::time::Duration::from_millis(200))
+        .connect_lazy("postgres://user:pass@127.0.0.1:1/db")
+        .expect("connect_lazy should not fail");
+    AccountsDB::Postgres(PostgresAccountsDB {
+        pool: Arc::new(pool),
+        read_only: true,
+    })
+}
+
+/// A Redis-backed AccountsDB whose server has been stopped. Built with a
+/// low-retry connection manager so a command fails fast rather than spending
+/// seconds on reconnect backoff.
+#[cfg(test)]
+pub(crate) async fn dead_redis_db() -> crate::accounts::RedisAccountsDB {
+    use redis::aio::{ConnectionManager, ConnectionManagerConfig};
+
+    let (_raw, container) = start_test_redis().await;
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(6379).await.unwrap();
+    let url = format!("redis://{}:{}", host, port);
+
+    let client = redis::Client::open(url).unwrap();
+    let config = ConnectionManagerConfig::new()
+        .set_number_of_retries(1)
+        .set_factor(1)
+        .set_max_delay(5);
+    let connection = ConnectionManager::new_with_config(client, config)
+        .await
+        .unwrap();
+    let db = crate::accounts::RedisAccountsDB { connection };
+
+    // Stop the server; subsequent commands fail after a single short reconnect.
+    drop(container);
+    db
+}
+
 /// Create a BOB with empty state and a dummy (non-connecting) Postgres pool.
 /// The pool uses a bogus URL — any accidental DB call will fail with a
 /// connection timeout. Only for unit tests that stay in-memory.


### PR DESCRIPTION
## Summary

`BOB::preload_accounts` previously used `Option<AccountSharedData>` to represent both genuinely missing accounts and database read failures. As a result, transient DB errors such as connection drops, pool timeouts, or storage failures could be misinterpreted as missing accounts, causing the SVM to either fail with `ProgramAccountNotFound` or execute against a default empty account. In the latter case, the settler could persist the empty state over valid live data. This change restores the invariant that database load failures must never be represented as `None`.

The account loading path now returns `Result<Vec<Option<AccountSharedData>>, AccountLoadError>`, clearly distinguishing found accounts, genuinely absent accounts, transient backend failures, and corrupt rows. Transient DB failures are retried with bounded exponential backoff and surface as `AccountLoadError::Backend` if retries are exhausted. Corrupt data returns `AccountLoadError::Corrupt`; both fatal cases abort the batch before execution or settlement, keeping transactions resubmittable and preventing state corruption. Genuine account absence remains `None`, preserving existing Agave semantics. The error-free path remains unchanged with no additional allocation or DB round-trip.

Both fatal error types use the same fail-closed batch-abort path, while the existing public `AccountsDB::get_accounts` API remains as a thin lossy adapter for non-preload callers. Separate Prometheus counters distinguish transient preload failures from account corruption. 
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,970 | 13,595 | 88.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30002150949) |
| Indexer | 22,947 | 26,047 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30002150949) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30002150949) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30002150949) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,236 | 15,271 | 80.1% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30002150949) |
| **Total** | **48,973** | **57,011** | **85.9%** | |

> Last updated: 2026-07-23 11:40:33 UTC by E2E Integration