### PR TITLE
fix: prevent deposit misattribution from short getSignatureStatuses responses (issue-280)

### DIFF
--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -236,6 +236,8 @@ pub fn init_labels(program_type: &str) {
         "confirmation_error",
         "deposit_ownership_lost",
         "jit_missing_claim_lease",
+        "malformed_status_response",
+        "status_poll_rpc_error",
     ] {
         OPERATOR_TRANSACTION_ERRORS.with_label_values(&[program_type, error_reason]);
     }

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -16,6 +16,7 @@ use crate::operator::{
 };
 use crate::operator::{utils::mint_util::MintCache, RpcClientWithRetry};
 use crate::storage::common::models::{DbTransaction, TransactionStatus};
+use crate::storage::common::storage::RequeueOutcome;
 use crate::storage::Storage;
 use crate::ProgramType;
 use chrono::Utc;
@@ -257,26 +258,40 @@ async fn halt_withdrawal_pipeline(
 /// CAS one owned, unsent withdrawal `Processing -> Pending` so the fetcher can
 /// re-claim it. Safe because a transient error before any send proves nothing
 /// was broadcast and no signature was recorded. Mirrors the sender's
-/// pre-broadcast requeue: `Ok(false)` (CAS missed - row no longer `Processing`)
-/// and `Err` (write failed) are logged and the row is left `Processing` for
-/// recovery to reconcile.
+/// pre-broadcast requeue: only `Requeued` flips the row. `AtCap` (recovery cap
+/// reached), `NotProcessing` (row already advanced) and `Err` (write failed)
+/// all leave the row `Processing` for recovery to reconcile.
 async fn requeue_single_prebroadcast(
     storage: &Storage,
     pt_label: &str,
     transaction: &DbTransaction,
 ) {
-    match storage.try_requeue_prebroadcast(transaction.id).await {
-        Ok(true) => {
+    match storage
+        .try_requeue_prebroadcast(transaction.id, MAX_RECOVERY_REQUEUE_ATTEMPTS)
+        .await
+    {
+        Ok(RequeueOutcome::Requeued { attempts }) => {
             metrics::OPERATOR_TRANSACTION_ERRORS
                 .with_label_values(&[pt_label, "prebroadcast_requeued"])
                 .inc();
             info!(
                 txn_id = transaction.id,
                 trace_id = %transaction.trace_id,
+                attempts,
                 "Requeued withdrawal to Pending after pre-broadcast transient error"
             );
         }
-        Ok(false) => warn!(
+        Ok(RequeueOutcome::AtCap) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[pt_label, "prebroadcast_requeue_cap"])
+                .inc();
+            warn!(
+                txn_id = transaction.id,
+                trace_id = %transaction.trace_id,
+                "Pre-broadcast requeue skipped: recovery cap reached, row left Processing"
+            );
+        }
+        Ok(RequeueOutcome::NotProcessing) => warn!(
             txn_id = transaction.id,
             trace_id = %transaction.trace_id,
             "Pre-broadcast requeue skipped: row no longer Processing"

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1596,13 +1596,32 @@ pub(super) async fn route_poll_results(
     }
 }
 
+/// Why a chunked status fetch was rejected. Both variants make the caller reinsert
+/// the batch and retry; the split only picks the metric reason label.
+#[derive(Debug)]
+enum StatusFetchError {
+    /// A chunk response length did not equal the request (short or oversized).
+    MalformedLength,
+    /// The RPC call itself failed after retries.
+    Rpc,
+}
+
+impl StatusFetchError {
+    fn reason(&self) -> &'static str {
+        match self {
+            StatusFetchError::MalformedLength => "malformed_status_response",
+            StatusFetchError::Rpc => "status_poll_rpc_error",
+        }
+    }
+}
+
 /// Fetch statuses in `MAX_SIGS_PER_CALL` chunks. `getSignatureStatuses` is positional, so a
 /// chunk whose length differs from the request would misalign every later status; reject it.
 /// Returns `Err` on any RPC error or length mismatch so the caller reinserts the batch and retries.
 async fn fetch_statuses_checked(
     rpc_client: &RpcClientWithRetry,
     signatures: &[Signature],
-) -> Result<Vec<Option<solana_transaction_status::TransactionStatus>>, ()> {
+) -> Result<Vec<Option<solana_transaction_status::TransactionStatus>>, StatusFetchError> {
     let mut statuses = Vec::with_capacity(signatures.len());
     for chunk in signatures.chunks(MAX_SIGS_PER_CALL) {
         match rpc_client.get_signature_statuses(chunk).await {
@@ -1615,7 +1634,7 @@ async fn fetch_statuses_checked(
                     chunk.len(),
                     signatures.len()
                 );
-                return Err(());
+                return Err(StatusFetchError::MalformedLength);
             }
             Err(e) => {
                 warn!(
@@ -1623,7 +1642,7 @@ async fn fetch_statuses_checked(
                     signatures.len(),
                     e
                 );
-                return Err(());
+                return Err(StatusFetchError::Rpc);
             }
         }
     }
@@ -1647,7 +1666,10 @@ pub(super) async fn poll_in_flight(
 
     let statuses = match fetch_statuses_checked(&state.rpc_client, &signatures).await {
         Ok(s) => s,
-        Err(()) => {
+        Err(e) => {
+            metrics::OPERATOR_TRANSACTION_ERRORS
+                .with_label_values(&[state.program_type.as_label(), e.reason()])
+                .inc();
             // Reinsert the full batch so the next drain_in_flight iteration retries.
             state.in_flight.push_all(batch);
             return;
@@ -1718,7 +1740,10 @@ pub(super) async fn run_poll_task(
 
         let statuses = match fetch_statuses_checked(&rpc_client, &signatures).await {
             Ok(s) => s,
-            Err(()) => {
+            Err(e) => {
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[program_type.as_label(), e.reason()])
+                    .inc();
                 // Put everything back in one lock acquisition and retry next tick.
                 in_flight.push_all(batch);
                 continue;

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1596,6 +1596,40 @@ pub(super) async fn route_poll_results(
     }
 }
 
+/// Fetch statuses in `MAX_SIGS_PER_CALL` chunks. `getSignatureStatuses` is positional, so a
+/// chunk whose length differs from the request would misalign every later status; reject it.
+/// Returns `Err` on any RPC error or length mismatch so the caller reinserts the batch and retries.
+async fn fetch_statuses_checked(
+    rpc_client: &RpcClientWithRetry,
+    signatures: &[Signature],
+) -> Result<Vec<Option<solana_transaction_status::TransactionStatus>>, ()> {
+    let mut statuses = Vec::with_capacity(signatures.len());
+    for chunk in signatures.chunks(MAX_SIGS_PER_CALL) {
+        match rpc_client.get_signature_statuses(chunk).await {
+            Ok(resp) if resp.value.len() == chunk.len() => statuses.extend(resp.value),
+            Ok(resp) => {
+                warn!(
+                    "getSignatureStatuses returned {} statuses for {} signatures \
+                     ({} in-flight) - treating as RPC failure, will retry next tick",
+                    resp.value.len(),
+                    chunk.len(),
+                    signatures.len()
+                );
+                return Err(());
+            }
+            Err(e) => {
+                warn!(
+                    "getSignatureStatuses failed ({} in-flight) - will retry next tick: {}",
+                    signatures.len(),
+                    e
+                );
+                return Err(());
+            }
+        }
+    }
+    Ok(statuses)
+}
+
 /// Single-cycle poll: drain the shared queue, call `getSignatureStatuses`, then
 /// route results via `route_poll_results`.
 ///
@@ -1610,25 +1644,15 @@ pub(super) async fn poll_in_flight(
     }
     let batch = state.in_flight.drain_all();
     let signatures: Vec<Signature> = batch.iter().map(|t| t.signature).collect();
-    let mut statuses: Vec<Option<_>> = Vec::with_capacity(signatures.len());
 
-    for chunk in signatures.chunks(MAX_SIGS_PER_CALL) {
-        match state.rpc_client.get_signature_statuses(chunk).await {
-            Ok(resp) => statuses.extend(resp.value),
-            Err(e) => {
-                warn!(
-                    "getSignatureStatuses failed ({} in-flight) — will retry next tick: {}",
-                    batch.len(),
-                    e
-                );
-                // Put everything back so the next drain_in_flight iteration retries.
-                for tx in batch {
-                    state.in_flight.push(tx);
-                }
-                return;
-            }
+    let statuses = match fetch_statuses_checked(&state.rpc_client, &signatures).await {
+        Ok(s) => s,
+        Err(()) => {
+            // Reinsert the full batch so the next drain_in_flight iteration retries.
+            state.in_flight.push_all(batch);
+            return;
         }
-    }
+    };
 
     let results: Vec<_> = batch.into_iter().zip(statuses).collect();
     route_poll_results(state, results, storage_tx).await;
@@ -1691,29 +1715,15 @@ pub(super) async fn run_poll_task(
 
         signatures.clear();
         signatures.extend(batch.iter().map(|t| t.signature));
-        let mut statuses: Vec<Option<_>> = Vec::with_capacity(signatures.len());
-        let mut rpc_ok = true;
 
-        for chunk in signatures.chunks(MAX_SIGS_PER_CALL) {
-            match rpc_client.get_signature_statuses(chunk).await {
-                Ok(resp) => statuses.extend(resp.value),
-                Err(e) => {
-                    warn!(
-                        "getSignatureStatuses failed ({} in-flight) — will retry next tick: {}",
-                        batch.len(),
-                        e
-                    );
-                    rpc_ok = false;
-                    break;
-                }
+        let statuses = match fetch_statuses_checked(&rpc_client, &signatures).await {
+            Ok(s) => s,
+            Err(()) => {
+                // Put everything back in one lock acquisition and retry next tick.
+                in_flight.push_all(batch);
+                continue;
             }
-        }
-
-        if !rpc_ok {
-            // Put everything back in one lock acquisition.
-            in_flight.push_all(batch);
-            continue;
-        }
+        };
 
         let mut results: Vec<PollTaskResult> = Vec::with_capacity(batch.len());
 
@@ -4571,28 +4581,14 @@ mod tests {
     // ── poll_in_flight: chunking ──────────────────────────────────────
 
     /// When in_flight exceeds 256 entries (the getSignatureStatuses limit), poll_in_flight
-    /// must issue multiple RPC calls — one per 256-sig chunk — and merge the results.
+    /// must issue multiple RPC calls, one per 256-sig chunk, and merge the results.
     ///
-    /// Strategy: mock returns all-null statuses (not yet confirmed) so every entry stays
-    /// in `remaining` after the call.  We seed 300 entries and assert the mock was hit
-    /// at least twice (≥ 2 chunks: 256 + 44), and that all 300 entries are still in-flight.
+    /// Each chunk response is sized to exactly the number of signatures requested
+    /// (256 then 44) so strict length validation passes and the legitimate multi-chunk
+    /// merge is exercised. We seed 300 all-null entries and assert the mock was hit at
+    /// least twice and that all 300 entries stay in-flight (none confirmed, none dropped).
     #[tokio::test]
     async fn poll_in_flight_chunks_large_batch() {
-        // Build a response body with 256 null slots — enough for the largest chunk.
-        // The zip in poll_in_flight stops at the shorter of (batch, statuses), so
-        // returning 256 nulls for both the 256-sig chunk and the 44-sig chunk is fine:
-        // extra slots are ignored, missing slots cause zip to stop early (entries stay).
-        let null_statuses: Vec<serde_json::Value> = vec![serde_json::Value::Null; 256];
-        let response_body = serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "result": {
-                "context": {"slot": 1},
-                "value": null_statuses
-            }
-        })
-        .to_string();
-
         let mut server = mockito::Server::new_async().await;
         let _m = server
             .mock("POST", "/")
@@ -4600,8 +4596,14 @@ mod tests {
                 "method": "getSignatureStatuses"
             })))
             .with_status(200)
-            .with_body(response_body)
-            .expect_at_least(2) // 256 sigs → chunk 1; 44 sigs → chunk 2
+            .with_body_from_request(|req| {
+                let v: serde_json::Value =
+                    serde_json::from_slice(req.body().expect("request body present"))
+                        .expect("request body is json");
+                let requested = v["params"][0].as_array().map(|a| a.len()).unwrap_or(0);
+                null_value_body(requested).into_bytes()
+            })
+            .expect_at_least(2) // 256 sigs -> chunk 1; 44 sigs -> chunk 2
             .create();
 
         let total = 300usize;
@@ -4615,13 +4617,513 @@ mod tests {
         let (storage_tx, _rx) = mpsc::channel(10);
         poll_in_flight(&mut state, &storage_tx).await;
 
-        // All entries stay in-flight (all statuses were null → not confirmed).
+        // All entries stay in-flight (all statuses were null, so not confirmed).
         assert_eq!(
             state.in_flight.len(),
             total,
             "all entries must stay in-flight"
         );
-        _m.assert(); // verifies ≥ 2 RPC calls were made
+        _m.assert(); // verifies >= 2 RPC calls were made
+    }
+
+    // ── fetch_statuses_checked: length-gate + wiring ─────────────────────
+
+    // Build an RpcClientWithRetry that points at a mockito server and fails fast.
+    fn make_rpc_client(url: &str) -> RpcClientWithRetry {
+        RpcClientWithRetry::with_retry_config(
+            url.to_string(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: std::time::Duration::from_millis(1),
+                max_delay: std::time::Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        )
+    }
+
+    // A getSignatureStatuses response body with `count` null status slots.
+    fn null_value_body(count: usize) -> String {
+        let value = vec![serde_json::Value::Null; count];
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"context": {"slot": 1}, "value": value}
+        })
+        .to_string()
+    }
+
+    // A getSignatureStatuses response body with `count` confirmed-success slots.
+    fn confirmed_value_body(count: usize) -> String {
+        let one = serde_json::json!({
+            "confirmationStatus": "confirmed",
+            "confirmations": 1,
+            "err": null,
+            "slot": 100,
+            "status": {"Ok": null}
+        });
+        let value = vec![one; count];
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"context": {"slot": 100}, "value": value}
+        })
+        .to_string()
+    }
+
+    // Mock getSignatureStatuses; the per-call counter lets a test shape one chunk while sizing the rest to their request.
+    fn mock_status_bodies<F>(server: &mut mockito::ServerGuard, f: F) -> mockito::Mock
+    where
+        F: Fn(usize, usize) -> String + Send + Sync + 'static,
+    {
+        let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body_from_request(move |req| {
+                let idx = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let body = req.body().expect("request body present");
+                let v: serde_json::Value =
+                    serde_json::from_slice(body).expect("request body is json");
+                let requested = v["params"][0].as_array().map(|a| a.len()).unwrap_or(0);
+                f(idx, requested).into_bytes()
+            })
+            .expect_at_least(1)
+            .create()
+    }
+
+    // ── fetch_statuses_checked: response shape matrix ────────────────────
+
+    // An exactly-sized single chunk returns Ok with the requested length.
+    #[tokio::test]
+    async fn fetch_statuses_e1_exact_single_chunk_ok() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |_idx, req| null_value_body(req));
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..10).map(|_| Signature::new_unique()).collect();
+
+        let out = fetch_statuses_checked(&rpc, &sigs).await;
+        let statuses = out.expect("exact chunk must be Ok");
+        assert_eq!(statuses.len(), 10);
+    }
+
+    // A short single chunk (N-1 for N) is rejected.
+    #[tokio::test]
+    async fn fetch_statuses_e2_short_single_chunk_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |_idx, req| null_value_body(req - 1));
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..10).map(|_| Signature::new_unique()).collect();
+
+        assert!(fetch_statuses_checked(&rpc, &sigs).await.is_err());
+    }
+
+    // An oversized single chunk (N+1 for N) is rejected.
+    #[tokio::test]
+    async fn fetch_statuses_e3_oversized_single_chunk_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |_idx, req| null_value_body(req + 1));
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..10).map(|_| Signature::new_unique()).collect();
+
+        assert!(fetch_statuses_checked(&rpc, &sigs).await.is_err());
+    }
+
+    // An empty value array for a non-empty request is rejected.
+    #[tokio::test]
+    async fn fetch_statuses_e4_empty_value_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |_idx, _req| null_value_body(0));
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..5).map(|_| Signature::new_unique()).collect();
+
+        assert!(fetch_statuses_checked(&rpc, &sigs).await.is_err());
+    }
+
+    // A multi-chunk request with every chunk exact returns Ok in order; only the first chunk is confirmed.
+    #[tokio::test]
+    async fn fetch_statuses_e5_multi_chunk_all_exact_ok_ordered() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |idx, req| {
+            if idx == 0 {
+                confirmed_value_body(req)
+            } else {
+                null_value_body(req)
+            }
+        });
+        let rpc = make_rpc_client(&server.url());
+        // 600 sigs -> chunks of 256 + 256 + 88.
+        let sigs: Vec<Signature> = (0..600).map(|_| Signature::new_unique()).collect();
+
+        let statuses = fetch_statuses_checked(&rpc, &sigs)
+            .await
+            .expect("all-exact multi-chunk must be Ok");
+        assert_eq!(statuses.len(), 600);
+        // First chunk confirmed, remaining chunks null: proves concatenation order.
+        assert!(statuses[0].is_some());
+        assert!(statuses[255].is_some());
+        assert!(statuses[256].is_none());
+        assert!(statuses[599].is_none());
+    }
+
+    // A short first chunk is rejected.
+    #[tokio::test]
+    async fn fetch_statuses_e6_short_first_chunk_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |idx, req| {
+            if idx == 0 {
+                null_value_body(req - 1)
+            } else {
+                null_value_body(req)
+            }
+        });
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..600).map(|_| Signature::new_unique()).collect();
+
+        assert!(fetch_statuses_checked(&rpc, &sigs).await.is_err());
+    }
+
+    // A short middle chunk is rejected.
+    #[tokio::test]
+    async fn fetch_statuses_e7_short_middle_chunk_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |idx, req| {
+            if idx == 1 {
+                null_value_body(req - 1)
+            } else {
+                null_value_body(req)
+            }
+        });
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..600).map(|_| Signature::new_unique()).collect();
+
+        assert!(fetch_statuses_checked(&rpc, &sigs).await.is_err());
+    }
+
+    // A short final chunk is rejected.
+    #[tokio::test]
+    async fn fetch_statuses_e8_short_final_chunk_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |idx, req| {
+            if idx == 2 {
+                null_value_body(req - 1)
+            } else {
+                null_value_body(req)
+            }
+        });
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..600).map(|_| Signature::new_unique()).collect();
+
+        assert!(fetch_statuses_checked(&rpc, &sigs).await.is_err());
+    }
+
+    // An oversized middle chunk is rejected.
+    #[tokio::test]
+    async fn fetch_statuses_e9_oversized_middle_chunk_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |idx, req| {
+            if idx == 1 {
+                null_value_body(req + 1)
+            } else {
+                null_value_body(req)
+            }
+        });
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..600).map(|_| Signature::new_unique()).collect();
+
+        assert!(fetch_statuses_checked(&rpc, &sigs).await.is_err());
+    }
+
+    // An RPC transport error on a chunk is surfaced as Err (existing behavior).
+    #[tokio::test]
+    async fn fetch_statuses_e10_rpc_error_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32600, "message": "Internal error"}
+                })
+                .to_string(),
+            )
+            .create();
+        let rpc = make_rpc_client(&server.url());
+        let sigs: Vec<Signature> = (0..3).map(|_| Signature::new_unique()).collect();
+
+        assert!(fetch_statuses_checked(&rpc, &sigs).await.is_err());
+    }
+
+    // An empty signature slice returns Ok(empty) and issues no RPC call.
+    #[tokio::test]
+    async fn fetch_statuses_e11_empty_slice_ok_no_call() {
+        let mut server = mockito::Server::new_async().await;
+        // Any call would be a bug: assert the mock is never hit.
+        let m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "method": "getSignatureStatuses"
+            })))
+            .with_status(200)
+            .with_body(null_value_body(0))
+            .expect(0)
+            .create();
+        let rpc = make_rpc_client(&server.url());
+
+        let statuses = fetch_statuses_checked(&rpc, &[])
+            .await
+            .expect("empty is Ok");
+        assert!(statuses.is_empty());
+        m.assert();
+    }
+
+    // ── poll_in_flight: wiring and anti-misattribution ───────────────────
+
+    // A short only-chunk reinserts the full batch and settles nothing.
+    #[tokio::test]
+    async fn poll_in_flight_short_chunk_full_reinsert_no_settlement() {
+        let mut server = mockito::Server::new_async().await;
+        // Return one fewer status than requested for the single chunk.
+        let _m = mock_status_bodies(&mut server, |_idx, req| null_value_body(req - 1));
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let ids: Vec<i64> = (1..=5).collect();
+        for id in &ids {
+            state
+                .in_flight
+                .push(make_in_flight_tx(Signature::new_unique(), *id));
+        }
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        assert_eq!(state.in_flight.len(), 5, "all entries reinserted");
+        {
+            let guard = state.in_flight.entries.lock().unwrap();
+            let mut present: Vec<i64> = guard.iter().filter_map(|t| t.ctx.transaction_id).collect();
+            present.sort_unstable();
+            assert_eq!(present, ids, "no entry dropped");
+            assert!(
+                guard.iter().all(|t| t.poll_attempts == 0),
+                "poll_attempts not incremented on a malformed cycle"
+            );
+        }
+        assert!(storage_rx.try_recv().is_err(), "no Completed emitted");
+    }
+
+    // Reported repro: 257 entries across a chunk boundary, chunk 1 confirmed and chunk 2 short, must settle nothing and drop nothing.
+    #[tokio::test]
+    async fn poll_in_flight_cross_chunk_short_no_misattribution() {
+        let mut server = mockito::Server::new_async().await;
+        // Chunk 0 (256 sigs) all confirmed; chunk 1 (1 sig) returns an empty value.
+        let _m = mock_status_bodies(&mut server, |idx, req| {
+            if idx == 0 {
+                confirmed_value_body(req)
+            } else {
+                null_value_body(0)
+            }
+        });
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let ids: Vec<i64> = (1..=257).collect();
+        for id in &ids {
+            state
+                .in_flight
+                .push(make_in_flight_tx(Signature::new_unique(), *id));
+        }
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(300);
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        assert_eq!(state.in_flight.len(), 257, "all 257 entries reinserted");
+        {
+            let guard = state.in_flight.entries.lock().unwrap();
+            let mut present: Vec<i64> = guard.iter().filter_map(|t| t.ctx.transaction_id).collect();
+            present.sort_unstable();
+            assert_eq!(present, ids, "tail entry (id 257) not dropped");
+        }
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no Completed for any transaction on a malformed cross-chunk cycle"
+        );
+    }
+
+    // An oversized middle chunk is caught by the same gate as the short-chunk cases.
+    #[tokio::test]
+    async fn poll_in_flight_oversized_chunk_full_reinsert_no_settlement() {
+        let mut server = mockito::Server::new_async().await;
+        // Chunk 0 (256) confirmed; chunk 1 (1 sig) returns two statuses (oversized).
+        let _m = mock_status_bodies(&mut server, |idx, req| {
+            if idx == 0 {
+                confirmed_value_body(req)
+            } else {
+                null_value_body(req + 1)
+            }
+        });
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let ids: Vec<i64> = (1..=257).collect();
+        for id in &ids {
+            state
+                .in_flight
+                .push(make_in_flight_tx(Signature::new_unique(), *id));
+        }
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(300);
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        assert_eq!(state.in_flight.len(), 257, "all entries reinserted");
+        assert!(storage_rx.try_recv().is_err(), "no Completed emitted");
+    }
+
+    // Happy-path multi-chunk: every chunk returns correctly-sized confirmed statuses, so all entries settle with one Completed each.
+    #[tokio::test]
+    async fn poll_in_flight_multi_chunk_confirmed_settles_with_correct_pairing() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |_idx, req| confirmed_value_body(req));
+
+        let mut state = make_sender_state_with_server(&server.url());
+        let total = 300usize;
+        // Map each transaction_id to the signature we seeded it with.
+        let mut sig_by_id: std::collections::HashMap<i64, String> = HashMap::new();
+        for i in 0..total {
+            let sig = Signature::new_unique();
+            let id = i as i64 + 1;
+            sig_by_id.insert(id, sig.to_string());
+            state.in_flight.push(make_in_flight_tx(sig, id));
+        }
+
+        let (storage_tx, mut storage_rx) = mpsc::channel(total + 10);
+        poll_in_flight(&mut state, &storage_tx).await;
+
+        assert!(state.in_flight.is_empty(), "all confirmed entries settled");
+        let mut seen = 0usize;
+        while let Ok(update) = storage_rx.try_recv() {
+            assert_eq!(update.status, TransactionStatus::Completed);
+            // Each Completed must carry the requesting transaction's own signature.
+            assert_eq!(
+                update.counterpart_signature.as_deref(),
+                sig_by_id.get(&update.transaction_id).map(|s| s.as_str()),
+                "Completed must pair each transaction with its own signature"
+            );
+            seen += 1;
+        }
+        assert_eq!(seen, total, "exactly one Completed per transaction");
+    }
+
+    // ── run_poll_task: parity with poll_in_flight ────────────────────────
+
+    // A short chunk on the production poll task reinserts the batch and settles nothing (no PollTaskResult, no Completed).
+    #[tokio::test]
+    async fn run_poll_task_short_chunk_reinserts_no_settlement() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |_idx, req| null_value_body(req - 1));
+
+        let in_flight = InFlightQueue::new();
+        let (result_tx, mut result_rx) = mpsc::channel::<Vec<PollTaskResult>>(8);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+        let rpc = Arc::new(make_rpc_client(&server.url()));
+        let token = tokio_util::sync::CancellationToken::new();
+
+        let ids: Vec<i64> = (1..=5).collect();
+        for id in &ids {
+            in_flight.push(make_in_flight_tx(Signature::new_unique(), *id));
+        }
+
+        let handle = tokio::spawn(run_poll_task(
+            in_flight.clone(),
+            result_tx,
+            rpc,
+            storage_tx,
+            ProgramType::Escrow,
+            5,
+            token.clone(),
+        ));
+
+        // Give the task time to drain, poll, hit the short response, and reinsert.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        token.cancel();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("task must exit after cancellation")
+            .expect("task must not panic");
+
+        assert!(
+            result_rx.try_recv().is_err(),
+            "no PollTaskResult on malformed cycle"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no Completed on malformed cycle"
+        );
+        assert_eq!(in_flight.len(), 5, "batch reinserted after short chunk");
+        let mut present: Vec<i64> = {
+            let guard = in_flight.entries.lock().unwrap();
+            guard.iter().filter_map(|t| t.ctx.transaction_id).collect()
+        };
+        present.sort_unstable();
+        assert_eq!(present, ids, "no entry dropped");
+        // Prove the task actually polled, so the negative assertions above are not vacuous.
+        _m.assert();
+    }
+
+    // Happy-path confirmed multi-chunk on the production task settles every entry and emits a Completed for each.
+    #[tokio::test]
+    async fn run_poll_task_multi_chunk_confirmed_settles() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = mock_status_bodies(&mut server, |_idx, req| confirmed_value_body(req));
+
+        let in_flight = InFlightQueue::new();
+        let (result_tx, _result_rx) = mpsc::channel::<Vec<PollTaskResult>>(8);
+        let (storage_tx, mut storage_rx) = mpsc::channel(400);
+        let rpc = Arc::new(make_rpc_client(&server.url()));
+        let token = tokio_util::sync::CancellationToken::new();
+
+        let total = 300usize;
+        let mut sig_by_id: std::collections::HashMap<i64, String> = HashMap::new();
+        for i in 0..total {
+            let sig = Signature::new_unique();
+            let id = i as i64 + 1;
+            sig_by_id.insert(id, sig.to_string());
+            in_flight.push(make_in_flight_tx(sig, id));
+        }
+
+        let handle = tokio::spawn(run_poll_task(
+            in_flight.clone(),
+            result_tx,
+            rpc,
+            storage_tx,
+            ProgramType::Escrow,
+            5,
+            token.clone(),
+        ));
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        token.cancel();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("task must exit after cancellation")
+            .expect("task must not panic");
+
+        assert_eq!(in_flight.len(), 0, "all confirmed entries settled");
+        let mut seen = 0usize;
+        while let Ok(update) = storage_rx.try_recv() {
+            assert_eq!(update.status, TransactionStatus::Completed);
+            assert_eq!(
+                update.counterpart_signature.as_deref(),
+                sig_by_id.get(&update.transaction_id).map(|s| s.as_str()),
+                "Completed must pair each transaction with its own signature"
+            );
+            seen += 1;
+        }
+        assert_eq!(seen, total, "exactly one Completed per transaction");
     }
 
     /// An idempotent tx that exhausts its resend_count budget must be declared a

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -4652,11 +4652,11 @@ mod tests {
         .to_string()
     }
 
