### PR TITLE
fix(indexer): remint to the initiator, not the withdrawal destination

### DIFF
--- a/indexer/src/operator/processor.rs
+++ b/indexer/src/operator/processor.rs
@@ -393,8 +393,15 @@ async fn build_release_funds(
     let private_channel_token_program = processor_state
         .mint_cache
         .get_private_channel_token_program();
+    // The burn debited the initiator, so the remint credits them, not `recipient`
+    // (the Solana destination, which only the release leg above uses).
+    let initiator =
+        Pubkey::from_str(&transaction.initiator).map_err(|e| OperatorError::InvalidPubkey {
+            pubkey: transaction.initiator.clone(),
+            reason: e.to_string(),
+        })?;
     let remint_user_ata = get_associated_token_address_with_program_id(
-        &recipient,
+        &initiator,
         &mint,
         &private_channel_token_program,
     );
@@ -402,7 +409,7 @@ async fn build_release_funds(
         transaction_id: transaction.id,
         trace_id: transaction.trace_id.clone(),
         mint,
-        user: recipient,
+        user: initiator,
         user_ata: remint_user_ata,
         token_program: private_channel_token_program,
         amount,
@@ -906,7 +913,7 @@ mod tests {
             signature: format!("sig_{id}"),
             trace_id: format!("trace-{id}"),
             slot: 100,
-            initiator: "initiator".to_string(),
+            initiator: Pubkey::new_unique().to_string(),
             recipient: recipient.to_string(),
             mint: mint.to_string(),
             amount: TokenAmount(1000),
@@ -927,6 +934,57 @@ mod tests {
             inner_index: None,
             landed_remint_signature: None,
         }
+    }
+
+    /// The remint reverses a burn on the private channel, so it must credit the
+    /// account that was debited (`initiator`), not the withdrawal's Solana
+    /// destination (`recipient`).
+    #[tokio::test]
+    async fn build_release_funds_remints_to_initiator_not_destination() {
+        let mint_pubkey = Pubkey::new_unique();
+        let initiator = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
+
+        let mock = MockStorage::new();
+        let storage = Arc::new(Storage::Mock(mock));
+        insert_mint_row(&storage, &mint_pubkey);
+
+        let mut processor_state = ProcessorState {
+            admin_pubkey: Pubkey::new_unique(),
+            release_funds_state: Some(make_release_funds_state()),
+            mint_cache: crate::operator::MintCache::new(storage),
+        };
+
+        let mut txn = make_db_transaction(
+            1,
+            &mint_pubkey.to_string(),
+            &destination.to_string(),
+            Some(3),
+            TransactionType::Withdrawal,
+        );
+        txn.initiator = initiator.to_string();
+
+        let builder = build_release_funds(&mut processor_state, &txn)
+            .await
+            .expect("a valid withdrawal row must build");
+        let TransactionBuilder::ReleaseFunds(release) = builder else {
+            panic!("a withdrawal must build a ReleaseFunds builder");
+        };
+        let remint = release
+            .remint_info
+            .expect("a withdrawal must carry remint info");
+
+        assert_eq!(remint.user, initiator);
+        assert_ne!(remint.user, destination);
+        assert_eq!(
+            remint.user_ata,
+            get_associated_token_address_with_program_id(
+                &initiator,
+                &mint_pubkey,
+                &spl_token::id()
+            ),
+            "remint must mint into the initiator's private channel ATA"
+        );
     }
 
     #[tokio::test]
@@ -2390,7 +2448,7 @@ mod tests {
             signature: "test_sig".to_string(),
             trace_id: "trace-42".to_string(),
             slot: 100,
-            initiator: "initiator".to_string(),
+            initiator: Pubkey::new_unique().to_string(),
             recipient: recipient.to_string(),
             mint: mint_pubkey.to_string(),
             amount: TokenAmount(1000), // > on-chain balance of 500
@@ -2498,7 +2556,7 @@ mod tests {
             signature: "test_sig".to_string(),
             trace_id: "trace-7".to_string(),
             slot: 100,
-            initiator: "initiator".to_string(),
+            initiator: Pubkey::new_unique().to_string(),
             recipient: recipient.to_string(),
             mint: mint_pubkey.to_string(),
             amount: TokenAmount(1000), // < on-chain balance of 5000

--- a/indexer/src/operator/sender/state.rs
+++ b/indexer/src/operator/sender/state.rs
@@ -255,8 +255,11 @@ impl SenderState {
                 continue;
             };
 
-            let Some(user) = Self::or_manual_review(
-                Pubkey::from_str(&tx.recipient).map_err(|e| format!("invalid user pubkey: {e}")),
+            // The burn debited the initiator, so the remint credits them, not
+            // `recipient` (the Solana destination of the failed release).
+            let Some(initiator) = Self::or_manual_review(
+                Pubkey::from_str(&tx.initiator)
+                    .map_err(|e| format!("invalid initiator pubkey: {e}")),
                 storage_tx,
                 tx.id,
                 &tx.trace_id,
@@ -266,8 +269,8 @@ impl SenderState {
                 continue;
             };
 
-            let user_ata = get_associated_token_address_with_program_id(
-                &user,
+            let initiator_ata = get_associated_token_address_with_program_id(
+                &initiator,
                 &mint,
                 &private_channel_token_program,
             );
@@ -328,8 +331,8 @@ impl SenderState {
                 transaction_id: tx.id,
                 trace_id: tx.trace_id.clone(),
                 mint,
-                user,
-                user_ata,
+                user: initiator,
+                user_ata: initiator_ata,
                 token_program: private_channel_token_program,
                 amount,
             };
@@ -430,6 +433,7 @@ mod tests {
     fn make_pending_remint_row(
         id: i64,
         mint: &Pubkey,
+        initiator: &Pubkey,
         recipient: &Pubkey,
         sig: &Signature,
         deadline: chrono::DateTime<Utc>,
@@ -440,7 +444,7 @@ mod tests {
             signature: Signature::new_unique().to_string(),
             trace_id: format!("trace-{id}"),
             slot: 100,
-            initiator: Pubkey::new_unique().to_string(),
+            initiator: initiator.to_string(),
             recipient: recipient.to_string(),
             mint: mint.to_string(),
             amount: TokenAmount(5_000),
@@ -470,7 +474,7 @@ mod tests {
     /// operator can continue where it left off before the crash.
     ///
     /// This test verifies that every field is correctly restored:
-    /// - transaction_id, trace_id, amount, mint, recipient
+    /// - transaction_id, trace_id, amount, mint, initiator
     /// - withdrawal signatures (needed for the finality check)
     /// - the original deadline (not a fresh 32s window — the clock keeps
     ///   ticking across restarts)
@@ -483,6 +487,9 @@ mod tests {
     async fn recover_pending_remints_rehydrates_queue() {
         let mock = MockStorage::new();
         let mint = Pubkey::new_unique();
+        // Distinct from `recipient`: the burn debited the initiator, so the
+        // remint must target them, not the withdrawal's Solana destination.
+        let initiator = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
         let sig = Signature::new_unique();
         let deadline = Utc::now() + chrono::Duration::seconds(20);
@@ -490,7 +497,7 @@ mod tests {
         // Mid-budget value so the round-trip assertion is meaningful: a reset
         // to 0 on recovery would re-arm the cap and let an ambiguous row
         // outlive the intended ManualReview escalation.
-        let mut row = make_pending_remint_row(42, &mint, &recipient, &sig, deadline);
+        let mut row = make_pending_remint_row(42, &mint, &initiator, &recipient, &sig, deadline);
         row.finality_check_attempts = 2;
         mock.pending_remint_transactions.lock().unwrap().push(row);
 
@@ -512,7 +519,16 @@ mod tests {
 
         // Pubkeys must be correctly parsed from their string representation.
         assert_eq!(entry.remint_info.mint, mint);
-        assert_eq!(entry.remint_info.user, recipient);
+
+        // The remint reverses a burn, so it must credit the account that was
+        // debited (initiator), not the withdrawal's Solana destination.
+        assert_eq!(entry.remint_info.user, initiator);
+        assert_ne!(entry.remint_info.user, recipient);
+        assert_eq!(
+            entry.remint_info.user_ata,
+            get_associated_token_address_with_program_id(&initiator, &mint, &spl_token::id()),
+            "remint must mint into the initiator's private channel ATA"
+        );
 
         // Signatures must be parsed back — they drive the finality check.
         // lvbh must round-trip too: the gate needs it to prove a broadcast
@@ -555,7 +571,8 @@ mod tests {
         let sig = Signature::new_unique();
         let deadline = Utc::now() + chrono::Duration::seconds(20);
 
-        let mut row = make_pending_remint_row(7, &mint, &recipient, &sig, deadline);
+        let mut row =
+            make_pending_remint_row(7, &mint, &Pubkey::new_unique(), &recipient, &sig, deadline);
         row.finality_check_attempts = -1;
         mock.pending_remint_transactions.lock().unwrap().push(row);
 
@@ -592,13 +609,26 @@ mod tests {
         let deadline = Utc::now() + chrono::Duration::seconds(20);
 
         // Row 1: invalid mint — should escalate to ManualReview and be skipped.
-        let mut bad_row =
-            make_pending_remint_row(10, &Pubkey::new_unique(), &recipient, &sig, deadline);
+        let mut bad_row = make_pending_remint_row(
+            10,
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+            &recipient,
+            &sig,
+            deadline,
+        );
         bad_row.mint = "not-a-valid-pubkey".to_string();
 
         // Row 2: valid — must still be recovered despite the bad row above.
         let good_mint = Pubkey::new_unique();
-        let good_row = make_pending_remint_row(11, &good_mint, &recipient, &sig, deadline);
+        let good_row = make_pending_remint_row(
+            11,
+            &good_mint,
+            &Pubkey::new_unique(),
+            &recipient,
+            &sig,
+            deadline,
+        );
 
         mock.pending_remint_transactions
             .lock()
@@ -630,21 +660,28 @@ mod tests {
         assert!(storage_rx.try_recv().is_err());
     }
 
-    /// A corrupted recipient pubkey cannot be parsed into a `Pubkey`, so the
-    /// operator cannot compute the user's ATA and has no valid destination
+    /// A corrupted initiator pubkey cannot be parsed into a `Pubkey`, so the
+    /// operator cannot compute the burner's ATA and has no valid destination
     /// for the remint.
     ///
     /// Same escalation rule as invalid mint: ManualReview immediately, do not
     /// skip silently, do not block other rows.
     #[tokio::test]
-    async fn recover_pending_remints_escalates_invalid_recipient_to_manual_review() {
+    async fn recover_pending_remints_escalates_invalid_initiator_to_manual_review() {
         let mock = MockStorage::new();
         let mint = Pubkey::new_unique();
         let sig = Signature::new_unique();
         let deadline = Utc::now() + chrono::Duration::seconds(20);
 
-        let mut bad_row = make_pending_remint_row(20, &mint, &Pubkey::new_unique(), &sig, deadline);
-        bad_row.recipient = "not-a-valid-pubkey".to_string();
+        let mut bad_row = make_pending_remint_row(
+            20,
+            &mint,
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+            &sig,
+            deadline,
+        );
+        bad_row.initiator = "not-a-valid-pubkey".to_string();
 
         mock.pending_remint_transactions
             .lock()
@@ -658,12 +695,12 @@ mod tests {
 
         let update = storage_rx
             .try_recv()
-            .expect("should receive ManualReview for bad recipient");
+            .expect("should receive ManualReview for bad initiator");
         assert_eq!(update.transaction_id, 20);
         assert_eq!(update.status, TransactionStatus::ManualReview);
         let err = update.error_message.as_deref().unwrap_or("");
         assert!(
-            err.contains("invalid user pubkey"),
+            err.contains("invalid initiator pubkey"),
             "error message should describe the parse failure: {err}"
         );
 
@@ -691,8 +728,14 @@ mod tests {
         let recipient = Pubkey::new_unique();
         let deadline = Utc::now() + chrono::Duration::seconds(20);
 
-        let mut bad_row =
-            make_pending_remint_row(40, &mint, &recipient, &Signature::new_unique(), deadline);
+        let mut bad_row = make_pending_remint_row(
+            40,
+            &mint,
+            &Pubkey::new_unique(),
+            &recipient,
+            &Signature::new_unique(),
+            deadline,
+        );
         // Replace the valid signature with garbage.
         bad_row.remint_signatures = Some(vec!["not-a-valid-signature".to_string()]);
 
@@ -737,8 +780,14 @@ mod tests {
         let recipient = Pubkey::new_unique();
         let deadline = Utc::now() + chrono::Duration::seconds(20);
 
-        let mut bad_row =
-            make_pending_remint_row(50, &mint, &recipient, &Signature::new_unique(), deadline);
+        let mut bad_row = make_pending_remint_row(
+            50,
+            &mint,
+            &Pubkey::new_unique(),
+            &recipient,
+            &Signature::new_unique(),
+            deadline,
+        );
         bad_row.remint_signatures = Some(vec![
             Signature::new_unique().to_string(),
             Signature::new_unique().to_string(),
@@ -815,6 +864,7 @@ mod tests {
             .push(make_pending_remint_row(
                 50,
                 &mint,
+                &Pubkey::new_unique(),
                 &recipient,
                 &sig,
                 past_deadline,
@@ -855,6 +905,7 @@ mod tests {
         let mut row = make_pending_remint_row(
             60,
             &mint,
+            &Pubkey::new_unique(),
             &recipient,
             &sig,
             Utc::now() + chrono::Duration::seconds(30),

--- a/integration/tests/indexer/remint_recovery.rs
+++ b/integration/tests/indexer/remint_recovery.rs
@@ -44,6 +44,7 @@ use {
 fn make_row(
     id: i64,
     mint: &Pubkey,
+    initiator: &Pubkey,
     recipient: &Pubkey,
     sig: &Signature,
     amount: u64,
@@ -55,7 +56,7 @@ fn make_row(
         signature: Signature::new_unique().to_string(),
         trace_id: format!("trace-{id}"),
         slot: 100,
-        initiator: Pubkey::new_unique().to_string(),
+        initiator: initiator.to_string(),
         recipient: recipient.to_string(),
         mint: mint.to_string(),
         amount: TokenAmount(amount),
@@ -101,6 +102,9 @@ async fn recover_rehydrates_valid_pending_remint_row() {
     let mock = MockStorage::new();
 
     let mint = Pubkey::new_unique();
+    // Distinct from `recipient`: the burn debited the initiator, so the remint
+    // must target them, not the withdrawal's Solana destination.
+    let initiator = Pubkey::new_unique();
     let recipient = Pubkey::new_unique();
     let sig = Signature::new_unique();
     let deadline = Utc::now() + chrono::Duration::seconds(20);
@@ -108,7 +112,9 @@ async fn recover_rehydrates_valid_pending_remint_row() {
     mock.pending_remint_transactions
         .lock()
         .unwrap()
-        .push(make_row(42, &mint, &recipient, &sig, 5_000, deadline));
+        .push(make_row(
+            42, &mint, &initiator, &recipient, &sig, 5_000, deadline,
+        ));
 
     let storage = Arc::new(Storage::Mock(mock));
     let mut state = test_hooks::new_sender_state(
@@ -134,7 +140,8 @@ async fn recover_rehydrates_valid_pending_remint_row() {
     assert_eq!(entry.ctx.transaction_id, Some(42));
     assert_eq!(entry.ctx.trace_id.as_deref(), Some("trace-42"));
     assert_eq!(entry.remint_info.mint, mint);
-    assert_eq!(entry.remint_info.user, recipient);
+    assert_eq!(entry.remint_info.user, initiator);
+    assert_ne!(entry.remint_info.user, recipient);
     assert_eq!(entry.remint_info.amount, 5_000u64);
     assert_eq!(entry.signatures.len(), 1);
     assert_eq!(entry.signatures[0].signature, sig);
@@ -196,12 +203,28 @@ async fn recover_escalates_malformed_row_but_continues_with_others() {
     let deadline = Utc::now() + chrono::Duration::seconds(20);
 
     // Row 1 — invalid mint string, cannot be parsed back to a Pubkey.
-    let mut bad = make_row(10, &Pubkey::new_unique(), &recipient, &sig, 1_000, deadline);
+    let mut bad = make_row(
+        10,
+        &Pubkey::new_unique(),
+        &Pubkey::new_unique(),
+        &recipient,
+        &sig,
+        1_000,
+        deadline,
+    );
     bad.mint = "definitely-not-base58".to_string();
 
     // Row 2 — valid, must still be queued despite the bad sibling.
     let good_mint = Pubkey::new_unique();
-    let good = make_row(11, &good_mint, &recipient, &sig, 2_500, deadline);
+    let good = make_row(
+        11,
+        &good_mint,
+        &Pubkey::new_unique(),
+        &recipient,
+        &sig,
+        2_500,
+        deadline,
+    );
 
     mock.pending_remint_transactions
         .lock()

--- a/integration/tests/indexer/state_recovery_malformed.rs
+++ b/integration/tests/indexer/state_recovery_malformed.rs
@@ -9,7 +9,7 @@
 //!
 //!   - invalid `mint` pubkey string (redundant with t12, kept for
 //!     regression anchoring)
-//!   - invalid `recipient` pubkey string
+//!   - invalid `initiator` pubkey string
 //!   - invalid withdrawal `remint_signatures[i]` string
 //!
 //! The former negative-amount shape is gone: `amount` is a `TokenAmount(u64)`,
@@ -42,7 +42,7 @@ use {
 fn make_row(
     id: i64,
     mint: String,
-    recipient: String,
+    initiator: String,
     sig_strings: Vec<String>,
     amount: u64,
     deadline: DateTime<Utc>,
@@ -54,8 +54,8 @@ fn make_row(
         signature: Signature::new_unique().to_string(),
         trace_id: format!("trace-{id}"),
         slot: 100,
-        initiator: Pubkey::new_unique().to_string(),
-        recipient,
+        initiator,
+        recipient: Pubkey::new_unique().to_string(),
         mint,
         amount: TokenAmount(amount),
         memo: None,
@@ -102,7 +102,7 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
 
     let deadline = Utc::now() + chrono::Duration::seconds(20);
     let good_mint = Pubkey::new_unique();
-    let good_recipient = Pubkey::new_unique();
+    let good_initiator = Pubkey::new_unique();
     let good_sig = Signature::new_unique();
 
     // Row 10 — invalid mint string
@@ -115,8 +115,8 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
         deadline,
     );
 
-    // Row 11 — invalid recipient string
-    let bad_recipient = make_row(
+    // Row 11 — invalid initiator string
+    let bad_initiator = make_row(
         11,
         Pubkey::new_unique().to_string(),
         "not-a-valid-pubkey-either".to_string(),
@@ -139,7 +139,7 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
     let good = make_row(
         14,
         good_mint.to_string(),
-        good_recipient.to_string(),
+        good_initiator.to_string(),
         vec![good_sig.to_string()],
         4_000,
         deadline,
@@ -147,7 +147,7 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
 
     mock.pending_remint_transactions.lock().unwrap().extend([
         bad_mint,
-        bad_recipient,
+        bad_initiator,
         bad_sig,
         good,
     ]);
@@ -179,7 +179,7 @@ async fn recover_escalates_every_parse_error_shape_and_preserves_valid_sibling()
     let entry = &state.pending_remints[0];
     assert_eq!(entry.ctx.transaction_id, Some(14));
     assert_eq!(entry.remint_info.mint, good_mint);
-    assert_eq!(entry.remint_info.user, good_recipient);
+    assert_eq!(entry.remint_info.user, good_initiator);
     assert_eq!(entry.signatures.len(), 1);
     assert_eq!(entry.signatures[0].signature, good_sig);
 


### PR DESCRIPTION
## Problem

On permanent withdrawal failure the operator reminted private channel tokens to `transactions.recipient`, which for a withdrawal is the Solana payout destination (`data.destination`), not the account that was debited.

The burn is bound to the signer: `withdraw_funds` validates the token account against `user_info` and burns with `authority: user_info`. `destination` is payload for the mainnet leg only.

So a withdrawal with an explicit destination that failed to release credited the destination on the private channel and left the burner with nothing. The row still landed on `failed_reminted`, so the alert read as a successful compensation. The two identities coincide when no destination is passed (`.unwrap_or(user)`), which is why this went unnoticed.

## Fix

Both remint construction sites now read `transactions.initiator`:
  - `processor.rs` (hot path)
  - `sender/state.rs` (restart recovery)

The parse is strict, matching the existing mint and recipient parses, so a corrupt initiator routes the row to ManualReview instead of reminting to a guess. The release leg is unchanged and still pays `recipient`.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,994 | 13,619 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30492223093) |
| Indexer | 23,032 | 26,130 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30492223093) |
| Gateway | 1,055 | 1,230 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30492223093) |
| Auth | 830 | 949 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30492223093) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,252 | 15,283 | 80.2% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30492223093) |
| **Total** | **49,163** | **57,211** | **85.9%** | |

> Last updated: 2026-07-29 21:59:45 UTC by E2E Integration