### PR TITLE
fix(indexer): couple RPC backfill target and live cursor to one startup boundary (issue-281)

### DIFF
--- a/indexer/src/indexer/backfill.rs
+++ b/indexer/src/indexer/backfill.rs
@@ -216,6 +216,17 @@ pub async fn fill_slot_range(
     Ok(processed_count)
 }
 
+/// Resolved startup boundary shared by both producers. Backfill fills `gap` and the
+/// live RPC source resumes at `live_start_slot`, so the two meet with no hole and no
+/// overlap: `live_start_slot` is one past the highest slot backfill covers (or one past
+/// the durable checkpoint when there is no gap).
+pub struct StartupRange {
+    /// Range backfill must fill `(from_slot, target]`, or `None` when there's no gap.
+    pub gap: Option<(u64, u64)>,
+    /// First slot the live RPC source must request.
+    pub live_start_slot: u64,
+}
+
 /// Backfill service for recovering missed slots on startup
 pub struct BackfillService {
     storage: Arc<Storage>,
@@ -250,7 +261,9 @@ impl BackfillService {
     ///
     /// The caller resolves the range once and uses it for two things — gating the
     /// checkpoint writer and driving the fill — so both see the exact same bounds.
-    pub async fn resolve_range(&self) -> Result<Option<(u64, u64)>, IndexerError> {
+    /// It also carries `live_start_slot` so the live source resumes on the same
+    /// boundary and no slot is skipped between backfill and the live stream.
+    pub async fn resolve_range(&self) -> Result<StartupRange, IndexerError> {
         info!(
             "Checking for gaps in indexed data for {:?}...",
             self.program_type
@@ -312,6 +325,10 @@ impl BackfillService {
             }
         };
 
+        // One past the highest slot backfill covers (gap) or the durable checkpoint
+        // (no gap); max guards against an RPC node lagging behind the checkpoint.
+        let live_start_slot = std::cmp::max(from_slot, current_slot) + 1;
+
         match validate_gap(current_slot, from_slot, self.config.max_gap_slots)
             .map_err(DataSourceError::from)?
         {
@@ -320,14 +337,20 @@ impl BackfillService {
                     "No gap detected for {:?}. Current slot: {}, From slot: {}",
                     self.program_type, current_slot, from_slot
                 );
-                Ok(None)
+                Ok(StartupRange {
+                    gap: None,
+                    live_start_slot,
+                })
             }
             Some(gap) => {
                 info!(
                     "Gap detected for {:?}: {} slots (from {} to {}). Starting backfill...",
                     self.program_type, gap, from_slot, current_slot
                 );
-                Ok(Some((from_slot, current_slot)))
+                Ok(StartupRange {
+                    gap: Some((from_slot, current_slot)),
+                    live_start_slot,
+                })
             }
         }
     }
@@ -357,7 +380,7 @@ impl BackfillService {
     /// Run the backfill process
     /// Returns Ok(()) if no gap or backfill successful, Err if gap too large or backfill failed
     pub async fn run(&self, instruction_tx: InstructionSender) -> Result<(), IndexerError> {
-        match self.resolve_range().await? {
+        match self.resolve_range().await?.gap {
             None => Ok(()),
             Some((from_slot, to_slot)) => self.run_range(from_slot, to_slot, instruction_tx).await,
         }
@@ -1015,6 +1038,89 @@ mod tests {
                 rx.try_recv().is_err(),
                 "no messages expected for zero-slot no-gap case"
             );
+        }
+
+        // ---- BackfillService::resolve_range — shared startup boundary ----
+
+        /// With a gap, the live source's first slot is exactly one past backfill's
+        /// target, so the two producers meet with no hole and no overlap.
+        #[tokio::test]
+        async fn resolve_range_gap_sets_live_start_to_target_plus_one() {
+            let mut server = Server::new_async().await;
+            let _m_slot = mock_get_slot(&mut server, 110);
+
+            let mock = MockStorage::new();
+            mock.set_checkpoint("escrow", 100);
+            let storage = Arc::new(Storage::Mock(mock));
+            let poller = make_poller(&server.url());
+            let config = make_config(&server.url(), 1000);
+
+            let service = BackfillService::new(storage, poller, ProgramType::Escrow, config, None);
+            let range = service.resolve_range().await.unwrap();
+
+            assert_eq!(range.gap, Some((100, 110)));
+            assert_eq!(range.live_start_slot, 111);
+        }
+
+        /// No gap (tip == checkpoint): the live boundary is pinned one past the
+        /// durable checkpoint, not a freshly sampled tip.
+        #[tokio::test]
+        async fn resolve_range_no_gap_sets_live_start_to_checkpoint_plus_one() {
+            let mut server = Server::new_async().await;
+            let _m_slot = mock_get_slot(&mut server, 100);
+
+            let mock = MockStorage::new();
+            mock.set_checkpoint("escrow", 100);
+            let storage = Arc::new(Storage::Mock(mock));
+            let poller = make_poller(&server.url());
+            let config = make_config(&server.url(), 1000);
+
+            let service = BackfillService::new(storage, poller, ProgramType::Escrow, config, None);
+            let range = service.resolve_range().await.unwrap();
+
+            assert_eq!(range.gap, None);
+            assert_eq!(range.live_start_slot, 101);
+        }
+
+        /// RPC node lagging behind the checkpoint: max guard keeps the live boundary
+        /// at checkpoint+1, never rewinding below the durable checkpoint.
+        #[tokio::test]
+        async fn resolve_range_no_gap_rpc_behind_uses_checkpoint_plus_one() {
+            let mut server = Server::new_async().await;
+            let _m_slot = mock_get_slot(&mut server, 50);
+
+            let mock = MockStorage::new();
+            mock.set_checkpoint("escrow", 100);
+            let storage = Arc::new(Storage::Mock(mock));
+            let poller = make_poller(&server.url());
+            let config = make_config(&server.url(), 1000);
+
+            let service = BackfillService::new(storage, poller, ProgramType::Escrow, config, None);
+            let range = service.resolve_range().await.unwrap();
+
+            assert_eq!(range.gap, None);
+            assert_eq!(range.live_start_slot, 101);
+        }
+
+        /// A configured start_slot ahead of the tip flows through from_slot, so the
+        /// live source begins at start_slot, preserving operator intent.
+        #[tokio::test]
+        async fn resolve_range_start_slot_ahead_sets_live_start_to_start_slot() {
+            let mut server = Server::new_async().await;
+            let _m_slot = mock_get_slot(&mut server, 150);
+
+            let mock = MockStorage::new();
+            mock.set_checkpoint("escrow", 100);
+            let storage = Arc::new(Storage::Mock(mock));
+            let poller = make_poller(&server.url());
+            let mut config = make_config(&server.url(), 10_000);
+            config.start_slot = Some(200);
+
+            let service = BackfillService::new(storage, poller, ProgramType::Escrow, config, None);
+            let range = service.resolve_range().await.unwrap();
+
+            assert_eq!(range.gap, None);
+            assert_eq!(range.live_start_slot, 200);
         }
     }
 }

--- a/indexer/src/indexer/indexer.rs
+++ b/indexer/src/indexer/indexer.rs
@@ -124,6 +124,12 @@ pub async fn run(
     //    no live-tip slot can slip past it and push the checkpoint over the gap.
     let mut checkpoint_writer = CheckpointWriter::new(storage.clone());
 
+    // First slot the live RPC source must request, captured from the backfill range so
+    // both producers share one boundary. None when backfill is disabled or resolves no
+    // range, in which case step 6 falls back to the configured from_slot.
+    #[cfg(feature = "datasource-rpc")]
+    let mut rpc_live_start_slot: Option<u64> = None;
+
     if indexer_config.backfill.enabled {
         #[cfg(not(feature = "datasource-rpc"))]
         return Err(DataSourceError::InvalidConfig {
@@ -159,12 +165,12 @@ pub async fn run(
                 // leapfrogged by a later one. No live stream, so a resolve failure
                 // fails closed rather than falling back to ungated.
                 let range = backfill_service.resolve_range().await?;
-                if let Some((from_slot, target)) = range {
+                if let Some((from_slot, target)) = range.gap {
                     checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
                 }
                 let checkpoint_handle = checkpoint_writer.start(checkpoint_rx);
                 info!("CheckpointWriter service started");
-                if let Some((from_slot, target)) = range {
+                if let Some((from_slot, target)) = range.gap {
                     backfill_service
                         .run_range(from_slot, target, instruction_tx.clone())
                         .await?;
@@ -181,22 +187,26 @@ pub async fn run(
                 // Gate the writer to the range backfill will fill. resolve_range retries
                 // transient RPC failures; a persistent failure fails closed (see below).
                 match backfill_service.resolve_range().await {
-                    Ok(Some((from_slot, target))) => {
-                        checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
-                        let instruction_tx_clone = instruction_tx.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = backfill_service
-                                .run_range(from_slot, target, instruction_tx_clone)
-                                .await
-                            {
-                                error!("Backfill failed: {}", e);
-                            } else {
-                                info!("Backfill completed successfully");
-                            }
-                        });
-                    }
-                    Ok(None) => {
-                        info!("No backfill gap; checkpoint writer left ungated");
+                    Ok(range) => {
+                        // Pin the live source to backfill's boundary so it resumes with
+                        // no hole and no overlap, whether or not there is a gap to fill.
+                        rpc_live_start_slot = Some(range.live_start_slot);
+                        if let Some((from_slot, target)) = range.gap {
+                            checkpoint_writer = checkpoint_writer.with_gate(from_slot, target);
+                            let instruction_tx_clone = instruction_tx.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = backfill_service
+                                    .run_range(from_slot, target, instruction_tx_clone)
+                                    .await
+                                {
+                                    error!("Backfill failed: {}", e);
+                                } else {
+                                    info!("Backfill completed successfully");
+                                }
+                            });
+                        } else {
+                            info!("No backfill gap; checkpoint writer left ungated");
+                        }
                     }
                     Err(e) => {
                         error!(
@@ -226,7 +236,8 @@ pub async fn run(
 
             let mut source = RpcPollingSource::new(
                 common_config.rpc_url.clone(),
-                rpc_config.from_slot,
+                // Resume on backfill's boundary when it ran; otherwise the configured start.
+                rpc_live_start_slot.or(rpc_config.from_slot),
                 rpc_config.poll_interval_ms,
                 rpc_config.error_retry_interval_ms,
                 rpc_config.batch_size,

--- a/indexer/src/indexer/transaction_processor.rs
+++ b/indexer/src/indexer/transaction_processor.rs
@@ -1828,6 +1828,71 @@ mod tests {
         assert!(committed >= DEPOSIT_SLOT);
     }
 
+    /// With the shared startup boundary the live source resumes at target+1, so the
+    /// frontier folds through the gap and continues into the live slots with no hole:
+    /// gate `(100, 105]`, backfill fills 101..=105, live sends 106 and 107.
+    #[tokio::test]
+    async fn concurrent_backfill_hands_off_contiguously_to_live_start() {
+        const FROM: u64 = 100;
+        const T0: u64 = 105;
+        const DEPOSIT_SLOT: u64 = 103;
+        const LIVE_START: u64 = T0 + 1; // live source begins one past backfill's target
+        const LIVE_END: u64 = 107;
+        let (tx, processor_handle, checkpoint_handle, mock) =
+            spawn_pipeline(deposit_instance(), Some((FROM, T0)));
+
+        // A historical deposit inside the gap, then backfill closes the gap.
+        tx.send(ProcessorMessage::Instruction(make_deposit_instruction(
+            DEPOSIT_SLOT,
+            Some("dep-103".to_string()),
+            None,
+        )))
+        .await
+        .unwrap();
+        for slot in (FROM + 1)..=T0 {
+            tx.send(ProcessorMessage::SlotComplete {
+                slot,
+                program_type: ProgramType::Escrow,
+            })
+            .await
+            .unwrap();
+        }
+
+        // The live source, starting at target+1, continues contiguously.
+        for slot in LIVE_START..=LIVE_END {
+            tx.send(ProcessorMessage::SlotComplete {
+                slot,
+                program_type: ProgramType::Escrow,
+            })
+            .await
+            .unwrap();
+        }
+
+        drop(tx);
+        processor_handle.await.unwrap();
+        checkpoint_handle.await.unwrap();
+
+        // The checkpoint advances through the gap into the live slots with no hole.
+        let committed = mock
+            .get_committed_checkpoint("escrow")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            committed, LIVE_END,
+            "checkpoint hands off from backfill's target into the live slots"
+        );
+
+        // The historical deposit row exists and every slot 101..=107 was covered.
+        let inserted = mock.inserted_transactions.lock().unwrap();
+        assert_eq!(inserted.len(), 1);
+        assert_eq!(inserted[0][0].slot, DEPOSIT_SLOT as i64);
+        assert!(
+            committed >= LIVE_END,
+            "no slot in 101..=107 is skipped between backfill and live"
+        );
+    }
+
     /// The exact reconnect residual-gap reproduction, end-to-end through the real
     /// pipeline: the residual window (T_gf, T_sub] must be indexed, never leapfrogged by
     /// the live tip that resumes above it. Removing the writer's Regate arm makes this


### PR DESCRIPTION
## Summary

Closes issue 281. At startup with backfill enabled, backfill and the live `RpcPollingSource` independently sampled the chain tip to determine their starting slots. Because the live source starts after backfill resolves, its tip is always greater than or equal to backfill's, so any slot finalized during that window is consumed by neither producer. The checkpoint then advances past the gap, making it permanent across restarts. The no-gap path had the same defect: even when backfill found nothing to replay, the live source still sampled a fresh tip and skipped any slots finalized during startup. A missed withdrawal permanently blocks release after receipt burn, while a missed deposit locks source assets without minting a receipt.

The fix derives a single shared startup boundary and uses it consistently for both backfill and the live datasource, eliminating the startup race. The existing checkpoint gate continues to coordinate the handoff, buffering live traffic until backfill catches up before resuming contiguous processing. Existing behaviors, including configured start_slots and RPC-behind scenarios, remain unchanged.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,846 | 13,489 | 87.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30271291831) |
| Indexer | 30,943 | 34,305 | 90.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30271291831) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30271291831) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30271291831) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,224 | 16,790 | 78.8% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30271291831) |
| **Total** | **58,123** | **67,002** | **86.7%** | |

> Last updated: 2026-07-27 14:35:49 UTC by E2E Integration