### PR TITLE
fix(indexer): gate release-side Dead on an on-chain SMT membership proof (issue-15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6578,6 +6578,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
+ "borsh 1.5.7",
  "bs58",
  "chrono",
  "dvp-swap-program-client",

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -187,6 +187,17 @@ counter_vec!(
     &["program_type", "outcome"]
 );
 
+// Release-side SMT confirmation gate: the on-chain root verdict on the terminal
+// Dead branch of a release consumer. `site` is one of {recovery, remint}; `verdict`
+// is one of {landed, not_landed, uncertain}. A rising `uncertain` rate is a stuck
+// DB-vs-chain divergence worth alerting on.
+counter_vec!(
+    OPERATOR_RELEASE_VERIFY,
+    "private_channel_operator_release_verify_total",
+    "Release-side SMT confirmation verdicts on the Dead branch",
+    &["site", "verdict"]
+);
+
 pub fn init_labels(program_type: &str) {
     INDEXER_MINTS_SAVED.with_label_values(&[program_type]);
     INDEXER_TRANSACTIONS_SAVED.with_label_values(&[program_type]);
@@ -285,6 +296,14 @@ pub fn init_labels(program_type: &str) {
             ]);
         }
     }
+
+    // Release-verify gate labels are program-independent (site, verdict); the
+    // idempotent pre-registration is harmless across repeated init_labels calls.
+    for site in &["recovery", "remint"] {
+        for verdict in &["landed", "not_landed", "uncertain"] {
+            OPERATOR_RELEASE_VERIFY.with_label_values(&[site, verdict]);
+        }
+    }
 }
 
 pub fn init() {
@@ -312,6 +331,7 @@ pub fn init() {
         OPERATOR_TASK_EXIT,
         OPERATOR_STALE_PROCESSING_RECOVERED,
         OPERATOR_REOPENED_DEPOSIT_GATE,
+        OPERATOR_RELEASE_VERIFY,
     );
 }
 

--- a/indexer/src/operator/db_transaction_writer.rs
+++ b/indexer/src/operator/db_transaction_writer.rs
@@ -73,6 +73,7 @@ impl DbTransactionWriter {
                 update.status,
                 update.counterpart_signature.clone(),
                 update.processed_at.unwrap_or_else(Utc::now),
+                update.release_signatures.clone(),
             )
             .await
         {
@@ -196,6 +197,7 @@ mod tests {
             processed_at: Some(Utc::now()),
             remint_signature: None,
             remint_attempted: false,
+            release_signatures: None,
         }
     }
 
@@ -375,6 +377,7 @@ mod tests {
             processed_at: Some(Utc::now()),
             remint_signature: Some("remint_sig_abc".to_string()),
             remint_attempted: true,
+            release_signatures: None,
         };
 
         writer.send_webhook_alert(&server.url(), &update).await;
@@ -408,6 +411,7 @@ mod tests {
             processed_at: Some(Utc::now()),
             remint_signature: None,
             remint_attempted: true,
+            release_signatures: None,
         };
 
         writer.send_webhook_alert(&server.url(), &update).await;
@@ -442,6 +446,7 @@ mod tests {
             processed_at: Some(Utc::now()),
             remint_signature: None,
             remint_attempted: false,
+            release_signatures: None,
         };
 
         writer.send_webhook_alert(&server.url(), &update).await;
