### PR TITLE
fix(indexer): halt when a channel mint authority is not the configured amin (issue-240)

### DIFF
--- a/docs/ESCROW_INTERACTION_GUIDE.md
+++ b/docs/ESCROW_INTERACTION_GUIDE.md
@@ -204,7 +204,7 @@ const removeOperatorIx = await getRemoveOperatorInstructionAsync({
 
 ## SetNewAdmin
 
-Transfers admin control to a new address. Useful for key rotation, organizational changes, or upgrading to multisig governance.
+Transfers admin control to a new address. This is one step of a key rotation, not the whole of it: follow [the admin rotation runbook](runbooks/admin_rotation_runbook.md).
 
 ### TypeScript Example
 
@@ -226,7 +226,7 @@ const setAdminIx = getSetNewAdminInstruction({
 **Important:**
 - Both current admin and new admin must sign the transaction
 - Change is immediate and irreversible
-- Old admin loses all privileges once confirmed
+- Old admin loses all escrow admin privileges once confirmed, but keeps the mint and freeze authority on every existing channel mint until those are migrated separately
 - Verify new admin address carefully (typos = permanent loss of control)
 
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -83,11 +83,14 @@ The runbooks call this out at every relevant site.
   Every "escalate" call-site in the recovery runbooks links here.
 - [`withdrawal_pipeline_halt_runbook.md`](withdrawal_pipeline_halt_runbook.md) -
   the SMT-root-mismatch startup halt (log-discovered, not paged).
+- [`admin_rotation_runbook.md`](admin_rotation_runbook.md) - replacing the admin
+  key. Planned procedure, not an alert response; `SetNewAdmin` alone leaves the
+  old key holding every channel mint's authority.
 
 ## Drills
 
 [`indexer/tests/runbook_drills.rs`](../../indexer/tests/runbook_drills.rs)
-contains seventeen `#[ignore]`-flagged drills that verify these runbooks'
+contains eighteen `#[ignore]`-flagged drills that verify these runbooks'
 commands actually do what the prose claims. Drills are **manually
 triggered, not in CI** - they exist so a human about to use a runbook
 (or about to publish an edit) can confirm the diagnostic and recovery
@@ -113,6 +116,7 @@ pins the relevant contract.
 | `drill_15_deposit_manual_review_recovery_idempotency_failure_flow` | deposit | `deposit_manual_review.md` § Path E: recovery-worker `deposit idempotency:` triage substring present in `recovery.rs`; re-arm SQL flips `manual_review` → `pending` and is row-scoped by id. |
 | `drill_16_withdrawal_manual_review_recovery_missing_nonce_flow` | withdrawal | `withdrawal_manual_review.md` § Path F: recovery-worker `withdrawal row missing nonce` triage substring present in `recovery.rs`; recovery branch SQL is row-scoped; no re-arm SQL exists for this path. |
 | `drill_17_deposit_manual_review_allowlist_gate_recovery_flows` | deposit | Allowlist-gate recovery flow in `deposit_manual_review.md` is in sync with source: triage strings still exist and recovery SQL is row-scoped. |
+| `drill_18_admin_rotation_contracts_present_in_source` | escrow | `reconciliation_halt_runbook.md` halt-reason dispatch substrings, both halt log lines and the startup authority line exist in `reconciliation.rs`; the authority halt routes through `freeze_pipelines`; `admin_rotation_runbook.md` § 4 classification labels exist in the migration binary; cross-links between both runbooks and `ESCROW_INTERACTION_GUIDE.md` hold. |
 
 Trigger (`make` shorthand, runs from repo root):
 
@@ -141,5 +145,7 @@ RUST_LOG=trace cargo test -p private-channel-indexer --test runbook_drills -- \
   (the `JitOutcome::ManualReview` reason strings live here — drill_14
   specifically), `sender/remint.rs`, `db_transaction_writer.rs`
   (including its webhook-payload serializer — drill_13 anchors on the
-  `"remint_signature"` JSON key string literal), or the indexer
-  schema.
+  `"remint_signature"` JSON key string literal), `reconciliation.rs`
+  (halt reason strings and the startup authority log line — drill_18),
+  `bin/migrate_mint_authority.rs` (its per-mint classification labels —
+  drill_18), or the indexer schema.

--- a/docs/runbooks/admin_rotation_runbook.md
+++ b/docs/runbooks/admin_rotation_runbook.md
@@ -1,0 +1,88 @@
+# Runbook - Admin Key Rotation
+
+`SetNewAdmin` changes `Instance.admin` and nothing else. It does not move the SPL
+mint and freeze authorities on the channel mints, and those are what let a key
+issue channel tokens. Skip the migration step and the old key can still issue
+tokens for every mint it created, which convert to real escrow funds through the
+permissionless withdraw program.
+
+Requires downtime: the operator signs with one key at a time, so any mint whose
+authority has moved is unusable until the configuration catches up.
+
+---
+
+## The constraint
+
+SPL Token accepts `SetAuthority` only from the **current** authority, so the new
+admin cannot migrate the mints to itself. Every migration step is signed by the
+old key.
+
+> **Do not destroy or lose the old key until step 8 passes.** An unmigrated mint
+> with no reachable authority is permanently unusable; recovery is a coordinated
+> mint replacement ([`deposit_manual_review.md`](deposit_manual_review.md)
+> § `NOT_LANDED`).
+
+## Steps
+
+**1. Capture the mint list.** Step 9 must re-allow exactly this set.
+
+```sql
+SELECT mint_address FROM mints ORDER BY mint_address;
+```
+
+**2. Block every mint.** `BlockMint` each one, signed by the old admin. Closes the
+`AllowedMint` PDA that `ReleaseFunds` requires, stopping deposits and releases.
+
+**3. Drain in-flight work.** Proceed only when this returns nothing; a withdrawal
+landing mid-migration fails on mint authority and ends in `manual_review`.
+
+```sql
+SELECT status, transaction_type, COUNT(*) FROM transactions WHERE status IN ('pending','processing','parked','pending_remint') GROUP BY status, transaction_type;
+```
+
+**4. Dry-run the migration.** Sends nothing; prints one line per mint.
+
+```bash
+cargo run --bin migrate_mint_authority -- --database-url "$DATABASE_URL" --channel-rpc-url "$CHANNEL_RPC_URL" --old-authority-keypair ./keypairs/admin.json --new-authority <NEW_PUBKEY> --dry-run
+```
+
+`WOULD MIGRATE` held by the old key. `OK` already migrated. `SKIP` not initialized
+yet, the first deposit creates it under the new admin. `FOREIGN` held by neither
+key, which aborts the run before anything is sent: resolve those via
+[`reconciliation_halt_runbook.md`](reconciliation_halt_runbook.md) § "Halt reason:
+stale mint authority".
+
+**5. Migrate.** Same command without `--dry-run`. Both authorities move in one
+transaction per mint, then the tool re-reads everything and exits non-zero if any
+mint is still off the new authority. Non-zero means stop. Re-running is safe.
+
+To reverse, run it again with the pubkeys swapped and the new key as
+`--old-authority-keypair`.
+
+**6. Update config.** `ADMIN_PRIVATE_KEY`, `PRIVATE_CHANNEL_ADMIN_KEYS`, and
+`OPERATOR_PRIVATE_KEY` if it shares the admin key (it does in the shipped compose
+files).
+
+**7. Restart** both operators **and the write node**.
+`PRIVATE_CHANNEL_ADMIN_KEYS` is read once at node startup.
+
+**8. Verify.** The escrow operator's first reconciliation tick runs immediately at
+startup. It must log `Expected channel mint authority: <NEW_PUBKEY>` (the new key,
+not the old, or the env did not take), with no `MINT AUTHORITY HALT` and no row
+from:
+
+```sql
+SELECT halted, reason FROM reconciliation_halt WHERE id = TRUE;
+```
+
+A halt here means a mint was missed. Return to step 4.
+
+**9. `SetNewAdmin`,** signed by both admins, then `AllowMint` the step 1 list
+signed by the new admin. This order makes the re-allow the proof that the new
+escrow admin works.
+
+**10. Resume.** Clear any halt flag
+([`reconciliation_halt_runbook.md`](reconciliation_halt_runbook.md) § Recover), run
+one deposit and one withdrawal, re-queue anything left in `manual_review`.
+
+**11. Retire the old key.** Not before step 8 passed.

--- a/docs/runbooks/reconciliation_halt_runbook.md
+++ b/docs/runbooks/reconciliation_halt_runbook.md
@@ -1,16 +1,25 @@
 # Runbook - Reconciliation Halt
 
 This runbook covers the **runtime reconciliation halt** in the escrow operator.
-Unlike the alert-only behavior of the past, a **proven** insolvency now fails
-closed: it sets a durable DB flag that freezes **both** operators' fetchers
-(deposits and withdrawals), quarantines active withdrawals, forces the escrow
-operator's `/health` to 503, and posts a webhook.
+Unlike the alert-only behavior of the past, the operator now fails closed: it sets
+a durable DB flag that freezes **both** operators' fetchers (deposits and
+withdrawals), quarantines active withdrawals, forces the escrow operator's
+`/health` to 503, and posts a webhook.
 
-A halt is deliberate: it trades liveness for integrity. It only fires when the
-on-chain channel-token supply exceeds on-chain escrow custody by more than the
-DB-computed in-flight envelope for three consecutive finalized-read ticks, so a
-transient (in-flight activity, a one-off bad RPC read) cannot trip it. Recovery
-is **manual** - a human must confirm real backing before clearing the flag.
+A halt is deliberate: it trades liveness for integrity. Two conditions trip it,
+and they confirm differently:
+
+| Condition | Reason substring | Confirmation |
+|---|---|---|
+| **Insolvency** - channel-token supply exceeds escrow custody beyond the in-flight envelope | `short of supply by` | three consecutive finalized-read ticks |
+| **Stale mint authority** - a channel mint no longer names the operator's configured admin | `names mint_authority` | first observation |
+
+Insolvency needs repetition because in-flight activity or a one-off bad RPC read
+can produce a gap that is not real. An authority is one pubkey compared against
+another, so there is nothing for a second tick to confirm.
+
+Recovery is **manual** for both - a human must confirm real backing, or restore
+the authority, before clearing the flag.
 
 As with every runbook here, the recovery `UPDATE` statements are
 **bookkeeping, not fund movement** - see
@@ -21,10 +30,13 @@ human-in-the-loop".
 
 ## What the operator does automatically
 
-Runtime reconciliation checks a single on-chain invariant against **finalized**
-reads, per mint:
+Runtime reconciliation reads each channel mint once per tick at **finalized** and
+checks two invariants against it:
 
-> **channel `Mint.supply` (PrivateChannel) must not exceed escrow custody (Solana).**
+> **1. channel `Mint.supply` (PrivateChannel) must not exceed escrow custody (Solana).**
+>
+> **2. every initialized channel mint must name the operator's configured admin as
+> its mint and freeze authority.**
 
 On-chain supply is already net of burns (the program burns channel tokens at
 withdrawal initiation, not at release), so `supply <= custody` is a pure
@@ -33,8 +45,26 @@ to (a) enumerate the mint universe (the `mints` table, so a blocked or not-held
 mint with outstanding supply is still checked) and (b) compute the per-mint
 in-flight envelope; neither is compared against custody.
 
+The second invariant catches the state that precedes an unbacked issuance rather
+than its result. A key other than the configured admin holding mint authority can
+issue channel tokens against live custody, and burning them through the
+permissionless withdraw program turns them into a real escrow release. Invariant
+1 does see that eventually, but only once custody has already left, so it reports
+a loss already taken. Invariant 2 fires on the authority itself.
+
+It is a periodic check, not a guard on the mint path, so a mint whose authority
+changes mid-interval is caught on the next tick rather than instantly. The first
+tick runs at operator startup, which is what makes it tight for the case it exists
+for: a rotation that updated the configuration without migrating the mints.
+
+An **absent** freeze authority is accepted. A foreign key there could freeze any
+holder's account, but no key at all means the capability does not exist, and
+halting on it would be unclearable since a freeze authority cannot be reinstalled.
+An absent **mint** authority is not accepted: it bricks the mint.
+
 When a mint shows `supply - custody` greater than its in-flight envelope (plus a
-small bps cushion) for three consecutive ticks, the operator **halts**:
+small bps cushion) for three consecutive ticks, or names an authority other than
+the configured admin on any tick, the operator **halts**:
 
 1. Sets the durable `reconciliation_halt` flag (reason recorded).
 2. Quarantines every active (`pending`/`processing`/`parked`) withdrawal to
@@ -51,8 +81,11 @@ re-read it at first poll and stay frozen until it is cleared.
 
 - Deposits stop minting and withdrawals stop releasing across both operators.
 - The escrow operator's `/health` returns 503 with `"reason":"forced"`.
-- Logs carry `RECONCILIATION HALT tripped; freezing both pipelines` with the
-  mint, the supply gap, envelope, tolerance, and tick count.
+- Logs carry one of:
+  - `RECONCILIATION HALT tripped; freezing both pipelines` with the mint, the
+    supply gap, envelope, tolerance, and tick count.
+  - `MINT AUTHORITY HALT tripped; freezing both pipelines` with the mint, the
+    authorities it names, and the configured admin it was compared against.
 - Active withdrawals are in `manual_review`.
 
 ## Detection
@@ -63,8 +96,16 @@ Inspect the flag directly:
 SELECT halted, reason, halted_at FROM reconciliation_halt WHERE id = TRUE;
 ```
 
-A `halted = TRUE` row is an active halt. `reason` carries the offending mint and
-the exact custody / supply-gap / envelope / tolerance numbers.
+A `halted = TRUE` row is an active halt. Route on `reason`:
+
+- contains `short of supply by` → insolvency. Continue to
+  [§ Investigate before clearing](#investigate-before-clearing). `reason` carries
+  the offending mint and the exact custody / supply-gap / envelope / tolerance
+  numbers.
+- contains `names mint_authority` → stale authority. Skip to
+  [§ Halt reason: stale mint authority](#halt-reason-stale-mint-authority).
+  Custody is **not** in question and the insolvency procedure below does not
+  apply.
 
 ## Investigate before clearing
 
@@ -103,10 +144,49 @@ the halt reason:
 If `supply > custody` persists beyond the in-flight envelope once the in-flight
 work settles, this is a **real** solvency incident (operator-key over-issuance or
 a custody shortfall). Escalate per [`_escalation.md`](_escalation.md); rotate the
-operator/admin key if over-issuance is suspected, and do **not** resume the
-pipelines.
+operator/admin key per
+[`admin_rotation_runbook.md`](admin_rotation_runbook.md) if over-issuance is
+suspected, and do **not** resume the pipelines.
+
+## Halt reason: stale mint authority
+
+The reason names one channel mint, the `mint_authority` and `freeze_authority` it
+carries on the channel, and the configured admin they were compared against.
+Custody is untouched and nothing has been over-issued yet. What has happened is
+that a key other than the one this operator signs with can issue channel tokens
+for a mint the escrow still backs.
+
+**Do not clear the flag to make this go away.** It re-trips on the next tick, and
+clearing it without restoring the authority is precisely what lets an unbacked
+issuance reach a real escrow release.
+
+Read the named mint on the PrivateChannel RPC:
+
+```bash
+spl-token display <MINT> --url <private-channel-rpc>
+```
+
+Compare `Mint authority` and `Freeze authority` to the pubkey in the halt reason.
+The operator logs what it expects once at startup, as
+`Expected channel mint authority: <pubkey>`.
+
+Then match the cause:
+
+| Authority on the channel | Cause | Action |
+|---|---|---|
+| The organisation's previous admin key | An admin rotation was started and not finished, or was never migrated at all. | Complete the rotation per [`admin_rotation_runbook.md`](admin_rotation_runbook.md). The migration step is what clears this. |
+| A key nobody recognises | The mint was initialized on the channel by a third party before the operator got to it. | Escalate (Tier 2) per [`_escalation.md`](_escalation.md). Do not attempt migration: the signature needed to move the authority is not ours. Outstanding channel tokens for this mint were not operator-issued. |
+| `none` (cleared) | The authority was removed via `SetAuthority`. No key can mint this token again, and none can be installed. | Escalate (Tier 1). The mint is permanently unusable; recovery is the coordinated mint replacement in [`deposit_manual_review.md`](deposit_manual_review.md) § `NOT_LANDED`. |
+
+Only the first row is self-service. Once every channel mint names the configured
+admin, re-run the verification step in the rotation runbook and clear the flag
+with the SQL below.
 
 ## Recover (only after backing is confirmed)
+
+For an **insolvency** halt, confirm backing first (§ Investigate before clearing).
+For a **stale authority** halt, restore the authority first (§ Halt reason: stale
+mint authority). Clearing the flag is the same for both.
 
 Once you have verified that custody genuinely backs the minted supply (e.g. the
 gap was a transient the reads have since settled, or the discrepancy has been

--- a/indexer/src/bin/migrate_mint_authority.rs
+++ b/indexer/src/bin/migrate_mint_authority.rs
@@ -1,0 +1,169 @@
+//! CLI for moving channel mint authorities from the old admin key to a new one.
+//!
+//! Argument parsing, mint enumeration and reporting only. The migration itself
+//! lives in `operator::mint_authority_migration` so it can be covered by an
+//! integration test against a real validator.
+//!
+//! Driven by `docs/runbooks/admin_rotation_runbook.md` § 4-5.
+
+use clap::Parser;
+use private_channel_indexer::config::PostgresConfig;
+use private_channel_indexer::operator::escrow_sweep::describe_authority;
+use private_channel_indexer::operator::mint_authority_migration::{
+    migrate_mint_authorities, MigrationError, Plan,
+};
+use private_channel_indexer::operator::utils::rpc_util::{RetryConfig, RpcClientWithRetry};
+use private_channel_indexer::storage::{PostgresDb, Storage};
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{read_keypair_file, Signer};
+use std::str::FromStr;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "migrate-mint-authority",
+    about = "Move channel mint and freeze authority from the old admin key to a new one"
+)]
+struct Args {
+    /// Indexer database, used only to enumerate which mints exist.
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: String,
+
+    /// PrivateChannel RPC. The channel mints live here, not on the source chain.
+    #[arg(long, env = "CHANNEL_RPC_URL")]
+    channel_rpc_url: String,
+
+    /// Keypair file for the key that currently holds the authorities. It has to
+    /// sign every SetAuthority, so the migration must run before it is retired.
+    #[arg(long)]
+    old_authority_keypair: String,
+
+    /// Pubkey the authorities move to. This is what the operator's ADMIN_SIGNER
+    /// must resolve to once the rotation completes.
+    #[arg(long)]
+    new_authority: String,
+
+    /// Classify and report without sending anything.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    let old_authority = read_keypair_file(&args.old_authority_keypair)
+        .map_err(|e| format!("Failed to read {}: {}", args.old_authority_keypair, e))?;
+    let new_authority = Pubkey::from_str(&args.new_authority)?;
+
+    if old_authority.pubkey() == new_authority {
+        return Err("old and new authority are the same key; nothing to migrate".into());
+    }
+
+    println!("Old authority: {}", old_authority.pubkey());
+    println!("New authority: {}", new_authority);
+    println!("Channel RPC:   {}", args.channel_rpc_url);
+    if args.dry_run {
+        println!("Mode:          dry run, nothing will be sent");
+    }
+
+    let storage = Storage::Postgres(
+        PostgresDb::new(&PostgresConfig {
+            database_url: args.database_url.clone(),
+            max_connections: 2,
+        })
+        .await?,
+    );
+
+    // Every mint the indexer has ever seen, blocked ones included: a blocked
+    // mint's channel tokens still exist and its authority still needs moving.
+    let mut mints = Vec::new();
+    for row in storage.get_escrow_balances_by_mint().await? {
+        mints.push(Pubkey::from_str(&row.mint_address)?);
+    }
+    mints.sort();
+    println!("Mints to inspect: {}\n", mints.len());
+
+    let channel_rpc = RpcClientWithRetry::with_retry_config(
+        args.channel_rpc_url.clone(),
+        RetryConfig::default(),
+        CommitmentConfig::confirmed(),
+    );
+
+    let outcome = match migrate_mint_authorities(
+        &channel_rpc,
+        &mints,
+        &old_authority,
+        &new_authority,
+        args.dry_run,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(MigrationError::ForeignMints(foreign)) => {
+            for entry in &foreign {
+                println!(
+                    "{}  FOREIGN  mint_authority={} freeze_authority={}",
+                    entry.mint, entry.mint_authority, entry.freeze_authority
+                );
+            }
+            return Err(MigrationError::ForeignMints(foreign).into());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    for report in &outcome.reports {
+        match report.plan {
+            Plan::Skip => println!("{}  SKIP     not initialized on the channel", report.mint),
+            Plan::AlreadyMigrated => {
+                println!("{}  OK       already on the new authority", report.mint)
+            }
+            Plan::Migrate { freeze } if outcome.dry_run => {
+                let scope = if freeze {
+                    "mint + freeze authority"
+                } else {
+                    "mint authority only, no freeze authority set"
+                };
+                println!("{}  WOULD MIGRATE  {}", report.mint, scope);
+            }
+            Plan::Migrate { .. } => match (&report.signature, &report.error) {
+                (Some(signature), _) => {
+                    println!("{}  MIGRATED  {}", report.mint, signature)
+                }
+                (None, Some(error)) => {
+                    println!("{}  FAILED    {}", report.mint, error)
+                }
+                (None, None) => println!("{}  MIGRATE   no result recorded", report.mint),
+            },
+            // migrate_mint_authorities aborts on foreign mints before reporting.
+            Plan::Foreign {
+                mint_authority,
+                freeze_authority,
+            } => println!(
+                "{}  FOREIGN  mint_authority={} freeze_authority={}",
+                report.mint,
+                describe_authority(mint_authority),
+                describe_authority(freeze_authority)
+            ),
+        }
+    }
+
+    if outcome.dry_run {
+        println!("\nDry run complete, nothing was sent.");
+        return Ok(());
+    }
+
+    println!("\nMigrated {} mint(s).", outcome.migrated());
+    let failed = outcome.failed();
+    if !failed.is_empty() {
+        return Err(format!(
+            "{} mint(s) failed to migrate; re-run before completing the rotation",
+            failed.len()
+        )
+        .into());
+    }
+
+    println!("Every channel mint names the new authority.");
+    Ok(())
+}

--- a/indexer/src/indexer/reconciliation.rs
+++ b/indexer/src/indexer/reconciliation.rs
@@ -23,7 +23,7 @@ use crate::{
     config::{ProgramType, ReconciliationConfig},
     error::{IndexerError, ReconciliationError},
     operator::{
-        escrow_sweep::{fetch_channel_supply, fetch_escrow_balances_by_mint},
+        escrow_sweep::{fetch_channel_mint_state, fetch_escrow_balances_by_mint},
         rpc_util::RpcClientWithRetry,
         RetryConfig,
     },
@@ -173,8 +173,14 @@ async fn check_channel_supply_invariant(
                 pubkey: r.mint.clone(),
                 reason: e.to_string(),
             })?;
-        let supply = match fetch_channel_supply(&channel_rpc, &mint).await {
-            Ok(s) => s,
+        let supply = match fetch_channel_mint_state(
+            &channel_rpc,
+            &mint,
+            CommitmentConfig::finalized(),
+        )
+        .await
+        {
+            Ok(state) => state.supply,
             Err(e) => {
                 warn!(
                     mint = %r.mint,

--- a/indexer/src/operator/escrow_sweep.rs
+++ b/indexer/src/operator/escrow_sweep.rs
@@ -123,18 +123,58 @@ pub async fn fetch_escrow_balances_by_mint(
     Ok(balances)
 }
 
-/// Read the channel-token supply for `mint` on the PrivateChannel chain. An
-/// absent mint account (nothing minted yet) reads as supply 0; any other RPC or
-/// decode failure is surfaced so a bad read never silently looks like 0 supply.
-pub async fn fetch_channel_supply(
+/// The state of one channel mint: how much of it exists, and who controls it.
+///
+/// Both authority fields read `None` for an uninitialized mint and for a live
+/// mint whose authority was cleared. Check `initialized` to tell those apart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelMintState {
+    pub supply: u64,
+    pub mint_authority: Option<Pubkey>,
+    pub freeze_authority: Option<Pubkey>,
+    pub initialized: bool,
+}
+
+/// Render an authority for an operator-facing message. A cleared authority reads
+/// as "none" rather than Debug's `None`.
+pub fn describe_authority(authority: Option<Pubkey>) -> String {
+    match authority {
+        Some(key) => key.to_string(),
+        None => "none".to_string(),
+    }
+}
+
+impl ChannelMintState {
+    /// The state of a channel mint that does not exist yet.
+    fn absent() -> Self {
+        Self {
+            supply: 0,
+            mint_authority: None,
+            freeze_authority: None,
+            initialized: false,
+        }
+    }
+}
+
+/// Read the channel-side state of `mint` on the PrivateChannel chain. An absent
+/// mint account (nothing minted yet) reads as `ChannelMintState::absent()`; any
+/// other RPC or decode failure is surfaced so a bad read never silently looks
+/// like 0 supply.
+///
+/// `commitment` is explicit rather than taken from the client because the two
+/// callers need different levels. The solvency and authority invariants read
+/// `finalized`, since a halt must not fire on state that can still be rolled back.
+/// The authority migration reads `confirmed`, because it has to see and act on the
+/// mint it just wrote, and finalized lags too far behind for that.
+pub async fn fetch_channel_mint_state(
     channel_rpc: &RpcClientWithRetry,
     mint: &Pubkey,
-) -> Result<u64, EscrowSweepError> {
+    commitment: CommitmentConfig,
+) -> Result<ChannelMintState, EscrowSweepError> {
     // get_account_with_commitment cleanly separates a truly-absent account
     // (Ok(value = None)) from a transport/node error (Err). The plain get_account
     // convenience formats BOTH as an "AccountNotFound" error, which would let an
     // RPC outage masquerade as zero supply and blind the supply invariant.
-    let commitment = CommitmentConfig::finalized();
     let response = channel_rpc
         .with_retry(
             "get_channel_mint_account",
@@ -154,14 +194,28 @@ pub async fn fetch_channel_supply(
     // Absent account = nothing minted yet.
     let account = match response.value {
         Some(account) => account,
-        None => return Ok(0),
+        None => return Ok(ChannelMintState::absent()),
     };
 
     // The channel program mints classic SPL tokens (not Token-2022).
-    let mint_state = Mint::unpack(&account.data).map_err(|e| EscrowSweepError {
+    // `unpack_unchecked` skips only the is_initialized check, so a wrong length
+    // or an invalid COption discriminant still errors here. Inspecting
+    // is_initialized ourselves keeps "allocated but not a mint" out of the
+    // corruption bucket.
+    let mint_state = Mint::unpack_unchecked(&account.data).map_err(|e| EscrowSweepError {
         reason: format!("Failed to parse channel mint account {mint}: {e}"),
     })?;
-    Ok(mint_state.supply)
+
+    if !mint_state.is_initialized {
+        return Ok(ChannelMintState::absent());
+    }
+
+    Ok(ChannelMintState {
+        supply: mint_state.supply,
+        mint_authority: mint_state.mint_authority.into(),
+        freeze_authority: mint_state.freeze_authority.into(),
+        initialized: true,
+    })
 }
 
 #[cfg(test)]
@@ -328,14 +382,19 @@ mod tests {
         assert!(balances.is_empty());
     }
 
-    /// getAccountInfo response wrapping an 82-byte SPL Mint blob with `supply`.
-    fn mint_account_body(supply: u64) -> String {
+    /// getAccountInfo response wrapping an 82-byte SPL Mint blob.
+    fn mint_account_body(
+        supply: u64,
+        mint_authority: COption<Pubkey>,
+        freeze_authority: COption<Pubkey>,
+        is_initialized: bool,
+    ) -> String {
         let mint = Mint {
-            mint_authority: COption::Some(Pubkey::new_unique()),
+            mint_authority,
             supply,
             decimals: 6,
-            is_initialized: true,
-            freeze_authority: COption::None,
+            is_initialized,
+            freeze_authority,
         };
         let mut buf = vec![0u8; Mint::LEN];
         mint.pack_into_slice(&mut buf);
@@ -346,41 +405,113 @@ mod tests {
         )
     }
 
-    #[tokio::test]
-    async fn fetch_channel_supply_decodes_supply() {
-        let mut server = mockito::Server::new_async().await;
+    /// An initialized mint with both authorities set to the same pubkey, which
+    /// is how `InitializeMintBuilder` creates every channel mint.
+    fn initialized_mint_body(supply: u64, authority: Pubkey) -> String {
+        mint_account_body(
+            supply,
+            COption::Some(authority),
+            COption::Some(authority),
+            true,
+        )
+    }
+
+    async fn mock_account_response(server: &mut mockito::ServerGuard, body: String) {
         server
             .mock("POST", "/")
             .with_status(200)
-            .with_body(mint_account_body(1_234_567))
+            .with_body(body)
             .create_async()
             .await;
-
-        let supply = fetch_channel_supply(&client(&server.url()), &Pubkey::new_unique())
-            .await
-            .unwrap();
-        assert_eq!(supply, 1_234_567);
     }
 
     #[tokio::test]
-    async fn fetch_channel_supply_absent_mint_is_zero() {
+    async fn fetch_channel_mint_state_decodes_supply_and_authorities() {
+        let mut server = mockito::Server::new_async().await;
+        let authority = Pubkey::new_unique();
+        mock_account_response(&mut server, initialized_mint_body(1_234_567, authority)).await;
+
+        let state = fetch_channel_mint_state(
+            &client(&server.url()),
+            &Pubkey::new_unique(),
+            CommitmentConfig::finalized(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(state.supply, 1_234_567);
+        assert_eq!(state.mint_authority, Some(authority));
+        assert_eq!(state.freeze_authority, Some(authority));
+        assert!(state.initialized);
+    }
+
+    /// A live mint whose authority was cleared via SetAuthority. `initialized`
+    /// stays true so callers can separate this from a mint that was never
+    /// created.
+    #[tokio::test]
+    async fn fetch_channel_mint_state_cleared_authority_is_initialized() {
+        let mut server = mockito::Server::new_async().await;
+        let body = mint_account_body(500, COption::None, COption::None, true);
+        mock_account_response(&mut server, body).await;
+
+        let state = fetch_channel_mint_state(
+            &client(&server.url()),
+            &Pubkey::new_unique(),
+            CommitmentConfig::finalized(),
+        )
+        .await
+        .unwrap();
+
+        assert!(state.initialized);
+        assert_eq!(state.mint_authority, None);
+        assert_eq!(state.freeze_authority, None);
+        assert_eq!(state.supply, 500);
+    }
+
+    /// SPL-Token-owned bytes that decode but carry `is_initialized = false`
+    /// are not corruption, they are a mint that does not exist yet.
+    #[tokio::test]
+    async fn fetch_channel_mint_state_uninitialized_bytes_are_not_an_error() {
+        let mut server = mockito::Server::new_async().await;
+        let body = mint_account_body(0, COption::None, COption::None, false);
+        mock_account_response(&mut server, body).await;
+
+        let state = fetch_channel_mint_state(
+            &client(&server.url()),
+            &Pubkey::new_unique(),
+            CommitmentConfig::finalized(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!state.initialized);
+    }
+
+    #[tokio::test]
+    async fn fetch_channel_mint_state_absent_mint_is_zero() {
         let mut server = mockito::Server::new_async().await;
         // A null account value: the channel mint does not exist yet -> 0 supply.
-        server
-            .mock("POST", "/")
-            .with_status(200)
-            .with_body(r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":null}}"#)
-            .create_async()
-            .await;
+        let body =
+            r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":null}}"#.to_string();
+        mock_account_response(&mut server, body).await;
 
-        let supply = fetch_channel_supply(&client(&server.url()), &Pubkey::new_unique())
-            .await
-            .unwrap();
-        assert_eq!(supply, 0, "absent mint account must read as zero supply");
+        let state = fetch_channel_mint_state(
+            &client(&server.url()),
+            &Pubkey::new_unique(),
+            CommitmentConfig::finalized(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            state.supply, 0,
+            "absent mint account must read as zero supply"
+        );
+        assert!(!state.initialized);
     }
 
     #[tokio::test]
-    async fn fetch_channel_supply_rpc_error_is_err() {
+    async fn fetch_channel_mint_state_rpc_error_is_err() {
         // A transport/node error must surface as Err, never Ok(0): the plain
         // get_account convenience formats a 503 with the same AccountNotFound
         // prefix as a genuinely-absent mint, which would let an RPC outage
@@ -401,7 +532,9 @@ mod tests {
             },
             CommitmentConfig::finalized(),
         );
-        let result = fetch_channel_supply(&fast, &Pubkey::new_unique()).await;
+        let result =
+            fetch_channel_mint_state(&fast, &Pubkey::new_unique(), CommitmentConfig::finalized())
+                .await;
         assert!(result.is_err(), "an RPC outage must be Err, not Ok(0)");
     }
 

--- a/indexer/src/operator/mint_authority_migration.rs
+++ b/indexer/src/operator/mint_authority_migration.rs
@@ -1,0 +1,426 @@
+//! Move the mint and freeze authority of channel mints from one key to another.
+//!
+//! SPL Token only accepts `SetAuthority` signed by the *current* authority, so a
+//! new admin cannot migrate mints to itself. Every send here is signed by the old
+//! key, which is why this is a one-shot operation driven by
+//! `bin/migrate_mint_authority.rs` rather than anything the operator does on its
+//! own: the old key exists for the length of one run and is never configured into
+//! a long-lived process.
+//!
+//! Driven by `docs/runbooks/admin_rotation_runbook.md` § 4-5.
+
+use crate::operator::escrow_sweep::{
+    describe_authority, fetch_channel_mint_state, ChannelMintState,
+};
+use crate::operator::utils::rpc_util::RpcClientWithRetry;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signature, Signer};
+use solana_sdk::transaction::Transaction;
+use spl_token::instruction::AuthorityType;
+use tracing::{info, warn};
+
+/// Migration reads at `confirmed`, not `finalized`. It has to see the mint it just
+/// wrote, and finalized lags far enough behind that the verify pass would read the
+/// pre-migration state and report a false failure. The operator's own finalized
+/// authority check (rotation runbook § 8) is the durable gate; this is the
+/// act-on-current-state read.
+const READ_COMMITMENT: CommitmentConfig = CommitmentConfig::confirmed();
+
+/// What one mint needs. Decided for every mint before anything is sent, so a run
+/// that has to abort leaves no partial work behind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Plan {
+    /// Not created on the channel yet. The JIT path will create it under the
+    /// current admin on the next deposit, so there is nothing to move.
+    Skip,
+    /// Already on the new authority, from an earlier run.
+    AlreadyMigrated,
+    /// Mint authority is the old key: migrate. `freeze` is false when the mint
+    /// carries no freeze authority, in which case only the mint authority moves.
+    Migrate { freeze: bool },
+    /// Held by neither key. Migrating would need a signature we do not have, and
+    /// guessing is worse than stopping.
+    Foreign {
+        mint_authority: Option<Pubkey>,
+        freeze_authority: Option<Pubkey>,
+    },
+}
+
+/// Classify one mint from the state it currently carries on the channel.
+///
+/// The freeze authority is allowed to be absent: `SetAuthority` cannot move an
+/// authority that does not exist, and a mint nobody can freeze is not a problem to
+/// fix. This matches `find_stale_authority` in the reconciliation halt, which also
+/// accepts an absent freeze authority.
+pub fn plan_for(state: &ChannelMintState, old: &Pubkey, new: &Pubkey) -> Plan {
+    if !state.initialized {
+        return Plan::Skip;
+    }
+
+    let mint_is = |key: &Pubkey| state.mint_authority == Some(*key);
+    let freeze_is_or_absent = |key: &Pubkey| match state.freeze_authority {
+        None => true,
+        Some(actual) => actual == *key,
+    };
+
+    if mint_is(new) && freeze_is_or_absent(new) {
+        return Plan::AlreadyMigrated;
+    }
+    if mint_is(old) && freeze_is_or_absent(old) {
+        return Plan::Migrate {
+            freeze: state.freeze_authority == Some(*old),
+        };
+    }
+    Plan::Foreign {
+        mint_authority: state.mint_authority,
+        freeze_authority: state.freeze_authority,
+    }
+}
+
+/// A mint held by a key that is neither the old nor the new authority. Collected
+/// across the whole set so the caller can report every one before aborting.
+#[derive(Debug, Clone)]
+pub struct ForeignMint {
+    pub mint: Pubkey,
+    pub mint_authority: String,
+    pub freeze_authority: String,
+}
+
+#[derive(Debug)]
+pub enum MigrationError {
+    /// A channel read failed. Nothing was sent.
+    Read { mint: Pubkey, reason: String },
+    /// At least one mint is held by an unknown key. Nothing was sent.
+    ForeignMints(Vec<ForeignMint>),
+    /// Sends were attempted; these mints do not name the new authority afterwards.
+    Unverified(Vec<Pubkey>),
+}
+
+impl std::fmt::Display for MigrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read { mint, reason } => {
+                write!(f, "failed to read channel mint {mint}: {reason}")
+            }
+            Self::ForeignMints(foreign) => write!(
+                f,
+                "{} mint(s) are held by neither the old nor the new authority; \
+                 resolve them before migrating (nothing was sent)",
+                foreign.len()
+            ),
+            Self::Unverified(mints) => write!(
+                f,
+                "{} mint(s) still do not name the new authority; re-run before \
+                 completing the rotation",
+                mints.len()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MigrationError {}
+
+/// Per-mint result, in the order the mints were supplied.
+#[derive(Debug, Clone)]
+pub struct MintReport {
+    pub mint: Pubkey,
+    pub plan: Plan,
+    /// `Some` once a send landed, `None` for skipped and dry-run mints.
+    pub signature: Option<Signature>,
+    /// `Some` when the send failed. The mint keeps its old authority.
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MigrationOutcome {
+    pub reports: Vec<MintReport>,
+    pub dry_run: bool,
+}
+
+impl MigrationOutcome {
+    pub fn migrated(&self) -> usize {
+        self.reports
+            .iter()
+            .filter(|r| r.signature.is_some())
+            .count()
+    }
+
+    pub fn failed(&self) -> Vec<&MintReport> {
+        self.reports.iter().filter(|r| r.error.is_some()).collect()
+    }
+}
+
+/// Move both authorities of one mint in a single transaction, so a mint is never
+/// left with the two split across keys.
+///
+/// `freeze` is false for a mint with no freeze authority; including a
+/// `FreezeAccount` `SetAuthority` for it would fail the whole transaction and
+/// leave the mint authority behind too.
+async fn migrate_one(
+    channel_rpc: &RpcClientWithRetry,
+    mint: &Pubkey,
+    old_authority: &Keypair,
+    new_authority: &Pubkey,
+    freeze: bool,
+) -> Result<Signature, Box<dyn std::error::Error>> {
+    let mut authority_types = vec![AuthorityType::MintTokens];
+    if freeze {
+        authority_types.push(AuthorityType::FreezeAccount);
+    }
+
+    let mut instructions = Vec::with_capacity(authority_types.len());
+    for authority_type in authority_types {
+        instructions.push(spl_token::instruction::set_authority(
+            &spl_token::id(),
+            mint,
+            Some(new_authority),
+            authority_type,
+            &old_authority.pubkey(),
+            &[],
+        )?);
+    }
+
+    let blockhash = channel_rpc.rpc_client.get_latest_blockhash().await?;
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&old_authority.pubkey()),
+        &[old_authority],
+        blockhash,
+    );
+
+    // `send_and_confirm_transaction` rather than the operator's
+    // `sign_and_send_transaction` + `check_transaction_status` pair: this is a
+    // one-shot human-supervised command with no retry state machine to feed, and
+    // the verify pass below re-reads every mint, so a false "send failed" on a
+    // transaction that actually landed self-corrects on the next run.
+    Ok(channel_rpc
+        .rpc_client
+        .send_and_confirm_transaction(&transaction)
+        .await?)
+}
+
+/// Classify every mint, then migrate the ones held by the old key.
+///
+/// Aborts with `ForeignMints` before sending anything if any mint is held by an
+/// unknown key: a partially-rotated set is worse than an unstarted one. With
+/// `dry_run` the classification is returned and nothing is sent.
+///
+/// After sending, re-reads every mint and returns `Unverified` if any still fails
+/// to name the new authority, so a caller's exit code reflects channel state
+/// rather than what the sends reported.
+pub async fn migrate_mint_authorities(
+    channel_rpc: &RpcClientWithRetry,
+    mints: &[Pubkey],
+    old_authority: &Keypair,
+    new_authority: &Pubkey,
+    dry_run: bool,
+) -> Result<MigrationOutcome, MigrationError> {
+    let old_pubkey = old_authority.pubkey();
+
+    let mut plans = Vec::with_capacity(mints.len());
+    let mut foreign = Vec::new();
+    for mint in mints {
+        let state = fetch_channel_mint_state(channel_rpc, mint, READ_COMMITMENT)
+            .await
+            .map_err(|e| MigrationError::Read {
+                mint: *mint,
+                reason: e.reason,
+            })?;
+        let plan = plan_for(&state, &old_pubkey, new_authority);
+        if let Plan::Foreign {
+            mint_authority,
+            freeze_authority,
+        } = plan
+        {
+            warn!(
+                mint = %mint,
+                mint_authority = %describe_authority(mint_authority),
+                freeze_authority = %describe_authority(freeze_authority),
+                "channel mint is held by neither the old nor the new authority"
+            );
+            foreign.push(ForeignMint {
+                mint: *mint,
+                mint_authority: describe_authority(mint_authority),
+                freeze_authority: describe_authority(freeze_authority),
+            });
+        }
+        plans.push((*mint, plan));
+    }
+
+    if !foreign.is_empty() {
+        return Err(MigrationError::ForeignMints(foreign));
+    }
+
+    let mut reports = Vec::with_capacity(plans.len());
+    for (mint, plan) in plans {
+        let mut report = MintReport {
+            mint,
+            plan,
+            signature: None,
+            error: None,
+        };
+        if let (Plan::Migrate { freeze }, false) = (plan, dry_run) {
+            match migrate_one(channel_rpc, &mint, old_authority, new_authority, freeze).await {
+                Ok(signature) => {
+                    info!(mint = %mint, %signature, "migrated channel mint authority");
+                    report.signature = Some(signature);
+                }
+                Err(e) => {
+                    warn!(mint = %mint, "failed to migrate channel mint authority: {}", e);
+                    report.error = Some(e.to_string());
+                }
+            }
+        }
+        reports.push(report);
+    }
+
+    if dry_run {
+        return Ok(MigrationOutcome {
+            reports,
+            dry_run: true,
+        });
+    }
+
+    let mut unverified = Vec::new();
+    for mint in mints {
+        let state = fetch_channel_mint_state(channel_rpc, mint, READ_COMMITMENT)
+            .await
+            .map_err(|e| MigrationError::Read {
+                mint: *mint,
+                reason: e.reason,
+            })?;
+        if !state.initialized {
+            continue;
+        }
+        if plan_for(&state, &old_pubkey, new_authority) != Plan::AlreadyMigrated {
+            warn!(
+                mint = %mint,
+                mint_authority = %describe_authority(state.mint_authority),
+                freeze_authority = %describe_authority(state.freeze_authority),
+                "channel mint still does not name the new authority"
+            );
+            unverified.push(*mint);
+        }
+    }
+
+    if !unverified.is_empty() {
+        return Err(MigrationError::Unverified(unverified));
+    }
+
+    Ok(MigrationOutcome {
+        reports,
+        dry_run: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pk(seed: u8) -> Pubkey {
+        Pubkey::new_from_array([seed; 32])
+    }
+
+    fn state(mint_authority: Option<Pubkey>, freeze_authority: Option<Pubkey>) -> ChannelMintState {
+        ChannelMintState {
+            supply: 100,
+            mint_authority,
+            freeze_authority,
+            initialized: true,
+        }
+    }
+
+    #[test]
+    fn old_authority_on_both_migrates_both() {
+        let old = pk(1);
+        let new = pk(2);
+        assert_eq!(
+            plan_for(&state(Some(old), Some(old)), &old, &new),
+            Plan::Migrate { freeze: true }
+        );
+    }
+
+    /// A mint with no freeze authority migrates the mint authority only. Asking
+    /// SPL to move an authority that does not exist would fail the transaction and
+    /// strand the mint authority too.
+    #[test]
+    fn absent_freeze_authority_migrates_mint_authority_only() {
+        let old = pk(1);
+        let new = pk(2);
+        assert_eq!(
+            plan_for(&state(Some(old), None), &old, &new),
+            Plan::Migrate { freeze: false }
+        );
+    }
+
+    #[test]
+    fn new_authority_on_both_is_already_migrated() {
+        let old = pk(1);
+        let new = pk(2);
+        assert_eq!(
+            plan_for(&state(Some(new), Some(new)), &old, &new),
+            Plan::AlreadyMigrated
+        );
+    }
+
+    /// Re-running against a mint that had no freeze authority to begin with must
+    /// report it done, not try again.
+    #[test]
+    fn migrated_mint_without_freeze_authority_is_already_migrated() {
+        let old = pk(1);
+        let new = pk(2);
+        assert_eq!(
+            plan_for(&state(Some(new), None), &old, &new),
+            Plan::AlreadyMigrated
+        );
+    }
+
+    /// Authorities split across the two keys. We cannot sign for both with either
+    /// key alone, so it aborts the run rather than being half-fixed.
+    #[test]
+    fn split_authorities_are_foreign() {
+        let old = pk(1);
+        let new = pk(2);
+        assert!(matches!(
+            plan_for(&state(Some(old), Some(new)), &old, &new),
+            Plan::Foreign { .. }
+        ));
+    }
+
+    #[test]
+    fn third_party_authority_is_foreign() {
+        let old = pk(1);
+        let new = pk(2);
+        let stranger = pk(3);
+        assert!(matches!(
+            plan_for(&state(Some(stranger), Some(stranger)), &old, &new),
+            Plan::Foreign { .. }
+        ));
+    }
+
+    /// A cleared mint authority cannot be moved by anyone. Reporting it as foreign
+    /// stops the run so an operator sees it instead of a silent skip.
+    #[test]
+    fn cleared_mint_authority_is_foreign() {
+        let old = pk(1);
+        let new = pk(2);
+        assert!(matches!(
+            plan_for(&state(None, None), &old, &new),
+            Plan::Foreign { .. }
+        ));
+    }
+
+    #[test]
+    fn uninitialized_mint_is_skipped() {
+        let old = pk(1);
+        let new = pk(2);
+        let uninitialized = ChannelMintState {
+            supply: 0,
+            mint_authority: None,
+            freeze_authority: None,
+            initialized: false,
+        };
+        assert_eq!(plan_for(&uninitialized, &old, &new), Plan::Skip);
+    }
+}

--- a/indexer/src/operator/mod.rs
+++ b/indexer/src/operator/mod.rs
@@ -3,6 +3,7 @@ pub mod db_transaction_writer;
 pub mod escrow_sweep;
 pub mod feepayer_monitor;
 pub mod fetcher;
+pub mod mint_authority_migration;
 #[allow(clippy::module_inception)]
 pub mod operator;
 pub mod processor;

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -291,6 +291,7 @@ pub async fn run(
                         reconciliation_rpc,
                         reconciliation_channel_rpc,
                         reconciliation_escrow,
+                        crate::operator::SignerUtil::get_admin_pubkey(),
                         reconciliation_health,
                         reconciliation_token,
                     )

--- a/indexer/src/operator/reconciliation.rs
+++ b/indexer/src/operator/reconciliation.rs
@@ -13,12 +13,15 @@
 
 use crate::config::OperatorConfig;
 use crate::error::OperatorError;
-use crate::operator::escrow_sweep::{fetch_channel_supply, fetch_escrow_balances_by_mint};
+use crate::operator::escrow_sweep::{
+    describe_authority, fetch_channel_mint_state, fetch_escrow_balances_by_mint, ChannelMintState,
+};
 use crate::operator::RpcClientWithRetry;
 use crate::storage::common::amount::{net_to_u64, NetBalance};
 use crate::storage::Storage;
 use private_channel_core::webhook::{WebhookClient, WebhookRetryConfig};
 use private_channel_metrics::HealthState;
+use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -38,17 +41,20 @@ const HALT_CONFIRM_TICKS: u32 = 3;
 
 /// Runs periodic escrow balance reconciliation checks
 ///
-/// Each tick reads escrow custody on-chain and channel supply per mint, then
-/// halts (durable flag + quarantine + forced-unhealthy + webhook) when supply
-/// exceeds custody beyond the in-flight envelope for `HALT_CONFIRM_TICKS`
-/// consecutive ticks. Reads are lock-free since reconciliation never mutates
+/// Each tick reads escrow custody on-chain plus the supply and SPL authorities of
+/// every channel mint, then halts (durable flag + quarantine + forced-unhealthy +
+/// webhook) when supply exceeds custody beyond the in-flight envelope for
+/// `HALT_CONFIRM_TICKS` consecutive ticks, or when any mint stops naming
+/// `expected_authority`. Reads are lock-free since reconciliation never mutates
 /// transaction state outside the halt path.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_reconciliation(
     storage: Arc<Storage>,
     config: OperatorConfig,
     rpc_client: Arc<RpcClientWithRetry>,
     channel_rpc: Arc<RpcClientWithRetry>,
     escrow_instance_id: Pubkey,
+    expected_authority: Pubkey,
     health: Option<Arc<HealthState>>,
     cancellation_token: CancellationToken,
 ) -> Result<(), OperatorError> {
@@ -61,6 +67,10 @@ pub async fn run_reconciliation(
         "Tolerance threshold: {} basis points",
         config.reconciliation_tolerance_bps
     );
+
+    // Every channel mint must name this key as its mint and freeze authority.
+    // Logged so an operator can match a halt against the key they configured.
+    info!("Expected channel mint authority: {}", expected_authority);
 
     let webhook_client = WebhookClient::new(
         WEBHOOK_TIMEOUT,
@@ -100,6 +110,7 @@ pub async fn run_reconciliation(
             escrow_instance_id,
             &webhook_client,
             &health,
+            &expected_authority,
             &mut previously_alerted_orphans,
             &mut breach_counters,
             &mut halted,
@@ -161,6 +172,51 @@ fn evaluate_insolvency(
     }
 }
 
+/// The authorities a channel mint actually carries, when they are not the ones
+/// the operator expects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StaleAuthority {
+    pub mint_authority: Option<Pubkey>,
+    pub freeze_authority: Option<Pubkey>,
+}
+
+/// Decide whether one channel mint is still controlled by `expected`.
+/// `InitializeMintBuilder` sets both authorities to the operator's admin, so a
+/// departure means the mint outlived a key change or was initialized by someone
+/// else.
+///
+/// The two authorities are judged differently, because a cleared one means
+/// opposite things for each:
+///
+/// - `mint_authority` must be exactly `expected`. Another key can issue channel
+///   tokens against live escrow custody, and no key at all bricks the mint, since
+///   no deposit for it can be serviced again.
+/// - `freeze_authority` may be `expected` or absent. A foreign key there can
+///   freeze any holder's account, but an absent one means the capability does not
+///   exist, which is safer than holding it. Halting on absent would also be
+///   unclearable, since a freeze authority cannot be reinstalled once cleared.
+///
+/// An uninitialized mint has no authority to be wrong; the JIT path creates it
+/// with the current admin on the next deposit.
+fn find_stale_authority(state: &ChannelMintState, expected: &Pubkey) -> Option<StaleAuthority> {
+    if !state.initialized {
+        return None;
+    }
+    let mint_authority_ok = state.mint_authority == Some(*expected);
+    let freeze_authority_ok = match state.freeze_authority {
+        None => true,
+        Some(key) => key == *expected,
+    };
+
+    if mint_authority_ok && freeze_authority_ok {
+        return None;
+    }
+    Some(StaleAuthority {
+        mint_authority: state.mint_authority,
+        freeze_authority: state.freeze_authority,
+    })
+}
+
 /// Convert an in-flight envelope BigDecimal into u64. The sum is non-negative by
 /// construction; an over-u64 sum reports u64::MAX, which only ever enlarges the
 /// envelope (delays a halt), never fabricates one.
@@ -210,6 +266,7 @@ async fn perform_reconciliation_check(
     escrow_instance_id: Pubkey,
     webhook_client: &WebhookClient,
     health: &Option<Arc<HealthState>>,
+    expected_authority: &Pubkey,
     previously_alerted_orphans: &mut Option<HashSet<i64>>,
     breach_counters: &mut HashMap<Pubkey, u32>,
     halted: &mut bool,
@@ -236,11 +293,11 @@ async fn perform_reconciliation_check(
     let mut mints: HashSet<Pubkey> = custody.keys().copied().collect();
     mints.extend(fetch_db_mint_set(storage).await?);
 
-    // Envelope (DB) and channel supply (PrivateChannel RPC) are the remaining
+    // Envelope (DB) and channel mint state (PrivateChannel RPC) are the remaining
     // halt inputs. A failure of either holds the breach counters and skips the
     // tick, so a transient glitch cannot reset a building breach.
     match load_halt_inputs(storage, channel_rpc, &mints).await {
-        Ok((supply, envelope)) => {
+        Ok((mint_states, envelope)) => {
             evaluate_and_maybe_halt(
                 storage,
                 config,
@@ -248,8 +305,9 @@ async fn perform_reconciliation_check(
                 webhook_client,
                 &custody,
                 &mints,
-                &supply,
+                &mint_states,
                 &envelope,
+                expected_authority,
                 breach_counters,
                 halted,
             )
@@ -292,31 +350,34 @@ async fn fetch_in_flight_envelope(
     Ok(out)
 }
 
-/// Load the halt inputs: the in-flight envelope (DB) and per-mint channel supply
-/// (PrivateChannel RPC) for the given mint set. An envelope-query failure skips
-/// the whole tick (one DB read), but a single mint's supply read failing must not
-/// blind the others: that mint is omitted from the returned map and held in
-/// `evaluate_and_maybe_halt`, so a flaky read on one mint cannot suppress
-/// detection on a genuinely over-issued one.
+/// Load the halt inputs: the in-flight envelope (DB) and per-mint channel state
+/// (PrivateChannel RPC) for the given mint set. One read per mint serves both
+/// halt checks, since supply and the SPL authorities live in the same account.
+///
+/// An envelope-query failure skips the whole tick (one DB read), but a single
+/// mint's read failing must not blind the others: that mint is omitted from the
+/// returned map and held in `evaluate_and_maybe_halt`, so a flaky read on one
+/// mint cannot suppress detection on a genuinely over-issued one.
 async fn load_halt_inputs(
     storage: &Arc<Storage>,
     channel_rpc: &Arc<RpcClientWithRetry>,
     mints: &HashSet<Pubkey>,
-) -> Result<(HashMap<Pubkey, u64>, HashMap<Pubkey, u64>), OperatorError> {
+) -> Result<(HashMap<Pubkey, ChannelMintState>, HashMap<Pubkey, u64>), OperatorError> {
     let envelope = fetch_in_flight_envelope(storage).await?;
-    let mut supply = HashMap::new();
+    let mut mint_states = HashMap::new();
     for mint in mints {
-        match fetch_channel_supply(channel_rpc, mint).await {
-            Ok(s) => {
-                supply.insert(*mint, s);
+        // Finalized: a halt must not fire on state that can still be rolled back.
+        match fetch_channel_mint_state(channel_rpc, mint, CommitmentConfig::finalized()).await {
+            Ok(state) => {
+                mint_states.insert(*mint, state);
             }
             Err(e) => warn!(
                 mint = %mint,
-                "Channel supply read failed; skipping this mint this tick: {}", e.reason
+                "Channel mint read failed; skipping this mint this tick: {}", e.reason
             ),
         }
     }
-    Ok((supply, envelope))
+    Ok((mint_states, envelope))
 }
 
 fn parse_mint(mint_address: &str) -> Result<Pubkey, OperatorError> {
@@ -328,12 +389,16 @@ fn parse_mint(mint_address: &str) -> Result<Pubkey, OperatorError> {
         })
 }
 
-/// Halt path: per mint, decide insolvency, advance/reset the breach counter, and
-/// on the `HALT_CONFIRM_TICKS`-th consecutive breach freeze the pipelines once
-/// (durable flag + quarantine + forced-unhealthy + webhook). Every action is
-/// best-effort and logged, so one failing action never skips the others.
-/// `mints` is the shared custody-plus-DB enumeration set; the DB net is never
-/// compared, only the addresses widen the set.
+/// Halt path: per mint, check the SPL authorities and decide insolvency, then
+/// freeze the pipelines once (durable flag + quarantine + forced-unhealthy +
+/// webhook). Every action is best-effort and logged, so one failing action never
+/// skips the others. `mints` is the shared custody-plus-DB enumeration set; the
+/// DB net is never compared, only the addresses widen the set.
+///
+/// The two conditions confirm differently. A supply gap can be an artifact of
+/// reads taken at different moments, so it needs `HALT_CONFIRM_TICKS`
+/// consecutive breaches. An authority is one pubkey compared against another, so
+/// a mismatch halts on the first observation.
 #[allow(clippy::too_many_arguments)]
 async fn evaluate_and_maybe_halt(
     storage: &Arc<Storage>,
@@ -342,8 +407,9 @@ async fn evaluate_and_maybe_halt(
     webhook_client: &WebhookClient,
     custody: &HashMap<Pubkey, u64>,
     mints: &HashSet<Pubkey>,
-    supply: &HashMap<Pubkey, u64>,
+    mint_states: &HashMap<Pubkey, ChannelMintState>,
     envelope: &HashMap<Pubkey, u64>,
+    expected_authority: &Pubkey,
     breach_counters: &mut HashMap<Pubkey, u32>,
     halted: &mut bool,
 ) {
@@ -351,21 +417,41 @@ async fn evaluate_and_maybe_halt(
     // disappears) resets to zero rather than lingering.
     let mut next_counters: HashMap<Pubkey, u32> = HashMap::new();
     for &mint in mints {
-        // A mint absent from `supply` had its read fail this tick (an absent
-        // account reads as Ok(0), not a miss). Hold its counter rather than
+        // A mint absent from `mint_states` had its read fail this tick. Both a
+        // missing account and an uninitialized one read as Ok(absent) with supply
+        // 0, so only a genuine read error lands here. Hold its counter rather than
         // resetting, so a transient per-mint glitch neither halts it nor erases
         // its evidence, and never blocks the other mints.
-        let Some(&s) = supply.get(&mint) else {
+        let Some(state) = mint_states.get(&mint) else {
             if let Some(&held) = breach_counters.get(&mint) {
                 next_counters.insert(mint, held);
             }
             continue;
         };
+
+        // Runs before the insolvency check, which means a stale authority claims
+        // the halt reason when both conditions hold on the same tick, and the
+        // set-once guard then suppresses the insolvency webhook. `mints` is a
+        // HashSet, so with several mints breaching it is already unspecified which
+        // one's reason is recorded; investigating a halt means checking both
+        // invariants regardless of which reason it carries.
+        check_mint_authority(
+            storage,
+            config,
+            health,
+            webhook_client,
+            &mint,
+            state,
+            expected_authority,
+            halted,
+        )
+        .await;
+
         let c = *custody.get(&mint).unwrap_or(&0);
         let env = *envelope.get(&mint).unwrap_or(&0);
         let tolerance = insolvency_tolerance_raw(c, config.reconciliation_tolerance_bps);
 
-        let Some(breach) = evaluate_insolvency(c, s, env, tolerance) else {
+        let Some(breach) = evaluate_insolvency(c, state.supply, env, tolerance) else {
             continue;
         };
 
@@ -408,10 +494,24 @@ async fn evaluate_and_maybe_halt(
     *breach_counters = next_counters;
 }
 
-/// Fire every fail-closed lever for a confirmed insolvency. Each is best-effort
+/// Fire the fail-closed levers every halt condition shares. Each is best-effort
 /// and independently logged: the durable flag is the cross-process freeze,
-/// quarantine flips rows active right now, forced-unhealthy pages orchestration,
-/// and the webhook notifies operators. None of them gate the others.
+/// quarantine flips rows active right now, and forced-unhealthy pages
+/// orchestration. None of them gate the others. Callers send their own webhook.
+async fn freeze_pipelines(storage: &Arc<Storage>, health: &Option<Arc<HealthState>>, reason: &str) {
+    if let Err(e) = storage.set_reconciliation_halt(reason).await {
+        error!("Failed to set durable reconciliation halt flag: {}", e);
+    }
+    match storage.quarantine_all_active_withdrawals(None).await {
+        Ok(n) => info!(rows = n, "Quarantined active withdrawals on halt"),
+        Err(e) => error!("Failed to quarantine active withdrawals on halt: {}", e),
+    }
+    if let Some(h) = health {
+        h.force_unhealthy(reason.to_string());
+    }
+}
+
+/// Freeze the pipelines for a confirmed insolvency and alert operators.
 #[allow(clippy::too_many_arguments)]
 async fn trip_halt(
     storage: &Arc<Storage>,
@@ -423,16 +523,7 @@ async fn trip_halt(
     breach: &InsolvencyBreach,
     reason: &str,
 ) {
-    if let Err(e) = storage.set_reconciliation_halt(reason).await {
-        error!("Failed to set durable reconciliation halt flag: {}", e);
-    }
-    match storage.quarantine_all_active_withdrawals(None).await {
-        Ok(n) => info!(rows = n, "Quarantined active withdrawals on halt"),
-        Err(e) => error!("Failed to quarantine active withdrawals on halt: {}", e),
-    }
-    if let Some(h) = health {
-        h.force_unhealthy(reason.to_string());
-    }
+    freeze_pipelines(storage, health, reason).await;
     // Payload carries real custody and the supply the escrow could not honor;
     // delta_bps stays in basis points to match every other reconciliation alert
     // (u64::MAX when custody is 0).
@@ -448,6 +539,69 @@ async fn trip_halt(
         send_webhook_alert(&config.reconciliation_webhook_url, &[alert], webhook_client).await
     {
         error!("Failed to send reconciliation halt webhook: {}", e);
+    }
+}
+
+/// Freeze the pipelines when `mint` no longer names the configured admin as both
+/// its mint and freeze authority.
+///
+/// A stale authority means a key other than the configured admin can issue
+/// channel tokens for a mint the escrow still backs. The insolvency check
+/// catches the result of that, but only once the tokens have been burned and
+/// custody has actually left, so it reports a loss already taken. This check
+/// fires on the precondition instead, before any of it happens.
+///
+/// It also covers the benign case: after a key change the operator can no longer
+/// mint for this mint, and every deposit would fail one at a time instead of
+/// once, loudly, here.
+///
+/// Trips only once, matching the insolvency halt: a still-set flag keeps
+/// re-firing suppressed until an operator clears it.
+#[allow(clippy::too_many_arguments)]
+async fn check_mint_authority(
+    storage: &Arc<Storage>,
+    config: &OperatorConfig,
+    health: &Option<Arc<HealthState>>,
+    webhook_client: &WebhookClient,
+    mint: &Pubkey,
+    state: &ChannelMintState,
+    expected_authority: &Pubkey,
+    halted: &mut bool,
+) {
+    let Some(stale) = find_stale_authority(state, expected_authority) else {
+        return;
+    };
+
+    if *halted {
+        warn!(
+            mint = %mint,
+            "Channel mint authority is not the configured admin; already halted"
+        );
+        return;
+    }
+
+    *halted = true;
+    let reason = format!(
+        "reconciliation halt: channel mint {} names mint_authority {} and freeze_authority {}, \
+         expected the configured admin {}",
+        mint,
+        describe_authority(stale.mint_authority),
+        describe_authority(stale.freeze_authority),
+        expected_authority
+    );
+    error!(reason = %reason, "MINT AUTHORITY HALT tripped; freezing both pipelines");
+    freeze_pipelines(storage, health, &reason).await;
+
+    if let Err(e) = send_mint_authority_alert(
+        &config.reconciliation_webhook_url,
+        mint,
+        &stale,
+        expected_authority,
+        webhook_client,
+    )
+    .await
+    {
+        error!("Failed to send mint authority halt webhook: {}", e);
     }
 }
 
@@ -708,6 +862,62 @@ pub async fn send_orphan_deposit_alert(
     Ok(())
 }
 
+/// Posts a stale channel-mint authority to `webhook_url` as
+/// `{ mint, expected_authority, mint_authority, freeze_authority, timestamp }`.
+///
+/// Retries up to 3 times with exponential backoff on transient HTTP errors.
+/// A `None` URL logs a `warn!` and returns `Ok`. Returns
+/// `Err(OperatorError::WebhookError)` if delivery fails after retries.
+pub async fn send_mint_authority_alert(
+    webhook_url: &Option<String>,
+    mint: &Pubkey,
+    stale: &StaleAuthority,
+    expected_authority: &Pubkey,
+    webhook_client: &WebhookClient,
+) -> Result<(), OperatorError> {
+    // If no webhook URL configured, log and return early
+    let url = match webhook_url {
+        Some(url) => url,
+        None => {
+            warn!(
+                mint = %mint,
+                "Stale channel mint authority detected but no webhook URL configured"
+            );
+            return Ok(());
+        }
+    };
+
+    let payload = serde_json::json!({
+        "mint": mint.to_string(),
+        "expected_authority": expected_authority.to_string(),
+        "mint_authority": describe_authority(stale.mint_authority),
+        "freeze_authority": describe_authority(stale.freeze_authority),
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    });
+
+    let context = format!("stale mint authority: mint {}", mint);
+
+    webhook_client
+        .post_json(url, &payload, &context)
+        .await
+        .map_err(|error| {
+            error!(
+                "Failed to send mint authority webhook alert after {} attempts: {}",
+                error.attempts(),
+                error.message()
+            );
+            OperatorError::WebhookError(format!(
+                "Failed to send mint authority webhook alert after {} attempts: {}",
+                error.attempts(),
+                error.message()
+            ))
+        })?;
+
+    info!(mint = %mint, "Mint authority webhook alert sent");
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -760,6 +970,7 @@ mod tests {
             config,
             rpc_client,
             channel_rpc,
+            solana_sdk::pubkey::Pubkey::new_unique(),
             solana_sdk::pubkey::Pubkey::new_unique(),
             None,
             ct,
@@ -888,11 +1099,27 @@ mod tests {
             });
     }
 
-    // (custody, db_mints, supply, envelope, mint) for the halt-path tests.
+    /// The configured admin every halt-path test compares against. The insolvency
+    /// tests give their mints this same authority so only the supply gap can halt.
+    fn test_authority() -> Pubkey {
+        Pubkey::new_from_array([7u8; 32])
+    }
+
+    /// A live channel mint holding `supply`, controlled by `test_authority()`.
+    fn mint_state(supply: u64) -> ChannelMintState {
+        ChannelMintState {
+            supply,
+            mint_authority: Some(test_authority()),
+            freeze_authority: Some(test_authority()),
+            initialized: true,
+        }
+    }
+
+    // (custody, db_mints, mint_states, envelope, mint) for the halt-path tests.
     type BreachMaps = (
         HashMap<Pubkey, u64>,
         HashSet<Pubkey>,
-        HashMap<Pubkey, u64>,
+        HashMap<Pubkey, ChannelMintState>,
         HashMap<Pubkey, u64>,
         Pubkey,
     );
@@ -902,9 +1129,9 @@ mod tests {
         let mint = Pubkey::new_unique();
         let custody = HashMap::from([(mint, 900u64)]);
         let db_mints = HashSet::from([mint]);
-        let supply = HashMap::from([(mint, 1200u64)]);
+        let mint_states = HashMap::from([(mint, mint_state(1200))]);
         let envelope = HashMap::from([(mint, 100u64)]);
-        (custody, db_mints, supply, envelope, mint)
+        (custody, db_mints, mint_states, envelope, mint)
     }
 
     #[tokio::test]
@@ -924,6 +1151,7 @@ mod tests {
             &db_mints,
             &supply,
             &envelope,
+            &test_authority(),
             &mut counters,
             &mut halted,
         )
@@ -956,6 +1184,7 @@ mod tests {
                 &db_mints,
                 &supply,
                 &envelope,
+                &test_authority(),
                 &mut counters,
                 &mut halted,
             )
@@ -981,7 +1210,7 @@ mod tests {
         let config = recon_config_zero_tolerance();
         let (custody, db_mints, supply, envelope, mint) = breach_maps();
         // A clean map: supply matches custody, no gap.
-        let clean_supply = HashMap::from([(mint, 900u64)]);
+        let clean_supply = HashMap::from([(mint, mint_state(900))]);
         let mut counters = HashMap::new();
         let mut halted = false;
         let webhook = test_webhook_client();
@@ -997,6 +1226,7 @@ mod tests {
                 &db_mints,
                 supply,
                 &envelope,
+                &test_authority(),
                 &mut counters,
                 &mut halted,
             )
@@ -1031,6 +1261,7 @@ mod tests {
                 &db_mints,
                 &supply,
                 &envelope,
+                &test_authority(),
                 &mut counters,
                 &mut halted,
             )
@@ -1047,6 +1278,7 @@ mod tests {
             &db_mints,
             &supply,
             &envelope,
+            &test_authority(),
             &mut counters,
             &mut halted,
         )
@@ -1073,6 +1305,7 @@ mod tests {
                 &db_mints,
                 &supply,
                 &envelope,
+                &test_authority(),
                 &mut counters,
                 &mut halted,
             )
@@ -1092,6 +1325,7 @@ mod tests {
             &db_mints,
             &supply,
             &envelope,
+            &test_authority(),
             &mut counters,
             &mut halted,
         )
@@ -1116,7 +1350,7 @@ mod tests {
         let mint = Pubkey::new_unique();
         let custody: HashMap<Pubkey, u64> = HashMap::new();
         let db_mints = HashSet::from([mint]);
-        let supply = HashMap::from([(mint, 500u64)]);
+        let supply = HashMap::from([(mint, mint_state(500))]);
         let envelope = HashMap::from([(mint, 100u64)]);
         let mut counters = HashMap::new();
         let mut halted = false;
@@ -1132,6 +1366,7 @@ mod tests {
                 &db_mints,
                 &supply,
                 &envelope,
+                &test_authority(),
                 &mut counters,
                 &mut halted,
             )
@@ -1162,9 +1397,9 @@ mod tests {
         let mut halted = false;
         let webhook = test_webhook_client();
 
-        let t1 = HashMap::from([(a, 1200u64), (b, 900u64)]); // A breaches, B clean
-        let t2 = HashMap::from([(a, 1200u64), (b, 900u64)]); // A breaches, B clean
-        let t3 = HashMap::from([(a, 900u64), (b, 1200u64)]); // A clean (reset), B breaches
+        let t1 = HashMap::from([(a, mint_state(1200)), (b, mint_state(900))]); // A breaches, B clean
+        let t2 = HashMap::from([(a, mint_state(1200)), (b, mint_state(900))]); // A breaches, B clean
+        let t3 = HashMap::from([(a, mint_state(900)), (b, mint_state(1200))]); // A clean (reset), B breaches
         for supply in [&t1, &t2, &t3] {
             evaluate_and_maybe_halt(
                 &storage,
@@ -1175,6 +1410,7 @@ mod tests {
                 &db_mints,
                 supply,
                 &envelope,
+                &test_authority(),
                 &mut counters,
                 &mut halted,
             )
@@ -1198,7 +1434,7 @@ mod tests {
         let custody = HashMap::from([(a, 900u64), (b, 900u64)]);
         let db_mints = HashSet::from([a, b]);
         let envelope = HashMap::from([(a, 100u64), (b, 100u64)]);
-        let supply = HashMap::from([(b, 1200u64)]); // A absent: read failed
+        let supply = HashMap::from([(b, mint_state(1200))]); // A absent: read failed
         let mut counters = HashMap::new();
         let mut halted = false;
         let webhook = test_webhook_client();
@@ -1213,6 +1449,7 @@ mod tests {
                 &db_mints,
                 &supply,
                 &envelope,
+                &test_authority(),
                 &mut counters,
                 &mut halted,
             )
@@ -1224,6 +1461,161 @@ mod tests {
             "a failed supply read on one mint must not block another"
         );
         assert_eq!(counters.get(&b).copied(), Some(3));
+    }
+
+    /// Run one tick against a single mint whose supply equals its custody, so the
+    /// insolvency check stays quiet and only the authority check can halt.
+    /// Returns whether the halt tripped.
+    async fn authority_tick(state: ChannelMintState) -> bool {
+        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+        let mint = Pubkey::new_unique();
+        let custody = HashMap::from([(mint, state.supply)]);
+        let db_mints = HashSet::from([mint]);
+        let mint_states = HashMap::from([(mint, state)]);
+        let envelope = HashMap::new();
+        let mut counters = HashMap::new();
+        let mut halted = false;
+
+        evaluate_and_maybe_halt(
+            &storage,
+            &recon_config_zero_tolerance(),
+            &None,
+            &test_webhook_client(),
+            &custody,
+            &db_mints,
+            &mint_states,
+            &envelope,
+            &test_authority(),
+            &mut counters,
+            &mut halted,
+        )
+        .await;
+
+        halted
+    }
+
+    #[tokio::test]
+    async fn mint_owned_by_configured_admin_does_not_halt() {
+        assert!(!authority_tick(mint_state(500)).await);
+    }
+
+    /// One tick is enough: an authority is a pubkey comparison, so unlike a supply
+    /// gap it needs no confirmation ticks.
+    #[tokio::test]
+    async fn foreign_mint_authority_halts_on_first_tick() {
+        let state = ChannelMintState {
+            supply: 500,
+            mint_authority: Some(Pubkey::new_unique()),
+            freeze_authority: Some(test_authority()),
+            initialized: true,
+        };
+
+        assert!(
+            authority_tick(state).await,
+            "a mint authority other than the configured admin must halt"
+        );
+    }
+
+    /// The freeze authority matters on its own: it cannot mint, but it can freeze
+    /// any holder's token account.
+    #[tokio::test]
+    async fn foreign_freeze_authority_halts() {
+        let state = ChannelMintState {
+            supply: 500,
+            mint_authority: Some(test_authority()),
+            freeze_authority: Some(Pubkey::new_unique()),
+            initialized: true,
+        };
+
+        assert!(authority_tick(state).await);
+    }
+
+    /// A cleared mint authority is irreversible: nobody can ever mint this token
+    /// again, so it must halt rather than read as "unreachable, therefore
+    /// harmless". Matches `decode_and_check_authority`, which treats a cleared
+    /// mint authority as a mismatch for the same reason.
+    #[tokio::test]
+    async fn cleared_mint_authority_halts() {
+        let state = ChannelMintState {
+            supply: 500,
+            mint_authority: None,
+            freeze_authority: Some(test_authority()),
+            initialized: true,
+        };
+
+        assert!(authority_tick(state).await);
+    }
+
+    /// A cleared freeze authority removes the freeze capability rather than handing
+    /// it to anyone, so it is safe. Halting would also be unclearable, since a
+    /// freeze authority cannot be reinstalled.
+    #[tokio::test]
+    async fn cleared_freeze_authority_does_not_halt() {
+        let state = ChannelMintState {
+            supply: 500,
+            mint_authority: Some(test_authority()),
+            freeze_authority: None,
+            initialized: true,
+        };
+
+        assert!(!authority_tick(state).await);
+    }
+
+    /// A mint that does not exist on the channel yet has no authority to be wrong.
+    /// The JIT path creates it with the current admin on the next deposit.
+    #[tokio::test]
+    async fn uninitialized_mint_does_not_halt() {
+        let state = ChannelMintState {
+            supply: 0,
+            mint_authority: None,
+            freeze_authority: None,
+            initialized: false,
+        };
+
+        assert!(!authority_tick(state).await);
+    }
+
+    /// The `halted` bool alone stops nothing. Assert the three side effects that
+    /// actually freeze the bridge, so dropping the `freeze_pipelines` call from the
+    /// authority path cannot pass silently.
+    #[tokio::test]
+    async fn authority_halt_freezes_the_withdrawal_pipeline() {
+        use private_channel_metrics::{HealthConfig, HealthState};
+        let mock = MockStorage::new();
+        seed_pending_withdrawal(&mock, 1, 1);
+        let storage = Arc::new(Storage::Mock(mock.clone()));
+        let health_state = HealthState::new(HealthConfig::operator());
+        let mint = Pubkey::new_unique();
+        let state = ChannelMintState {
+            supply: 500,
+            mint_authority: Some(Pubkey::new_unique()),
+            freeze_authority: Some(test_authority()),
+            initialized: true,
+        };
+        let mut counters = HashMap::new();
+        let mut halted = false;
+
+        evaluate_and_maybe_halt(
+            &storage,
+            &recon_config_zero_tolerance(),
+            &Some(health_state.clone()),
+            &test_webhook_client(),
+            &HashMap::from([(mint, 500u64)]),
+            &HashSet::from([mint]),
+            &HashMap::from([(mint, state)]),
+            &HashMap::new(),
+            &test_authority(),
+            &mut counters,
+            &mut halted,
+        )
+        .await;
+
+        assert!(storage.is_reconciliation_halted().await.unwrap().is_some());
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            crate::storage::common::models::TransactionStatus::ManualReview
+        );
+        assert!(!health_state.is_healthy());
     }
 
     /// Mock the escrow custody sweep on a mockito server: the SPL Token program
@@ -1321,6 +1713,7 @@ mod tests {
             Pubkey::new_unique(),
             &webhook_client,
             &None,
+            &test_authority(),
             &mut orphans,
             &mut counters,
             &mut halted,
@@ -1373,6 +1766,7 @@ mod tests {
             Pubkey::new_unique(),
             &webhook,
             &None,
+            &test_authority(),
             &mut orphans,
             &mut counters,
             &mut halted,
@@ -1391,6 +1785,7 @@ mod tests {
             Pubkey::new_unique(),
             &webhook,
             &None,
+            &test_authority(),
             &mut orphans,
             &mut counters,
             &mut halted,

--- a/indexer/tests/runbook_drills.rs
+++ b/indexer/tests/runbook_drills.rs
@@ -1742,3 +1742,167 @@ async fn drill_16_withdrawal_manual_review_recovery_missing_nonce_flow(
     eprintln!("Path F triage substring + terminal SQL verified.");
     Ok(())
 }
+
+// ── Drill 18: admin rotation + stale mint authority halt contracts ──────────
+//
+// Two runbooks dispatch on strings the operator emits at runtime:
+//
+//   reconciliation_halt_runbook.md routes by `reconciliation_halt.reason`
+//   substring, and names the log lines and the startup expectation line an
+//   on-call greps for.
+//
+//   admin_rotation_runbook.md § 4 documents the migration tool's per-mint
+//   classification labels, and § 8 tells the operator to verify the rotation by
+//   the startup line.
+//
+// None of these are compiler-checked. Reword a reason string or a label and both
+// runbooks silently stop matching reality, which for the authority halt means an
+// on-call reaches for the insolvency procedure on a halt that has nothing to do
+// with custody. Also pins the cross-links, since each runbook's recovery routes
+// into the other. No Postgres needed.
+
+#[test]
+#[ignore]
+fn drill_18_admin_rotation_contracts_present_in_source() {
+    drill_header(
+        "reconciliation_halt_runbook.md + admin_rotation_runbook.md",
+        "Halt reason: stale mint authority / rotation steps 4 and 8",
+    );
+
+    // Each entry: (substring the runbooks depend on, file expected to contain it).
+    let contracts: &[(&str, &str)] = &[
+        // Halt dispatch: the two reason substrings the Detection section routes on.
+        (
+            "names mint_authority",
+            "indexer/src/operator/reconciliation.rs",
+        ),
+        (
+            "short of supply by",
+            "indexer/src/operator/reconciliation.rs",
+        ),
+        // Symptom section: the log lines that distinguish the two halts.
+        (
+            "MINT AUTHORITY HALT tripped; freezing both pipelines",
+            "indexer/src/operator/reconciliation.rs",
+        ),
+        (
+            "RECONCILIATION HALT tripped; freezing both pipelines",
+            "indexer/src/operator/reconciliation.rs",
+        ),
+        // Startup expectation line. Both runbooks tell the operator to read it:
+        // the halt runbook to compare against the on-chain authority, the
+        // rotation runbook as the step-8 pass signal.
+        (
+            "Expected channel mint authority:",
+            "indexer/src/operator/reconciliation.rs",
+        ),
+        // Rotation § 4: the migration tool's classification labels. `OK` and
+        // `SKIP` are matched by their descriptive tails, which are unique;
+        // the bare labels are too generic to anchor.
+        ("WOULD MIGRATE", "indexer/src/bin/migrate_mint_authority.rs"),
+        ("FOREIGN", "indexer/src/bin/migrate_mint_authority.rs"),
+        (
+            "already on the new authority",
+            "indexer/src/bin/migrate_mint_authority.rs",
+        ),
+        (
+            "not initialized on the channel",
+            "indexer/src/bin/migrate_mint_authority.rs",
+        ),
+    ];
+
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(&crate_root)
+        .parent()
+        .expect("workspace root");
+
+    let mut missing: Vec<String> = Vec::new();
+    for (substr, path) in contracts {
+        let full = workspace_root.join(path);
+        let content =
+            std::fs::read_to_string(&full).unwrap_or_else(|e| panic!("read {full:?}: {e}"));
+        if content.contains(substr) {
+            eprintln!("OK   {path}: {substr:?}");
+        } else {
+            eprintln!("MISS {path}: {substr:?}");
+            missing.push(format!("{path}: {substr:?}"));
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "runbook contracts missing in source: {missing:#?}"
+    );
+
+    // The authority halt must fire the same freeze levers the halt runbook
+    // promises. `check_mint_authority` setting its own flag without calling
+    // `freeze_pipelines` would leave the bridge releasing funds while the runbook
+    // says it is frozen.
+    //
+    // Scoped to that function's body on purpose: `freeze_pipelines` also appears
+    // at its definition and in `trip_halt`, so a whole-file `contains` would pass
+    // even with the call deleted.
+    let reconciliation =
+        std::fs::read_to_string(workspace_root.join("indexer/src/operator/reconciliation.rs"))
+            .expect("read reconciliation.rs");
+    let body_start = reconciliation
+        .find("async fn check_mint_authority")
+        .expect("check_mint_authority must exist — the authority halt lives there");
+    let body = &reconciliation[body_start..];
+    let body_end = body[1..]
+        .find("\nasync fn ")
+        .or_else(|| body[1..].find("\nfn "))
+        .map(|i| i + 1)
+        .unwrap_or(body.len());
+    assert!(
+        body[..body_end].contains("freeze_pipelines("),
+        "`check_mint_authority` must call `freeze_pipelines` — the halt runbook \
+         promises the durable flag, quarantine and forced-unhealthy"
+    );
+    eprintln!("OK   reconciliation.rs: check_mint_authority body calls freeze_pipelines");
+
+    // Cross-links. Each runbook's recovery routes into the other, and the
+    // interaction guide points at the rotation procedure instead of implying
+    // SetNewAdmin is sufficient on its own.
+    let links: &[(&str, &str, &str)] = &[
+        (
+            "docs/runbooks/reconciliation_halt_runbook.md",
+            "admin_rotation_runbook.md",
+            "the stale-authority cause table routes to the rotation runbook",
+        ),
+        (
+            "docs/runbooks/admin_rotation_runbook.md",
+            "migrate_mint_authority",
+            "rotation § 4 and § 5 invoke the migration tool by name",
+        ),
+        (
+            "docs/runbooks/admin_rotation_runbook.md",
+            "reconciliation_halt_runbook.md",
+            "rotation § 4 routes FOREIGN mints to the halt runbook's cause table",
+        ),
+        (
+            "docs/ESCROW_INTERACTION_GUIDE.md",
+            "admin_rotation_runbook.md",
+            "SetNewAdmin is documented as one step of a rotation, not the whole",
+        ),
+    ];
+    for (path, needle, why) in links {
+        let full = workspace_root.join(path);
+        let content =
+            std::fs::read_to_string(&full).unwrap_or_else(|e| panic!("read {full:?}: {e}"));
+        assert!(
+            content.contains(needle),
+            "{path} must reference {needle:?}: {why}"
+        );
+        eprintln!("OK   {path}: references {needle:?}");
+    }
+
+    // The command in rotation § 4 has to name a binary that exists.
+    assert!(
+        workspace_root
+            .join("indexer/src/bin/migrate_mint_authority.rs")
+            .exists(),
+        "rotation § 4 runs `cargo run --bin migrate_mint_authority`; the binary \
+         source must exist at that name"
+    );
+    eprintln!("OK   migrate_mint_authority binary present");
+}

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -104,6 +104,10 @@ name = "yellowstone_reconnect_gap"
 path = "tests/indexer/yellowstone_reconnect_gap.rs"
 
 [[test]]
+name = "mint_authority_migration_integration"
+path = "tests/indexer/mint_authority_migration.rs"
+
+[[test]]
 name = "reconnect_gap_fill_fail_closed"
 path = "tests/indexer/reconnect_gap_fill_fail_closed.rs"
 

--- a/integration/tests/indexer/mint_authority_migration.rs
+++ b/integration/tests/indexer/mint_authority_migration.rs
@@ -1,0 +1,190 @@
+//! Integration test for `operator::mint_authority_migration` against a real
+//! validator and the real SPL Token program.
+//!
+//! The unit tests cover `plan_for`, which is pure. What only a validator can show
+//! is that the classification actually matches what SPL accepts: that both
+//! authorities move in one transaction, that a mint with no freeze authority is
+//! migrated without asking SPL to move an authority that does not exist (which
+//! would fail the whole transaction and strand the mint authority too), and that
+//! re-running is idempotent.
+//!
+//! No Postgres: the migration takes a plain mint list, so enumeration stays in the
+//! CLI and is not under test here.
+//!
+//! Backs `docs/runbooks/admin_rotation_runbook.md` § 4-5.
+
+#[path = "helpers/mod.rs"]
+mod helpers;
+
+use helpers::{generate_mint, send_and_confirm_instructions};
+use private_channel_indexer::operator::escrow_sweep::fetch_channel_mint_state;
+use private_channel_indexer::operator::mint_authority_migration::{
+    migrate_mint_authorities, MigrationError, Plan,
+};
+use private_channel_indexer::operator::utils::rpc_util::{RetryConfig, RpcClientWithRetry};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::signature::{Keypair, Signer};
+use spl_token::instruction::AuthorityType;
+use test_utils::validator_helper::start_test_validator_no_geyser;
+
+/// The migration reads at `confirmed`, so the test's assertions read at the same
+/// level. `finalized` lags ~32 slots on a fresh validator, which would show mints
+/// created moments ago as not yet existing.
+const READ_COMMITMENT: CommitmentConfig = CommitmentConfig::confirmed();
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mint_authority_migration_moves_authorities_and_is_idempotent(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (test_validator, faucet) = start_test_validator_no_geyser().await;
+    let client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::confirmed());
+    let channel_rpc = RpcClientWithRetry::with_retry_config(
+        test_validator.rpc_url(),
+        RetryConfig::default(),
+        CommitmentConfig::confirmed(),
+    );
+
+    // The faucet is the old authority so it can pay its own fees; the new
+    // authority never signs, it only has to be a pubkey.
+    let old_authority = faucet;
+    let new_authority = Keypair::new().pubkey();
+
+    // Mint 1: both authorities on the old key, the shape `InitializeMintBuilder`
+    // produces on the channel.
+    let both = generate_mint(&client, &old_authority, &old_authority, &Keypair::new()).await?;
+
+    // Mint 2: freeze authority cleared, so only the mint authority can move.
+    let freezeless =
+        generate_mint(&client, &old_authority, &old_authority, &Keypair::new()).await?;
+    send_and_confirm_instructions(
+        &client,
+        &[spl_token::instruction::set_authority(
+            &spl_token::id(),
+            &freezeless,
+            None,
+            AuthorityType::FreezeAccount,
+            &old_authority.pubkey(),
+            &[],
+        )?],
+        &old_authority,
+        &[&old_authority],
+        "Clear freeze authority",
+    )
+    .await?;
+
+    let mints = vec![both, freezeless];
+
+    // ── Dry run classifies without sending ──────────────────────────────────
+    let dry = migrate_mint_authorities(&channel_rpc, &mints, &old_authority, &new_authority, true)
+        .await?;
+
+    assert_eq!(
+        dry.reports[0].plan,
+        Plan::Migrate { freeze: true },
+        "a mint holding both authorities must migrate both"
+    );
+    assert_eq!(
+        dry.reports[1].plan,
+        Plan::Migrate { freeze: false },
+        "a mint with no freeze authority must migrate the mint authority only"
+    );
+    assert_eq!(dry.migrated(), 0, "a dry run must send nothing");
+    assert_eq!(
+        fetch_channel_mint_state(&channel_rpc, &both, READ_COMMITMENT)
+            .await?
+            .mint_authority,
+        Some(old_authority.pubkey()),
+        "a dry run must leave the on-chain authority untouched"
+    );
+
+    // ── Real run moves the authorities ──────────────────────────────────────
+    let outcome =
+        migrate_mint_authorities(&channel_rpc, &mints, &old_authority, &new_authority, false)
+            .await?;
+
+    assert_eq!(outcome.migrated(), 2);
+    assert!(outcome.failed().is_empty(), "{:?}", outcome.failed());
+
+    let both_state = fetch_channel_mint_state(&channel_rpc, &both, READ_COMMITMENT).await?;
+    assert_eq!(both_state.mint_authority, Some(new_authority));
+    assert_eq!(both_state.freeze_authority, Some(new_authority));
+
+    let freezeless_state =
+        fetch_channel_mint_state(&channel_rpc, &freezeless, READ_COMMITMENT).await?;
+    assert_eq!(freezeless_state.mint_authority, Some(new_authority));
+    assert_eq!(
+        freezeless_state.freeze_authority, None,
+        "migration must not invent a freeze authority the mint never had"
+    );
+
+    // ── Re-running is idempotent ────────────────────────────────────────────
+    let rerun =
+        migrate_mint_authorities(&channel_rpc, &mints, &old_authority, &new_authority, false)
+            .await?;
+
+    assert!(
+        rerun
+            .reports
+            .iter()
+            .all(|r| r.plan == Plan::AlreadyMigrated),
+        "a second run must report every mint already migrated: {:?}",
+        rerun.reports
+    );
+    assert_eq!(rerun.migrated(), 0, "a second run must send nothing");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn foreign_mint_aborts_before_sending() -> Result<(), Box<dyn std::error::Error>> {
+    let (test_validator, faucet) = start_test_validator_no_geyser().await;
+    let client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::confirmed());
+    let channel_rpc = RpcClientWithRetry::with_retry_config(
+        test_validator.rpc_url(),
+        RetryConfig::default(),
+        CommitmentConfig::confirmed(),
+    );
+
+    let old_authority = faucet;
+    let new_authority = Keypair::new().pubkey();
+
+    // One migratable mint and one held by a third party. The migratable mint is
+    // listed first, so if the abort happened after the send loop rather than
+    // before it, its authority would already have moved.
+    //
+    // `generate_mint` only embeds the authority pubkey, so the stranger never
+    // signs and needs no funding.
+    let migratable =
+        generate_mint(&client, &old_authority, &old_authority, &Keypair::new()).await?;
+    let stranger = Keypair::new();
+    let foreign = generate_mint(&client, &old_authority, &stranger, &Keypair::new()).await?;
+
+    let result = migrate_mint_authorities(
+        &channel_rpc,
+        &[migratable, foreign],
+        &old_authority,
+        &new_authority,
+        false,
+    )
+    .await;
+
+    match result {
+        Err(MigrationError::ForeignMints(entries)) => {
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].mint, foreign);
+        }
+        other => panic!("expected ForeignMints, got {other:?}"),
+    }
+
+    assert_eq!(
+        fetch_channel_mint_state(&channel_rpc, &migratable, READ_COMMITMENT)
+            .await?
+            .mint_authority,
+        Some(old_authority.pubkey()),
+        "a foreign mint must abort the run before any authority moves"
+    );
+
+    Ok(())
+}

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -1033,6 +1033,11 @@ async fn test_runtime_reconciliation_halts_on_supply_over_issuance(
         .await?,
     ));
 
+    // `generate_mint` gave the mint this admin as both its mint and freeze
+    // authority, so the authority check stays quiet and the supply gap is what
+    // trips the halt asserted below.
+    let recon_authority = admin.pubkey();
+
     let cancellation_token = CancellationToken::new();
     let recon_token_clone = cancellation_token.clone();
     let recon_handle: JoinHandle<()> = tokio::spawn(async move {
@@ -1042,6 +1047,7 @@ async fn test_runtime_reconciliation_halts_on_supply_over_issuance(
             rpc_client,
             channel_rpc_client,
             instance,
+            recon_authority,
             health_for_task,
             recon_token_clone,
         )


### PR DESCRIPTION
## Problem

`SetNewAdmin` changes `Instance.admin` and nothing else. The SPL mint and freeze authorities on every channel mint stay with the old key — and those, not `Instance.admin`, are what let a key issue channel tokens.

A retired admin therefore keeps the ability to mint unbacked channel tokens, burn them through the permissionless withdraw program, and have an honest operator release real escrow funds against them. The interaction guide asserted the opposite: "Old admin loses all privileges once confirmed."

The same gap has a benign form that has already cost operator time: flip `ADMIN_SIGNER` without migrating the mints and every deposit fails `OwnerMismatch`, one row at a time, with no single signal saying why.

## Solution

**A fail-closed invariant.** The reconciliation tick already read every channel mint for the supply check. It now also requires each one to name the configured admin as its authority, and halts the bridge the first time one doesn't — no confirmation ticks needed, because a pubkey either matches or it doesn't. This makes a missed or half-finished migration impossible to run past: the withdrawal pipeline freezes, active withdrawals quarantine, `/health` goes 503, and the webhook fires, all through the existing halt levers.

**A migration tool that can't half-finish.** `migrate_mint_authority` moves both authorities off the old key. It classifies every mint before sending anything and aborts outright if one is held by an unknown key, moves both authorities in a single transaction per mint so none is left split, then re-reads every mint and exits non-zero unless all of them landed. Idempotent, with `--dry-run`.

**Docs that match reality.** A rotation runbook that sequences the two (the old key must sign the migration, so it cannot be retired first), halt-reason dispatch so an on-call lands on the right procedure, the corrected guarantee in the interaction guide, and `drill_18` pinning the reason strings and CLI labels against source so they can't drift.

## Design notes

**The freeze-authority rule is asymmetric.** The admin or absent both pass. Absent means the freeze capability doesn't exist, which is strictly safer than the admin holding it — and halting on it would be unclearable, since a freeze authority can't be reinstalled once cleared. An absent *mint* authority does halt: that one bricks the mint.

**Read commitment is now an explicit parameter.** The halt invariants read `finalized`, because a halt must never fire on state that can roll back. The migration reads `confirmed`, because it has to see the mint it just wrote — at `finalized` its verify pass would read pre-migration state and fail every rotation.

## Scope

Deliberately no escrow program changes: no new instruction, no account migration, no redeploy. The fix lives entirely in the operator and its tooling.

The invariant this establishes is that exactly one key — the configured admin — holds mint authority over the channel mints, instead of that set growing with every rotation. Trust in the current admin is unchanged and by design.

### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,846 | 13,489 | 87.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30413015160) |
| Indexer | 31,357 | 34,891 | 89.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30413015160) |
| Gateway | 1,325 | 1,515 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30413015160) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30413015160) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,327 | 17,099 | 77.9% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30413015160) |
| **Total** | **58,640** | **67,897** | **86.4%** | |

> Last updated: 2026-07-29 02:01:56 UTC by E2E Integration