### PR TITLE
fix(auth): name account and wallet in the signing challenge

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -24,7 +24,7 @@ Create a new account. All users are registered with the `user` role.
 { "username": "alice", "password": "hunter2" }
 ```
 
-Username requirements: 5–32 characters, alphanumeric plus underscores and hyphens only.
+Username requirements: 5–32 characters, ASCII alphanumeric plus underscores and hyphens only.
 
 Password requirements: 6–72 characters (Argon2's input limit — inputs beyond 72 bytes are silently truncated, so longer passwords are rejected outright).
 
@@ -54,7 +54,7 @@ Returns a `message`, `nonce`, and `expires_at`. The challenge expires in 10 minu
 
 ```json
 {
-  "message": "PrivateChannel wallet verification\n\nAccount: <username>\nWallet: <base58 pubkey>\n\nOnly sign this if \"<username>\" is YOUR PrivateChannel account.\n\nnonce: <uuid>\nexpires: <unix>",
+  "message": "PrivateChannel wallet verification\n\nAccount: <username> (id: <uuid>)\nWallet: <base58 pubkey>\n\nOnly sign this if \"<username>\" is YOUR PrivateChannel account.\n\nnonce: <uuid>\nexpires: <unix>",
   "nonce": "<uuid>",
   "expires_at": "<iso8601>"
 }

--- a/auth/README.md
+++ b/auth/README.md
@@ -46,13 +46,15 @@ Returns `{ "token": "<jwt>" }`. Both wrong username and wrong password return `4
 
 ### `POST /auth/challenge-wallet` 🔒
 
-Request a sign challenge to prove ownership of a Solana wallet. Requires a valid JWT.
+Request a sign challenge to prove ownership of a Solana wallet. Requires a valid JWT. Send the wallet you want to link, so it can be named in the message the user signs.
 
-Returns a `message`, `nonce`, and `expires_at`. The challenge expires in 10 minutes.
+Request: `{ "pubkey": "<base58 pubkey>" }`
+
+Returns a `message`, `nonce`, and `expires_at`. The challenge expires in 10 minutes. The message names both the account and the wallet so a signer only ever consents to linking their own wallet to their own account.
 
 ```json
 {
-  "message": "Solana Private Channels wallet verification\nuser: <uuid>\nnonce: <uuid>\nexpires: <unix>",
+  "message": "PrivateChannel wallet verification\n\nAccount: <username>\nWallet: <base58 pubkey>\n\nOnly sign this if \"<username>\" is YOUR PrivateChannel account.\n\nnonce: <uuid>\nexpires: <unix>",
   "nonce": "<uuid>",
   "expires_at": "<iso8601>"
 }