-    // A getSignatureStatuses response body with `count` confirmed-success slots.
-    fn confirmed_value_body(count: usize) -> String {
+    // A getSignatureStatuses response body with `count` finalized-success slots.
+    fn finalized_value_body(count: usize) -> String {
         let one = serde_json::json!({
-            "confirmationStatus": "confirmed",
-            "confirmations": 1,
+            "confirmationStatus": "finalized",
+            "confirmations": null,
             "err": null,
             "slot": 100,
             "status": {"Ok": null}
@@ -4748,7 +4748,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let _m = mock_status_bodies(&mut server, |idx, req| {
             if idx == 0 {
-                confirmed_value_body(req)
+                finalized_value_body(req)
             } else {
                 null_value_body(req)
             }
@@ -4761,7 +4761,7 @@ mod tests {
             .await
             .expect("all-exact multi-chunk must be Ok");
         assert_eq!(statuses.len(), 600);
-        // First chunk confirmed, remaining chunks null: proves concatenation order.
+        // First chunk finalized, remaining chunks null: proves concatenation order.
         assert!(statuses[0].is_some());
         assert!(statuses[255].is_some());
         assert!(statuses[256].is_none());
@@ -4922,10 +4922,10 @@ mod tests {
     #[tokio::test]
     async fn poll_in_flight_cross_chunk_short_no_misattribution() {
         let mut server = mockito::Server::new_async().await;
-        // Chunk 0 (256 sigs) all confirmed; chunk 1 (1 sig) returns an empty value.
+        // Chunk 0 (256 sigs) all finalized; chunk 1 (1 sig) returns an empty value.
         let _m = mock_status_bodies(&mut server, |idx, req| {
             if idx == 0 {
-                confirmed_value_body(req)
+                finalized_value_body(req)
             } else {
                 null_value_body(0)
             }
@@ -4959,10 +4959,10 @@ mod tests {
     #[tokio::test]
     async fn poll_in_flight_oversized_chunk_full_reinsert_no_settlement() {
         let mut server = mockito::Server::new_async().await;
-        // Chunk 0 (256) confirmed; chunk 1 (1 sig) returns two statuses (oversized).
+        // Chunk 0 (256) finalized; chunk 1 (1 sig) returns two statuses (oversized).
         let _m = mock_status_bodies(&mut server, |idx, req| {
             if idx == 0 {
-                confirmed_value_body(req)
+                finalized_value_body(req)
             } else {
                 null_value_body(req + 1)
             }
@@ -4983,11 +4983,11 @@ mod tests {
         assert!(storage_rx.try_recv().is_err(), "no Completed emitted");
     }
 
-    // Happy-path multi-chunk: every chunk returns correctly-sized confirmed statuses, so all entries settle with one Completed each.
+    // Happy-path multi-chunk: every chunk returns correctly-sized finalized statuses, so all entries settle with one Completed each.
     #[tokio::test]
     async fn poll_in_flight_multi_chunk_confirmed_settles_with_correct_pairing() {
         let mut server = mockito::Server::new_async().await;
-        let _m = mock_status_bodies(&mut server, |_idx, req| confirmed_value_body(req));
+        let _m = mock_status_bodies(&mut server, |_idx, req| finalized_value_body(req));
 
         let mut state = make_sender_state_with_server(&server.url());
         let total = 300usize;
@@ -5074,11 +5074,11 @@ mod tests {
         _m.assert();
     }
 
-    // Happy-path confirmed multi-chunk on the production task settles every entry and emits a Completed for each.
+    // Happy-path finalized multi-chunk on the production task settles every entry and emits a Completed for each.
     #[tokio::test]
     async fn run_poll_task_multi_chunk_confirmed_settles() {
         let mut server = mockito::Server::new_async().await;
-        let _m = mock_status_bodies(&mut server, |_idx, req| confirmed_value_body(req));
+        let _m = mock_status_bodies(&mut server, |_idx, req| finalized_value_body(req));
 
         let in_flight = InFlightQueue::new();
         let (result_tx, _result_rx) = mpsc::channel::<Vec<PollTaskResult>>(8);


### PR DESCRIPTION
## Summary

Closes issue 280. `getSignatureStatuses` returns results by position, but both confirmation pollers concatenated chunked RPC responses without verifying that each chunk returned the expected number of entries. A malformed response (too few or too many statuses) could shift later results, causing confirmations to be applied to the wrong transactions and potentially marking an unconfirmed deposit as `Completed`, preventing recovery from retrying it.

This PR introduces a shared `fetch_statuses_checked` helper that validates every chunk returns exactly one status per requested signature before combining the results. If any chunk has an incorrect length or the RPC call fails, the entire batch is requeued without incrementing `poll_attempts`, matching the existing transient-error behavior. This prevents positional misalignment while leaving the polling flow otherwise unchanged, adding only an O(1) length check per chunk.

### Additional changes

**Build fix:** Updated `processor.rs` to use the newer `RequeueOutcome` API after rebasing onto `cantina-audit`, fixing a compile error caused by an API mismatch between earlier PRs.


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,847 | 13,489 | 87.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30255234054) |
| Indexer | 30,831 | 34,191 | 90.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30255234054) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30255234054) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30255234054) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,249 | 16,780 | 79.0% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30255234054) |
| **Total** | **58,037** | **66,878** | **86.8%** | |

> Last updated: 2026-07-27 10:26:47 UTC by E2E Integration