### PR TITLE
fix: Retarget escrow program id to 9tgHa1, fix deposit.rs Token-2022 detection

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -57,5 +57,5 @@ GF_ADMIN_PASSWORD=admin
 # constants, so the localnet validator deploys the .so at the address the indexer
 # watches. These are fixed (not derived from the build keypair); do not change them
 # unless you also update declare_id! and the indexer/streamer constants and rebuild.
-ESCROW_PROGRAM_ID=GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
+ESCROW_PROGRAM_ID=9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU
 WITHDRAW_PROGRAM_ID=J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Within the payment channel, transactions are processed through a **five-stage pi
 
 ### Solana Private Channels Escrow/Withdrawal Programs
 
-- **Solana Private Channels Escrow Program**: Mainnet token custody with SMT security (Program ID: `GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83`)
+- **Solana Private Channels Escrow Program**: Mainnet token custody with SMT security (Program ID: `9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU`)
 - **Solana Private Channels Withdrawal Program**: Channel withdrawal processing (token burning) (Program ID: `J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi`)
 
 ### Indexer

--- a/bench-tps/.env.sample
+++ b/bench-tps/.env.sample
@@ -87,7 +87,7 @@ JWT_SECRET=
 # -----------------------------------------------------------------------------
 # Solana validator — program IDs must match the compiled .so files in target/deploy/
 # -----------------------------------------------------------------------------
-ESCROW_PROGRAM_ID=GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
+ESCROW_PROGRAM_ID=9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU
 WITHDRAW_PROGRAM_ID=J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi
 
 # RPC endpoint for the local validator (used by indexers/operators inside Docker)

--- a/bench-tps/.env.sample.devnet
+++ b/bench-tps/.env.sample.devnet
@@ -87,7 +87,7 @@ JWT_SECRET=
 # -----------------------------------------------------------------------------
 # Solana devnet — program IDs must match the deployed on-chain programs
 # -----------------------------------------------------------------------------
-ESCROW_PROGRAM_ID=GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
+ESCROW_PROGRAM_ID=9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU
 WITHDRAW_PROGRAM_ID=J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi
 
 # Solana devnet RPC endpoint (used by indexers/operators and bench Solana phase)

--- a/core/src/bin/streamer.rs
+++ b/core/src/bin/streamer.rs
@@ -55,7 +55,7 @@ const DISC_RELEASE_FUNDS: u8 = 7;
 const DISC_RESET_SMT: u8 = 8;
 
 /// Known program IDs
-const ESCROW_PROGRAM_ID: &str = "GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83";
+const ESCROW_PROGRAM_ID: &str = "9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU";
 const SPL_TOKEN_PROGRAM_ID: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 
 // ---------------------------------------------------------------------------

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@ The core payment channel processes transactions through a five-stage pipeline op
 
 **Purpose**: Locks tokens in escrow for use within the payment channel.
 
-**Program ID**: `GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83` (Solana Devnet)
+**Program ID**: `9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU` (Solana Devnet)
 
 **Location**: [`private-channel-escrow-program/`](../private-channel-escrow-program/)
 

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -8,7 +8,7 @@ Solana Private Channels is a private payment channel with direct access to Solan
 
 **Architecture Overview:**
 
-- **Escrow Program**: On-chain Solana program that holds deposited tokens (Devnet Program ID: `GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83`)
+- **Escrow Program**: On-chain Solana program that holds deposited tokens (Devnet Program ID: `9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU`)
 - **Solana Private Channels Payment Channel**: Private execution environment (write node, read node, gateway)
 - **Indexer** (2 instances): `indexer-solana` watches the Escrow program on Solana for deposits; `indexer-private-channel` watches the Withdraw program on the Solana Private Channels payment channel for withdrawals
 - **Operator** (2 instances): `operator-solana` processes deposits (mints on the Solana Private Channels payment channel); `operator-private-channel` processes withdrawals (releases from escrow on Solana)
@@ -42,7 +42,7 @@ The escrow/withdraw programs are already deployed on Devnet at their canonical I
 **Check staleness** — compare the on-chain deploy point to your source:
 
 ```shell
-solana program show GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83 --url devnet   # note "Last Deployed In Slot"
+solana program show 9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU --url devnet   # note "Last Deployed In Slot"
 solana block-time <that-slot> --url devnet                                       # -> deploy date
 git log -1 --format="%ci %s" -- private-channel-escrow-program/program           # source last-changed date
 ```