@@ -118,7 +120,7 @@ AUTH_DATABASE_URL=postgres://... cargo run -p auth --bin admin -- attach-wallet 
 Wallets are not trusted on assertion — the user must cryptographically prove they control the private key.
 
 ```
-1. POST /auth/challenge-wallet
+1. POST /auth/challenge-wallet  { pubkey }
    ← { message, nonce, expires_at }
 
 2. Sign `message` with the wallet's private key (Ed25519)

--- a/auth/src/db.rs
+++ b/auth/src/db.rs
@@ -187,8 +187,9 @@ pub async fn insert_challenge(pool: &PgPool, user_id: Uuid, nonce: Uuid) -> AppR
 
 /// Mark the challenge as used and return it. Returns None if not found, already used, or expired.
 /// The atomic UPDATE prevents the same challenge from being consumed twice.
-pub async fn consume_challenge(
-    pool: &PgPool,
+/// Takes any executor so the caller can run it inside a transaction alongside the wallet insert.
+pub async fn consume_challenge<'e, E: sqlx::PgExecutor<'e>>(
+    executor: E,
     user_id: Uuid,
     nonce: Uuid,
 ) -> AppResult<Option<Challenge>> {
@@ -201,14 +202,16 @@ pub async fn consume_challenge(
     )
     .bind(user_id)
     .bind(nonce)
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await?;
 
     Ok(row.map(|(nonce, expires_at)| Challenge { nonce, expires_at }))
 }
 
-pub async fn insert_verified_wallet(
-    pool: &PgPool,
+/// Takes any executor so the caller can run it inside a transaction alongside the
+/// challenge consume, keeping the nonce spent only if the wallet is actually linked.
+pub async fn insert_verified_wallet<'e, E: sqlx::PgExecutor<'e>>(
+    executor: E,
     user_id: Uuid,
     pubkey: &str,
 ) -> AppResult<VerifiedWallet> {
@@ -222,7 +225,7 @@ pub async fn insert_verified_wallet(
     .bind(Uuid::new_v4())
     .bind(user_id)
     .bind(pubkey)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await?;
 
     Ok(VerifiedWallet {

--- a/auth/src/db.rs
+++ b/auth/src/db.rs
@@ -110,6 +110,17 @@ pub async fn find_user_by_username(pool: &PgPool, username: &str) -> AppResult<O
     )
 }
 
+/// Look up a user's username by id. Used to name the account in the wallet challenge message.
+pub async fn find_username_by_id(pool: &PgPool, id: Uuid) -> AppResult<Option<String>> {
+    let row: Option<(String,)> =
+        sqlx::query_as(r#"SELECT username FROM private_channel_auth.users WHERE id = $1"#)
+            .bind(id)
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(row.map(|(username,)| username))
+}
+
 pub async fn insert_user(pool: &PgPool, username: &str, password_hash: &str) -> AppResult<User> {
     let row: (Uuid, String, String, String, DateTime<Utc>) = sqlx::query_as(
         r#"

--- a/auth/src/models.rs
+++ b/auth/src/models.rs
@@ -57,12 +57,39 @@ pub struct LoginResponse {
     pub token: String,
 }
 
+#[derive(Deserialize)]
+pub struct ChallengeRequest {
+    /// The wallet the caller wants to link. Bound into the signed message.
+    pub pubkey: String,
+}
+
 #[derive(Serialize)]
 pub struct ChallengeResponse {
     /// The exact message the client must sign with their wallet.
     pub message: String,
     pub nonce: Uuid,
     pub expires_at: DateTime<Utc>,
+}
+
+/// Builds the message a user signs to prove wallet ownership.
+/// The challenge and verify endpoints both call this so their messages always match.
+/// The account name and wallet are spelled out so a signer can tell they are
+/// linking their own wallet to their own account, not someone else's.
+pub fn wallet_verification_message(
+    username: &str,
+    pubkey: &str,
+    nonce: Uuid,
+    expires_at: DateTime<Utc>,
+) -> String {
+    format!(
+        "PrivateChannel wallet verification\n\n\
+         Account: {username}\n\
+         Wallet: {pubkey}\n\n\
+         Only sign this if \"{username}\" is YOUR PrivateChannel account.\n\n\
+         nonce: {nonce}\n\
+         expires: {expires}",
+        expires = expires_at.timestamp(),
+    )
 }
 
 #[derive(Deserialize)]

--- a/auth/src/models.rs
+++ b/auth/src/models.rs
@@ -75,15 +75,18 @@ pub struct ChallengeResponse {
 /// The challenge and verify endpoints both call this so their messages always match.
 /// The account name and wallet are spelled out so a signer can tell they are
 /// linking their own wallet to their own account, not someone else's.
+/// The id is the unforgeable half: a lookalike username can be registered, a uuid cannot,
+/// so a client can check the id against the session it is connected to.
 pub fn wallet_verification_message(
     username: &str,
+    user_id: Uuid,
     pubkey: &str,
     nonce: Uuid,
     expires_at: DateTime<Utc>,
 ) -> String {
     format!(
         "PrivateChannel wallet verification\n\n\
-         Account: {username}\n\
+         Account: {username} (id: {user_id})\n\
          Wallet: {pubkey}\n\n\
          Only sign this if \"{username}\" is YOUR PrivateChannel account.\n\n\
          nonce: {nonce}\n\

--- a/auth/src/routes/challenge.rs
+++ b/auth/src/routes/challenge.rs
@@ -1,24 +1,40 @@
 use axum::{extract::State, Json};
+use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
 use uuid::Uuid;
 
-use crate::{db, error::AppResult, jwt::Claims, models::ChallengeResponse, AppState};
+use crate::{
+    db,
+    error::{AppError, AppResult},
+    jwt::Claims,
+    models::{wallet_verification_message, ChallengeRequest, ChallengeResponse},
+    AppState,
+};
 
 pub async fn challenge(
     State(state): State<AppState>,
     claims: Claims,
+    Json(request): Json<ChallengeRequest>,
 ) -> AppResult<Json<ChallengeResponse>> {
-    let nonce = Uuid::new_v4();
-    let r = db::insert_challenge(&state.pool, claims.sub, nonce).await;
-    state.pool_status.observe_app(&r);
-    let challenge = r?;
+    // Reject a malformed pubkey before issuing a challenge for it.
+    Pubkey::from_str(&request.pubkey).map_err(|_| AppError::BadRequest("invalid pubkey".into()))?;
 
-    // The message includes user id and nonce so it is bound to this specific user and request.
-    // The client must sign this exact string with their wallet's private key.
-    let message = format!(
-        "PrivateChannel wallet verification\nuser: {}\nnonce: {}\nexpires: {}",
-        claims.sub,
+    // Name the account in the signed message so the signer knows what they are linking.
+    let username_result = db::find_username_by_id(&state.pool, claims.sub).await;
+    state.pool_status.observe_app(&username_result);
+    let username = username_result?.ok_or(AppError::Unauthorized)?;
+
+    let nonce = Uuid::new_v4();
+    let challenge_result = db::insert_challenge(&state.pool, claims.sub, nonce).await;
+    state.pool_status.observe_app(&challenge_result);
+    let challenge = challenge_result?;
+
+    // The client must sign this exact string with the wallet's private key.
+    let message = wallet_verification_message(
+        &username,
+        &request.pubkey,
         challenge.nonce,
-        challenge.expires_at.timestamp()
+        challenge.expires_at,
     );
 
     Ok(Json(ChallengeResponse {

--- a/auth/src/routes/challenge.rs
+++ b/auth/src/routes/challenge.rs
@@ -32,6 +32,7 @@ pub async fn challenge(
     // The client must sign this exact string with the wallet's private key.
     let message = wallet_verification_message(
         &username,
+        claims.sub,
         &request.pubkey,
         challenge.nonce,
         challenge.expires_at,

--- a/auth/src/routes/register.rs
+++ b/auth/src/routes/register.rs
@@ -25,8 +25,8 @@ pub async fn register(
     Json(req): Json<RegisterRequest>,
 ) -> AppResult<Json<User>> {
     // Validate username length and characters.
-    // Only alphanumeric, underscores, and hyphens are allowed — keeps usernames
-    // URL-safe and unambiguous in display contexts.
+    // ASCII only: Unicode alphanumerics include homoglyphs that render identically to
+    // ASCII, and the signed wallet message names the account.
     if req.username.len() < USERNAME_MIN_LEN {
         return Err(AppError::BadRequest(format!(
             "username must be at least {USERNAME_MIN_LEN} characters"
@@ -40,7 +40,7 @@ pub async fn register(
     if !req
         .username
         .chars()
-        .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
         return Err(AppError::BadRequest(
             "username may only contain letters, numbers, underscores, and hyphens".into(),

--- a/auth/src/routes/verify_wallet.rs
+++ b/auth/src/routes/verify_wallet.rs
@@ -16,16 +16,17 @@ pub async fn verify_wallet(
     claims: Claims,
     Json(req): Json<VerifyWalletRequest>,
 ) -> AppResult<Json<WalletResponse>> {
+    // Look up the account name before consuming the challenge, so a transient lookup
+    // failure cannot burn an otherwise valid one-time challenge.
+    let username_result = db::find_username_by_id(&state.pool, claims.sub).await;
+    state.pool_status.observe_app(&username_result);
+    let username = username_result?.ok_or(AppError::Unauthorized)?;
+
     // Consume the challenge atomically so it cannot be replayed.
     let challenge_result = db::consume_challenge(&state.pool, claims.sub, req.nonce).await;
     state.pool_status.observe_app(&challenge_result);
     let challenge =
         challenge_result?.ok_or(AppError::BadRequest("invalid or expired challenge".into()))?;
-
-    // Same username the challenge endpoint used, so this matches what the client signed.
-    let username_result = db::find_username_by_id(&state.pool, claims.sub).await;
-    state.pool_status.observe_app(&username_result);
-    let username = username_result?.ok_or(AppError::Unauthorized)?;
 
     // Rebuild the exact message the client was asked to sign.
     let message = wallet_verification_message(

--- a/auth/src/routes/verify_wallet.rs
+++ b/auth/src/routes/verify_wallet.rs
@@ -22,6 +22,14 @@ pub async fn verify_wallet(
     state.pool_status.observe_app(&username_result);
     let username = username_result?.ok_or(AppError::Unauthorized)?;
 
+    // Parse both inputs before consuming the challenge, so malformed input cannot
+    // burn an otherwise valid one-time challenge.
+    let pubkey =
+        Pubkey::from_str(&req.pubkey).map_err(|_| AppError::BadRequest("invalid pubkey".into()))?;
+
+    let signature = Signature::from_str(&req.signature)
+        .map_err(|_| AppError::BadRequest("invalid signature".into()))?;
+
     // Consume the challenge atomically so it cannot be replayed.
     let challenge_result = db::consume_challenge(&state.pool, claims.sub, req.nonce).await;
     state.pool_status.observe_app(&challenge_result);
@@ -31,16 +39,11 @@ pub async fn verify_wallet(
     // Rebuild the exact message the client was asked to sign.
     let message = wallet_verification_message(
         &username,
+        claims.sub,
         &req.pubkey,
         challenge.nonce,
         challenge.expires_at,
     );
-
-    let pubkey =
-        Pubkey::from_str(&req.pubkey).map_err(|_| AppError::BadRequest("invalid pubkey".into()))?;
-
-    let signature = Signature::from_str(&req.signature)
-        .map_err(|_| AppError::BadRequest("invalid signature".into()))?;
 
     if !signature.verify(pubkey.as_ref(), message.as_bytes()) {
         warn!(user_id = %claims.sub, pubkey = %req.pubkey, "wallet verification failed: invalid signature");

--- a/auth/src/routes/verify_wallet.rs
+++ b/auth/src/routes/verify_wallet.rs
@@ -7,7 +7,7 @@ use crate::{
     db,
     error::{AppError, AppResult},
     jwt::Claims,
-    models::{VerifyWalletRequest, WalletResponse},
+    models::{wallet_verification_message, VerifyWalletRequest, WalletResponse},
     AppState,
 };
 
@@ -16,18 +16,23 @@ pub async fn verify_wallet(
     claims: Claims,
     Json(req): Json<VerifyWalletRequest>,
 ) -> AppResult<Json<WalletResponse>> {
-    // Consume the challenge atomically — marks it used so it cannot be replayed.
-    let r = db::consume_challenge(&state.pool, claims.sub, req.nonce).await;
-    state.pool_status.observe_app(&r);
-    let challenge = r?.ok_or(AppError::BadRequest("invalid or expired challenge".into()))?;
+    // Consume the challenge atomically so it cannot be replayed.
+    let challenge_result = db::consume_challenge(&state.pool, claims.sub, req.nonce).await;
+    state.pool_status.observe_app(&challenge_result);
+    let challenge =
+        challenge_result?.ok_or(AppError::BadRequest("invalid or expired challenge".into()))?;
 
-    // Reconstruct the exact message the client was asked to sign.
-    // Must match the format returned by /auth/challenge-wallet.
-    let message = format!(
-        "PrivateChannel wallet verification\nuser: {}\nnonce: {}\nexpires: {}",
-        claims.sub,
+    // Same username the challenge endpoint used, so this matches what the client signed.
+    let username_result = db::find_username_by_id(&state.pool, claims.sub).await;
+    state.pool_status.observe_app(&username_result);
+    let username = username_result?.ok_or(AppError::Unauthorized)?;
+
+    // Rebuild the exact message the client was asked to sign.
+    let message = wallet_verification_message(
+        &username,
+        &req.pubkey,
         challenge.nonce,
-        challenge.expires_at.timestamp()
+        challenge.expires_at,
     );
 
     let pubkey =
@@ -41,9 +46,9 @@ pub async fn verify_wallet(
         return Err(AppError::Unauthorized);
     }
 
-    let raw = db::insert_verified_wallet(&state.pool, claims.sub, &req.pubkey).await;
-    state.pool_status.observe_app(&raw);
-    let wallet = raw.map_err(|e| match e {
+    let insert_result = db::insert_verified_wallet(&state.pool, claims.sub, &req.pubkey).await;
+    state.pool_status.observe_app(&insert_result);
+    let wallet = insert_result.map_err(|e| match e {
         // Unique constraint on (user_id, pubkey) — wallet already verified.
         AppError::Db(sqlx::Error::Database(ref db_err))
             if db_err.constraint() == Some("verified_wallets_user_id_pubkey_key") =>

--- a/auth/src/routes/verify_wallet.rs
+++ b/auth/src/routes/verify_wallet.rs
@@ -30,8 +30,16 @@ pub async fn verify_wallet(
     let signature = Signature::from_str(&req.signature)
         .map_err(|_| AppError::BadRequest("invalid signature".into()))?;
 
-    // Consume the challenge atomically so it cannot be replayed.
-    let challenge_result = db::consume_challenge(&state.pool, claims.sub, req.nonce).await;
+    // Consume the challenge and link the wallet in one transaction. Both statements land
+    // or neither does, so a failed insert cannot leave the nonce spent with no wallet
+    // attached, which would force the user to sign a fresh challenge.
+    let tx_result = state.pool.begin().await;
+    state.pool_status.observe_sqlx(&tx_result);
+    let mut tx = tx_result?;
+
+    // The atomic UPDATE means a concurrent request for the same nonce blocks here and
+    // then finds it used, so it still cannot be replayed.
+    let challenge_result = db::consume_challenge(&mut *tx, claims.sub, req.nonce).await;
     state.pool_status.observe_app(&challenge_result);
     let challenge =
         challenge_result?.ok_or(AppError::BadRequest("invalid or expired challenge".into()))?;
@@ -46,11 +54,14 @@ pub async fn verify_wallet(
     );
 
     if !signature.verify(pubkey.as_ref(), message.as_bytes()) {
+        // Commit so a bad signature still burns the challenge: one attempt per nonce.
+        tx.commit().await?;
         warn!(user_id = %claims.sub, pubkey = %req.pubkey, "wallet verification failed: invalid signature");
         return Err(AppError::Unauthorized);
     }
 
-    let insert_result = db::insert_verified_wallet(&state.pool, claims.sub, &req.pubkey).await;
+    // On error the transaction is dropped and rolls back, leaving the nonce usable.
+    let insert_result = db::insert_verified_wallet(&mut *tx, claims.sub, &req.pubkey).await;
     state.pool_status.observe_app(&insert_result);
     let wallet = insert_result.map_err(|e| match e {
         // Unique constraint on (user_id, pubkey) — wallet already verified.
@@ -61,6 +72,8 @@ pub async fn verify_wallet(
         }
         other => other,
     })?;
+
+    tx.commit().await?;
 
     info!(user_id = %claims.sub, pubkey = %wallet.pubkey, "wallet verified");
 

--- a/auth/tests/integration.rs
+++ b/auth/tests/integration.rs
@@ -159,6 +159,36 @@ async fn test_register_username_invalid_chars() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_register_rejects_non_ascii_username() {
+    let (db_url, _container) = start_postgres().await;
+    let addr = start_app(&db_url).await;
+    let client = Client::new();
+
+    // Written as escapes because the whole point is that these render like "alice".
+    // Cyrillic ie, Cyrillic a, and fullwidth latin are all Unicode-alphanumeric, so
+    // they would otherwise register alongside the real account and be signed for.
+    for username in [
+        "alic\u{0435}",
+        "\u{0430}lice",
+        "\u{ff41}\u{ff4c}\u{ff49}\u{ff43}\u{ff45}",
+    ] {
+        let res = client
+            .post(format!("{}/auth/register", base_url(addr)))
+            .json(&json!({ "username": username, "password": "password123" }))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            res.status(),
+            400,
+            "expected 400 for username {:?}",
+            username
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_register_username_valid_formats() {
     let (db_url, _container) = start_postgres().await;
     let addr = start_app(&db_url).await;
@@ -423,12 +453,17 @@ async fn test_challenge_message_names_account_and_wallet() {
     let client = Client::new();
 
     let username = "alice";
-    client
+    let register_res: Value = client
         .post(format!("{}/auth/register", base_url(addr)))
         .json(&json!({ "username": username, "password": "password123" }))
         .send()
         .await
+        .unwrap()
+        .json()
+        .await
         .unwrap();
+
+    let user_id = register_res["id"].as_str().unwrap().to_string();
 
     let login_res: Value = client
         .post(format!("{}/auth/login", base_url(addr)))
@@ -457,9 +492,15 @@ async fn test_challenge_message_names_account_and_wallet() {
 
     // The message must name the account and the wallet so a signer can give informed
     // consent. This is the property whose absence let an opaque challenge be phished
-    // onto a victim wallet under someone else's account.
+    // onto a victim wallet under someone else's account. The id is there because a
+    // username can be impersonated by a lookalike, so a client has something exact
+    // to check against its own session.
     let message = challenge_res["message"].as_str().unwrap();
     assert!(message.contains(username), "message must name the account");
+    assert!(
+        message.contains(&user_id),
+        "message must carry the account id"
+    );
     assert!(message.contains(&pubkey), "message must name the wallet");
 }
 
@@ -588,6 +629,22 @@ async fn test_verify_wallet_invalid_pubkey() {
         .unwrap();
 
     assert_eq!(res.status(), 400);
+
+    // The rejected pubkey must not have consumed the challenge — retrying the same
+    // nonce with the real pubkey still succeeds.
+    let res = client
+        .post(format!("{}/auth/verify-wallet", base_url(addr)))
+        .bearer_auth(token)
+        .json(&json!({
+            "pubkey": keypair.pubkey().to_string(),
+            "nonce": nonce,
+            "signature": signature.to_string(),
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -696,6 +753,69 @@ async fn test_verify_wallet_wrong_signature() {
         .bearer_auth(token)
         .json(&json!({
             "pubkey": keypair.pubkey().to_string(),
+            "nonce": nonce,
+            "signature": signature.to_string(),
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_verify_wallet_substituted_pubkey_rejected() {
+    let (db_url, _container) = start_postgres().await;
+    let addr = start_app(&db_url).await;
+    let client = Client::new();
+
+    client
+        .post(format!("{}/auth/register", base_url(addr)))
+        .json(&json!({ "username": "alice", "password": "password123" }))
+        .send()
+        .await
+        .unwrap();
+
+    let login_res: Value = client
+        .post(format!("{}/auth/login", base_url(addr)))
+        .json(&json!({ "username": "alice", "password": "password123" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let token = login_res["token"].as_str().unwrap();
+
+    let challenge_wallet = Keypair::new();
+
+    let challenge_res: Value = client
+        .post(format!("{}/auth/challenge-wallet", base_url(addr)))
+        .bearer_auth(token)
+        .json(&json!({ "pubkey": challenge_wallet.pubkey().to_string() }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let message = challenge_res["message"].as_str().unwrap();
+    let nonce: Uuid = challenge_res["nonce"].as_str().unwrap().parse().unwrap();
+
+    // Sign the challenge with a second wallet and submit that wallet's pubkey. The
+    // signature is genuine for the submitted pubkey, but the message named the wallet
+    // the challenge was issued for, so verification must rebuild a different message
+    // and reject. This is what keeps a challenge from being redeemed for any wallet.
+    let submitted_wallet = Keypair::new();
+    let signature = submitted_wallet.sign_message(message.as_bytes());
+
+    let res = client
+        .post(format!("{}/auth/verify-wallet", base_url(addr)))
+        .bearer_auth(token)
+        .json(&json!({
+            "pubkey": submitted_wallet.pubkey().to_string(),
             "nonce": nonce,
             "signature": signature.to_string(),
         }))

--- a/auth/tests/integration.rs
+++ b/auth/tests/integration.rs
@@ -377,10 +377,14 @@ async fn test_verify_wallet_full_flow() {
 
     let token = login_res["token"].as_str().unwrap();
 
+    // Create the keypair first so its pubkey can go in the challenge request.
+    let keypair = Keypair::new();
+
     // Get challenge
     let challenge_res: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -391,8 +395,7 @@ async fn test_verify_wallet_full_flow() {
     let message = challenge_res["message"].as_str().unwrap();
     let nonce: Uuid = challenge_res["nonce"].as_str().unwrap().parse().unwrap();
 
-    // Sign the challenge message with a Solana keypair
-    let keypair = Keypair::new();
+    // Sign the challenge message with the wallet keypair.
     let signature = keypair.sign_message(message.as_bytes());
 
     // Verify wallet
@@ -411,6 +414,53 @@ async fn test_verify_wallet_full_flow() {
     assert_eq!(verify_res.status(), 200);
     let body: Value = verify_res.json().await.unwrap();
     assert_eq!(body["pubkey"], keypair.pubkey().to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_challenge_message_names_account_and_wallet() {
+    let (db_url, _container) = start_postgres().await;
+    let addr = start_app(&db_url).await;
+    let client = Client::new();
+
+    let username = "alice";
+    client
+        .post(format!("{}/auth/register", base_url(addr)))
+        .json(&json!({ "username": username, "password": "password123" }))
+        .send()
+        .await
+        .unwrap();
+
+    let login_res: Value = client
+        .post(format!("{}/auth/login", base_url(addr)))
+        .json(&json!({ "username": username, "password": "password123" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let token = login_res["token"].as_str().unwrap();
+    let keypair = Keypair::new();
+    let pubkey = keypair.pubkey().to_string();
+
+    let challenge_res: Value = client
+        .post(format!("{}/auth/challenge-wallet", base_url(addr)))
+        .bearer_auth(token)
+        .json(&json!({ "pubkey": pubkey }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    // The message must name the account and the wallet so a signer can give informed
+    // consent. This is the property whose absence let an opaque challenge be phished
+    // onto a victim wallet under someone else's account.
+    let message = challenge_res["message"].as_str().unwrap();
+    assert!(message.contains(username), "message must name the account");
+    assert!(message.contains(&pubkey), "message must name the wallet");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -438,9 +488,13 @@ async fn test_verify_wallet_replay_rejected() {
 
     let token = login_res["token"].as_str().unwrap();
 
+    // Create the keypair first so its pubkey can go in the challenge request.
+    let keypair = Keypair::new();
+
     let challenge_res: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -451,7 +505,6 @@ async fn test_verify_wallet_replay_rejected() {
     let message = challenge_res["message"].as_str().unwrap();
     let nonce: Uuid = challenge_res["nonce"].as_str().unwrap().parse().unwrap();
 
-    let keypair = Keypair::new();
     let signature = keypair.sign_message(message.as_bytes());
 
     let payload = json!({
@@ -506,9 +559,12 @@ async fn test_verify_wallet_invalid_pubkey() {
 
     let token = login_res["token"].as_str().unwrap();
 
+    let keypair = Keypair::new();
+
     let challenge_res: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -517,7 +573,6 @@ async fn test_verify_wallet_invalid_pubkey() {
         .unwrap();
 
     let nonce: Uuid = challenge_res["nonce"].as_str().unwrap().parse().unwrap();
-    let keypair = Keypair::new();
     let signature = keypair.sign_message(challenge_res["message"].as_str().unwrap().as_bytes());
 
     let res = client
@@ -560,9 +615,12 @@ async fn test_verify_wallet_invalid_signature_format() {
 
     let token = login_res["token"].as_str().unwrap();
 
+    let keypair = Keypair::new();
+
     let challenge_res: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -571,7 +629,6 @@ async fn test_verify_wallet_invalid_signature_format() {
         .unwrap();
 
     let nonce: Uuid = challenge_res["nonce"].as_str().unwrap().parse().unwrap();
-    let keypair = Keypair::new();
 
     let res = client
         .post(format!("{}/auth/verify-wallet", base_url(addr)))
@@ -613,9 +670,13 @@ async fn test_verify_wallet_wrong_signature() {
 
     let token = login_res["token"].as_str().unwrap();
 
+    // Create the keypair first so its pubkey can go in the challenge request.
+    let keypair = Keypair::new();
+
     let challenge_res: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -626,8 +687,7 @@ async fn test_verify_wallet_wrong_signature() {
     let message = challenge_res["message"].as_str().unwrap();
     let nonce: Uuid = challenge_res["nonce"].as_str().unwrap().parse().unwrap();
 
-    let keypair = Keypair::new();
-    // Sign with a different keypair — signature won't verify against the pubkey we submit.
+    // Sign with a different keypair so the signature won't match the submitted pubkey.
     let wrong_keypair = Keypair::new();
     let signature = wrong_keypair.sign_message(message.as_bytes());
 
@@ -686,6 +746,7 @@ async fn test_verify_wallet_duplicate() {
     let challenge1: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -712,6 +773,7 @@ async fn test_verify_wallet_duplicate() {
     let challenge2: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -774,9 +836,11 @@ async fn test_list_wallets() {
     assert_eq!(wallets.as_array().unwrap().len(), 0);
 
     // Verify a wallet
+    let keypair = Keypair::new();
     let challenge_res: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -786,7 +850,6 @@ async fn test_list_wallets() {
 
     let message = challenge_res["message"].as_str().unwrap();
     let nonce: Uuid = challenge_res["nonce"].as_str().unwrap().parse().unwrap();
-    let keypair = Keypair::new();
     let signature = keypair.sign_message(message.as_bytes());
 
     client
@@ -970,9 +1033,11 @@ async fn setup_user_with_wallet(addr: SocketAddr, username: &str) -> (String, St
 
     let token = login_res["token"].as_str().unwrap().to_string();
 
+    let keypair = Keypair::new();
     let challenge_res: Value = client
         .post(format!("{}/auth/challenge-wallet", base_url(addr)))
         .bearer_auth(&token)
+        .json(&json!({ "pubkey": keypair.pubkey().to_string() }))
         .send()
         .await
         .unwrap()
@@ -982,7 +1047,6 @@ async fn setup_user_with_wallet(addr: SocketAddr, username: &str) -> (String, St
 
     let message = challenge_res["message"].as_str().unwrap().to_string();
     let nonce: Uuid = challenge_res["nonce"].as_str().unwrap().parse().unwrap();
-    let keypair = Keypair::new();
     let signature = keypair.sign_message(message.as_bytes());
 
     client


### PR DESCRIPTION
## Problem
The wallet-verification challenge contained only an opaque user UUID, so a signer couldn't tell which account a signature would link a wallet to. An attacker could request a challenge for their own account, phish a victim into signing it, then register the victim's wallet under the attacker's account and read the victim's private data via the gateway.

## Fix
The signed message now names the **account (username)** and the **wallet pubkey**, so a signer only ever consents to linking their own wallet to their own account. Both the challenge and verify endpoints build the message through one shared helper, so the two can't drift.

## Changes
  - `challenge-wallet` now takes a `{ pubkey }` body and names the account + wallet in the message
  - `verify-wallet` rebuilds the same message via the shared helper
  - Added a test asserting the challenge message contains the account and wallet
  - Updated `auth/README.md`

## Notes
  - **Breaking API change:** `POST /auth/challenge-wallet` now requires `{ "pubkey": "<base58>" }`
  - Kept `UNIQUE (user_id, pubkey)` (a wallet can still be managed by multiple users)
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,994 | 13,619 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30289530641) |
| Indexer | 22,947 | 26,047 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30289530641) |
| Gateway | 1,055 | 1,230 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30289530641) |
| Auth | 830 | 949 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30289530641) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **36,826** | **41,845** | **88.0%** | |

> Last updated: 2026-07-27 17:40:10 UTC by Auth