@@ -476,6 +481,7 @@ mod tests {
             processed_at: Some(Utc::now()),
             remint_signature: None,
             remint_attempted: true,
+            release_signatures: None,
         };
 
         writer.send_webhook_alert(&server.url(), &update).await;

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -318,6 +318,7 @@ pub async fn run(
         let recovery_rpc = rpc_client.clone();
         let recovery_fallback = fallback_rpc_client.clone();
         let recovery_program_type = common_config.program_type;
+        let recovery_instance_pda = instance_pda;
         let recovery_token = cancellation_token.clone();
         tokio::spawn(async move {
             if let Err(e) = recovery::run_recovery_worker(
@@ -325,6 +326,7 @@ pub async fn run(
                 recovery_rpc,
                 recovery_fallback,
                 recovery_program_type,
+                recovery_instance_pda,
                 recovery_storage_tx,
                 recovery_token,
             )
@@ -453,6 +455,7 @@ async fn run_withdraw_preflight(
         rpc_client,
         fallback_rpc_client,
         crate::config::ProgramType::Withdraw,
+        Some(instance_pda),
         storage_tx,
         cancellation_token,
         MAX_RECONCILE_PASSES,
@@ -487,8 +490,9 @@ async fn run_withdraw_preflight(
     }
 }
 
-/// Withdraw-only gate for the mandatory Solana fallback: require a second endpoint that is independent, same-cluster
-/// (equal genesis hash), and reachable, or refuse to start. Archival depth is left to the per-attempt ledger-floor check.
+/// Withdraw-only gate for the Solana fallback: a missing fallback only warns (the on-chain SMT gate is the release-side
+/// authority), but a configured fallback must be independent, same-cluster (equal genesis hash), and reachable, else
+/// refuse to start. Archival depth is left to the per-attempt ledger-floor check.
 async fn validate_withdraw_fallback(
     program_type: crate::config::ProgramType,
     rpc_client: &RpcClientWithRetry,
@@ -500,12 +504,16 @@ async fn validate_withdraw_fallback(
         return Ok(());
     }
 
+    // A missing fallback is no longer refuse-to-start: the on-chain SMT gate is
+    // now the authority for a release-side Dead, so a second corroborating
+    // endpoint is defense-in-depth, not a correctness precondition. Warn so a
+    // single-endpoint deploy is visible, then start.
     let (Some(fallback), Some(fallback_url)) = (fallback, fallback_url) else {
-        return Err(OperatorError::RpcError(
-            "fallback_rpc_url is required for the withdraw operator: a lone Solana endpoint's \
-             absent status is not proof of non-inclusion"
-                .to_string(),
-        ));
+        warn!(
+            "withdraw operator started without a fallback_rpc_url: release-side Dead is gated by \
+             the on-chain SMT root; a second endpoint is recommended defense-in-depth"
+        );
+        return Ok(());
     };
 
     if fallback_url == rpc_url {
@@ -704,9 +712,10 @@ mod tests {
             .create()
     }
 
-    /// A withdraw operator with no fallback configured must refuse to start.
+    /// S1: a withdraw operator with no fallback now warns and starts (previously
+    /// refused). The SMT gate is the authority for a release-side Dead.
     #[tokio::test]
-    async fn withdraw_missing_fallback_refuses_start() {
+    async fn withdraw_missing_fallback_warns_and_starts() {
         let primary = make_rpc_client("http://localhost:8899");
         let result = validate_withdraw_fallback(
             ProgramType::Withdraw,
@@ -716,7 +725,10 @@ mod tests {
             None,
         )
         .await;
-        assert!(matches!(result, Err(OperatorError::RpcError(_))));
+        assert!(
+            result.is_ok(),
+            "missing fallback must now warn and start: {result:?}"
+        );
     }
 
     /// A fallback whose URL equals rpc_url is not independent; refuse to start.

--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -179,6 +179,7 @@ async fn quarantine_single(
         error_message: Some(error_message),
         remint_signature: None,
         remint_attempted: false,
+        release_signatures: None,
     };
     // send_guaranteed: losing a quarantine update is worse than blocking briefly —
     // the DB row would stay `Processing` and never alert.
@@ -838,6 +839,8 @@ pub async fn process_deposit_funds(
                                 transaction.id,
                                 transaction.updated_at,
                                 Some(signature.clone()),
+                                // Deposit completion carries no release-attempt list.
+                                None,
                             )
                         },
                     )

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -766,6 +766,27 @@ mod tests {
             .create()
     }
 
+    /// Finalized getLatestBlockhash carrying `context_slot` and `lvbh`, the verifier's
+    /// freshness anchor: it derives tip = lvbh - MAX_PROCESSING_AGE and binds the
+    /// instance account read to `context_slot`. Pick lvbh so tip is above (fresh) or
+    /// at/below (stale) the attempt's lvbh.
+    fn mock_latest_blockhash(
+        server: &mut mockito::ServerGuard,
+        context_slot: u64,
+        lvbh: u64,
+    ) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getLatestBlockhash""#.into(),
+            ))
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","result":{{"context":{{"slot":{context_slot}}},"value":{{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":{lvbh}}}}},"id":1}}"#
+            ))
+            .create()
+    }
+
     /// Covered ledger floor so an absence-Dead resolves to Dead, not a prune.
     fn mock_first_available_block(server: &mut mockito::ServerGuard, floor: u64) -> mockito::Mock {
         server
@@ -1088,7 +1109,9 @@ mod tests {
     async fn check_withdrawal_demotes_when_signature_dead() {
         let mut server = mockito::Server::new_async().await;
         mock_dead_by_absence(&mut server);
-        // On-chain tree 0 has no completed nonces; snapshot slot 1000 > lvbh 100.
+        // Fresh finalized tip (1000 - 150 = 850 > lvbh 100) binds the account read.
+        let _bh = mock_latest_blockhash(&mut server, 500, 1000);
+        // On-chain tree 0 has no completed nonces; snapshot slot 1000 >= bound slot.
         let _account = mock_instance_at_slot(&mut server, smt_root(0, &[]), 0, 1000, 1);
 
         let mock = MockStorage::new();
@@ -1119,7 +1142,9 @@ mod tests {
     async fn check_withdrawal_completes_when_smt_proves_landed() {
         let mut server = mockito::Server::new_async().await;
         mock_dead_by_absence(&mut server);
-        // On-chain tree 0 includes nonce 3; snapshot slot 1000 > lvbh 100.
+        // Fresh finalized tip (1000 - 150 = 850 > lvbh 100) binds the account read.
+        let _bh = mock_latest_blockhash(&mut server, 500, 1000);
+        // On-chain tree 0 includes nonce 3; snapshot slot 1000 >= bound slot.
         let _account = mock_instance_at_slot(&mut server, smt_root(0, &[3]), 0, 1000, 1);
 
         let mock = MockStorage::new();
@@ -1157,7 +1182,8 @@ mod tests {
     /// IR3: a Dead release whose finalized snapshot is not past the validity window
     /// is Uncertain, so it Quarantines (fails closed, never demotes). The release is
     /// finalized-failed so the classifier returns Dead without a block-height read,
-    /// leaving the verifier's finalized getBlockHeight the only one, mocked stale.
+    /// leaving the verifier's finalized getLatestBlockhash the only freshness read,
+    /// mocked stale. The stale gate short-circuits before the bound account read.
     #[tokio::test]
     async fn check_withdrawal_quarantines_when_snapshot_stale() {
         let mut server = mockito::Server::new_async().await;
@@ -1171,17 +1197,10 @@ mod tests {
                 r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"}]},"id":1}"#,
             )
             .create();
-        // Finalized height 100 == lvbh 100, so the freshness check fails closed to Uncertain.
-        server
-            .mock("POST", "/")
-            .match_body(mockito::Matcher::Regex(
-                r#""method"\s*:\s*"getBlockHeight""#.into(),
-            ))
-            .with_status(200)
-            .with_body(r#"{"jsonrpc":"2.0","result":100,"id":1}"#)
-            .create();
-        // Root would say NotLanded, but the stale height gates it to Uncertain.
-        let _account = mock_instance_at_slot(&mut server, smt_root(0, &[]), 0, 999, 1);
+        // Finalized tip 250 - 150 = 100 == lvbh 100, so freshness fails closed to Uncertain.
+        let _bh = mock_latest_blockhash(&mut server, 500, 250);
+        // The stale gate returns before the account read, so this must never fire.
+        let account = mock_instance_at_slot(&mut server, smt_root(0, &[]), 0, 999, 0);
 
         let mock = MockStorage::new();
         let row = make_withdrawal_row(1, Some(3));
@@ -1202,6 +1221,7 @@ mod tests {
             matches!(action, WithdrawalAction::Quarantine { .. }),
             "stale snapshot must Quarantine, never Demote"
         );
+        account.assert(); // stale gate short-circuits before the bound account read
     }
 
     /// F1: the classifier's finalized-success fast path completes WITHOUT the

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -3,15 +3,18 @@
 use crate::channel_utils::send_guaranteed;
 use crate::config::ProgramType;
 use crate::error::OperatorError;
-use crate::metrics::OPERATOR_STALE_PROCESSING_RECOVERED;
+use crate::metrics::{OPERATOR_RELEASE_VERIFY, OPERATOR_STALE_PROCESSING_RECOVERED};
 use crate::operator::sender::types::PendingSig;
-use crate::operator::sender::{classify_signatures, FinalityRpc, SigFinality};
+use crate::operator::sender::{
+    classify_signatures, verify_release_landed, FinalityRpc, ReleaseVerdict, SigFinality,
+};
 use crate::operator::utils::rpc_util::RpcClientWithRetry;
 use crate::operator::utils::storage_util::with_storage_backoff;
 use crate::operator::TransactionStatusUpdate;
 use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
 use crate::storage::common::storage::Storage;
 use chrono::{DateTime, Utc};
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -47,7 +50,12 @@ pub(crate) enum DepositOutcome {
 /// a release that already landed is never re-sent.
 enum WithdrawalAction {
     /// Release finalized on-chain → mark Completed with that signature.
-    Complete { signature: String },
+    /// `release_signatures` carries the full attempt list for durable provenance
+    /// when an SMT-confirmed release supplies it; `None` otherwise.
+    Complete {
+        signature: String,
+        release_signatures: Option<Vec<String>>,
+    },
     /// Every recorded signature is dead → safe to requeue.
     Demote,
     /// A recorded signature could still land → re-evaluate next sweep.
@@ -60,6 +68,7 @@ enum WithdrawalAction {
 enum RecoveryAction {
     Complete {
         signature: String,
+        release_signatures: Option<Vec<String>>,
     },
     Demote,
     /// Leave the row in Processing this tick (no CAS write).
@@ -77,6 +86,7 @@ pub async fn run_recovery_worker(
     rpc_client: Arc<RpcClientWithRetry>,
     fallback_rpc_client: Option<Arc<RpcClientWithRetry>>,
     program_type: ProgramType,
+    instance_pda: Option<Pubkey>,
     storage_tx: mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: CancellationToken,
 ) -> Result<(), OperatorError> {
@@ -99,6 +109,7 @@ pub async fn run_recovery_worker(
                     &storage,
                     &finality,
                     program_type,
+                    instance_pda,
                     &storage_tx,
                     &cancellation_token,
                     STALE_THRESHOLD,
@@ -128,6 +139,7 @@ async fn recover_once(
     storage: &Storage,
     finality: &FinalityRpc<'_>,
     program_type: ProgramType,
+    instance_pda: Option<Pubkey>,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: &CancellationToken,
     threshold: Duration,
@@ -166,7 +178,7 @@ async fn recover_once(
         }
         // Capture `updated_at` before the RPC so the write below CAS-checks it.
         let captured = row.updated_at;
-        let action = decide_action(&row, storage, finality).await;
+        let action = decide_action(&row, storage, finality, instance_pda).await;
         route_outcome(storage, &row, captured, action, program_type, storage_tx).await;
     }
 
@@ -194,23 +206,35 @@ async fn decide_action(
     row: &DbTransaction,
     storage: &Storage,
     finality: &FinalityRpc<'_>,
+    instance_pda: Option<Pubkey>,
 ) -> RecoveryAction {
     // Recovery is same-type by construction: the sweep queries filter on the
     // operator's own row type, so `finality` is always the chain the row's
     // signatures were broadcast to.
     let action = match row.transaction_type {
         TransactionType::Deposit => match check_deposit(row, storage, finality).await {
-            DepositOutcome::Landed { signature } => RecoveryAction::Complete { signature },
+            DepositOutcome::Landed { signature } => RecoveryAction::Complete {
+                signature,
+                release_signatures: None,
+            },
             DepositOutcome::NotLanded => RecoveryAction::Demote,
             DepositOutcome::Live { reason } => RecoveryAction::NoAction { reason },
             DepositOutcome::Ambiguous { reason } => RecoveryAction::Quarantine { reason },
         },
-        TransactionType::Withdrawal => match check_withdrawal(row, storage, finality).await {
-            WithdrawalAction::Complete { signature } => RecoveryAction::Complete { signature },
-            WithdrawalAction::Demote => RecoveryAction::Demote,
-            WithdrawalAction::LeaveProcessing { reason } => RecoveryAction::NoAction { reason },
-            WithdrawalAction::Quarantine { reason } => RecoveryAction::Quarantine { reason },
-        },
+        TransactionType::Withdrawal => {
+            match check_withdrawal(row, storage, finality, instance_pda).await {
+                WithdrawalAction::Complete {
+                    signature,
+                    release_signatures,
+                } => RecoveryAction::Complete {
+                    signature,
+                    release_signatures,
+                },
+                WithdrawalAction::Demote => RecoveryAction::Demote,
+                WithdrawalAction::LeaveProcessing { reason } => RecoveryAction::NoAction { reason },
+                WithdrawalAction::Quarantine { reason } => RecoveryAction::Quarantine { reason },
+            }
+        }
     };
     // Cap recovery requeue attempts. Rows that fail to make progress after
     // MAX_RECOVERY_REQUEUE_ATTEMPTS are quarantined (and paged) rather than
@@ -306,12 +330,14 @@ async fn check_withdrawal(
     row: &DbTransaction,
     storage: &Storage,
     finality: &FinalityRpc<'_>,
+    instance_pda: Option<Pubkey>,
 ) -> WithdrawalAction {
-    if row.withdrawal_nonce.is_none() {
+    let Some(nonce) = row.withdrawal_nonce else {
         return WithdrawalAction::Quarantine {
             reason: "withdrawal row missing nonce".to_string(),
         };
-    }
+    };
+    let nonce = nonce as u64;
 
     let pending = match load_pending_sigs(storage, row.id).await {
         Ok(p) => p,
@@ -329,8 +355,52 @@ async fn check_withdrawal(
     match classify_signatures(finality, &pending).await {
         SigFinality::Landed(sig) => WithdrawalAction::Complete {
             signature: sig.to_string(),
+            release_signatures: None,
         },
-        SigFinality::Dead => WithdrawalAction::Demote,
+        // The classifier calls the release dead by absence. Confirm it against the
+        // on-chain SMT root before demoting, since a pruned/lagging endpoint can
+        // report absence for a release that actually landed.
+        SigFinality::Dead => {
+            // pending is non-empty here, so max() is always Some.
+            let max_lvbh = pending
+                .iter()
+                .map(|p| p.last_valid_block_height)
+                .max()
+                .unwrap_or(0);
+            match verify_release_landed(finality.primary, storage, instance_pda, nonce, max_lvbh)
+                .await
+            {
+                ReleaseVerdict::Landed => {
+                    OPERATOR_RELEASE_VERIFY
+                        .with_label_values(&["recovery", "landed"])
+                        .inc();
+                    // The SMT proves the nonce released but not which attempt landed.
+                    // On-chain exclusion-proof insertion means only the earliest attempt
+                    // can consume the nonce, so the first recorded signature is the
+                    // correct single-value provenance; the full list is kept durably.
+                    WithdrawalAction::Complete {
+                        signature: pending[0].signature.to_string(),
+                        release_signatures: Some(
+                            pending.iter().map(|p| p.signature.to_string()).collect(),
+                        ),
+                    }
+                }
+                ReleaseVerdict::NotLanded => {
+                    OPERATOR_RELEASE_VERIFY
+                        .with_label_values(&["recovery", "not_landed"])
+                        .inc();
+                    WithdrawalAction::Demote
+                }
+                ReleaseVerdict::Uncertain(reason) => {
+                    OPERATOR_RELEASE_VERIFY
+                        .with_label_values(&["recovery", "uncertain"])
+                        .inc();
+                    WithdrawalAction::Quarantine {
+                        reason: format!("release verification uncertain ({reason})"),
+                    }
+                }
+            }
+        }
         SigFinality::Live(reason) => WithdrawalAction::LeaveProcessing { reason },
         SigFinality::Uncertain(reason) => WithdrawalAction::Quarantine {
             reason: format!(
@@ -410,9 +480,17 @@ async fn route_outcome(
     };
 
     match action {
-        RecoveryAction::Complete { signature } => {
+        RecoveryAction::Complete {
+            signature,
+            release_signatures,
+        } => {
             match storage
-                .try_complete_processing(row.id, captured_updated_at, Some(signature.clone()))
+                .try_complete_processing(
+                    row.id,
+                    captured_updated_at,
+                    Some(signature.clone()),
+                    release_signatures,
+                )
                 .await
             {
                 Ok(true) => {
@@ -490,6 +568,7 @@ async fn route_outcome(
                         error_message: Some(reason),
                         remint_signature: None,
                         remint_attempted: false,
+                        release_signatures: None,
                     };
                     // Closed channel = on-call alert lost; surface it loudly.
                     if let Err(e) =
@@ -520,11 +599,13 @@ async fn route_outcome(
 /// is no live sibling whose not-yet-stale work this could disrupt. Exhausting
 /// `max_passes` with rows still `Processing` returns `Ok`: the caller's
 /// `validate_smt_root` is the terminal gate that refuses to start on a real mismatch.
+#[allow(clippy::too_many_arguments)]
 pub async fn boot_reconcile_processing(
     storage: &Storage,
     rpc_client: &RpcClientWithRetry,
     fallback_rpc_client: Option<Arc<RpcClientWithRetry>>,
     program_type: ProgramType,
+    instance_pda: Option<Pubkey>,
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: &CancellationToken,
     max_passes: u32,
@@ -539,6 +620,7 @@ pub async fn boot_reconcile_processing(
             storage,
             &finality,
             program_type,
+            instance_pda,
             storage_tx,
             cancellation_token,
             Duration::ZERO,
@@ -577,6 +659,7 @@ pub mod test_hooks {
         storage: &Storage,
         rpc_client: &RpcClientWithRetry,
         program_type: ProgramType,
+        instance_pda: Option<Pubkey>,
         storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     ) -> Result<(), OperatorError> {
         // Fresh, never-cancelled token; tests run to completion. Uses the periodic
@@ -590,6 +673,7 @@ pub mod test_hooks {
             storage,
             &finality,
             program_type,
+            instance_pda,
             storage_tx,
             &token,
             STALE_THRESHOLD,
@@ -694,6 +778,67 @@ mod tests {
             .create()
     }
 
+    /// Root of a fresh tree carrying `nonces` (used to craft an on-chain instance).
+    fn smt_root(tree_index: u64, nonces: &[u64]) -> [u8; 32] {
+        use crate::operator::utils::smt_util::SmtState;
+        let mut smt = SmtState::new(tree_index);
+        for n in nonces {
+            smt.insert_nonce(*n);
+        }
+        smt.current_root()
+    }
+
+    /// getAccountInfo mock returning an escrow Instance with `root`/`tree_index`
+    /// at response context `slot`. `expect` bounds how many calls are allowed so a
+    /// fast-path test can assert the finalized read never fired (expect 0).
+    fn mock_instance_at_slot(
+        server: &mut mockito::ServerGuard,
+        root: [u8; 32],
+        tree_index: u64,
+        slot: u64,
+        expect: usize,
+    ) -> mockito::Mock {
+        use base64::{engine::general_purpose::STANDARD, Engine};
+        use borsh::BorshSerialize;
+        use private_channel_escrow_program_client::Instance;
+        let instance = Instance {
+            discriminator: 0,
+            bump: 0,
+            version: 0,
+            instance_seed: Pubkey::new_unique(),
+            admin: Pubkey::new_unique(),
+            withdrawal_transactions_root: root,
+            current_tree_index: tree_index,
+        };
+        let mut bytes = Vec::new();
+        instance.serialize(&mut bytes).unwrap();
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getAccountInfo""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": {"slot": slot},
+                        "value": {
+                            "owner": Pubkey::new_unique().to_string(),
+                            "lamports": 1_000_000u64,
+                            "data": [STANDARD.encode(&bytes), "base64"],
+                            "executable": false,
+                            "rentEpoch": 0
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .expect(expect)
+            .create()
+    }
+
     /// The keystone divergence from withdrawal: a deposit with no persisted signature is
     /// provably never broadcast (pre-broadcast persist), so it Demotes for a safe re-mint
     /// rather than Quarantining. No RPC is consulted.
@@ -709,7 +854,7 @@ mod tests {
         );
         // Same state on the withdrawal side Quarantines; assert the difference.
         let wrow = make_withdrawal_row(2, Some(42));
-        let waction = check_withdrawal(&wrow, &storage, &FinalityRpc::single(&client)).await;
+        let waction = check_withdrawal(&wrow, &storage, &FinalityRpc::single(&client), None).await;
         assert!(
             matches!(waction, WithdrawalAction::Quarantine { .. }),
             "withdrawal with no sigs must Quarantine - the deliberate deposit divergence"
@@ -877,7 +1022,7 @@ mod tests {
         let storage = Storage::Mock(mock);
         let client = make_rpc_client("http://localhost:1");
         let row = make_withdrawal_row(1, None);
-        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client)).await;
+        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client), None).await;
         match action {
             WithdrawalAction::Quarantine { reason } => {
                 assert!(reason.contains("withdrawal row missing nonce"));
@@ -893,7 +1038,7 @@ mod tests {
         let storage = Storage::Mock(mock);
         let client = make_rpc_client("http://localhost:1");
         let row = make_withdrawal_row(1, Some(42));
-        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client)).await;
+        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client), None).await;
         match action {
             WithdrawalAction::Quarantine { reason } => {
                 assert!(
@@ -905,11 +1050,10 @@ mod tests {
         }
     }
 
-    /// Null-status signature past blockhash validity is dead → demote.
-    #[tokio::test]
-    async fn check_withdrawal_demotes_when_signature_dead() {
-        let mut server = mockito::Server::new_async().await;
-        let _status = server
+    /// Register the Dead-by-absence classifier mocks (null status + expired height
+    /// + covered floor) on `server`. The withdrawal then routes through the SMT gate.
+    fn mock_dead_by_absence(server: &mut mockito::ServerGuard) {
+        server
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex(
                 r#""method"\s*:\s*"getSignatureStatuses""#.into(),
@@ -919,7 +1063,7 @@ mod tests {
                 r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":1}"#,
             )
             .create();
-        let _height = server
+        server
             .mock("POST", "/")
             .match_body(mockito::Matcher::Regex(
                 r#""method"\s*:\s*"getBlockHeight""#.into(),
@@ -928,22 +1072,219 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","result":1000,"id":1}"#)
             .create();
         // Covered floor (0) so the single-endpoint absence is proven Dead.
-        let _floor = mock_first_available_block(&mut server, 0);
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getFirstAvailableBlock""#.into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","result":0,"id":1}"#)
+            .create();
+    }
+
+    /// IR2: a Dead-by-absence release whose nonce is NOT in the fresh on-chain root
+    /// resolves NotLanded, so it Demotes (preserves the old behavior under the SMT gate).
+    #[tokio::test]
+    async fn check_withdrawal_demotes_when_signature_dead() {
+        let mut server = mockito::Server::new_async().await;
+        mock_dead_by_absence(&mut server);
+        // On-chain tree 0 has no completed nonces; snapshot slot 1000 > lvbh 100.
+        let _account = mock_instance_at_slot(&mut server, smt_root(0, &[]), 0, 1000, 1);
 
         let mock = MockStorage::new();
-        let row = make_withdrawal_row(1, Some(42));
-        // current_height (1000) > lvbh (100) means expired/dead.
+        // Small nonce so tree_index is 0 under both prod and test-tree sizes.
+        let row = make_withdrawal_row(1, Some(3));
         mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
             .await
             .unwrap();
         let storage = Storage::Mock(mock);
         let client = make_rpc_client(&server.url());
 
-        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client)).await;
+        let action = check_withdrawal(
+            &row,
+            &storage,
+            &FinalityRpc::single(&client),
+            Some(Pubkey::new_unique()),
+        )
+        .await;
         assert!(
             matches!(action, WithdrawalAction::Demote),
-            "expected Demote"
+            "root excludes nonce + fresh snapshot must Demote"
         );
+    }
+
+    /// IR1: a Dead-by-absence release whose nonce IS in the fresh on-chain root is
+    /// proven landed, so it Completes (not Demote), never re-sending a released withdrawal.
+    #[tokio::test]
+    async fn check_withdrawal_completes_when_smt_proves_landed() {
+        let mut server = mockito::Server::new_async().await;
+        mock_dead_by_absence(&mut server);
+        // On-chain tree 0 includes nonce 3; snapshot slot 1000 > lvbh 100.
+        let _account = mock_instance_at_slot(&mut server, smt_root(0, &[3]), 0, 1000, 1);
+
+        let mock = MockStorage::new();
+        let row = make_withdrawal_row(1, Some(3));
+        let recorded = Signature::new_unique().to_string();
+        mock.insert_release_signature(row.id, recorded.clone(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        let action = check_withdrawal(
+            &row,
+            &storage,
+            &FinalityRpc::single(&client),
+            Some(Pubkey::new_unique()),
+        )
+        .await;
+        match action {
+            WithdrawalAction::Complete {
+                signature,
+                release_signatures,
+            } => {
+                // The earliest recorded signature is the provenance pointer.
+                assert_eq!(signature, recorded, "earliest recorded sig is provenance");
+                assert_eq!(release_signatures, Some(vec![recorded]));
+            }
+            other => panic!(
+                "expected Complete, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    /// IR3: a Dead release whose finalized snapshot is not past the validity window
+    /// is Uncertain, so it Quarantines (fails closed, never demotes). The release is
+    /// finalized-failed so the classifier returns Dead without a block-height read,
+    /// leaving the verifier's finalized getBlockHeight the only one, mocked stale.
+    #[tokio::test]
+    async fn check_withdrawal_quarantines_when_snapshot_stale() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"}]},"id":1}"#,
+            )
+            .create();
+        // Finalized height 100 == lvbh 100, so the freshness check fails closed to Uncertain.
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getBlockHeight""#.into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","result":100,"id":1}"#)
+            .create();
+        // Root would say NotLanded, but the stale height gates it to Uncertain.
+        let _account = mock_instance_at_slot(&mut server, smt_root(0, &[]), 0, 999, 1);
+
+        let mock = MockStorage::new();
+        let row = make_withdrawal_row(1, Some(3));
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        let action = check_withdrawal(
+            &row,
+            &storage,
+            &FinalityRpc::single(&client),
+            Some(Pubkey::new_unique()),
+        )
+        .await;
+        assert!(
+            matches!(action, WithdrawalAction::Quarantine { .. }),
+            "stale snapshot must Quarantine, never Demote"
+        );
+    }
+
+    /// F1: the classifier's finalized-success fast path completes WITHOUT the
+    /// finalized getAccountInfo read; the SMT gate is paid only on the Dead branch.
+    #[tokio::test]
+    async fn check_withdrawal_landed_fast_path_skips_account_read() {
+        let landed_sig = Signature::new_unique();
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":null,"status":{"Ok":null},"confirmationStatus":"finalized"}]},"id":1}"#,
+            )
+            .create();
+        // Must never be hit on the fast path.
+        let account = mock_instance_at_slot(&mut server, smt_root(0, &[]), 0, 1000, 0);
+
+        let mock = MockStorage::new();
+        let row = make_withdrawal_row(1, Some(3));
+        mock.insert_release_signature(row.id, landed_sig.to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        let action = check_withdrawal(
+            &row,
+            &storage,
+            &FinalityRpc::single(&client),
+            Some(Pubkey::new_unique()),
+        )
+        .await;
+        assert!(matches!(action, WithdrawalAction::Complete { .. }));
+        account.assert(); // no getAccountInfo request fired
+    }
+
+    /// F2: a live (still within validity) signature leaves the row Processing
+    /// without any finalized getAccountInfo read.
+    #[tokio::test]
+    async fn check_withdrawal_live_fast_path_skips_account_read() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":1}"#,
+            )
+            .create();
+        // current_height (50) <= lvbh (1000) means still live.
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getBlockHeight""#.into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","result":50,"id":1}"#)
+            .create();
+        let account = mock_instance_at_slot(&mut server, smt_root(0, &[]), 0, 1000, 0);
+
+        let mock = MockStorage::new();
+        let row = make_withdrawal_row(1, Some(3));
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 1000)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client(&server.url());
+
+        let action = check_withdrawal(
+            &row,
+            &storage,
+            &FinalityRpc::single(&client),
+            Some(Pubkey::new_unique()),
+        )
+        .await;
+        assert!(matches!(action, WithdrawalAction::LeaveProcessing { .. }));
+        account.assert(); // no getAccountInfo request fired
     }
 
     /// Finalized-success signature → Complete with that sig.
@@ -970,9 +1311,9 @@ mod tests {
         let storage = Storage::Mock(mock);
         let client = make_rpc_client(&server.url());
 
-        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client)).await;
+        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client), None).await;
         match action {
-            WithdrawalAction::Complete { signature } => {
+            WithdrawalAction::Complete { signature, .. } => {
                 assert_eq!(signature, landed_sig.to_string());
             }
             _ => panic!("expected Complete"),
@@ -1011,7 +1352,7 @@ mod tests {
         let storage = Storage::Mock(mock);
         let client = make_rpc_client(&server.url());
 
-        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client)).await;
+        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client), None).await;
         assert!(
             matches!(action, WithdrawalAction::LeaveProcessing { .. }),
             "expected LeaveProcessing"
@@ -1037,7 +1378,7 @@ mod tests {
         let storage = Storage::Mock(mock);
         let client = make_rpc_client(&server.url());
 
-        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client)).await;
+        let action = check_withdrawal(&row, &storage, &FinalityRpc::single(&client), None).await;
         match action {
             WithdrawalAction::Quarantine { reason } => {
                 assert!(
@@ -1076,6 +1417,7 @@ mod tests {
             captured,
             RecoveryAction::Complete {
                 signature: "sig-abc".to_string(),
+                release_signatures: None,
             },
             ProgramType::Escrow,
             &storage_tx,
@@ -1164,7 +1506,7 @@ mod tests {
         let client = make_rpc_client("http://localhost:1");
         let (storage_tx, mut storage_rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
             .await
             .unwrap();
 
@@ -1197,7 +1539,7 @@ mod tests {
         let client = make_rpc_client("http://localhost:1");
         let (storage_tx, _rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
             .await
             .unwrap();
 
@@ -1225,7 +1567,7 @@ mod tests {
         let client = make_rpc_client("http://localhost:1");
         let (storage_tx, mut storage_rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
             .await
             .unwrap();
 
@@ -1256,7 +1598,7 @@ mod tests {
         let client = make_rpc_client("http://localhost:1");
         let (storage_tx, mut storage_rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
             .await
             .unwrap();
 
@@ -1286,7 +1628,7 @@ mod tests {
         let client = make_rpc_client("http://localhost:1");
         let (storage_tx, _rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
             .await
             .unwrap();
 
@@ -1316,6 +1658,7 @@ mod tests {
             &client,
             None,
             ProgramType::Withdraw,
+            None,
             &storage_tx,
             &CancellationToken::new(),
             5,
@@ -1357,7 +1700,7 @@ mod tests {
         let client = make_rpc_client("http://localhost:1");
         let (storage_tx, _rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
             .await
             .unwrap();
 
@@ -1390,7 +1733,7 @@ mod tests {
         let client = make_rpc_client("http://localhost:1");
         let (storage_tx, mut storage_rx) = mpsc::channel(8);
 
-        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
             .await
             .unwrap();
 
@@ -1425,14 +1768,14 @@ mod tests {
         let mut row = make_deposit_row(52);
         // One below the cap still demotes (requeues) - pins the off-by-one boundary.
         row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS - 1;
-        let below = decide_action(&row, &storage, &FinalityRpc::single(&client)).await;
+        let below = decide_action(&row, &storage, &FinalityRpc::single(&client), None).await;
         assert!(
             matches!(below, RecoveryAction::Demote),
             "one below the cap must still Demote (requeue)"
         );
         // At the cap, the demote is converted to Quarantine.
         row.recovery_requeue_attempts = MAX_RECOVERY_REQUEUE_ATTEMPTS;
-        let at_cap = decide_action(&row, &storage, &FinalityRpc::single(&client)).await;
+        let at_cap = decide_action(&row, &storage, &FinalityRpc::single(&client), None).await;
         assert!(
             matches!(at_cap, RecoveryAction::Quarantine { .. }),
             "demote at the cap must become Quarantine"
@@ -1555,6 +1898,7 @@ mod tests {
             &storage,
             &FinalityRpc::single(&client),
             ProgramType::Withdraw,
+            None,
             &storage_tx,
             &CancellationToken::new(),
             Duration::ZERO,
@@ -1601,6 +1945,7 @@ mod tests {
             &client,
             None,
             ProgramType::Withdraw,
+            None,
             &storage_tx,
             &token,
             5,
@@ -1649,6 +1994,7 @@ mod tests {
             &client,
             None,
             ProgramType::Withdraw,
+            None,
             &storage_tx,
             &token,
             5,
@@ -1726,6 +2072,7 @@ mod tests {
             &storage,
             &finality,
             ProgramType::Withdraw,
+            None,
             &storage_tx,
             &CancellationToken::new(),
             Duration::ZERO,

--- a/indexer/src/operator/sender/mod.rs
+++ b/indexer/src/operator/sender/mod.rs
@@ -7,7 +7,7 @@ pub mod types;
 
 pub use mint::{enumerate_consumed_mints, ConsumedMintKind, ConsumedSet, JitOutcome};
 pub(crate) use remint::{classify_signatures, FinalityRpc, SigFinality};
-pub(crate) use state::validate_smt_root;
+pub(crate) use state::{validate_smt_root, verify_release_landed, ReleaseVerdict};
 pub use types::TransactionStatusUpdate;
 
 #[cfg(any(test, feature = "test-mock-storage"))]
@@ -472,6 +472,7 @@ pub(super) async fn drain_rotation_retry_queue(
                         )),
                         remint_signature: None,
                         remint_attempted: false,
+                        release_signatures: None,
                     },
                     "transaction status update",
                 )

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 use super::types::InFlightQueue;
 use super::types::SenderState;
+use super::{verify_release_landed, ReleaseVerdict};
+use crate::metrics::OPERATOR_RELEASE_VERIFY;
 use crate::operator::tree_constants::MAX_TREE_LEAVES;
 use crate::{
     channel_utils::send_guaranteed,
@@ -296,6 +298,7 @@ pub async fn execute_deferred_remint(
                     error_message: Some(entry.original_error.clone()),
                     remint_signature: Some(signature.to_string()),
                     remint_attempted: true,
+                    release_signatures: None,
                 },
                 "transaction status update",
             )
@@ -329,6 +332,7 @@ pub async fn execute_deferred_remint(
                         error_message: Some(combined),
                         remint_signature: None,
                         remint_attempted: true,
+                        release_signatures: None,
                     },
                     "transaction status update",
                 )
@@ -614,22 +618,7 @@ pub async fn process_pending_remints(
         match classify_signatures(&state.dest_finality(), &entry.signatures).await {
             // Case 1: a sig finalized successfully, the withdrawal landed.
             SigFinality::Landed(sig) => {
-                // Chain root now includes this nonce. handle_permanent_failure
-                // removed it from the local SMT assuming the tx failed; put it
-                // back so local matches chain. Skip if the tree already rotated
-                // past this nonce's window.
-                if let Some(nonce) = entry.ctx.withdrawal_nonce {
-                    if let Some(smt) = state.smt_state.as_mut() {
-                        if smt.smt_state.tree_index() == nonce / MAX_TREE_LEAVES as u64 {
-                            if smt.smt_state.insert_nonce(nonce) {
-                                info!("Re-inserted landed nonce {nonce} into local SMT");
-                            } else {
-                                debug!("Landed nonce {nonce} already present in local SMT, no divergence");
-                            }
-                        }
-                    }
-                }
-                send_completed(storage_tx, &entry, &nonce_label, sig).await;
+                handle_release_landed(state, &entry, &nonce_label, sig, storage_tx).await;
             }
             // Case 2: could still land or unclassifiable → defer, don't remint.
             SigFinality::Live(reason) | SigFinality::Uncertain(reason) => {
@@ -643,32 +632,108 @@ pub async fn process_pending_remints(
                 )
                 .await;
             }
-            // Case 3: every sig is finalized-failed or expired, safe to remint.
+            // Case 3: the classifier calls every sig dead by absence. Before
+            // reminting (which moves value), confirm non-inclusion against the
+            // on-chain SMT root; a pruned/lagging endpoint can report absence for
+            // a release that actually landed. Only a proven NotLanded remints.
             SigFinality::Dead => {
-                info!(
-                    "All withdrawal signatures for nonce {} are finalized-failed or expired; attempting remint",
-                    nonce_label
-                );
-                match execute_deferred_remint(state, entry, storage_tx).await {
-                    DeferredRemintOutcome::Resolved => {}
-                    // Nothing was broadcast: bounded retry, then ManualReview. Safe
-                    // because no signature can land.
-                    DeferredRemintOutcome::DeferPreBroadcast(entry, reason) => {
+                let verdict = match entry.ctx.withdrawal_nonce {
+                    Some(nonce) => {
+                        let max_lvbh = entry
+                            .signatures
+                            .iter()
+                            .map(|p| p.last_valid_block_height)
+                            .max()
+                            .unwrap_or(0);
+                        let v = verify_release_landed(
+                            &state.rpc_client,
+                            &state.storage,
+                            state.instance_pda,
+                            nonce,
+                            max_lvbh,
+                        )
+                        .await;
+                        // Count only real verifications so the None short-circuit
+                        // below is not mislabeled as a verified non-landing.
+                        let label = match &v {
+                            ReleaseVerdict::Landed => "landed",
+                            ReleaseVerdict::NotLanded => "not_landed",
+                            ReleaseVerdict::Uncertain(_) => "uncertain",
+                        };
+                        OPERATOR_RELEASE_VERIFY
+                            .with_label_values(&["remint", label])
+                            .inc();
+                        v
+                    }
+                    // No nonce to prove membership; fall through to the remint path,
+                    // which re-checks remint idempotency before broadcasting. No
+                    // verification ran, so no release-verify metric is emitted here.
+                    None => ReleaseVerdict::NotLanded,
+                };
+
+                match verdict {
+                    // Proven landed on-chain: skip the remint, mark Completed.
+                    ReleaseVerdict::Landed => {
+                        match entry.signatures.first().map(|p| p.signature) {
+                            Some(sig) => {
+                                handle_release_landed(state, &entry, &nonce_label, sig, storage_tx)
+                                    .await;
+                            }
+                            // Landed but nothing recorded to attribute it to; defer
+                            // rather than complete with no provenance.
+                            None => {
+                                defer_or_escalate(
+                                    &mut remaining,
+                                    entry,
+                                    &nonce_label,
+                                    "release verified landed but no signature recorded",
+                                    &state.storage,
+                                    storage_tx,
+                                )
+                                .await;
+                            }
+                        }
+                    }
+                    // Proven not landed: remint is safe.
+                    ReleaseVerdict::NotLanded => {
+                        info!(
+                            "All withdrawal signatures for nonce {} are finalized-failed or expired; attempting remint",
+                            nonce_label
+                        );
+                        match execute_deferred_remint(state, entry, storage_tx).await {
+                            DeferredRemintOutcome::Resolved => {}
+                            // Nothing was broadcast: bounded retry, then ManualReview.
+                            // Safe because no signature can land.
+                            DeferredRemintOutcome::DeferPreBroadcast(entry, reason) => {
+                                defer_or_escalate(
+                                    &mut remaining,
+                                    *entry,
+                                    &nonce_label,
+                                    &reason,
+                                    &state.storage,
+                                    storage_tx,
+                                )
+                                .await;
+                            }
+                            // A signature is (or might be) persisted: re-queue without
+                            // the cap so it keeps reclassifying. Terminalizing here would
+                            // abandon a possibly-live sig and invite a double-mint.
+                            DeferredRemintOutcome::DeferInFlight(entry, reason) => {
+                                requeue_in_flight(&mut remaining, *entry, &nonce_label, &reason);
+                            }
+                        }
+                    }
+                    // Uncertain: fail closed. Defer to a later tick or escalate.
+                    ReleaseVerdict::Uncertain(reason) => {
                         defer_or_escalate(
                             &mut remaining,
-                            *entry,
+                            entry,
                             &nonce_label,
-                            &reason,
+                            &format!("release verification uncertain ({reason})"),
                             &state.storage,
                             storage_tx,
                         )
                         .await;
-                    }
-                    // A signature is (or might be) persisted: re-queue without the
-                    // cap so it keeps reclassifying. Terminalizing here would abandon
-                    // a possibly-live sig and invite an operator double-mint.
-                    DeferredRemintOutcome::DeferInFlight(entry, reason) => {
-                        requeue_in_flight(&mut remaining, *entry, &nonce_label, &reason);
                     }
                 }
             }
@@ -678,6 +743,31 @@ pub async fn process_pending_remints(
     // `remaining` = entries not yet due + entries re-queued by `defer_or_escalate`
     // or `requeue_in_flight`.
     state.pending_remints = remaining;
+}
+
+/// Shared handling for a release confirmed landed (by the classifier fast path
+/// or the SMT verify gate): re-insert the nonce into the local SMT, which
+/// handle_permanent_failure had removed assuming failure, then mark Completed.
+/// Skips the SMT touch if the tree already rotated past this nonce's window.
+async fn handle_release_landed(
+    state: &mut SenderState,
+    entry: &PendingRemint,
+    nonce_label: &str,
+    sig: Signature,
+    storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
+) {
+    if let Some(nonce) = entry.ctx.withdrawal_nonce {
+        if let Some(smt) = state.smt_state.as_mut() {
+            if smt.smt_state.tree_index() == nonce / MAX_TREE_LEAVES as u64 {
+                if smt.smt_state.insert_nonce(nonce) {
+                    info!("Re-inserted landed nonce {nonce} into local SMT");
+                } else {
+                    debug!("Landed nonce {nonce} already present in local SMT, no divergence");
+                }
+            }
+        }
+    }
+    send_completed(storage_tx, entry, nonce_label, sig).await;
 }
 
 /// Report a pending-remint entry as Completed because one of its withdrawal
@@ -713,6 +803,15 @@ async fn send_completed(
             error_message: None,
             remint_signature: None,
             remint_attempted: false,
+            // Durable provenance of every broadcast attempt. counterpart_signature
+            // stays the single landed sig; this keeps the full list.
+            release_signatures: Some(
+                entry
+                    .signatures
+                    .iter()
+                    .map(|p| p.signature.to_string())
+                    .collect(),
+            ),
         },
         "transaction status update",
     )
@@ -755,6 +854,7 @@ async fn defer_or_escalate(
                     )),
                     remint_signature: None,
                     remint_attempted: false,
+                    release_signatures: None,
                 },
                 "transaction status update",
             )
@@ -792,6 +892,7 @@ async fn defer_or_escalate(
                     )),
                     remint_signature: None,
                     remint_attempted: false,
+                    release_signatures: None,
                 },
                 "transaction status update",
             )
@@ -876,7 +977,7 @@ mod tests {
             source_rpc_client: rpc,
             fallback_rpc_client: None,
             storage: storage.clone(),
-            instance_pda: None,
+            instance_pda: Some(Pubkey::new_unique()),
             smt_state: None,
             retry_counts: HashMap::new(),
             mint_builders: HashMap::new(),
@@ -974,7 +1075,7 @@ mod tests {
             source_rpc_client: rpc,
             fallback_rpc_client: None,
             storage: storage.clone(),
-            instance_pda: None,
+            instance_pda: Some(Pubkey::new_unique()),
             smt_state: None,
             retry_counts: HashMap::new(),
             mint_builders: HashMap::new(),
@@ -1007,6 +1108,68 @@ mod tests {
             .with_body(body)
             .create_async()
             .await
+    }
+
+    /// getAccountInfo returning an escrow instance whose root proves `nonce` did
+    /// NOT land (empty completed set), fresh enough to pass the freshness gate, so
+    /// the SMT verify resolves NotLanded and the Dead branch remints exactly as it
+    /// did before the gate existed. Also registers a fresh finalized getBlockHeight
+    /// (read first by the verifier) so the freshness check passes. Feature-proof: tree_index is
+    /// derived from the same MAX_TREE_LEAVES the verifier uses.
+    fn mock_instance_not_landed(server: &mut mockito::Server, nonce: u64) -> mockito::Mock {
+        use crate::operator::utils::smt_util::SmtState;
+        use base64::{engine::general_purpose::STANDARD, Engine};
+        use borsh::BorshSerialize;
+        use private_channel_escrow_program_client::Instance;
+        // Finalized height well above any lvbh in these tests, so the freshness check passes.
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getBlockHeight""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"jsonrpc":"2.0","result":1000000000,"id":0}"#)
+            .create();
+        let tree_index = nonce / MAX_TREE_LEAVES as u64;
+        let root = SmtState::new(tree_index).current_root();
+        let instance = Instance {
+            discriminator: 0,
+            bump: 0,
+            version: 0,
+            instance_seed: Pubkey::new_unique(),
+            admin: Pubkey::new_unique(),
+            withdrawal_transactions_root: root,
+            current_tree_index: tree_index,
+        };
+        let mut bytes = Vec::new();
+        instance.serialize(&mut bytes).unwrap();
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getAccountInfo""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        // Context slot is no longer read by the gate; freshness uses height.
+                        "context": {"slot": 1_000_000_000u64},
+                        "value": {
+                            "owner": Pubkey::new_unique().to_string(),
+                            "lamports": 1_000_000u64,
+                            "data": [STANDARD.encode(&bytes), "base64"],
+                            "executable": false,
+                            "rentEpoch": 0
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create()
     }
 
     /// Builds a SenderState with distinct rpc_client and source_rpc_client
@@ -1046,7 +1209,7 @@ mod tests {
             source_rpc_client,
             fallback_rpc_client,
             storage: storage.clone(),
-            instance_pda: None,
+            instance_pda: Some(Pubkey::new_unique()),
             smt_state: None,
             retry_counts: HashMap::new(),
             mint_builders: HashMap::new(),
@@ -1097,6 +1260,8 @@ mod tests {
             )
             .create_async()
             .await;
+        // Dead branch now SMT-verifies before reminting; prove nonce 5 NotLanded.
+        let _dest_account = mock_instance_not_landed(&mut dest, 5);
 
         // Source: backs the remint blockhash and broadcast. With no stored
         // remint signatures the idempotency classification is skipped entirely.
@@ -1472,6 +1637,12 @@ mod tests {
             Some(sig.to_string().as_str()),
             "counterpart_signature must be the finalized withdrawal sig"
         );
+        // The full attempt list rides on the Completed update for durable provenance.
+        assert_eq!(
+            update.release_signatures,
+            Some(vec![sig.to_string()]),
+            "release_signatures must carry the broadcast attempt list"
+        );
         assert!(
             storage_rx.try_recv().is_err(),
             "should send exactly one status update — no remint attempted"
@@ -1480,6 +1651,199 @@ mod tests {
             state.pending_remints.is_empty(),
             "entry should be removed from queue after Completed"
         );
+    }
+
+    /// IM1: a Dead-by-absence release whose nonce IS in the fresh on-chain SMT
+    /// root is proven landed by the verify gate, so Completed is sent with the
+    /// attempt list, and no remint is broadcast.
+    #[tokio::test]
+    async fn process_pending_remints_smt_verify_landed_marks_completed() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let (mut state, _mock) = make_sender_state_with_rpc(&rpc_server.url());
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let recorded = Signature::new_unique();
+        // Release classified Dead (finalized-failed).
+        mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"}]},"id":0}"#,
+        )
+        .await;
+        // Finalized height 1_000_000 > max_lvbh 100 so the freshness check passes.
+        mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":1000000,"id":0}"#,
+        )
+        .await;
+        // On-chain root includes nonce 3 so the verifier resolves Landed.
+        {
+            use crate::operator::utils::smt_util::SmtState;
+            use base64::{engine::general_purpose::STANDARD, Engine};
+            use borsh::BorshSerialize;
+            use private_channel_escrow_program_client::Instance;
+            let tree_index = 3u64 / MAX_TREE_LEAVES as u64;
+            let mut smt = SmtState::new(tree_index);
+            smt.insert_nonce(3);
+            let instance = Instance {
+                discriminator: 0,
+                bump: 0,
+                version: 0,
+                instance_seed: Pubkey::new_unique(),
+                admin: Pubkey::new_unique(),
+                withdrawal_transactions_root: smt.current_root(),
+                current_tree_index: tree_index,
+            };
+            let mut bytes = Vec::new();
+            instance.serialize(&mut bytes).unwrap();
+            rpc_server
+                .mock("POST", "/")
+                .match_body(mockito::Matcher::Regex(
+                    r#""method"\s*:\s*"getAccountInfo""#.into(),
+                ))
+                .with_status(200)
+                .with_body(
+                    serde_json::json!({
+                        "jsonrpc": "2.0", "id": 1,
+                        "result": {"context": {"slot": 1_000_000u64}, "value": {
+                            "owner": Pubkey::new_unique().to_string(),
+                            "lamports": 1_000_000u64,
+                            "data": [STANDARD.encode(&bytes), "base64"],
+                            "executable": false, "rentEpoch": 0
+                        }}
+                    })
+                    .to_string(),
+                )
+                .create();
+        }
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(300),
+                withdrawal_nonce: Some(3),
+                trace_id: Some("trace-300".to_string()),
+                deposit_claim_lease: None,
+            },
+            remint_info: make_remint_info(300),
+            signatures: vec![PendingSig {
+                signature: recorded,
+                last_valid_block_height: 100,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        let update = storage_rx.try_recv().expect("Completed expected");
+        assert_eq!(update.status, TransactionStatus::Completed);
+        assert_eq!(
+            update.counterpart_signature.as_deref(),
+            Some(recorded.to_string().as_str())
+        );
+        assert_eq!(update.release_signatures, Some(vec![recorded.to_string()]));
+        assert!(
+            state.pending_remints.is_empty(),
+            "no remint, entry resolved"
+        );
+    }
+
+    /// IM3: a Dead-by-absence release whose finalized snapshot is too stale to
+    /// prove non-inclusion is Uncertain, so the entry defers (no remint broadcast).
+    #[tokio::test]
+    async fn process_pending_remints_smt_verify_uncertain_defers() {
+        let mut rpc_server = mockito::Server::new_async().await;
+        let (mut state, mock) = make_sender_state_with_rpc(&rpc_server.url());
+        seed_pending_remint_row(&mock, 301, 0);
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        mock_rpc(
+            &mut rpc_server,
+            "getSignatureStatuses",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"}]},"id":0}"#,
+        )
+        .await;
+        // Finalized height 100 == max_lvbh 100, so the freshness check fails closed to Uncertain.
+        mock_rpc(
+            &mut rpc_server,
+            "getBlockHeight",
+            r#"{"jsonrpc":"2.0","result":100,"id":0}"#,
+        )
+        .await;
+        {
+            use crate::operator::utils::smt_util::SmtState;
+            use base64::{engine::general_purpose::STANDARD, Engine};
+            use borsh::BorshSerialize;
+            use private_channel_escrow_program_client::Instance;
+            let tree_index = 3u64 / MAX_TREE_LEAVES as u64;
+            let instance = Instance {
+                discriminator: 0,
+                bump: 0,
+                version: 0,
+                instance_seed: Pubkey::new_unique(),
+                admin: Pubkey::new_unique(),
+                withdrawal_transactions_root: SmtState::new(tree_index).current_root(),
+                current_tree_index: tree_index,
+            };
+            let mut bytes = Vec::new();
+            instance.serialize(&mut bytes).unwrap();
+            rpc_server
+                .mock("POST", "/")
+                .match_body(mockito::Matcher::Regex(
+                    r#""method"\s*:\s*"getAccountInfo""#.into(),
+                ))
+                .with_status(200)
+                .with_body(
+                    serde_json::json!({
+                        "jsonrpc": "2.0", "id": 1,
+                        "result": {"context": {"slot": 100u64}, "value": {
+                            "owner": Pubkey::new_unique().to_string(),
+                            "lamports": 1_000_000u64,
+                            "data": [STANDARD.encode(&bytes), "base64"],
+                            "executable": false, "rentEpoch": 0
+                        }}
+                    })
+                    .to_string(),
+                )
+                .create();
+        }
+        // A remint broadcast here would be a double-pay bug; forbid it.
+        let no_send = rpc_server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"sendTransaction""#.into(),
+            ))
+            .expect(0)
+            .create();
+
+        state.pending_remints.push(PendingRemint {
+            ctx: TransactionContext {
+                transaction_id: Some(301),
+                withdrawal_nonce: Some(3),
+                trace_id: Some("trace-301".to_string()),
+                deposit_claim_lease: None,
+            },
+            remint_info: make_remint_info(301),
+            signatures: vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 100,
+            }],
+            original_error: "release_funds failed".to_string(),
+            deadline: Utc::now() - chrono::Duration::seconds(1),
+            finality_check_attempts: 0,
+        });
+
+        process_pending_remints(&mut state, &storage_tx).await;
+
+        // Uncertain fails closed: deferred, no terminal status, no remint.
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "no status update on Uncertain"
+        );
+        assert_eq!(state.pending_remints.len(), 1, "entry re-queued");
+        no_send.assert();
     }
 
     /// The deferred remint queue is a Withdraw-only responsibility. An Escrow
@@ -1743,6 +2107,7 @@ mod tests {
 
         // The defer path persists the bumped counter, so the row must exist.
         seed_pending_remint_row(&mock, 77, 0);
+        mock_instance_not_landed(&mut rpc_server, 11);
 
         let sig = Signature::new_unique();
 
@@ -1830,6 +2195,7 @@ mod tests {
         // The remint proceeds and defers on the (unmocked) blockhash, which
         // persists the bumped counter, so the row must exist.
         seed_pending_remint_row(&mock, 88, 0);
+        mock_instance_not_landed(&mut rpc_server, 12);
 
         let sig = Signature::new_unique();
 
@@ -1897,6 +2263,7 @@ mod tests {
 
         // The defer path persists the bumped counter, so the row must exist.
         seed_pending_remint_row(&mock, 89, 0);
+        mock_instance_not_landed(&mut rpc_server, 13);
 
         let sig = Signature::new_unique();
 
@@ -2692,6 +3059,7 @@ mod tests {
 
         // The defer path persists the bumped counter, so the row must exist.
         seed_pending_remint_row(&mock, 100, 0);
+        mock_instance_not_landed(&mut rpc_server, 20);
 
         let sig = Signature::new_unique();
 
@@ -2992,7 +3360,10 @@ mod tests {
     // ── write-ahead remint signature classification (classify #2) ────
 
     /// Finalized-failed release on the dest server so the gate proceeds to remint.
-    async fn mock_release_dead(server: &mut mockito::Server) -> mockito::Mock {
+    /// Also registers the SMT-verify NotLanded read the Dead branch now performs
+    /// before reminting; `nonce` must match the entry so the tree-window check passes.
+    async fn mock_release_dead(server: &mut mockito::Server, nonce: u64) -> mockito::Mock {
+        mock_instance_not_landed(server, nonce);
         server
             .mock("POST", "/")
             .match_body(mockito::Matcher::AllOf(vec![
@@ -3020,7 +3391,7 @@ mod tests {
         let mut dest = mockito::Server::new_async().await;
         let mut source = mockito::Server::new_async().await;
         // Release is dead, so the gate reaches the remint step.
-        let _dest_status = mock_release_dead(&mut dest).await;
+        let _dest_status = mock_release_dead(&mut dest, 9).await;
 
         // The stored attempt is on-chain but not yet finalized (still live).
         let _src_status = mock_rpc(
@@ -3108,7 +3479,7 @@ mod tests {
         let mut dest = mockito::Server::new_async().await;
         let mut source = mockito::Server::new_async().await;
         // Release is dead, so the gate reaches the remint step.
-        let _dest_status = mock_release_dead(&mut dest).await;
+        let _dest_status = mock_release_dead(&mut dest, 9).await;
 
         // The stored attempt is on-chain but not yet finalized (still live).
         let _src_status = mock_rpc(
@@ -3186,7 +3557,7 @@ mod tests {
         let mut dest = mockito::Server::new_async().await;
         let mut source = mockito::Server::new_async().await;
         // Release is dead, so the gate reaches the remint step.
-        let _dest_status = mock_release_dead(&mut dest).await;
+        let _dest_status = mock_release_dead(&mut dest, 9).await;
 
         // Blockhash present so build_and_sign succeeds and we reach the persist step.
         let _src_bh = mock_rpc(
@@ -3255,7 +3626,7 @@ mod tests {
         let mut dest = mockito::Server::new_async().await;
         let mut source = mockito::Server::new_async().await;
         // Release is dead, so the gate reaches the remint step.
-        let _dest_status = mock_release_dead(&mut dest).await;
+        let _dest_status = mock_release_dead(&mut dest, 9).await;
 
         // No stored attempt, so we sign and broadcast.
         let _src_bh = mock_rpc(
@@ -3337,7 +3708,7 @@ mod tests {
         let landed_remint = Signature::new_unique();
 
         // Release classifies dead, so the gate reaches the remint step.
-        let _dest_status = mock_release_dead(&mut dest).await;
+        let _dest_status = mock_release_dead(&mut dest, 905).await;
         // The stored remint attempt finalized on the source chain.
         let _src_status = mock_rpc(
             &mut source,
@@ -3415,7 +3786,7 @@ mod tests {
         ensure_test_signer();
         let mut dest = mockito::Server::new_async().await;
         let mut source = mockito::Server::new_async().await;
-        let _dest_status = mock_release_dead(&mut dest).await;
+        let _dest_status = mock_release_dead(&mut dest, 9).await;
 
         // Stored attempt already finalized, so the gate confirms via short-circuit.
         let landed_sig = Signature::new_unique();
@@ -3517,6 +3888,8 @@ mod tests {
 
         let (mut state, _mock) =
             make_sender_state_split_rpc(&dest.url(), &source.url(), Some(&dest_fb.url()));
+        // Dead branch SMT-verifies on the dest primary before reminting.
+        let _dest_account = mock_instance_not_landed(&mut dest, 15);
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
         state.pending_remints.push(PendingRemint {

--- a/indexer/src/operator/sender/remint.rs
+++ b/indexer/src/operator/sender/remint.rs
@@ -1113,23 +1113,25 @@ mod tests {
     /// getAccountInfo returning an escrow instance whose root proves `nonce` did
     /// NOT land (empty completed set), fresh enough to pass the freshness gate, so
     /// the SMT verify resolves NotLanded and the Dead branch remints exactly as it
-    /// did before the gate existed. Also registers a fresh finalized getBlockHeight
-    /// (read first by the verifier) so the freshness check passes. Feature-proof: tree_index is
-    /// derived from the same MAX_TREE_LEAVES the verifier uses.
+    /// did before the gate existed. Also registers a fresh finalized getLatestBlockhash
+    /// (the verifier's freshness anchor). It matches only the finalized commitment so
+    /// the remint's own confirmed getLatestBlockhash on the source path is untouched.
+    /// Feature-proof: tree_index is derived from the same MAX_TREE_LEAVES the verifier uses.
     fn mock_instance_not_landed(server: &mut mockito::Server, nonce: u64) -> mockito::Mock {
         use crate::operator::utils::smt_util::SmtState;
         use base64::{engine::general_purpose::STANDARD, Engine};
         use borsh::BorshSerialize;
         use private_channel_escrow_program_client::Instance;
-        // Finalized height well above any lvbh in these tests, so the freshness check passes.
+        // Finalized tip well above any lvbh in these tests, so the freshness check passes.
         server
             .mock("POST", "/")
-            .match_body(mockito::Matcher::Regex(
-                r#""method"\s*:\s*"getBlockHeight""#.into(),
-            ))
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex(r#""method"\s*:\s*"getLatestBlockhash""#.into()),
+                mockito::Matcher::Regex(r#""finalized""#.into()),
+            ]))
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body(r#"{"jsonrpc":"2.0","result":1000000000,"id":0}"#)
+            .with_body(r#"{"jsonrpc":"2.0","result":{"context":{"slot":1000000000},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":1000000000}},"id":0}"#)
             .create();
         let tree_index = nonce / MAX_TREE_LEAVES as u64;
         let root = SmtState::new(tree_index).current_root();
@@ -1670,11 +1672,11 @@ mod tests {
             r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"}]},"id":0}"#,
         )
         .await;
-        // Finalized height 1_000_000 > max_lvbh 100 so the freshness check passes.
+        // Finalized tip 1_000_000 - 150 > max_lvbh 100 so the freshness check passes.
         mock_rpc(
             &mut rpc_server,
-            "getBlockHeight",
-            r#"{"jsonrpc":"2.0","result":1000000,"id":0}"#,
+            "getLatestBlockhash",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":1000000},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":1000000}},"id":0}"#,
         )
         .await;
         // On-chain root includes nonce 3 so the verifier resolves Landed.
@@ -1765,11 +1767,11 @@ mod tests {
             r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"}]},"id":0}"#,
         )
         .await;
-        // Finalized height 100 == max_lvbh 100, so the freshness check fails closed to Uncertain.
+        // Finalized tip 250 - 150 = 100 == max_lvbh 100, so freshness fails closed to Uncertain.
         mock_rpc(
             &mut rpc_server,
-            "getBlockHeight",
-            r#"{"jsonrpc":"2.0","result":100,"id":0}"#,
+            "getLatestBlockhash",
+            r#"{"jsonrpc":"2.0","result":{"context":{"slot":500},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":250}},"id":0}"#,
         )
         .await;
         {

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -11,6 +11,7 @@ use crate::storage::common::storage::Storage;
 use crate::storage::TransactionStatus;
 use crate::PrivateChannelIndexerConfig;
 use chrono::Utc;
+use solana_sdk::clock::MAX_PROCESSING_AGE;
 use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
@@ -215,11 +216,19 @@ pub(crate) enum ReleaseVerdict {
 ///
 /// The escrow instance holds a Merkle root over every released nonce. We read it
 /// at finalized commitment, rebuild the same tree from our own DB, and compare.
-/// Any doubt returns `Uncertain`, never a false `NotLanded`: the nonce must
-/// belong to the tree the instance currently holds; the finalized snapshot must
-/// be newer than the release's expiry window (a stale one could predate a real
-/// release and look absent); and the rebuilt root must equal the on-chain root
-/// either with the nonce (`Landed`) or without it (`NotLanded`).
+/// Any doubt returns `Uncertain`, never a false `NotLanded`.
+///
+/// The hard part is proving the snapshot is fresh even behind a load-balanced RPC
+/// where two calls can hit different backends. We first read the finalized latest
+/// blockhash together with its response context slot in one call; the tip block
+/// height at that slot is the blockhash's last_valid_block_height minus
+/// MAX_PROCESSING_AGE. If that tip height is past every attempt's lvbh we then read
+/// the instance account requiring the node to answer at a context slot at least the
+/// blockhash's slot. That binds the account snapshot to a finalized height we have
+/// already proven fresh, so a lagging backend that still excludes a released nonce
+/// cannot pass as authoritative. The nonce must also belong to the tree the instance
+/// currently holds, and the rebuilt root must equal the on-chain root either with
+/// the nonce (`Landed`) or without it (`NotLanded`).
 pub(crate) async fn verify_release_landed(
     rpc: &RpcClientWithRetry,
     storage: &Storage,
@@ -231,21 +240,44 @@ pub(crate) async fn verify_release_landed(
         return ReleaseVerdict::Uncertain("no instance pda configured".to_string());
     };
 
-    // Read the finalized height before the account, so the account snapshot is at
-    // least this height. Then finalized_height > max_lvbh proves the snapshot
-    // already reflects every release that could have landed in its validity window.
-    let finalized_height = match rpc
-        .get_block_height_with_commitment(CommitmentConfig::finalized())
+    // Freshness: read the finalized latest blockhash and its context slot in one
+    // call so the slot and its height agree. The tip height at that slot is the
+    // blockhash's last_valid_block_height minus MAX_PROCESSING_AGE (a blockhash
+    // stays valid for that many blocks past the tip it was taken at).
+    let (ref_slot, lvbh0) = match rpc
+        .get_latest_blockhash_with_context(CommitmentConfig::finalized())
         .await
     {
-        Ok(h) => h,
+        Ok(v) => v,
         Err(e) => {
-            return ReleaseVerdict::Uncertain(format!("finalized block height read failed: {e}"))
+            return ReleaseVerdict::Uncertain(format!("finalized blockhash read failed: {e}"))
         }
     };
+    let Some(tip_height) = lvbh0.checked_sub(MAX_PROCESSING_AGE as u64) else {
+        return ReleaseVerdict::Uncertain(format!(
+            "finalized last_valid_block_height {lvbh0} below MAX_PROCESSING_AGE; cannot derive tip height"
+        ));
+    };
 
+    // The tip must be strictly past every attempt's lvbh. At height == lvbh a
+    // release can still land, so a snapshot only at that height could miss an
+    // edge-of-window release and wrongly report NotLanded, risking a double-pay.
+    if tip_height <= max_lvbh {
+        return ReleaseVerdict::Uncertain(format!(
+            "finalized tip height {tip_height} not past max lvbh {max_lvbh}; too stale to prove non-inclusion"
+        ));
+    }
+
+    // Bind the account snapshot to that proven-fresh point: require the node to
+    // answer at a context slot at least ref_slot, so its height is at least
+    // tip_height and therefore past max_lvbh. A lagging backend that cannot serve
+    // there errors instead of returning an older root, and we fail closed.
     let response = match rpc
-        .get_account_with_context(&instance_pda, CommitmentConfig::finalized())
+        .get_account_with_context_min_slot(
+            &instance_pda,
+            CommitmentConfig::finalized(),
+            Some(ref_slot),
+        )
         .await
     {
         Ok(r) => r,
@@ -268,16 +300,6 @@ pub(crate) async fn verify_release_landed(
         return ReleaseVerdict::Uncertain(format!(
             "nonce {nonce} maps to tree {expected_tree}, on-chain tree is {}",
             instance.current_tree_index
-        ));
-    }
-
-    // Freshness check: the finalized height must be strictly past every attempt's
-    // lvbh. At height == lvbh a release can still land, so require strictly greater;
-    // a stale snapshot that predates the validity window could miss an edge-of-window
-    // release and wrongly report NotLanded, risking a double-pay.
-    if finalized_height <= max_lvbh {
-        return ReleaseVerdict::Uncertain(format!(
-            "finalized block height {finalized_height} not past max lvbh {max_lvbh}; too stale to prove non-inclusion"
         ));
     }
 
@@ -1383,18 +1405,29 @@ mod tests {
         bytes
     }
 
-    /// Mock RPC whose finalized getBlockHeight returns `finalized_height` and whose
-    /// getAccountInfo returns an Instance account with the given root and tree_index.
-    /// The verifier reads the height first, so both mocks are required.
-    fn mock_instance_rpc(
-        root: [u8; 32],
-        tree_index: u64,
-        finalized_height: u64,
-    ) -> RpcClientWithRetry {
+    /// A finalized getLatestBlockhash Response whose derived tip height equals
+    /// `tip_height`. The verifier computes tip = last_valid_block_height -
+    /// MAX_PROCESSING_AGE, so we set the height to tip + MAX_PROCESSING_AGE. The
+    /// context slot (used as the account read's min_context_slot) is set to the
+    /// tip height too; the mock does not enforce it, so any value serves.
+    fn blockhash_context_response(tip_height: u64) -> serde_json::Value {
+        serde_json::json!({
+            "context": {"slot": tip_height},
+            "value": {
+                "blockhash": "11111111111111111111111111111111",
+                "lastValidBlockHeight": tip_height + MAX_PROCESSING_AGE as u64,
+            }
+        })
+    }
+
+    /// Mock RPC whose finalized getLatestBlockhash yields a tip height of
+    /// `tip_height` and whose getAccountInfo returns an Instance account with the
+    /// given root and tree_index. The verifier reads the blockhash first for
+    /// freshness, then binds the account read to it, so both mocks are required.
+    fn mock_instance_rpc(root: [u8; 32], tree_index: u64, tip_height: u64) -> RpcClientWithRetry {
         let bytes = instance_bytes(root, tree_index);
         let account_response = serde_json::json!({
-            // Context slot is no longer read by the gate; height drives freshness.
-            "context": {"slot": finalized_height},
+            "context": {"slot": tip_height},
             "value": {
                 "owner": Pubkey::new_unique().to_string(),
                 "lamports": 1_000_000u64,
@@ -1406,8 +1439,8 @@ mod tests {
         let mut mocks = HashMap::new();
         mocks.insert(RpcRequest::GetAccountInfo, account_response);
         mocks.insert(
-            RpcRequest::GetBlockHeight,
-            serde_json::json!(finalized_height),
+            RpcRequest::GetLatestBlockhash,
+            blockhash_context_response(tip_height),
         );
         RpcClientWithRetry {
             rpc_client: Arc::new(RpcClient::new_mock_with_mocks(
@@ -1419,15 +1452,14 @@ mod tests {
     }
 
     /// Mock RPC whose getAccountInfo returns a null value (account absent), with a
-    /// fresh finalized getBlockHeight so the gate reaches the absent-account check.
-    fn mock_absent_instance_rpc(finalized_height: u64) -> RpcClientWithRetry {
-        let account_response =
-            serde_json::json!({"context": {"slot": finalized_height}, "value": null});
+    /// fresh finalized getLatestBlockhash so the gate reaches the absent-account check.
+    fn mock_absent_instance_rpc(tip_height: u64) -> RpcClientWithRetry {
+        let account_response = serde_json::json!({"context": {"slot": tip_height}, "value": null});
         let mut mocks = HashMap::new();
         mocks.insert(RpcRequest::GetAccountInfo, account_response);
         mocks.insert(
-            RpcRequest::GetBlockHeight,
-            serde_json::json!(finalized_height),
+            RpcRequest::GetLatestBlockhash,
+            blockhash_context_response(tip_height),
         );
         RpcClientWithRetry {
             rpc_client: Arc::new(RpcClient::new_mock_with_mocks(
@@ -1549,14 +1581,15 @@ mod tests {
     }
 
     /// V4b regression: a large account context slot that WOULD have passed the old
-    /// slot-based check is still Uncertain when the finalized height is not past
-    /// max_lvbh, proving the old slot-vs-height confusion is closed.
+    /// slot-based check is still Uncertain when the finalized tip height is not past
+    /// max_lvbh, proving the old slot-vs-height confusion is closed. Freshness now
+    /// comes from the blockhash tip height, so the account slot cannot paper over it.
     #[tokio::test]
     async fn verify_release_landed_v4b_large_slot_stale_height_uncertain() {
         let storage = storage_with_completed(&[1]);
         let onchain = tree_root(0, &[1]);
         // Account context slot is huge (would pass a slot > lvbh test), but the
-        // finalized height 100 == max_lvbh 100 is not strictly past it.
+        // finalized tip height 100 == max_lvbh 100 is not strictly past it.
         let bytes = instance_bytes(onchain, 0);
         let account_response = serde_json::json!({
             "context": {"slot": 20_000_000u64},
@@ -1570,7 +1603,10 @@ mod tests {
         });
         let mut mocks = HashMap::new();
         mocks.insert(RpcRequest::GetAccountInfo, account_response);
-        mocks.insert(RpcRequest::GetBlockHeight, serde_json::json!(100u64));
+        mocks.insert(
+            RpcRequest::GetLatestBlockhash,
+            blockhash_context_response(100),
+        );
         let rpc = RpcClientWithRetry {
             rpc_client: Arc::new(RpcClient::new_mock_with_mocks(
                 "http://127.0.0.1:8899".to_string(),
@@ -1582,7 +1618,7 @@ mod tests {
             verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 100).await;
         assert!(
             matches!(verdict, ReleaseVerdict::Uncertain(_)),
-            "a large slot must not paper over a stale finalized height"
+            "a large slot must not paper over a stale finalized tip height"
         );
     }
 
@@ -1648,6 +1684,63 @@ mod tests {
         assert!(
             matches!(verdict, ReleaseVerdict::Landed),
             "remove_nonce base path must still resolve Landed"
+        );
+    }
+
+    /// Bind regression (the double-pay vector). The finalized tip height is fresh,
+    /// but the account backend is behind and cannot answer at the bound context
+    /// slot, so the min_context_slot read errors. The verifier must return Uncertain,
+    /// never a false NotLanded that would demote/remint a release that may have
+    /// landed on a lagging, load-balanced RPC endpoint.
+    #[tokio::test]
+    async fn verify_release_landed_bind_account_behind_is_uncertain() {
+        // The completed set without nonce 3 would look NotLanded IF the account
+        // were served; the bind is what forces Uncertain instead.
+        let storage = storage_with_completed(&[1]);
+
+        let mut server = mockito::Server::new_async().await;
+        // Fresh finalized blockhash: tip = 100150 - 150 = 100000, past max_lvbh 50.
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getLatestBlockhash""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":100000},"value":{"blockhash":"11111111111111111111111111111111","lastValidBlockHeight":100150}},"id":0}"#,
+            )
+            .create_async()
+            .await;
+        // The account backend is behind: it rejects the min_context_slot bind with
+        // an RPC error rather than returning an older snapshot.
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getAccountInfo""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","error":{"code":-32016,"message":"Minimum context slot has not been reached"},"id":0}"#,
+            )
+            .create_async()
+            .await;
+
+        let rpc = RpcClientWithRetry::with_retry_config(
+            server.url(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: std::time::Duration::from_millis(1),
+                max_delay: std::time::Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        );
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::Uncertain(_)),
+            "an account backend behind the freshness point must be Uncertain, never NotLanded"
         );
     }
 }

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -131,17 +131,7 @@ pub(crate) async fn validate_smt_root(
         })?;
 
     let tree_index = instance.current_tree_index;
-    let min_nonce = tree_index * MAX_TREE_LEAVES as u64;
-    let max_nonce = (tree_index + 1) * MAX_TREE_LEAVES as u64;
-
-    let nonces = storage
-        .get_completed_withdrawal_nonces(min_nonce, max_nonce)
-        .await?;
-
-    let mut smt_state = SmtState::new(tree_index);
-    for nonce in &nonces {
-        smt_state.insert_nonce(*nonce);
-    }
+    let smt_state = rebuild_completed_tree(storage, tree_index).await?;
 
     let computed_root = smt_state.current_root();
     let onchain_root = instance.withdrawal_transactions_root;
@@ -152,7 +142,7 @@ pub(crate) async fn validate_smt_root(
             tree_index,
             local_root = ?computed_root,
             onchain_root = ?onchain_root,
-            nonces = ?nonces,
+            nonces = ?smt_state.get_nonces(),
             "SMT root mismatch: database out of sync with on-chain state. \
              A release likely landed on-chain but its Completed write was lost; \
              resync the database from on-chain events to reconcile."
@@ -167,11 +157,151 @@ pub(crate) async fn validate_smt_root(
 
     info!(
         tree_index,
-        nonces = nonces.len(),
+        nonces = smt_state.nonce_count(),
         "SMT root verification passed"
     );
 
     Ok(smt_state)
+}
+
+/// Rebuild the local SMT for `tree_index` from the DB-completed withdrawal
+/// nonces in that tree's window. Shared by `validate_smt_root` and the release
+/// verifier so both reason from the identical window math and insert path.
+async fn rebuild_completed_tree(
+    storage: &Storage,
+    tree_index: u64,
+) -> Result<SmtState, OperatorError> {
+    let leaves = MAX_TREE_LEAVES as u64;
+    // Window is [tree_index*leaves, (tree_index+1)*leaves). Checked math so a
+    // corrupt tree_index cannot wrap into the wrong window.
+    let min_nonce =
+        tree_index
+            .checked_mul(leaves)
+            .ok_or(AccountError::AccountIndexOutOfBounds {
+                index: tree_index as usize,
+            })?;
+    let max_nonce = tree_index
+        .checked_add(1)
+        .and_then(|t| t.checked_mul(leaves))
+        .ok_or(AccountError::AccountIndexOutOfBounds {
+            index: tree_index as usize,
+        })?;
+
+    let nonces = storage
+        .get_completed_withdrawal_nonces(min_nonce, max_nonce)
+        .await?;
+
+    let mut smt_state = SmtState::new(tree_index);
+    for nonce in &nonces {
+        smt_state.insert_nonce(*nonce);
+    }
+    Ok(smt_state)
+}
+
+/// Three-way outcome of confirming a release from the on-chain SMT root.
+/// `Uncertain` fails closed: every read/parse/window/staleness ambiguity maps
+/// here, never to `NotLanded`, so a demote or remint never fires on doubt.
+pub(crate) enum ReleaseVerdict {
+    /// The on-chain root matches the completed set WITH the candidate nonce.
+    Landed,
+    /// The on-chain root matches the completed set WITHOUT the candidate nonce.
+    NotLanded,
+    /// Could not prove either way; treat as still-pending.
+    Uncertain(String),
+}
+
+/// Check whether the withdrawal `nonce` actually released on-chain, so recovery
+/// never re-pays a release that a pruned or lagging RPC endpoint is hiding.
+///
+/// The escrow instance holds a Merkle root over every released nonce. We read it
+/// at finalized commitment, rebuild the same tree from our own DB, and compare.
+/// Any doubt returns `Uncertain`, never a false `NotLanded`: the nonce must
+/// belong to the tree the instance currently holds; the finalized snapshot must
+/// be newer than the release's expiry window (a stale one could predate a real
+/// release and look absent); and the rebuilt root must equal the on-chain root
+/// either with the nonce (`Landed`) or without it (`NotLanded`).
+pub(crate) async fn verify_release_landed(
+    rpc: &RpcClientWithRetry,
+    storage: &Storage,
+    instance_pda: Option<Pubkey>,
+    nonce: u64,
+    max_lvbh: u64,
+) -> ReleaseVerdict {
+    let Some(instance_pda) = instance_pda else {
+        return ReleaseVerdict::Uncertain("no instance pda configured".to_string());
+    };
+
+    // Read the finalized height before the account, so the account snapshot is at
+    // least this height. Then finalized_height > max_lvbh proves the snapshot
+    // already reflects every release that could have landed in its validity window.
+    let finalized_height = match rpc
+        .get_block_height_with_commitment(CommitmentConfig::finalized())
+        .await
+    {
+        Ok(h) => h,
+        Err(e) => {
+            return ReleaseVerdict::Uncertain(format!("finalized block height read failed: {e}"))
+        }
+    };
+
+    let response = match rpc
+        .get_account_with_context(&instance_pda, CommitmentConfig::finalized())
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return ReleaseVerdict::Uncertain(format!("instance read failed: {e}")),
+    };
+    let Some(account) = response.value else {
+        return ReleaseVerdict::Uncertain(format!(
+            "instance {instance_pda} absent at finalized commitment"
+        ));
+    };
+    let instance = match parse_instance(&account.data) {
+        Ok(i) => i,
+        Err(e) => return ReleaseVerdict::Uncertain(format!("instance parse failed: {e}")),
+    };
+
+    // Tree-window check: membership can only be proven against the tree currently
+    // on-chain; a rotated-away nonce needs a historical root we do not fetch.
+    let expected_tree = nonce / MAX_TREE_LEAVES as u64;
+    if expected_tree != instance.current_tree_index {
+        return ReleaseVerdict::Uncertain(format!(
+            "nonce {nonce} maps to tree {expected_tree}, on-chain tree is {}",
+            instance.current_tree_index
+        ));
+    }
+
+    // Freshness check: the finalized height must be strictly past every attempt's
+    // lvbh. At height == lvbh a release can still land, so require strictly greater;
+    // a stale snapshot that predates the validity window could miss an edge-of-window
+    // release and wrongly report NotLanded, risking a double-pay.
+    if finalized_height <= max_lvbh {
+        return ReleaseVerdict::Uncertain(format!(
+            "finalized block height {finalized_height} not past max lvbh {max_lvbh}; too stale to prove non-inclusion"
+        ));
+    }
+
+    // Root-membership check: root equality is proof because the SMT is
+    // order-independent and collision-correct. Compare against the completed set
+    // without, then with, the candidate nonce.
+    let mut tree = match rebuild_completed_tree(storage, instance.current_tree_index).await {
+        Ok(t) => t,
+        Err(e) => return ReleaseVerdict::Uncertain(format!("completed-tree rebuild failed: {e}")),
+    };
+    let onchain_root = instance.withdrawal_transactions_root;
+
+    // Drop the candidate so `tree` is the completed set WITHOUT it.
+    tree.remove_nonce(nonce);
+    if tree.current_root() == onchain_root {
+        return ReleaseVerdict::NotLanded;
+    }
+    tree.insert_nonce(nonce);
+    if tree.current_root() == onchain_root {
+        return ReleaseVerdict::Landed;
+    }
+    ReleaseVerdict::Uncertain(format!(
+        "on-chain root matches neither completed set (with nor without nonce {nonce})"
+    ))
 }
 
 impl SenderState {
@@ -215,6 +345,7 @@ impl SenderState {
                 error_message: Some(format!("recovery failed: {}", reason)),
                 remint_signature: None,
                 remint_attempted: false,
+                release_signatures: None,
             },
             "transaction status update",
         )
@@ -1227,5 +1358,296 @@ mod tests {
             }
             other => panic!("expected SmtRootMismatch, got: {other}"),
         }
+    }
+
+    // verify_release_landed (SMT confirmation gate)
+    //
+    // These run under the `test-tree` feature so MAX_TREE_LEAVES = 8 keeps the
+    // tree windows small: tree 0 covers nonces [0,8), tree 1 covers [8,16).
+    use super::{verify_release_landed, ReleaseVerdict};
+    use solana_client::nonblocking::rpc_client::RpcClient;
+
+    /// Borsh-serialize an Instance carrying `root` and `tree_index`.
+    fn instance_bytes(root: [u8; 32], tree_index: u64) -> Vec<u8> {
+        let instance = Instance {
+            discriminator: 0,
+            bump: 0,
+            version: 0,
+            instance_seed: Pubkey::new_unique(),
+            admin: Pubkey::new_unique(),
+            withdrawal_transactions_root: root,
+            current_tree_index: tree_index,
+        };
+        let mut bytes = Vec::new();
+        instance.serialize(&mut bytes).unwrap();
+        bytes
+    }
+
+    /// Mock RPC whose finalized getBlockHeight returns `finalized_height` and whose
+    /// getAccountInfo returns an Instance account with the given root and tree_index.
+    /// The verifier reads the height first, so both mocks are required.
+    fn mock_instance_rpc(
+        root: [u8; 32],
+        tree_index: u64,
+        finalized_height: u64,
+    ) -> RpcClientWithRetry {
+        let bytes = instance_bytes(root, tree_index);
+        let account_response = serde_json::json!({
+            // Context slot is no longer read by the gate; height drives freshness.
+            "context": {"slot": finalized_height},
+            "value": {
+                "owner": Pubkey::new_unique().to_string(),
+                "lamports": 1_000_000u64,
+                "data": [STANDARD.encode(&bytes), "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        });
+        let mut mocks = HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, account_response);
+        mocks.insert(
+            RpcRequest::GetBlockHeight,
+            serde_json::json!(finalized_height),
+        );
+        RpcClientWithRetry {
+            rpc_client: Arc::new(RpcClient::new_mock_with_mocks(
+                "http://127.0.0.1:8899".to_string(),
+                mocks,
+            )),
+            retry_config: RetryConfig::default(),
+        }
+    }
+
+    /// Mock RPC whose getAccountInfo returns a null value (account absent), with a
+    /// fresh finalized getBlockHeight so the gate reaches the absent-account check.
+    fn mock_absent_instance_rpc(finalized_height: u64) -> RpcClientWithRetry {
+        let account_response =
+            serde_json::json!({"context": {"slot": finalized_height}, "value": null});
+        let mut mocks = HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, account_response);
+        mocks.insert(
+            RpcRequest::GetBlockHeight,
+            serde_json::json!(finalized_height),
+        );
+        RpcClientWithRetry {
+            rpc_client: Arc::new(RpcClient::new_mock_with_mocks(
+                "http://127.0.0.1:8899".to_string(),
+                mocks,
+            )),
+            retry_config: RetryConfig::default(),
+        }
+    }
+
+    /// A completed withdrawal row so `get_completed_withdrawal_nonces` sees `nonce`.
+    fn completed_withdrawal_row(id: i64, nonce: u64) -> DbTransaction {
+        let now = Utc::now();
+        DbTransaction {
+            id,
+            signature: Signature::new_unique().to_string(),
+            trace_id: format!("trace-{id}"),
+            slot: 100,
+            initiator: Pubkey::new_unique().to_string(),
+            recipient: Pubkey::new_unique().to_string(),
+            mint: Pubkey::new_unique().to_string(),
+            amount: TokenAmount(5_000),
+            memo: None,
+            transaction_type: TransactionType::Withdrawal,
+            withdrawal_nonce: Some(nonce as i64),
+            status: TransactionStatus::Completed,
+            created_at: now,
+            updated_at: now,
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: None,
+            remint_last_valid_block_heights: None,
+            pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
+            instruction_index: 0,
+            inner_index: None,
+            landed_remint_signature: None,
+        }
+    }
+
+    /// Build a mock storage seeded with the given completed nonces.
+    fn storage_with_completed(nonces: &[u64]) -> Arc<Storage> {
+        let mock = MockStorage::new();
+        for (i, n) in nonces.iter().enumerate() {
+            mock.pending_transactions
+                .lock()
+                .unwrap()
+                .push(completed_withdrawal_row(i as i64 + 1, *n));
+        }
+        Arc::new(Storage::Mock(mock))
+    }
+
+    /// Root of a fresh tree_index-0 tree containing `nonces`.
+    fn tree_root(tree_index: u64, nonces: &[u64]) -> [u8; 32] {
+        let mut smt = SmtState::new(tree_index);
+        for n in nonces {
+            smt.insert_nonce(*n);
+        }
+        smt.current_root()
+    }
+
+    /// V1: on-chain root includes N which the DB has not recorded, fresh height, yields Landed.
+    #[tokio::test]
+    async fn verify_release_landed_v1_with_candidate_match() {
+        let storage = storage_with_completed(&[1]);
+        let onchain = tree_root(0, &[1, 3]);
+        // Finalized height 100 > max_lvbh 50, so the freshness check passes.
+        let rpc = mock_instance_rpc(onchain, 0, 100);
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(matches!(verdict, ReleaseVerdict::Landed), "expected Landed");
+    }
+
+    /// V2: on-chain root equals the completed set without N, fresh height, yields NotLanded.
+    #[tokio::test]
+    async fn verify_release_landed_v2_without_candidate_match() {
+        let storage = storage_with_completed(&[1]);
+        let onchain = tree_root(0, &[1]);
+        let rpc = mock_instance_rpc(onchain, 0, 100);
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::NotLanded),
+            "expected NotLanded"
+        );
+    }
+
+    /// V3: nonce belongs to a different tree window than on-chain, yields Uncertain
+    /// (tree-window check).
+    #[tokio::test]
+    async fn verify_release_landed_v3_wrong_tree_window() {
+        let storage = storage_with_completed(&[]);
+        // nonce 3 maps to tree 0, but the on-chain instance is on tree 1.
+        let onchain = tree_root(1, &[]);
+        let rpc = mock_instance_rpc(onchain, 1, 100);
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::Uncertain(_)),
+            "tree-window check must fail closed"
+        );
+    }
+
+    /// V4: root would say NotLanded but the finalized height is not past max_lvbh,
+    /// yields Uncertain (freshness check).
+    #[tokio::test]
+    async fn verify_release_landed_v4_stale_snapshot() {
+        let storage = storage_with_completed(&[1]);
+        let onchain = tree_root(0, &[1]);
+        // Finalized height 50 == max_lvbh 50, so height <= max_lvbh fails the gate.
+        let rpc = mock_instance_rpc(onchain, 0, 50);
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::Uncertain(_)),
+            "freshness check must fail closed on a stale snapshot"
+        );
+    }
+
+    /// V4b regression: a large account context slot that WOULD have passed the old
+    /// slot-based check is still Uncertain when the finalized height is not past
+    /// max_lvbh, proving the old slot-vs-height confusion is closed.
+    #[tokio::test]
+    async fn verify_release_landed_v4b_large_slot_stale_height_uncertain() {
+        let storage = storage_with_completed(&[1]);
+        let onchain = tree_root(0, &[1]);
+        // Account context slot is huge (would pass a slot > lvbh test), but the
+        // finalized height 100 == max_lvbh 100 is not strictly past it.
+        let bytes = instance_bytes(onchain, 0);
+        let account_response = serde_json::json!({
+            "context": {"slot": 20_000_000u64},
+            "value": {
+                "owner": Pubkey::new_unique().to_string(),
+                "lamports": 1_000_000u64,
+                "data": [STANDARD.encode(&bytes), "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            }
+        });
+        let mut mocks = HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, account_response);
+        mocks.insert(RpcRequest::GetBlockHeight, serde_json::json!(100u64));
+        let rpc = RpcClientWithRetry {
+            rpc_client: Arc::new(RpcClient::new_mock_with_mocks(
+                "http://127.0.0.1:8899".to_string(),
+                mocks,
+            )),
+            retry_config: RetryConfig::default(),
+        };
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 100).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::Uncertain(_)),
+            "a large slot must not paper over a stale finalized height"
+        );
+    }
+
+    /// V5: on-chain root reflects a nonce beyond completed set plus or minus N,
+    /// yields Uncertain (matches-neither).
+    #[tokio::test]
+    async fn verify_release_landed_v5_matches_neither() {
+        let storage = storage_with_completed(&[1]);
+        let onchain = tree_root(0, &[1, 3, 5]);
+        let rpc = mock_instance_rpc(onchain, 0, 100);
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::Uncertain(_)),
+            "matches-neither must be Uncertain"
+        );
+    }
+
+    /// V6: getAccountInfo value null yields Uncertain (absent is not NotLanded).
+    #[tokio::test]
+    async fn verify_release_landed_v6_absent_instance() {
+        let storage = storage_with_completed(&[1]);
+        let rpc = mock_absent_instance_rpc(100);
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::Uncertain(_)),
+            "absent instance must be Uncertain"
+        );
+    }
+
+    /// V7: getAccountInfo RPC error yields Uncertain (read error is not NotLanded).
+    #[tokio::test]
+    async fn verify_release_landed_v7_rpc_error() {
+        let storage = storage_with_completed(&[1]);
+        // Unreachable endpoint, single attempt, so the read fails fast.
+        let rpc = RpcClientWithRetry::with_retry_config(
+            "http://127.0.0.1:1".to_string(),
+            RetryConfig {
+                max_attempts: 1,
+                base_delay: std::time::Duration::from_millis(1),
+                max_delay: std::time::Duration::from_millis(1),
+            },
+            CommitmentConfig::confirmed(),
+        );
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::Uncertain(_)),
+            "RPC error must be Uncertain"
+        );
+    }
+
+    /// V8: DB already records N as Completed and on-chain includes it, yields Landed
+    /// via the remove_nonce base path.
+    #[tokio::test]
+    async fn verify_release_landed_v8_db_has_candidate() {
+        let storage = storage_with_completed(&[1, 3]);
+        let onchain = tree_root(0, &[1, 3]);
+        let rpc = mock_instance_rpc(onchain, 0, 100);
+        let verdict =
+            verify_release_landed(&rpc, &storage, Some(Pubkey::new_unique()), 3, 50).await;
+        assert!(
+            matches!(verdict, ReleaseVerdict::Landed),
+            "remove_nonce base path must still resolve Landed"
+        );
     }
 }

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -752,6 +752,7 @@ pub(super) fn handle_confirmation_result<'a>(
                                 error_message: Some(reason),
                                 remint_signature: None,
                                 remint_attempted: false,
+                                release_signatures: None,
                             },
                             "transaction status update",
                         )
@@ -877,6 +878,7 @@ pub(super) async fn handle_success(
                     error_message: None,
                     remint_signature: None,
                     remint_attempted: false,
+                    release_signatures: None,
                 },
                 "transaction status update",
             )
@@ -905,6 +907,7 @@ pub(super) async fn handle_success(
                 error_message: None,
                 remint_signature: None,
                 remint_attempted: false,
+                release_signatures: None,
             },
             "transaction status update",
         )
@@ -1066,6 +1069,7 @@ pub(super) async fn handle_permanent_failure(
                     )),
                     remint_signature: None,
                     remint_attempted: false,
+                    release_signatures: None,
                 },
                 "transaction status update",
             )
@@ -1114,6 +1118,7 @@ pub(super) async fn handle_permanent_failure(
                     )),
                     remint_signature: None,
                     remint_attempted: false,
+                    release_signatures: None,
                 },
                 "transaction status update",
             )
@@ -1773,6 +1778,7 @@ pub(super) async fn run_poll_task(
                                     error_message: None,
                                     remint_signature: None,
                                     remint_attempted: false,
+                                    release_signatures: None,
                                 })
                                 .await
                                 .is_err()
@@ -1832,6 +1838,7 @@ pub(super) async fn send_fatal_error(
                 error_message: Some(error_msg.to_string()),
                 remint_signature: None,
                 remint_attempted: false,
+                release_signatures: None,
             },
             "transaction status update",
         )

--- a/indexer/src/operator/sender/types.rs
+++ b/indexer/src/operator/sender/types.rs
@@ -120,6 +120,9 @@ pub struct TransactionStatusUpdate {
     /// True when a remint was attempted but failed (ManualReview). Lets consumers
     /// distinguish "remint tried and failed" from "remint never attempted".
     pub remint_attempted: bool,
+    /// Full broadcast release-attempt list, set on an SMT-confirmed Completed so
+    /// the writer can durably record provenance. COALESCE-guarded downstream.
+    pub release_signatures: Option<Vec<String>>,
 }
 
 /// A Mint or InitializeMint transaction that has been sent but not yet confirmed.
@@ -225,6 +228,12 @@ impl SenderState {
 
     /// Finality oracle for the source `source_rpc_client`, single-endpoint: the
     /// PrivateChannel gateway is single-provider, with no second node to check.
+    ///
+    /// The source (remint MintTo) path deliberately stays absence-authoritative
+    /// and is NOT downgraded by an on-chain SMT check the way the destination
+    /// (release) path is. The self-hosted PrivateChannel node is the canonical
+    /// source of truth, so an absent status there is genuine non-inclusion, not a
+    /// prune or lag. Do not "fix" this into a symmetric SMT gate.
     pub(crate) fn source_finality(&self) -> FinalityRpc<'_> {
         FinalityRpc::single(&self.source_rpc_client)
     }

--- a/indexer/src/operator/utils/rpc_util.rs
+++ b/indexer/src/operator/utils/rpc_util.rs
@@ -1,10 +1,11 @@
+use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
-use solana_client::rpc_response::Response;
+use solana_client::rpc_response::{Response, RpcBlockhash};
 use solana_rpc_client_api::client_error;
 use solana_rpc_client_api::client_error::ErrorKind;
-use solana_rpc_client_api::config::RpcTransactionConfig;
-use solana_rpc_client_api::request::RpcError;
+use solana_rpc_client_api::config::{RpcAccountInfoConfig, RpcTransactionConfig};
+use solana_rpc_client_api::request::{RpcError, RpcRequest};
 use solana_sdk::account::Account;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::hash::Hash;
@@ -164,20 +165,26 @@ impl RpcClientWithRetry {
         .await
     }
 
-    /// Get the block height at an explicit commitment with retry. The release
-    /// verifier reads this at finalized before its account snapshot so a lagging
-    /// finalized root cannot masquerade as a fresh one.
-    pub async fn get_block_height_with_commitment(
+    /// Read the latest blockhash at `commitment` together with the response
+    /// context slot, returning `(context_slot, last_valid_block_height)`. One RPC
+    /// call so the slot and height come from the same backend and are mutually
+    /// consistent. The release verifier reads this at finalized to anchor a
+    /// freshness point it can then bind an account snapshot to via min_context_slot.
+    pub async fn get_latest_blockhash_with_context(
         &self,
         commitment: CommitmentConfig,
-    ) -> Result<u64, Box<client_error::Error>> {
+    ) -> Result<(u64, u64), Box<client_error::Error>> {
         self.with_retry(
-            "get_block_height_with_commitment",
+            "get_latest_blockhash_with_context",
             RetryPolicy::Idempotent,
             || async {
                 self.rpc_client
-                    .get_block_height_with_commitment(commitment)
+                    .send::<Response<RpcBlockhash>>(
+                        RpcRequest::GetLatestBlockhash,
+                        serde_json::json!([commitment]),
+                    )
                     .await
+                    .map(|resp| (resp.context.slot, resp.value.last_valid_block_height))
             },
         )
         .await
@@ -260,6 +267,35 @@ impl RpcClientWithRetry {
             || async {
                 self.rpc_client
                     .get_account_with_commitment(pubkey, commitment)
+                    .await
+            },
+        )
+        .await
+    }
+
+    /// Like `get_account_with_context`, but requires the node to answer from a
+    /// snapshot whose context slot is at least `min_context_slot`. If the node
+    /// cannot serve at that slot (a lagging or load-balanced backend) it returns
+    /// an RPC error rather than an older snapshot, letting the caller fail closed.
+    /// This binds the returned account to a slot the caller has already proven fresh.
+    pub async fn get_account_with_context_min_slot(
+        &self,
+        pubkey: &Pubkey,
+        commitment: CommitmentConfig,
+        min_context_slot: Option<u64>,
+    ) -> Result<Response<Option<Account>>, Box<client_error::Error>> {
+        self.with_retry(
+            "get_account_with_context_min_slot",
+            RetryPolicy::Idempotent,
+            || async {
+                let config = RpcAccountInfoConfig {
+                    encoding: Some(UiAccountEncoding::Base64),
+                    data_slice: None,
+                    commitment: Some(commitment),
+                    min_context_slot,
+                };
+                self.rpc_client
+                    .get_account_with_config(pubkey, config)
                     .await
             },
         )

--- a/indexer/src/operator/utils/rpc_util.rs
+++ b/indexer/src/operator/utils/rpc_util.rs
@@ -1,5 +1,6 @@
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
+use solana_client::rpc_response::Response;
 use solana_rpc_client_api::client_error;
 use solana_rpc_client_api::client_error::ErrorKind;
 use solana_rpc_client_api::config::RpcTransactionConfig;
@@ -163,6 +164,25 @@ impl RpcClientWithRetry {
         .await
     }
 
+    /// Get the block height at an explicit commitment with retry. The release
+    /// verifier reads this at finalized before its account snapshot so a lagging
+    /// finalized root cannot masquerade as a fresh one.
+    pub async fn get_block_height_with_commitment(
+        &self,
+        commitment: CommitmentConfig,
+    ) -> Result<u64, Box<client_error::Error>> {
+        self.with_retry(
+            "get_block_height_with_commitment",
+            RetryPolicy::Idempotent,
+            || async {
+                self.rpc_client
+                    .get_block_height_with_commitment(commitment)
+                    .await
+            },
+        )
+        .await
+    }
+
     /// Get the node's lowest retained slot with retry. An absence-based `Dead`
     /// finality verdict consults this to prove the endpoint still retains the
     /// attempt's slot range.
@@ -226,6 +246,26 @@ impl RpcClientWithRetry {
         .await
     }
 
+    /// Read an account at the given commitment, returning the response context
+    /// (its `slot`) with the account. An absent account is `Ok(None)`, kept
+    /// distinct from a read error (`Err`).
+    pub async fn get_account_with_context(
+        &self,
+        pubkey: &Pubkey,
+        commitment: CommitmentConfig,
+    ) -> Result<Response<Option<Account>>, Box<client_error::Error>> {
+        self.with_retry(
+            "get_account_with_context",
+            RetryPolicy::Idempotent,
+            || async {
+                self.rpc_client
+                    .get_account_with_commitment(pubkey, commitment)
+                    .await
+            },
+        )
+        .await
+    }
+
     /// Get token account balance with retry (read-only, safe to retry)
     pub async fn get_token_account_balance(
         &self,
@@ -245,9 +285,7 @@ impl RpcClientWithRetry {
         &self,
         signatures: &[Signature],
     ) -> Result<
-        solana_client::rpc_response::Response<
-            Vec<Option<solana_transaction_status::TransactionStatus>>,
-        >,
+        Response<Vec<Option<solana_transaction_status::TransactionStatus>>>,
         Box<client_error::Error>,
     > {
         self.with_retry(
@@ -267,9 +305,7 @@ impl RpcClientWithRetry {
         &self,
         signatures: &[Signature],
     ) -> Result<
-        solana_client::rpc_response::Response<
-            Vec<Option<solana_transaction_status::TransactionStatus>>,
-        >,
+        Response<Vec<Option<solana_transaction_status::TransactionStatus>>>,
         Box<client_error::Error>,
     > {
         self.with_retry(
@@ -756,6 +792,55 @@ mod tests {
             .await;
         let client = make_client_at(&server.url());
         assert!(client.get_first_available_block().await.is_err());
+    }
+
+    /// R1: a present account is returned as `Some`, and the response context
+    /// exposes the finalized snapshot slot.
+    #[tokio::test]
+    async fn get_account_with_context_some_exposes_slot() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getAccountInfo""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":4242},"value":{"owner":"11111111111111111111111111111111","lamports":1000000,"data":["","base64"],"executable":false,"rentEpoch":0}},"id":0}"#,
+            )
+            .create_async()
+            .await;
+        let client = make_client_at(&server.url());
+        let resp = client
+            .get_account_with_context(&Pubkey::default(), CommitmentConfig::finalized())
+            .await
+            .unwrap();
+        assert_eq!(resp.context.slot, 4242);
+        assert!(resp.value.is_some());
+    }
+
+    /// R2: an absent account (`value: null`) is `Ok(None)`, kept distinct from a
+    /// read error so the caller reads absence as uncertainty, never non-inclusion.
+    #[tokio::test]
+    async fn get_account_with_context_null_is_none() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getAccountInfo""#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"jsonrpc":"2.0","result":{"context":{"slot":7},"value":null},"id":0}"#)
+            .create_async()
+            .await;
+        let client = make_client_at(&server.url());
+        let resp = client
+            .get_account_with_context(&Pubkey::default(), CommitmentConfig::finalized())
+            .await
+            .unwrap();
+        assert!(resp.value.is_none());
     }
 
     #[tokio::test]

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -152,6 +152,7 @@ impl Storage {
         status: TransactionStatus,
         counterpart_signature: Option<String>,
         processed_at: chrono::DateTime<chrono::Utc>,
+        release_signatures: Option<Vec<String>>,
     ) -> Result<bool, StorageError> {
         update_transaction_status::update_transaction_status(
             self,
@@ -159,6 +160,7 @@ impl Storage {
             status,
             counterpart_signature,
             processed_at,
+            release_signatures,
         )
         .await
     }
@@ -452,17 +454,21 @@ impl Storage {
     }
 
     /// CAS `Processing` → `Completed` on `updated_at`; `Ok(false)` if stale.
+    /// `release_signatures` durably records the full broadcast attempt list on an
+    /// SMT-confirmed release; `None` leaves any existing value intact (COALESCE).
     pub async fn try_complete_processing(
         &self,
         transaction_id: i64,
         expected_updated_at: chrono::DateTime<chrono::Utc>,
         counterpart_signature: Option<String>,
+        release_signatures: Option<Vec<String>>,
     ) -> Result<bool, StorageError> {
         try_complete_processing::try_complete_processing(
             self,
             transaction_id,
             expected_updated_at,
             counterpart_signature,
+            release_signatures,
         )
         .await
     }
@@ -847,6 +853,7 @@ mod tests {
                 TransactionStatus::Completed,
                 Some("sig_abc".to_string()),
                 now,
+                None,
             )
             .await
             .unwrap();
@@ -863,9 +870,80 @@ mod tests {
         let (storage, mock) = make_mock_storage();
         mock.set_should_fail("update_transaction_status", true);
         assert!(storage
-            .update_transaction_status(1, TransactionStatus::Completed, None, Utc::now())
+            .update_transaction_status(1, TransactionStatus::Completed, None, Utc::now(), None)
             .await
             .is_err());
+    }
+
+    // Durable release_signatures on completion
+
+    /// try_complete_processing with a release-signature list persists the
+    /// array alongside the single counterpart_signature.
+    #[tokio::test]
+    async fn try_complete_processing_persists_release_signatures() {
+        let (storage, mock) = make_mock_storage();
+        let now = Utc::now();
+        {
+            let mut txn = make_db_transaction();
+            txn.id = 1;
+            txn.status = TransactionStatus::Processing;
+            txn.updated_at = now;
+            mock.pending_transactions.lock().unwrap().push(txn);
+        }
+
+        let ok = storage
+            .try_complete_processing(
+                1,
+                now,
+                Some("s1".to_string()),
+                Some(vec!["s1".to_string(), "s2".to_string()]),
+            )
+            .await
+            .unwrap();
+        assert!(ok);
+
+        assert_eq!(
+            mock.completed_release_signatures.lock().unwrap().get(&1),
+            Some(&vec!["s1".to_string(), "s2".to_string()])
+        );
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0]
+                .counterpart_signature
+                .as_deref(),
+            Some("s1")
+        );
+    }
+
+    /// A None release-signature list is COALESCE-guarded and never wipes an
+    /// existing array.
+    #[tokio::test]
+    async fn try_complete_processing_none_preserves_existing_release_signatures() {
+        let (storage, mock) = make_mock_storage();
+        let now = Utc::now();
+        {
+            let mut txn = make_db_transaction();
+            txn.id = 2;
+            txn.status = TransactionStatus::Processing;
+            txn.updated_at = now;
+            mock.pending_transactions.lock().unwrap().push(txn);
+        }
+        // An array already recorded (e.g. a prior write).
+        mock.completed_release_signatures
+            .lock()
+            .unwrap()
+            .insert(2, vec!["old1".to_string(), "old2".to_string()]);
+
+        let ok = storage
+            .try_complete_processing(2, now, Some("cp".to_string()), None)
+            .await
+            .unwrap();
+        assert!(ok);
+
+        assert_eq!(
+            mock.completed_release_signatures.lock().unwrap().get(&2),
+            Some(&vec!["old1".to_string(), "old2".to_string()]),
+            "None must not clobber an existing array"
+        );
     }
 
     // ── storage dispatch coverage ────────────────────────────────────

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -42,6 +42,9 @@ pub struct MockStorage {
     pub release_signatures: Arc<Mutex<ReleaseSignatureMap>>,
     /// Mirrors the `pending_remint_signatures` write-ahead table.
     pub remint_signatures: Arc<Mutex<ReleaseSignatureMap>>,
+    /// Mirrors the durable `transactions.release_signatures` column: the full
+    /// attempt list written on an SMT-confirmed completion. COALESCE-guarded.
+    pub completed_release_signatures: Arc<Mutex<HashMap<i64, Vec<String>>>>,
     /// Mirrors the single-row `reconciliation_halt` table; `None` = not halted.
     pub reconciliation_halt: Arc<Mutex<Option<HaltInfo>>>,
 }
@@ -324,8 +327,16 @@ impl MockStorage {
         status: TransactionStatus,
         counterpart_signature: Option<String>,
         processed_at: DateTime<Utc>,
+        release_signatures: Option<Vec<String>>,
     ) -> Result<bool, StorageError> {
         self.check_should_fail("update_transaction_status")?;
+        // COALESCE mirror: only overwrite the durable list when one is supplied.
+        if let Some(sigs) = release_signatures {
+            self.completed_release_signatures
+                .lock()
+                .unwrap()
+                .insert(transaction_id, sigs);
+        }
         // Mirror the Postgres status filter (Processing or PendingRemint only).
         let mut pending = self.pending_transactions.lock().unwrap();
         let updated = if let Some(txn) = pending.iter_mut().find(|t| t.id == transaction_id) {
@@ -884,6 +895,7 @@ impl MockStorage {
         transaction_id: i64,
         expected_updated_at: DateTime<Utc>,
         counterpart_signature: Option<String>,
+        release_signatures: Option<Vec<String>>,
     ) -> Result<bool, StorageError> {
         self.check_should_fail("try_complete_processing")?;
         let mut pending = self.pending_transactions.lock().unwrap();
@@ -895,6 +907,13 @@ impl MockStorage {
                 txn.status = TransactionStatus::Completed;
                 if counterpart_signature.is_some() {
                     txn.counterpart_signature = counterpart_signature;
+                }
+                // COALESCE: only overwrite when a list is supplied, never wipe.
+                if let Some(sigs) = release_signatures {
+                    self.completed_release_signatures
+                        .lock()
+                        .unwrap()
+                        .insert(transaction_id, sigs);
                 }
                 let now = Utc::now();
                 txn.processed_at = Some(now);

--- a/indexer/src/storage/common/storage/try_complete_processing.rs
+++ b/indexer/src/storage/common/storage/try_complete_processing.rs
@@ -6,6 +6,7 @@ pub async fn try_complete_processing(
     transaction_id: i64,
     expected_updated_at: chrono::DateTime<chrono::Utc>,
     counterpart_signature: Option<String>,
+    release_signatures: Option<Vec<String>>,
 ) -> Result<bool, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
@@ -13,12 +14,18 @@ pub async fn try_complete_processing(
                 transaction_id,
                 expected_updated_at,
                 counterpart_signature,
+                release_signatures,
             )
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .try_complete_processing(transaction_id, expected_updated_at, counterpart_signature)
+                .try_complete_processing(
+                    transaction_id,
+                    expected_updated_at,
+                    counterpart_signature,
+                    release_signatures,
+                )
                 .await
         }
     }

--- a/indexer/src/storage/common/storage/update_transaction_status.rs
+++ b/indexer/src/storage/common/storage/update_transaction_status.rs
@@ -11,6 +11,7 @@ pub async fn update_transaction_status(
     status: TransactionStatus,
     counterpart_signature: Option<String>,
     processed_at: DateTime<Utc>,
+    release_signatures: Option<Vec<String>>,
 ) -> Result<bool, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
@@ -19,6 +20,7 @@ pub async fn update_transaction_status(
                 status,
                 counterpart_signature,
                 processed_at,
+                release_signatures,
             )
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
@@ -29,6 +31,7 @@ pub async fn update_transaction_status(
                     status,
                     counterpart_signature,
                     processed_at,
+                    release_signatures,
                 )
                 .await
         }

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -243,6 +243,20 @@ impl PostgresDb {
         .await?;
         info!("remint_signatures migration complete");
 
+        // Idempotent migration: durable full release-attempt list recorded on an
+        // SMT-confirmed completion. Mirrors the remint_signatures column shape.
+        info!("Running release_signatures migration if needed...");
+        sqlx::query(
+            r#"
+            DO $$ BEGIN
+                ALTER TABLE transactions ADD COLUMN IF NOT EXISTS release_signatures TEXT[];
+            END $$;
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        info!("release_signatures migration complete");
+
         // Idempotent migration: add pending_remint_deadline_at to existing databases
         info!("Running pending_remint_deadline_at migration if needed...");
         sqlx::query(
@@ -1236,15 +1250,18 @@ impl PostgresDb {
         status: TransactionStatus,
         counterpart_signature: Option<String>,
         processed_at: chrono::DateTime<chrono::Utc>,
+        release_signatures: Option<Vec<String>>,
     ) -> Result<bool, sqlx::Error> {
         // Only write non-terminal source states — blocks late writes after recovery.
+        // release_signatures is COALESCE-guarded so a None never wipes provenance.
         let result = sqlx::query(
             r#"
             UPDATE transactions
             SET
                 status = $2,
                 counterpart_signature = $3,
-                processed_at = $4
+                processed_at = $4,
+                release_signatures = COALESCE($5, release_signatures)
             WHERE id = $1
               AND status IN ('processing', 'pending_remint')
             "#,
@@ -1253,6 +1270,7 @@ impl PostgresDb {
         .bind(status)
         .bind(counterpart_signature)
         .bind(processed_at)
+        .bind(release_signatures)
         .execute(&self.pool)
         .await?;
 
@@ -1504,17 +1522,20 @@ impl PostgresDb {
     }
 
     /// CAS `Processing` → `Completed` keyed on `updated_at`; sig may be `None`.
+    /// `release_signatures` is COALESCE-guarded so `None` never clobbers a value.
     pub async fn try_complete_processing_internal(
         &self,
         transaction_id: i64,
         expected_updated_at: chrono::DateTime<chrono::Utc>,
         counterpart_signature: Option<String>,
+        release_signatures: Option<Vec<String>>,
     ) -> Result<bool, sqlx::Error> {
         let result = sqlx::query(
             r#"
             UPDATE transactions
             SET status = 'completed',
                 counterpart_signature = COALESCE($3, counterpart_signature),
+                release_signatures = COALESCE($4, release_signatures),
                 processed_at = NOW()
             WHERE id = $1
               AND status = 'processing'
@@ -1524,6 +1545,7 @@ impl PostgresDb {
         .bind(transaction_id)
         .bind(expected_updated_at)
         .bind(counterpart_signature)
+        .bind(release_signatures)
         .execute(&self.pool)
         .await?;
 

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -517,6 +517,7 @@ async fn update_transaction_status_updates_fields() -> Result<(), Box<dyn std::e
             TransactionStatus::Completed,
             Some("counter_sig".to_string()),
             now,
+            None,
         )
         .await?;
     assert!(

--- a/indexer/tests/remint_e2e_test.rs
+++ b/indexer/tests/remint_e2e_test.rs
@@ -273,6 +273,7 @@ async fn test_resolved_remint_not_returned_by_recovery_query(
             TransactionStatus::Completed,
             Some(sig.to_string()),
             Utc::now(),
+            None,
         )
         .await?;
 
@@ -316,7 +317,13 @@ async fn test_failed_reminted_row_not_returned_by_recovery_query(
     //    (counterpart_signature is None for FailedReminted — the withdrawal never
     //    landed, so there is no release_funds sig to record.)
     storage
-        .update_transaction_status(tx_id, TransactionStatus::FailedReminted, None, Utc::now())
+        .update_transaction_status(
+            tx_id,
+            TransactionStatus::FailedReminted,
+            None,
+            Utc::now(),
+            None,
+        )
         .await?;
 
     // 3. Row must not appear in recovery — a second remint would double-credit the user.
@@ -394,7 +401,13 @@ async fn test_withdrawal_failure_remint_restores_balance() -> Result<(), Box<dyn
 
     // Step 4: finality check passes (no sig finalized), remint succeeds.
     storage
-        .update_transaction_status(tx_id, TransactionStatus::FailedReminted, None, Utc::now())
+        .update_transaction_status(
+            tx_id,
+            TransactionStatus::FailedReminted,
+            None,
+            Utc::now(),
+            None,
+        )
         .await?;
 
     // Step 5a: resolved row must not surface in recovery — prevents duplicate remint.
@@ -513,7 +526,13 @@ async fn test_manual_review_not_returned_by_recovery_query(
 
     // Simulate exhausted finality check retries escalating to ManualReview.
     storage
-        .update_transaction_status(tx_id, TransactionStatus::ManualReview, None, Utc::now())
+        .update_transaction_status(
+            tx_id,
+            TransactionStatus::ManualReview,
+            None,
+            Utc::now(),
+            None,
+        )
         .await?;
 
     // Must not appear in recovery — would loop re-queueing on every restart.

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -203,6 +203,7 @@ test-tree = ["private-channel-indexer/test-tree"]
 [dependencies]
 anyhow = "1.0.100"
 base64 = { workspace = true }
+borsh = { workspace = true }
 bs58 = { workspace = true }
 bincode = { workspace = true }
 chrono = { workspace = true }

--- a/integration/tests/indexer/parked_withdrawal_recovery.rs
+++ b/integration/tests/indexer/parked_withdrawal_recovery.rs
@@ -31,7 +31,7 @@ use {
     tokio::sync::mpsc,
 };
 
-// ── fixture helpers ─────────────────────────────────────────────────────────
+// -- fixture helpers ---------------------------------------------------------
 
 async fn start_pg(
     db_name: &str,
@@ -145,10 +145,10 @@ fn dead_client() -> RpcClientWithRetry {
     )
 }
 
-// ── Postgres CAS primitives ───────────────────────────────────────────────
+// -- Postgres CAS primitives -----------------------------------------------
 
-/// `try_park_processing`: `Processing → Parked` succeeds, a re-park
-/// (`Parked → Parked`) is the heartbeat — it succeeds AND advances `updated_at`,
+/// `try_park_processing`: `Processing -> Parked` succeeds, a re-park
+/// (`Parked -> Parked`) is the heartbeat - it succeeds AND advances `updated_at`,
 /// and a row in any other state is a no-op.
 #[tokio::test(flavor = "multi_thread")]
 async fn try_park_processing_cas() {
@@ -163,11 +163,11 @@ async fn try_park_processing_cas() {
         .unwrap();
     set_status(&pool, id, "processing").await;
 
-    // Processing → Parked.
+    // Processing -> Parked.
     assert!(storage.try_park_processing(id).await.unwrap());
     assert_eq!(status_of(&pool, id).await, "parked");
 
-    // Heartbeat: Parked → Parked succeeds and the trigger bumps updated_at.
+    // Heartbeat: Parked -> Parked succeeds and the trigger bumps updated_at.
     let before = updated_at_of(&pool, id).await;
     assert!(storage.try_park_processing(id).await.unwrap());
     assert_eq!(status_of(&pool, id).await, "parked");
@@ -176,14 +176,14 @@ async fn try_park_processing_cas() {
         "re-park must refresh updated_at so recovery treats the row as live"
     );
 
-    // Wrong state → no-op.
+    // Wrong state -> no-op.
     set_status(&pool, id, "completed").await;
     assert!(!storage.try_park_processing(id).await.unwrap());
     assert_eq!(status_of(&pool, id).await, "completed");
 }
 
-/// `try_unpark_to_processing`: strict `Parked → Processing`. A non-`Parked` row
-/// is a no-op — this is what makes the drain drop its builder instead of
+/// `try_unpark_to_processing`: strict `Parked -> Processing`. A non-`Parked` row
+/// is a no-op - this is what makes the drain drop its builder instead of
 /// double-sending after recovery already requeued the nonce.
 #[tokio::test(flavor = "multi_thread")]
 async fn try_unpark_to_processing_cas() {
@@ -197,19 +197,19 @@ async fn try_unpark_to_processing_cas() {
         .await
         .unwrap();
 
-    // Parked → Processing.
+    // Parked -> Processing.
     set_status(&pool, id, "parked").await;
     assert!(storage.try_unpark_to_processing(id).await.unwrap());
     assert_eq!(status_of(&pool, id).await, "processing");
 
-    // Not parked (e.g. recovery already requeued it to pending) → no-op.
+    // Not parked (e.g. recovery already requeued it to pending) -> no-op.
     set_status(&pool, id, "pending").await;
     assert!(!storage.try_unpark_to_processing(id).await.unwrap());
     assert_eq!(status_of(&pool, id).await, "pending");
 }
 
 /// `try_requeue_parked` is an optimistic CAS keyed on `updated_at`: a matching
-/// timestamp flips `Parked → Pending`, a stale one (a live sender heartbeated
+/// timestamp flips `Parked -> Pending`, a stale one (a live sender heartbeated
 /// the row between recovery's SELECT and this write) no-ops and leaves it parked.
 #[tokio::test(flavor = "multi_thread")]
 async fn try_requeue_parked_cas() {
@@ -224,12 +224,12 @@ async fn try_requeue_parked_cas() {
         .unwrap();
     set_status(&pool, id, "parked").await;
 
-    // Stale timestamp (a heartbeat raced in after recovery read the row) → no-op.
+    // Stale timestamp (a heartbeat raced in after recovery read the row) -> no-op.
     let stale = updated_at_of(&pool, id).await - ChronoDuration::seconds(60);
     assert!(!storage.try_requeue_parked(id, stale).await.unwrap());
     assert_eq!(status_of(&pool, id).await, "parked");
 
-    // Matching timestamp (genuinely orphaned) → requeue to pending.
+    // Matching timestamp (genuinely orphaned) -> requeue to pending.
     let captured = updated_at_of(&pool, id).await;
     assert!(storage.try_requeue_parked(id, captured).await.unwrap());
     assert_eq!(status_of(&pool, id).await, "pending");
@@ -238,7 +238,7 @@ async fn try_requeue_parked_cas() {
 /// `get_stale_parked_transactions` is the read recovery uses to find orphaned
 /// rows: only `Parked` rows older than the threshold, oldest-first, capped at
 /// the limit. A freshly heartbeated parked row and rows in other states are
-/// excluded — that exclusion is what keeps recovery off rows a live sender owns.
+/// excluded - that exclusion is what keeps recovery off rows a live sender owns.
 #[tokio::test(flavor = "multi_thread")]
 async fn get_stale_parked_filters_and_orders() {
     let (db, url, _c) = start_pg("stale_parked_query").await;
@@ -266,7 +266,7 @@ async fn get_stale_parked_filters_and_orders() {
         .insert_transaction_internal(&make_withdrawal(&Signature::new_unique().to_string(), 12))
         .await
         .unwrap();
-    set_status(&pool, fresh, "parked").await; // updated_at ≈ now → within threshold
+    set_status(&pool, fresh, "parked").await; // updated_at ~ now -> within threshold
 
     let processing = db
         .insert_transaction_internal(&make_withdrawal(&Signature::new_unique().to_string(), 13))
@@ -287,7 +287,7 @@ async fn get_stale_parked_filters_and_orders() {
     let ids: Vec<i64> = stale.iter().map(|t| t.id).collect();
     assert_eq!(ids, vec![old, newer]);
 
-    // Limit is honored (FIFO over stale → the oldest).
+    // Limit is honored (FIFO over stale -> the oldest).
     let limited = storage
         .get_stale_parked_transactions(TransactionType::Withdrawal, Duration::from_secs(5 * 60), 1)
         .await
@@ -296,11 +296,11 @@ async fn get_stale_parked_filters_and_orders() {
     assert_eq!(limited[0].id, old);
 }
 
-// ── recovery parked-sweep (E2E through run_recovery_once) ─────────────────
+// -- recovery parked-sweep (E2E through run_recovery_once) -----------------
 
 /// A stale `Parked` row orphaned by a restart is rescued by the recovery worker:
 /// flipped back to `Pending`, counted via the `requeued_parked` metric, and
-/// done silently (no webhook) without burning the recovery retry cap — the row
+/// done silently (no webhook) without burning the recovery retry cap - the row
 /// was never broadcast, so there is nothing to cap.
 #[tokio::test(flavor = "multi_thread")]
 async fn recovery_requeues_stale_parked_to_pending() {
@@ -322,9 +322,15 @@ async fn recovery_requeues_stale_parked_to_pending() {
         .get();
     let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(&storage, &dead_client(), ProgramType::Withdraw, &storage_tx)
-        .await
-        .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &dead_client(),
+        ProgramType::Withdraw,
+        None,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         status_of(&pool, id).await,
@@ -349,7 +355,7 @@ async fn recovery_requeues_stale_parked_to_pending() {
     );
 }
 
-/// A fresh `Parked` row — one a live sender just heartbeated — is within the
+/// A fresh `Parked` row - one a live sender just heartbeated - is within the
 /// staleness window, so recovery must leave it alone rather than steal a row
 /// another worker still owns.
 #[tokio::test(flavor = "multi_thread")]
@@ -363,12 +369,18 @@ async fn recovery_leaves_fresh_parked_untouched() {
         .insert_transaction_internal(&make_withdrawal(&Signature::new_unique().to_string(), 21))
         .await
         .unwrap();
-    set_status(&pool, id, "parked").await; // updated_at ≈ now → within threshold
+    set_status(&pool, id, "parked").await; // updated_at ~ now -> within threshold
 
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
-    test_hooks::run_recovery_once(&storage, &dead_client(), ProgramType::Withdraw, &storage_tx)
-        .await
-        .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &dead_client(),
+        ProgramType::Withdraw,
+        None,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         status_of(&pool, id).await,

--- a/integration/tests/indexer/storage_update_failure.rs
+++ b/integration/tests/indexer/storage_update_failure.rs
@@ -36,6 +36,7 @@ fn make_update(id: i64, status: TransactionStatus) -> TransactionStatusUpdate {
         processed_at: Some(Utc::now()),
         remint_signature: None,
         remint_attempted: false,
+        release_signatures: None,
     }
 }
 

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -59,7 +59,7 @@ fn assert_recovered_increment(
     );
 }
 
-// ── fixture helpers ─────────────────────────────────────────────────────────
+// -- fixture helpers ---------------------------------------------------------
 
 async fn start_pg(
     db_name: &str,
@@ -186,12 +186,54 @@ fn test_client(url: String) -> RpcClientWithRetry {
     )
 }
 
-// IT-1 / IT-D1: deposit whose persisted broadcast signature finalized to Completed,
+/// SMT root of a fresh tree carrying `nonces`, computed with the same lib helper
+/// the release-verify gate rebuilds from, so the crafted on-chain root is exact.
+fn smt_root(tree_index: u64, nonces: &[u64]) -> [u8; 32] {
+    use private_channel_indexer::operator::utils::smt_util::SmtState;
+    let mut smt = SmtState::new(tree_index);
+    for n in nonces {
+        smt.insert_nonce(*n);
+    }
+    smt.current_root()
+}
+
+/// A `getAccountInfo` reply carrying a borsh-serialized escrow `Instance` with the
+/// given SMT root and tree index. The verify gate reads this to prove/deny a release.
+fn instance_account_reply(root: [u8; 32], tree_index: u64) -> Reply {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use borsh::BorshSerialize;
+    use private_channel_escrow_program_client::Instance;
+    use solana_pubkey::Pubkey as EscrowPubkey;
+
+    let instance = Instance {
+        discriminator: 0,
+        bump: 0,
+        version: 0,
+        instance_seed: EscrowPubkey::new_unique(),
+        admin: EscrowPubkey::new_unique(),
+        withdrawal_transactions_root: root,
+        current_tree_index: tree_index,
+    };
+    let mut bytes = Vec::new();
+    instance.serialize(&mut bytes).expect("serialize instance");
+    Reply::result(json!({
+        "context": {"slot": 1000},
+        "value": {
+            "owner": EscrowPubkey::new_unique().to_string(),
+            "lamports": 1_000_000u64,
+            "data": [STANDARD.encode(&bytes), "base64"],
+            "executable": false,
+            "rentEpoch": 0
+        }
+    }))
+}
+
+// Deposit whose persisted broadcast signature finalized to Completed,
 // recovered from the durable signature with no double-mint (no sendTransaction).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it1_deposit_landed_promoted_to_completed() {
-    let (db, url, _container) = start_pg("it1_landed").await;
+async fn deposit_landed_promoted_to_completed() {
+    let (db, url, _container) = start_pg("dep_landed").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -232,7 +274,7 @@ async fn it1_deposit_landed_promoted_to_completed() {
 
     let metric_before = snapshot_recovered("escrow", "completed", "deposit");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
 
@@ -243,16 +285,22 @@ async fn it1_deposit_landed_promoted_to_completed() {
     );
     // Recovery never re-mints a landed deposit (no double-mint).
     assert_eq!(mock.call_count("sendTransaction"), 0);
-    assert_recovered_increment("escrow", "completed", "deposit", metric_before, "IT-1");
+    assert_recovered_increment(
+        "escrow",
+        "completed",
+        "deposit",
+        metric_before,
+        "deposit landed completed",
+    );
     mock.shutdown().await;
 }
 
-// IT-2 / IT-D2: deposit with no persisted signature, provably never broadcast,
+// Deposit with no persisted signature, provably never broadcast,
 // demoted to Pending for a safe re-mint, consulting no RPC.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it2_deposit_not_landed_demoted_to_pending() {
-    let (db, url, _container) = start_pg("it2_demote").await;
+async fn deposit_not_landed_demoted_to_pending() {
+    let (db, url, _container) = start_pg("dep_demote").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -270,7 +318,7 @@ async fn it2_deposit_not_landed_demoted_to_pending() {
 
     let metric_before = snapshot_recovered("escrow", "requeued", "deposit");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
 
@@ -282,18 +330,24 @@ async fn it2_deposit_not_landed_demoted_to_pending() {
     );
     // Live fetcher picks it up on the next tick (out of scope here).
     assert_eq!(mock.call_count("sendTransaction"), 0);
-    assert_recovered_increment("escrow", "requeued", "deposit", metric_before, "IT-2");
+    assert_recovered_increment(
+        "escrow",
+        "requeued",
+        "deposit",
+        metric_before,
+        "deposit not landed requeued",
+    );
     mock.shutdown().await;
 }
 
-// IT-2b: deposit that WAS broadcast (persisted signature present) but whose mint is
+// Deposit that WAS broadcast (persisted signature present) but whose mint is
 // provably dead (null status, blockhash expired) is demoted for a safe re-mint. Unlike
-// IT-2 (no signature, no RPC), this exercises the RPC finality classification driving
+// the no-signature case above, this exercises the RPC finality classification driving
 // the re-mint decision, the case-(B)-dead double-mint boundary for deposits.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it2b_deposit_dead_signature_demoted() {
-    let (db, url, _container) = start_pg("it2b_dep_dead").await;
+async fn deposit_dead_signature_demoted() {
+    let (db, url, _container) = start_pg("dep_dead_sig").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -309,7 +363,7 @@ async fn it2b_deposit_dead_signature_demoted() {
         .unwrap();
 
     let mock = MockRpcServer::start().await;
-    // Status null + current height (1000) > lvbh (100) → expired/dead.
+    // Status null + current height (1000) > lvbh (100) -> expired/dead.
     mock.enqueue(
         "getSignatureStatuses",
         Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
@@ -322,22 +376,28 @@ async fn it2b_deposit_dead_signature_demoted() {
 
     let metric_before = snapshot_recovered("escrow", "requeued", "deposit");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "pending");
     // Recovery classifies the dead signature but never re-mints itself (the fetcher does).
     assert_eq!(mock.call_count("sendTransaction"), 0);
-    assert_recovered_increment("escrow", "requeued", "deposit", metric_before, "IT-2b");
+    assert_recovered_increment(
+        "escrow",
+        "requeued",
+        "deposit",
+        metric_before,
+        "deposit dead signature requeued",
+    );
     mock.shutdown().await;
 }
 
-// IT-3: withdrawal whose recorded release signature is dead (null status, blockhash expired) → demote.
+// Withdrawal whose recorded release signature is dead (null status, blockhash expired) -> demote.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it3_withdrawal_dead_signature_demoted() {
-    let (db, url, _container) = start_pg("it3_wd_demote").await;
+async fn withdrawal_dead_signature_demoted() {
+    let (db, url, _container) = start_pg("wd_demote").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -349,8 +409,9 @@ async fn it3_withdrawal_dead_signature_demoted() {
         .await
         .unwrap();
 
+    let instance_pda = Pubkey::new_unique();
     let mock = MockRpcServer::start().await;
-    // Status null + current height (1000) > lvbh (100) → expired/dead.
+    // Status null + current height (1000) > lvbh (100) -> expired/dead.
     mock.enqueue(
         "getSignatureStatuses",
         Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
@@ -358,14 +419,29 @@ async fn it3_withdrawal_dead_signature_demoted() {
     mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
     // Ledger floor 0 covers the attempt window, so the expired absence is proven dead, not uncertain.
     mock.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
+    // Release-verify gate on the Dead arm: a finalized height (1000) past the
+    // attempt lvbh (100) plus an on-chain root that excludes nonce 7 prove
+    // NotLanded, so the withdrawal is safe to demote. This getBlockHeight is the
+    // verifier's second read after the classifier's expiry check consumed the first.
+    mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    mock.enqueue(
+        "getAccountInfo",
+        instance_account_reply(smt_root(0, &[]), 0),
+    );
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     let metric_before = snapshot_recovered("withdraw", "requeued", "withdrawal");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
-        .await
-        .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        ProgramType::Withdraw,
+        Some(instance_pda),
+        &storage_tx,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "pending");
     let fresh = updated_at_of(&pool, tx_id).await;
@@ -374,15 +450,101 @@ async fn it3_withdrawal_dead_signature_demoted() {
         "updated_at should be fresh"
     );
     assert_eq!(mock.call_count("sendTransaction"), 0);
-    assert_recovered_increment("withdraw", "requeued", "withdrawal", metric_before, "IT-3");
+    assert_recovered_increment(
+        "withdraw",
+        "requeued",
+        "withdrawal",
+        metric_before,
+        "withdrawal dead signature requeued",
+    );
     mock.shutdown().await;
 }
 
-// IT-4: withdrawal whose recorded release signature finalized → Completed, no re-send.
+/// The original issue-15 double-pay bug, closed: a pruned/lagging endpoint hides a
+/// release that actually landed on-chain, so the classifier says Dead; the SMT-root
+/// verifier proves Landed and we complete the row instead of re-paying it.
+#[tokio::test(flavor = "multi_thread")]
+async fn withdrawal_dead_but_landed_completes_without_double_pay() {
+    let (db, url, _container) = start_pg("wd_dead_but_landed").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let nonce = 7i64;
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), nonce);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    // insert_transaction_internal does not persist the nonce column, so set it
+    // explicitly: the SMT gate keys the on-chain membership proof off this value.
+    sqlx::query("UPDATE transactions SET withdrawal_nonce = $1 WHERE id = $2")
+        .bind(nonce)
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    // The release write-ahead that actually landed, though the endpoint hides it.
+    let landed_sig = Signature::new_unique();
+    db.insert_release_signature_internal(tx_id, landed_sig.to_string(), 100)
+        .await
+        .unwrap();
+
+    let instance_pda = Pubkey::new_unique();
+    let mock = MockRpcServer::start().await;
+    // Classifier says Dead: null status + current height (1000) > lvbh (100),
+    // ledger floor 0 covers the attempt window (coverage-proven absence).
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
+    );
+    mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    mock.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
+    // Release-verify gate: a finalized height (1000) past the attempt lvbh (100)
+    // plus an on-chain root that INCLUDES nonce 7 prove the release Landed, so the
+    // withdrawal is completed, not re-paid. This getBlockHeight is the verifier's
+    // second read after the classifier's expiry check consumed the first.
+    mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    mock.enqueue(
+        "getAccountInfo",
+        instance_account_reply(smt_root(0, &[nonce as u64]), 0),
+    );
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    let metric_before = snapshot_recovered("withdraw", "completed", "withdrawal");
+
+    test_hooks::run_recovery_once(
+        &storage,
+        &client,
+        ProgramType::Withdraw,
+        Some(instance_pda),
+        &storage_tx,
+    )
+    .await
+    .unwrap();
+
+    // Landed-but-hidden release completes the row from its recorded signature.
+    assert_eq!(status_of(&pool, tx_id).await, "completed");
+    assert_eq!(
+        counterpart_sig_of(&pool, tx_id).await,
+        Some(landed_sig.to_string())
+    );
+    // The whole point: nothing is re-broadcast, so no double-pay.
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    assert_recovered_increment(
+        "withdraw",
+        "completed",
+        "withdrawal",
+        metric_before,
+        "withdrawal dead but landed completed",
+    );
+    mock.shutdown().await;
+}
+
+// Withdrawal whose recorded release signature finalized -> Completed, no re-send.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it4_withdrawal_landed_signature_completed_no_resend() {
-    let (db, url, _container) = start_pg("it4_landed").await;
+async fn withdrawal_landed_signature_completed_no_resend() {
+    let (db, url, _container) = start_pg("wd_landed").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -414,7 +576,7 @@ async fn it4_withdrawal_landed_signature_completed_no_resend() {
 
     let metric_before = snapshot_recovered("withdraw", "completed", "withdrawal");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
         .await
         .unwrap();
 
@@ -424,15 +586,21 @@ async fn it4_withdrawal_landed_signature_completed_no_resend() {
         Some(landed_sig.to_string())
     );
     assert_eq!(mock.call_count("sendTransaction"), 0);
-    assert_recovered_increment("withdraw", "completed", "withdrawal", metric_before, "IT-4");
+    assert_recovered_increment(
+        "withdraw",
+        "completed",
+        "withdrawal",
+        metric_before,
+        "withdrawal landed completed",
+    );
     mock.shutdown().await;
 }
 
-// IT-4b: withdrawal whose recorded signature is still live → left in Processing (no CAS write).
+// Withdrawal whose recorded signature is still live -> left in Processing (no CAS write).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it4b_withdrawal_live_signature_left_processing() {
-    let (db, url, _container) = start_pg("it4b_live").await;
+async fn withdrawal_live_signature_left_processing() {
+    let (db, url, _container) = start_pg("wd_live").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -445,7 +613,7 @@ async fn it4b_withdrawal_live_signature_left_processing() {
         .unwrap();
 
     let mock = MockRpcServer::start().await;
-    // Status null + current height (50) <= lvbh (1000) → still live.
+    // Status null + current height (50) <= lvbh (1000) -> still live.
     mock.enqueue(
         "getSignatureStatuses",
         Reply::result(json!({"context": {"slot": 200}, "value": [null]})),
@@ -454,7 +622,7 @@ async fn it4b_withdrawal_live_signature_left_processing() {
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
         .await
         .unwrap();
 
@@ -463,7 +631,7 @@ async fn it4b_withdrawal_live_signature_left_processing() {
         "processing",
         "live signature must leave the row in Processing for the next sweep"
     );
-    // No CAS write → updated_at stays backdated, not refreshed to "now".
+    // No CAS write -> updated_at stays backdated, not refreshed to "now".
     assert!(
         updated_at_of(&pool, tx_id).await < Utc::now() - ChronoDuration::minutes(5),
         "no CAS write means updated_at must stay backdated, not refreshed"
@@ -472,11 +640,11 @@ async fn it4b_withdrawal_live_signature_left_processing() {
     mock.shutdown().await;
 }
 
-// IT-4c: withdrawal with no recorded signatures → quarantine (can't verify, double-payout risk).
+// Withdrawal with no recorded signatures -> quarantine (can't verify, double-payout risk).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it4c_withdrawal_no_signatures_quarantined() {
-    let (db, url, _container) = start_pg("it4c_no_sigs").await;
+async fn withdrawal_no_signatures_quarantined() {
+    let (db, url, _container) = start_pg("wd_no_sigs").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -491,12 +659,12 @@ async fn it4c_withdrawal_no_signatures_quarantined() {
 
     let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
         .await
         .unwrap();
 
     assert_eq!(status_of(&pool, tx_id).await, "manual_review");
-    // No RPC needed — empty signature set short-circuits before classification.
+    // No RPC needed - empty signature set short-circuits before classification.
     assert_eq!(mock.call_count("getSignatureStatuses"), 0);
     assert_eq!(mock.call_count("sendTransaction"), 0);
     let update = storage_rx
@@ -512,16 +680,16 @@ async fn it4c_withdrawal_no_signatures_quarantined() {
         "quarantined",
         "withdrawal",
         metric_before,
-        "IT-4c",
+        "withdrawal no signatures quarantined",
     );
     mock.shutdown().await;
 }
 
-// IT-4d: RPC uncertainty during classification → quarantine, never demote.
+// RPC uncertainty during classification -> quarantine, never demote.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it4d_withdrawal_rpc_uncertain_quarantined() {
-    let (db, url, _container) = start_pg("it4d_uncertain").await;
+async fn withdrawal_rpc_uncertain_quarantined() {
+    let (db, url, _container) = start_pg("wd_uncertain").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -534,7 +702,7 @@ async fn it4d_withdrawal_rpc_uncertain_quarantined() {
         .unwrap();
 
     let mock = MockRpcServer::start().await;
-    // getSignatureStatuses fails on every retry → Uncertain.
+    // getSignatureStatuses fails on every retry -> Uncertain.
     mock.enqueue_sequence(
         "getSignatureStatuses",
         vec![
@@ -548,7 +716,7 @@ async fn it4d_withdrawal_rpc_uncertain_quarantined() {
 
     let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
         .await
         .unwrap();
 
@@ -571,16 +739,16 @@ async fn it4d_withdrawal_rpc_uncertain_quarantined() {
         "quarantined",
         "withdrawal",
         metric_before,
-        "IT-4d",
+        "withdrawal rpc uncertain quarantined",
     );
     mock.shutdown().await;
 }
 
-// IT-4e: GC backstop reclaims release sigs whose parent left Processing.
+// GC backstop reclaims release sigs whose parent left Processing.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it4e_gc_reclaims_non_processing_release_sigs() {
-    let (db, url, _container) = start_pg("it4e_gc").await;
+async fn gc_reclaims_non_processing_release_sigs() {
+    let (db, url, _container) = start_pg("gc_reclaim").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -612,7 +780,7 @@ async fn it4e_gc_reclaims_non_processing_release_sigs() {
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     // recover_once runs gc_stale_release_signatures at the top of the sweep.
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
         .await
         .unwrap();
 
@@ -635,12 +803,12 @@ async fn it4e_gc_reclaims_non_processing_release_sigs() {
     mock.shutdown().await;
 }
 
-// IT-5 / IT-D5: deposit with a persisted signature but an RPC that cannot classify it.
+// Deposit with a persisted signature but an RPC that cannot classify it.
 // ManualReview (never a silent demote, which would risk a double-mint).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
-    let (db, url, _container) = start_pg("it5_rpc_down").await;
+async fn rpc_failure_deposit_quarantines_to_manual_review() {
+    let (db, url, _container) = start_pg("dep_rpc_down").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -669,7 +837,7 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
 
     let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
 
@@ -687,16 +855,22 @@ async fn it5_rpc_failure_deposit_quarantines_to_manual_review() {
         err.contains("could not verify mint landed"),
         "reason should match runbook substring: {err}"
     );
-    assert_recovered_increment("escrow", "quarantined", "deposit", metric_before, "IT-5");
+    assert_recovered_increment(
+        "escrow",
+        "quarantined",
+        "deposit",
+        metric_before,
+        "deposit rpc failure quarantined",
+    );
     mock.shutdown().await;
 }
 
-// IT-6: a malformed persisted signature is uncertainty (never read as "dead"),
+// A malformed persisted signature is uncertainty (never read as "dead"),
 // quarantine via the shared load_pending_sigs path, with no RPC consulted.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it6_malformed_stored_sig_quarantines_deposit() {
-    let (db, url, _container) = start_pg("it6_malformed_sig").await;
+async fn malformed_stored_sig_quarantines_deposit() {
+    let (db, url, _container) = start_pg("dep_malformed_sig").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -716,7 +890,7 @@ async fn it6_malformed_stored_sig_quarantines_deposit() {
 
     let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
 
@@ -739,15 +913,21 @@ async fn it6_malformed_stored_sig_quarantines_deposit() {
         err.contains("malformed stored release signature"),
         "reason should name the malformed signature: {err}"
     );
-    assert_recovered_increment("escrow", "quarantined", "deposit", metric_before, "IT-6");
+    assert_recovered_increment(
+        "escrow",
+        "quarantined",
+        "deposit",
+        metric_before,
+        "deposit malformed signature quarantined",
+    );
     mock.shutdown().await;
 }
 
-// IT-7: fresh row is untouched (no RPC, no DB write).
+// A fresh row is untouched (no RPC, no DB write).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it7_fresh_processing_row_untouched() {
-    let (db, url, _container) = start_pg("it7_fresh").await;
+async fn fresh_processing_row_untouched() {
+    let (db, url, _container) = start_pg("fresh_row").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -756,7 +936,7 @@ async fn it7_fresh_processing_row_untouched() {
     let recipient = Pubkey::new_unique();
     let tx = make_deposit(&Signature::new_unique().to_string(), mint, recipient, 100);
     let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
-    // Flip to processing without backdating — updated_at is "now".
+    // Flip to processing without backdating - updated_at is "now".
     sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
         .bind(tx_id)
         .execute(&pool)
@@ -768,7 +948,7 @@ async fn it7_fresh_processing_row_untouched() {
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
 
@@ -792,11 +972,11 @@ async fn it7_fresh_processing_row_untouched() {
     mock.shutdown().await;
 }
 
-// IT-8: conditional write is a no-op if the row moved between SELECT and write.
+// The conditional write is a no-op if the row moved between SELECT and write.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it8_conditional_write_noops_when_row_moved() {
-    let (db, url, _container) = start_pg("it8_cond").await;
+async fn conditional_write_noops_when_row_moved() {
+    let (db, url, _container) = start_pg("cond_write").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
 
@@ -807,7 +987,7 @@ async fn it8_conditional_write_noops_when_row_moved() {
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
     let _captured = seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
 
-    // Race: row already moved off Processing → try_requeue returns false.
+    // Race: row already moved off Processing -> try_requeue returns false.
     sqlx::query("UPDATE transactions SET status = 'completed'::transaction_status WHERE id = $1")
         .bind(tx_id)
         .execute(&pool)
@@ -830,11 +1010,11 @@ async fn it8_conditional_write_noops_when_row_moved() {
     );
 }
 
-// IT-9: lagging terminal write cannot stomp a recovery demote.
+// A lagging terminal write cannot stomp a recovery demote.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
-    let (db, url, _container) = start_pg("it9_lagging").await;
+async fn lagging_terminal_write_no_ops_after_recovery_demote() {
+    let (db, url, _container) = start_pg("lagging_write").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -850,17 +1030,18 @@ async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
     assert_eq!(status_of(&pool, tx_id).await, "pending");
 
-    // Lagging in-flight write from dead operator — must no-op.
+    // Lagging in-flight write from dead operator - must no-op.
     db.update_transaction_status_internal(
         tx_id,
         private_channel_indexer::storage::common::models::TransactionStatus::Completed,
         Some("lagging-sig".to_string()),
         Utc::now(),
+        None,
     )
     .await
     .unwrap();
@@ -877,11 +1058,11 @@ async fn it9_lagging_terminal_write_no_ops_after_recovery_demote() {
     mock.shutdown().await;
 }
 
-// IT-10: 250-row backlog drained across multiple ticks.
+// A 250-row backlog drained across multiple ticks.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it10_backlog_batched_across_ticks() {
-    let (db, url, _container) = start_pg("it10_batched").await;
+async fn backlog_batched_across_ticks() {
+    let (db, url, _container) = start_pg("backlog_batched").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -924,7 +1105,7 @@ async fn it10_backlog_batched_across_ticks() {
 
     // Tick 1: should heal exactly RECOVERY_BATCH_LIMIT (100) rows.
     let t0 = std::time::Instant::now();
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
     assert!(
@@ -939,10 +1120,10 @@ async fn it10_backlog_batched_across_ticks() {
     assert_eq!(pending_count, 100, "tick 1 must heal exactly the batch cap");
 
     // Ticks 2-3: drain the rest. Healed rows are excluded (trigger bumped updated_at).
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
     let pending_count: i64 =
@@ -957,11 +1138,11 @@ async fn it10_backlog_batched_across_ticks() {
     mock.shutdown().await;
 }
 
-// IT-11: PendingRemint rows are NOT touched by recovery.
+// PendingRemint rows are NOT touched by recovery.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it11_pending_remint_rows_untouched() {
-    let (db, url, _container) = start_pg("it11_pending_remint").await;
+async fn pending_remint_rows_untouched() {
+    let (db, url, _container) = start_pg("pending_remint_db").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -1002,7 +1183,7 @@ async fn it11_pending_remint_rows_untouched() {
     let client = test_client(mock.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
         .await
         .unwrap();
 
@@ -1014,11 +1195,11 @@ async fn it11_pending_remint_rows_untouched() {
     mock.shutdown().await;
 }
 
-// IT-12: withdrawal with NULL nonce → ManualReview (runbook reason string).
+// Withdrawal with NULL nonce -> ManualReview (runbook reason string).
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it12_withdrawal_missing_nonce_quarantines() {
-    let (db, url, _container) = start_pg("it12_missing_nonce").await;
+async fn withdrawal_missing_nonce_quarantines() {
+    let (db, url, _container) = start_pg("missing_nonce").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -1039,7 +1220,7 @@ async fn it12_withdrawal_missing_nonce_quarantines() {
 
     let metric_before = snapshot_recovered("withdraw", "quarantined", "withdrawal");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, None, &storage_tx)
         .await
         .unwrap();
 
@@ -1056,17 +1237,17 @@ async fn it12_withdrawal_missing_nonce_quarantines() {
         "quarantined",
         "withdrawal",
         metric_before,
-        "IT-12",
+        "withdrawal missing nonce quarantined",
     );
     mock.shutdown().await;
 }
 
-// IT-13: a deposit that keeps coming back NotLanded is quarantined once it hits
-// the requeue cap instead of looping pending→processing→pending forever.
+// A deposit that keeps coming back NotLanded is quarantined once it hits
+// the requeue cap instead of looping pending->processing->pending forever.
 
 #[tokio::test(flavor = "multi_thread")]
-async fn it13_recovery_requeue_cap_quarantines_after_max() {
-    let (db, url, _container) = start_pg("it13_requeue_cap").await;
+async fn recovery_requeue_cap_quarantines_after_max() {
+    let (db, url, _container) = start_pg("requeue_cap").await;
     let storage = Arc::new(Storage::Postgres(db.clone()));
     storage.init_schema().await.unwrap();
     let pool = sqlx::PgPool::connect(&url).await.unwrap();
@@ -1100,7 +1281,7 @@ async fn it13_recovery_requeue_cap_quarantines_after_max() {
 
     let metric_before = snapshot_recovered("escrow", "quarantined", "deposit");
 
-    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, None, &storage_tx)
         .await
         .unwrap();
 
@@ -1120,7 +1301,13 @@ async fn it13_recovery_requeue_cap_quarantines_after_max() {
         "alert must name the requeue cap and its count: {err}"
     );
     assert_eq!(mock.call_count("sendTransaction"), 0);
-    assert_recovered_increment("escrow", "quarantined", "deposit", metric_before, "IT-13");
+    assert_recovered_increment(
+        "escrow",
+        "quarantined",
+        "deposit",
+        metric_before,
+        "deposit requeue cap quarantined",
+    );
     mock.shutdown().await;
 }
 
@@ -1190,7 +1377,7 @@ async fn threshold_boundary_returns_only_strictly_older_rows() {
     );
 }
 
-// ── ownership-checked deposit claim: the double-mint invariant end-to-end ─────
+// -- ownership-checked deposit claim: the double-mint invariant end-to-end -----
 //
 // One escrow deposit must produce at most one channel mint even when the
 // recovery worker demotes a row while a live in-memory Mint builder still
@@ -1243,7 +1430,7 @@ async fn drive_first_fire(
     .await;
 }
 
-// IT1: a stale sender-owned builder whose row recovery already demoted must NOT
+// A stale sender-owned builder whose row recovery already demoted must NOT
 // broadcast. This is the exact reported bug, closed.
 #[tokio::test(flavor = "multi_thread")]
 async fn stale_owned_builder_does_not_double_mint() {
@@ -1270,9 +1457,15 @@ async fn stale_owned_builder_does_not_double_mint() {
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     // Recovery sees empty sigs and demotes the row to Pending (bumping updated_at).
-    test_hooks::run_recovery_once(&storage, &recovery_client, ProgramType::Escrow, &storage_tx)
-        .await
-        .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &recovery_client,
+        ProgramType::Escrow,
+        None,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
     assert_eq!(status_of(&pool, tx_id).await, "pending");
 
     let metric = OPERATOR_TRANSACTION_ERRORS.with_label_values(&["escrow", OWNERSHIP_LOST_REASON]);
@@ -1354,9 +1547,15 @@ async fn stale_jit_refire_does_not_double_mint() {
     mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
     mock.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
     let recovery_client = test_client(mock.url());
-    test_hooks::run_recovery_once(&storage, &recovery_client, ProgramType::Escrow, &storage_tx)
-        .await
-        .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &recovery_client,
+        ProgramType::Escrow,
+        None,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
     assert_eq!(status_of(&pool, tx_id).await, "pending");
     let sigs_after_demote = db.get_release_signatures_internal(tx_id).await.unwrap();
 
@@ -1412,7 +1611,7 @@ async fn stale_jit_refire_does_not_double_mint() {
     mock.shutdown().await;
 }
 
-// IT2: an owned deposit mints exactly once. The happy-path oracle proving the
+// An owned deposit mints exactly once. The happy-path oracle proving the
 // guard does not strangle a legitimate mint.
 #[tokio::test(flavor = "multi_thread")]
 async fn owned_deposit_mints_once() {
@@ -1472,7 +1671,7 @@ async fn owned_deposit_mints_once() {
     mock.shutdown().await;
 }
 
-// IT3: demote then re-fetch, then drive BOTH the stale first builder and the
+// Demote then re-fetch, then drive BOTH the stale first builder and the
 // second builder. Exactly one mint broadcasts across the whole sequence.
 #[tokio::test(flavor = "multi_thread")]
 async fn demote_then_refetch_mints_exactly_once() {
@@ -1501,9 +1700,15 @@ async fn demote_then_refetch_mints_exactly_once() {
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
     // Recovery demotes B1's row to Pending.
-    test_hooks::run_recovery_once(&storage, &recovery_client, ProgramType::Escrow, &storage_tx)
-        .await
-        .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &recovery_client,
+        ProgramType::Escrow,
+        None,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
 
     // A fresh fetch re-locks the row as a new incarnation B2 with token T_lock2.
     let relocked = storage
@@ -1537,7 +1742,7 @@ async fn demote_then_refetch_mints_exactly_once() {
     mock.shutdown().await;
 }
 
-// ── cross-operator recovery and the reopened-row gate ───────────────────────
+// -- cross-operator recovery and the reopened-row gate -----------------------
 
 // The reported exploit end-to-end: a stale Processing deposit whose mint landed
 // on the channel is invisible to the withdraw operator's sweep (whose Solana
@@ -1575,9 +1780,15 @@ async fn cross_operator_recovery_does_not_replay_deposit_mint() {
     let solana_client = test_client(solana.url());
     let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
 
-    test_hooks::run_recovery_once(&storage, &solana_client, ProgramType::Withdraw, &storage_tx)
-        .await
-        .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &solana_client,
+        ProgramType::Withdraw,
+        None,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         status_of(&pool, tx_id).await,
         "processing",
@@ -1605,9 +1816,15 @@ async fn cross_operator_recovery_does_not_replay_deposit_mint() {
         })),
     );
     let channel_client = test_client(channel.url());
-    test_hooks::run_recovery_once(&storage, &channel_client, ProgramType::Escrow, &storage_tx)
-        .await
-        .unwrap();
+    test_hooks::run_recovery_once(
+        &storage,
+        &channel_client,
+        ProgramType::Escrow,
+        None,
+        &storage_tx,
+    )
+    .await
+    .unwrap();
     assert_eq!(status_of(&pool, tx_id).await, "completed");
     assert_eq!(
         counterpart_sig_of(&pool, tx_id).await,

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -419,11 +419,17 @@ async fn withdrawal_dead_signature_demoted() {
     mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
     // Ledger floor 0 covers the attempt window, so the expired absence is proven dead, not uncertain.
     mock.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
-    // Release-verify gate on the Dead arm: a finalized height (1000) past the
-    // attempt lvbh (100) plus an on-chain root that excludes nonce 7 prove
-    // NotLanded, so the withdrawal is safe to demote. This getBlockHeight is the
-    // verifier's second read after the classifier's expiry check consumed the first.
-    mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    // Release-verify gate on the Dead arm: a finalized blockhash whose tip height
+    // (1000 - 150 = 850) is past the attempt lvbh (100), plus an on-chain root that
+    // excludes nonce 7, prove NotLanded, so the withdrawal is safe to demote. The
+    // verifier binds the account read to this blockhash's context slot.
+    mock.enqueue(
+        "getLatestBlockhash",
+        Reply::result(json!({
+            "context": {"slot": 500},
+            "value": {"blockhash": "11111111111111111111111111111111", "lastValidBlockHeight": 1000}
+        })),
+    );
     mock.enqueue(
         "getAccountInfo",
         instance_account_reply(smt_root(0, &[]), 0),
@@ -498,11 +504,17 @@ async fn withdrawal_dead_but_landed_completes_without_double_pay() {
     );
     mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
     mock.enqueue("getFirstAvailableBlock", Reply::result(json!(0)));
-    // Release-verify gate: a finalized height (1000) past the attempt lvbh (100)
-    // plus an on-chain root that INCLUDES nonce 7 prove the release Landed, so the
-    // withdrawal is completed, not re-paid. This getBlockHeight is the verifier's
-    // second read after the classifier's expiry check consumed the first.
-    mock.enqueue("getBlockHeight", Reply::result(json!(1000)));
+    // Release-verify gate: a finalized blockhash whose tip height (1000 - 150 = 850)
+    // is past the attempt lvbh (100), plus an on-chain root that INCLUDES nonce 7,
+    // prove the release Landed, so the withdrawal is completed, not re-paid. The
+    // verifier binds the account read to this blockhash's context slot.
+    mock.enqueue(
+        "getLatestBlockhash",
+        Reply::result(json!({
+            "context": {"slot": 500},
+            "value": {"blockhash": "11111111111111111111111111111111", "lastValidBlockHeight": 1000}
+        })),
+    );
     mock.enqueue(
         "getAccountInfo",
         instance_account_reply(smt_root(0, &[nonce as u64]), 0),


### PR DESCRIPTION
## Summary

Closes issue 15. The release-side finality logic treated RPC history absence as proof a withdrawal never landed. A pruned or lagging RPC could therefore misclassify a successful `ReleaseFunds` as `Dead`, causing the recovery sweep or deferred-remint flow to double-pay.

The fix verifies landed releases against the on-chain Sparse Merkle Tree instead of relying on transaction history. Only the terminal `Dead` path invokes `verify_release_landed`, which proves whether the withdrawal nonce is committed by the finalized root. The verifier performs freshness, tree-window, and root-membership checks, using `min_context_slot` to bind the finalized tip and account snapshot to the same state and fail closed on stale or inconsistent RPC responses. The `Landed`, `Live`, and `Uncertain` fast paths remain unchanged.

The change also makes the withdraw operator fallback RPC optional, since the SMT root is now the authoritative source of truth. Tests cover all verifier outcomes, stale-backend regressions, recovery and remint flows, durable signature persistence, and the updated fallback behavior. A new `OPERATOR_RELEASE_VERIFY{site, verdict}` metric makes verification outcomes observable.


### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 12,361 | 13,989 | 88.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30446478612) |
| Indexer | 32,527 | 35,947 | 90.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30446478612) |
| Gateway | 1,330 | 1,521 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30446478612) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30446478612) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,589 | 17,326 | 78.4% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30446478612) |
| **Total** | **60,592** | **69,686** | **87.0%** | |

> Last updated: 2026-07-29 12:02:51 UTC by E2E Integration