@@ -54,7 +54,7 @@ If the source date is newer than the deploy date, the on-chain program is stale.
 ```shell
 make build-devnet          # rebuild both program .so files from current source
 solana program deploy target/deploy/private_channel_escrow_program.so \
-  --program-id GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83 \
+  --program-id 9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU \
   --upgrade-authority <authority.json> --url devnet
 solana program deploy target/deploy/private_channel_withdraw_program.so \
   --program-id J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi \

--- a/docs/ESCROW_INTERACTION_GUIDE.md
+++ b/docs/ESCROW_INTERACTION_GUIDE.md
@@ -15,7 +15,7 @@ The Solana Private Channels Escrow Program manages token deposits to and withdra
 
 ### Program Address
 ```
-GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
+9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU
 ```
 
 ### Installation

--- a/docs/ESCROW_PROGRAM.md
+++ b/docs/ESCROW_PROGRAM.md
@@ -3,7 +3,7 @@
 ## Program ID
 
 ```
-GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
+9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU
 ```
 
 - [Instruction Details](#instruction-details)

--- a/indexer/Makefile
+++ b/indexer/Makefile
@@ -13,7 +13,7 @@
 # on signal::ctrl_c(); no logic of their own and covered by integration tests.
 COV_IGNORE := --ignore-filename-regex '(error/|constants\.rs|bin/|models\.rs|shutdown_utils\.rs|types\.rs|indexer/indexer\.rs|operator/operator\.rs)'
 
-PRIVATE_CHANNEL_ESCROW_PROGRAM_ID ?= GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
+PRIVATE_CHANNEL_ESCROW_PROGRAM_ID ?= 9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU
 PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID ?= J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi
 PRIVATE_CHANNEL_ESCROW_PROGRAM_SO ?= ../target/deploy/private_channel_escrow_program.so
 PRIVATE_CHANNEL_WITHDRAW_PROGRAM_SO ?= ../target/deploy/private_channel_withdraw_program.so

--- a/indexer/src/indexer/datasource/common/parser/escrow.rs
+++ b/indexer/src/indexer/datasource/common/parser/escrow.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 
 // PrivateChannel Escrow Program ID
-pub const PRIVATE_CHANNEL_ESCROW_PROGRAM_ID: &str = "GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83";
+pub const PRIVATE_CHANNEL_ESCROW_PROGRAM_ID: &str = "9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU";
 
 // Instruction discriminators (from IDL)
 const CREATE_INSTANCE: u8 = 0;

--- a/private-channel-deploy/templates/env.j2
+++ b/private-channel-deploy/templates/env.j2
@@ -12,7 +12,7 @@ DEVNET_RPC_URL={{ rpc_url }}
 # localnet ignores these (compose hardcodes http://validator:10000); devnet/mainnet uses both.
 DEVNET_YELLOWSTONE_ENDPOINT={{ yellowstone_endpoint | default('') }}
 INDEXER_YELLOWSTONE_TOKEN={{ yellowstone_token | default('') }}
-ESCROW_PROGRAM_ID={{ escrow_program_id | default('GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83') }}
+ESCROW_PROGRAM_ID={{ escrow_program_id | default('9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU') }}
 WITHDRAW_PROGRAM_ID={{ withdraw_program_id | default('J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi') }}
 # Fallback: a syntactically-valid Pubkey (the system program's all-1s) so the
 # indexer's `Pubkey::from_str` parses cleanly on first boot. Whoever runs

--- a/private-channel-deploy/vars/dev.yml
+++ b/private-channel-deploy/vars/dev.yml
@@ -56,7 +56,7 @@ gateway_enforce_jwt: false
 # Addresses the indexer/operator watch. On localnet these are also where the
 # bundled validator deploys the repo's .so files (pinned to the repo keypairs).
 # On devnet/mainnet the programs must already be deployed; set these to match.
-escrow_program_id: GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83
+escrow_program_id: 9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU
 withdraw_program_id: J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi
 
 # === Escrow instance =======================================================

--- a/private-channel-escrow-program/clients/typescript/tests/setup/mocks.ts
+++ b/private-channel-escrow-program/clients/typescript/tests/setup/mocks.ts
@@ -46,7 +46,7 @@ export const TEST_ADDRESSES = {
     MINT: 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address,
     ALLOWED_MINT: '8MKrYq1F8xKhXp4FJWfYSgYZNgPqvP3DQa2Jv7rXfQN8' as Address,
     INSTANCE_ATA: '9LqZxwCF5N4FdpTJGcZpYPvT2GcLXMdNzQf5EyN5DhYx' as Address,
-    EVENT_AUTHORITY: 'G9CCHrvvmKuoM9vqcEWCxmbFiyJqXTLJBJjpSFv5v3Fm' as Address,
+    EVENT_AUTHORITY: 'FngERuuhrF13VUpEVuTgVrBH9TM861Wwzr9d6qMSVjMd' as Address,
 } as const;
 
 /**
@@ -59,4 +59,4 @@ export const TEST_SIBLING_PROOFS: Array<number> = Array.from(new Uint8Array(512)
 /**
  * Expected program address for all instructions
  */
-export const EXPECTED_PROGRAM_ADDRESS = 'GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83';
+export const EXPECTED_PROGRAM_ADDRESS = '9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU';

--- a/private-channel-escrow-program/clients/typescript/tests/unit/instructions/resetSmtRoot.test.ts
+++ b/private-channel-escrow-program/clients/typescript/tests/unit/instructions/resetSmtRoot.test.ts
@@ -215,7 +215,7 @@ describe('resetSmtRoot', () => {
 
             // Verify default privateChannelEscrowProgram is used
             const privateChannelEscrowProgramAccount = instruction.accounts[5];
-            expect(privateChannelEscrowProgramAccount.address).toBe('GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83');
+            expect(privateChannelEscrowProgramAccount.address).toBe('9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU');
         });
 
         it('should use provided PDAs when supplied (override auto-derivation)', async () => {

--- a/private-channel-escrow-program/idl/private_channel_escrow_program.json
+++ b/private-channel-escrow-program/idl/private_channel_escrow_program.json
@@ -1683,7 +1683,7 @@
     "kind": "programNode",
     "name": "privateChannelEscrowProgram",
     "pdas": [],
-    "publicKey": "GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83",
+    "publicKey": "9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU",
     "version": "0.1.0"
   },
   "standard": "codama",

--- a/private-channel-escrow-program/program/src/lib.rs
+++ b/private-channel-escrow-program/program/src/lib.rs
@@ -11,4 +11,4 @@ pub mod state;
 pub mod entrypoint;
 
 use pinocchio::address::declare_id;
-declare_id!("GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83");
+declare_id!("9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU");

--- a/private-channel-escrow-program/scripts/lib/updates/set-instruction-account-default-values.ts
+++ b/private-channel-escrow-program/scripts/lib/updates/set-instruction-account-default-values.ts
@@ -11,11 +11,11 @@ import {
     setInstructionAccountDefaultValuesVisitor,
 } from 'codama';
 
-const PRIVATE_CHANNEL_ESCROW_PROGRAM_ID = 'GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83';
+const PRIVATE_CHANNEL_ESCROW_PROGRAM_ID = '9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU';
 const ATA_PROGRAM_ID = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
 const SYSTEM_PROGRAM_ID = '11111111111111111111111111111111';
 const TOKEN_PROGRAM_ID = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
-const EVENT_AUTHORITY_PDA = 'G9CCHrvvmKuoM9vqcEWCxmbFiyJqXTLJBJjpSFv5v3Fm';
+const EVENT_AUTHORITY_PDA = 'FngERuuhrF13VUpEVuTgVrBH9TM861Wwzr9d6qMSVjMd';
 
 function createAtaPdaValueNode(ownerAccount: string, mintAccount: string, tokenProgram: string) {
     return pdaValueNode(

--- a/private-channel-escrow-program/tests/integration-tests/src/utils.rs
+++ b/private-channel-escrow-program/tests/integration-tests/src/utils.rs
@@ -37,7 +37,7 @@ const MIN_LAMPORTS: u64 = 500_000_000;
 
 pub const ATA_PROGRAM_ID: Pubkey = pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 pub const PRIVATE_CHANNEL_ESCROW_PROGRAM_ID: Pubkey =
-    pubkey!("GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83");
+    pubkey!("9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU");
 pub const TOKEN_2022_PROGRAM_ID: Pubkey = spl_token_2022::ID;
 
 // PrivateChannel Escrow Program Error Codes (using generated error enum)

--- a/private-channel-escrow-program/tests/trident-tests/Trident.toml
+++ b/private-channel-escrow-program/tests/trident-tests/Trident.toml
@@ -2,5 +2,5 @@
 enabled = true
 
 [[fuzz.programs]]
-address = "GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83"
+address = "9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU"
 program = "../../../target/deploy/private_channel_escrow_program.so"

--- a/private-channel-escrow-program/tests/trident-tests/shared.rs
+++ b/private-channel-escrow-program/tests/trident-tests/shared.rs
@@ -8,7 +8,7 @@ use spl_associated_token_account::get_associated_token_address_with_program_id;
 use trident_fuzz::fuzzing::*;
 
 pub const PRIVATE_CHANNEL_ESCROW_PROGRAM_ID: Pubkey =
-    pubkey!("GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83");
+    pubkey!("9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU");
 pub const SPL_TOKEN_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
 /// Clamp raw fuzz amounts to [1, 999_999].

--- a/scripts/devnet/src/bin/deposit.rs
+++ b/scripts/devnet/src/bin/deposit.rs
@@ -9,7 +9,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
-use spl_associated_token_account::get_associated_token_address;
+use spl_associated_token_account::get_associated_token_address_with_program_id;
 use std::{env, error::Error, str::FromStr};
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
@@ -65,8 +65,17 @@ fn main() -> Result<()> {
 
     let (allowed_mint_pda, _) = find_allowed_mint_pda(&instance_id, &mint);
     let (event_authority_pda, _) = find_event_authority_pda();
-    let user_ata = get_associated_token_address(&user_keypair.pubkey(), &mint);
-    let instance_ata = get_associated_token_address(&instance_id, &mint);
+    // Detect the mint's token program (classic SPL Token vs Token-2022) so the
+    // ATAs and the instruction's token_program account match the actual mint.
+    let token_program = client
+        .get_account(&mint)
+        .map_err(|e| format!("Failed to fetch mint {}: {}", mint, e))?
+        .owner;
+    println!("Token program: {}", token_program);
+    let user_ata =
+        get_associated_token_address_with_program_id(&user_keypair.pubkey(), &mint, &token_program);
+    let instance_ata =
+        get_associated_token_address_with_program_id(&instance_id, &mint, &token_program);
 
     println!("\nDepositing tokens...");
     println!("User ATA: {}", user_ata);
@@ -87,7 +96,7 @@ fn main() -> Result<()> {
         user_ata,
         instance_ata,
         system_program: SYSTEM_PROGRAM_ID,
-        token_program: spl_token::ID,
+        token_program,
         associated_token_program: spl_associated_token_account::ID,
         event_authority: event_authority_pda,
         private_channel_escrow_program: PRIVATE_CHANNEL_ESCROW_PROGRAM_ID,


### PR DESCRIPTION
## Summary
- Main was still pointing at the old placeholder escrow program (GokvZqD2yP696rzNBNbQvcZ4VsLW7jNvFXU1kW9m7k83), but devnet has actually been running on our own program (9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU) for weeks. Updates streamer.rs, the indexer's escrow parser, the IDL, and the program's own declare_id to match.
- deposit.rs hardcoded spl_token::ID for the ATA derivation and token_program account, which breaks for Token-2022 mints. Fixes it to detect the mint's actual owning token program, same as allow_mint.rs got in #174 (that PR missed this sibling script).
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,407 | 13,001 | 87.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30300664689) |
| Indexer | 23,018 | 26,109 | 88.2% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30300664689) |
| Gateway | 1,035 | 1,195 | 86.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30300664689) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30300664689) |
| Withdraw Program | 129 | 241 | 53.5% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30300664801) |
| Escrow Program | 1,195 | 1,982 | 60.3% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30300664801) |
| DvP Swap Program | 270 | 1,179 | 22.9% | [unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30300664801) |
| E2E Integration | 12,144 | 15,174 | 80.0% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30300664689) |
| **Total** | **49,713** | **58,605** | **84.8%** | |

> Last updated: 2026-07-27 20:25:34 UTC by E2E Integration