### PR TITLE
fix(core): replace the writable-lamport cap with fabricated fee-payer conservation (issue-115-131)

### DIFF
--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -134,14 +134,18 @@ impl BOB {
         &self.precompiles
     }
 
-    /// Whether BOB would hand this account to the SVM. Mirrors
-    /// `get_account_shared_data`'s presence rules without cloning the account.
-    pub fn knows_account(&self, pubkey: &Pubkey) -> bool {
-        self.precompiles.contains_key(pubkey)
-            || self
-                .accounts
-                .get(pubkey)
-                .is_some_and(|entry| !entry.deleted)
+    /// Lamports BOB would hand the SVM for this account, or `None` if it would
+    /// hand nothing. Mirrors `get_account_shared_data`'s presence rules without
+    /// cloning the account, so callers get both presence and balance in one
+    /// lookup.
+    pub fn account_lamports(&self, pubkey: &Pubkey) -> Option<u64> {
+        if let Some(account) = self.precompiles.get(pubkey) {
+            return Some(account.lamports());
+        }
+        self.accounts
+            .get(pubkey)
+            .filter(|entry| !entry.deleted)
+            .map(|entry| entry.account.lamports())
     }
 
     /// Preloads accounts into BOB from the database.
@@ -1458,12 +1462,13 @@ mod tests {
         );
     }
 
-    /// `knows_account` must answer exactly what `get_account_shared_data`
-    /// answers, for every entry shape: precompile, live, deleted, absent.
-    /// The conservation check keys "this account is new" off it, so a drift
-    /// would silently reclassify accounts the SVM did load.
+    /// `account_lamports` must report exactly what `get_account_shared_data`
+    /// reports, for every entry shape: precompile, live, deleted, absent. The
+    /// conservation check reads both "this account is new" and "this is what it
+    /// held before" off it, so a drift would misclassify accounts the SVM loaded
+    /// or misjudge whether a balance grew.
     #[tokio::test]
-    async fn bob_knows_account_matches_loader_semantics() {
+    async fn bob_account_lamports_matches_loader_semantics() {
         let (mut bob, _settled_tx) = create_test_bob();
 
         let precompile = Pubkey::new_unique();
@@ -1489,12 +1494,17 @@ mod tests {
 
         for pubkey in [precompile, live, deleted, absent] {
             assert_eq!(
-                bob.knows_account(&pubkey),
-                bob.get_account_shared_data(&pubkey).is_some(),
-                "knows_account disagrees with the loader for {pubkey}"
+                bob.account_lamports(&pubkey),
+                bob.get_account_shared_data(&pubkey)
+                    .map(|account| account.lamports()),
+                "account_lamports disagrees with the loader for {pubkey}"
             );
         }
-        assert!(bob.knows_account(&precompile) && bob.knows_account(&live));
-        assert!(!bob.knows_account(&deleted) && !bob.knows_account(&absent));
+        // `token_like` carries its balance in data and sits on the 1-lamport
+        // existence floor, so 1 is the lamport figure the check must see.
+        assert_eq!(bob.account_lamports(&precompile), Some(1));
+        assert_eq!(bob.account_lamports(&live), Some(1));
+        assert_eq!(bob.account_lamports(&deleted), None);
+        assert_eq!(bob.account_lamports(&absent), None);
     }
 }

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -134,6 +134,16 @@ impl BOB {
         &self.precompiles
     }
 
+    /// Whether BOB would hand this account to the SVM. Mirrors
+    /// `get_account_shared_data`'s presence rules without cloning the account.
+    pub fn knows_account(&self, pubkey: &Pubkey) -> bool {
+        self.precompiles.contains_key(pubkey)
+            || self
+                .accounts
+                .get(pubkey)
+                .is_some_and(|entry| !entry.deleted)
+    }
+
     /// Preloads accounts into BOB from the database.
     ///
     /// Returns `(fetched, cached)` where:
@@ -1446,5 +1456,45 @@ mod tests {
             !bob.accounts.contains_key(&pubkey),
             "a clean DB-loaded account is age-evictable, no longer pinned in memory"
         );
+    }
+
+    /// `knows_account` must answer exactly what `get_account_shared_data`
+    /// answers, for every entry shape: precompile, live, deleted, absent.
+    /// The conservation check keys "this account is new" off it, so a drift
+    /// would silently reclassify accounts the SVM did load.
+    #[tokio::test]
+    async fn bob_knows_account_matches_loader_semantics() {
+        let (mut bob, _settled_tx) = create_test_bob();
+
+        let precompile = Pubkey::new_unique();
+        bob.precompiles
+            .insert(precompile, make_account(1, b"elf", &Pubkey::new_unique()));
+
+        let live = Pubkey::new_unique();
+        bob.insert_account_for_test(live, token_like(10));
+
+        // Build the deleted entry the production way: a successful tx writing
+        // a zero-lamport, empty-data account tombstones it.
+        let from = Keypair::new();
+        let deleted = from.pubkey();
+        bob.insert_account_for_test(deleted, token_like(10));
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 0);
+        let output = svm_output(executed_with_status(
+            Ok(()),
+            vec![(deleted, AccountSharedData::default())],
+        ));
+        bob.update_accounts(&output, std::slice::from_ref(&tx));
+
+        let absent = Pubkey::new_unique();
+
+        for pubkey in [precompile, live, deleted, absent] {
+            assert_eq!(
+                bob.knows_account(&pubkey),
+                bob.get_account_shared_data(&pubkey).is_some(),
+                "knows_account disagrees with the loader for {pubkey}"
+            );
+        }
+        assert!(bob.knows_account(&precompile) && bob.knows_account(&live));
+        assert!(!bob.knows_account(&deleted) && !bob.knows_account(&absent));
     }
 }

--- a/core/src/stage_metrics.rs
+++ b/core/src/stage_metrics.rs
@@ -25,6 +25,7 @@ pub trait StageMetrics: Send + Sync {
     fn executor_results_send_failed(&self, kind: &'static str);
     fn executor_missing_results(&self, kind: &'static str);
     fn executor_dropped_expired_blockhash(&self, count: usize);
+    fn executor_conservation_rejected(&self);
 
     // Executor — latency histograms (durations in milliseconds)
     fn executor_batch_duration_ms(&self, ms: f64);
@@ -99,6 +100,9 @@ impl StageMetrics for NoopMetrics {
     }
     fn executor_dropped_expired_blockhash(&self, count: usize) {
         debug!("executor: dropped {} expired blockhash txs", count);
+    }
+    fn executor_conservation_rejected(&self) {
+        debug!("executor: rejected tx failing lamport conservation");
     }
     fn executor_batch_duration_ms(&self, ms: f64) {
         debug!("executor: batch_duration={:.3}ms", ms);
@@ -236,6 +240,12 @@ counter_vec!(
     EXECUTOR_DROPPED_EXPIRED_BH,
     "private_channel_executor_dropped_expired_bh_total",
     "Transactions dropped at execution due to expired blockhash",
+    &[]
+);
+counter_vec!(
+    EXECUTOR_CONSERVATION_REJECTED,
+    "private_channel_executor_conservation_rejected_total",
+    "Transactions failed at execution for leaking fabricated fee-payer lamports",
     &[]
 );
 counter_vec!(
@@ -401,6 +411,11 @@ impl StageMetrics for PrometheusMetrics {
             .with_label_values(&[] as &[&str])
             .inc_by(count as f64);
     }
+    fn executor_conservation_rejected(&self) {
+        EXECUTOR_CONSERVATION_REJECTED
+            .with_label_values(&[] as &[&str])
+            .inc();
+    }
     fn executor_batch_duration_ms(&self, ms: f64) {
         EXECUTOR_BATCH_DURATION
             .with_label_values(&[] as &[&str])
@@ -502,6 +517,7 @@ pub fn init_prometheus_metrics() {
         EXECUTOR_RESULTS_SEND_FAILED,
         EXECUTOR_MISSING_RESULTS,
         EXECUTOR_DROPPED_EXPIRED_BH,
+        EXECUTOR_CONSERVATION_REJECTED,
         SETTLER_TXS_SETTLED,
         BOB_CACHE_EVICTED,
         BOB_CACHE_ENTRIES,

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -418,17 +418,23 @@ fn enforce_lamport_conservation(
         }
 
         fabricated.clear();
-        // How much of the invented float went missing, and how many brand new
-        // accounts exist to justify it.
+        // How much of the invented float went missing, how many brand new
+        // accounts exist to justify it, and whether any account that already
+        // existed ended up richer than it started.
         let mut shortfall = 0u64;
         let mut created = 0u64;
+        let mut credited = false;
         for (index, (pubkey, acct)) in executed.loaded_transaction.accounts.iter().enumerate() {
-            // Read-only accounts are never persisted, and anything BOB already
-            // knew is real money this check must not touch or count.
-            if !tx.is_writable(index) || bob.knows_account(pubkey) {
+            // Read-only accounts are never persisted, so they are never touched
+            // or counted.
+            if !tx.is_writable(index) {
                 continue;
             }
-            if fee_payers.contains(pubkey) {
+            if let Some(before) = bob.account_lamports(pubkey) {
+                // Already existed, so its balance is real money this check must
+                // never rewrite. Only note whether it grew.
+                credited |= acct.lamports() > before;
+            } else if fee_payers.contains(pubkey) {
                 // An invented payer: whatever it no longer holds has escaped.
                 // The set is batch-wide, so draining one payer into another
                 // still registers as a shortfall rather than as repayment.
@@ -443,7 +449,12 @@ fn enforce_lamport_conservation(
         // Lamports against a count, because the rate is exactly one: the SVM
         // deletes a 0-lamport account, and with rent at zero every creation
         // path funds a single lamport. So `created` is also the allowance.
-        if shortfall > created {
+        //
+        // The second clause closes an attribution gap. Counting creations does
+        // not prove the float paid for them, so a creation funded by real money
+        // could licence a float lamport that actually landed somewhere durable.
+        // While any float is missing, no pre-existing balance may grow.
+        if shortfall > created || (shortfall > 0 && credited) {
             // Reject rather than claw back, which would mean rewriting accounts
             // the transaction legitimately owns. Downstream skips failed txs.
             executed.execution_details.status = Err(TransactionError::UnbalancedTransaction);
@@ -1145,6 +1156,62 @@ mod tests {
             data_account(6000),
             "the credited side keeps the credit"
         );
+    }
+
+    /// Counting creations does not prove the float paid for them. Here a new
+    /// account is funded by real money while one float lamport lands in an
+    /// account that already existed, so the count would licence a fabricated
+    /// lamport becoming durable. The credit clause rejects it instead.
+    #[tokio::test]
+    async fn credited_pre_existing_account_rejects_when_float_is_missing() {
+        let payer = Pubkey::new_unique();
+        let funder = Pubkey::new_unique();
+        let escrow = Pubkey::new_unique();
+        let fresh = Pubkey::new_unique();
+        let out = run_conservation(
+            &[(funder, dataless_account(2)), (escrow, data_account(5000))],
+            vec![
+                // One lamport of the float is gone.
+                (payer, dataless_account(FLOAT - 1)),
+                // A real account paid for the new one, not the payer.
+                (funder, dataless_account(1)),
+                (fresh, data_account(1)),
+                // The float lamport ended up here, in durable state.
+                (escrow, data_account(5001)),
+            ],
+            &[payer],
+        );
+        assert!(
+            out.rejected(),
+            "a credited pre-existing account must not be licenced by an unrelated creation, status was {:?}",
+            out.status
+        );
+        assert_eq!(
+            out.accounts[3],
+            data_account(5001),
+            "a rejected transaction must still not rewrite the account that gained"
+        );
+    }
+
+    /// The credit clause is conditional, not blanket: with the float intact,
+    /// pre-existing accounts may move real lamports between themselves. A
+    /// creation funded entirely by real money is still allowed to persist.
+    #[tokio::test]
+    async fn credited_pre_existing_account_is_fine_when_float_is_intact() {
+        let payer = Pubkey::new_unique();
+        let funder = Pubkey::new_unique();
+        let escrow = Pubkey::new_unique();
+        let out = run_conservation(
+            &[(funder, dataless_account(5000)), (escrow, data_account(10))],
+            vec![
+                (payer, dataless_account(FLOAT)),
+                (funder, dataless_account(4000)),
+                (escrow, data_account(1010)),
+            ],
+            &[payer],
+        );
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(out.accounts[2], data_account(1010), "the credit stands");
     }
 
     /// An ordinary wallet (lamports, no data) is neither zeroed nor deleted.

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -400,6 +400,7 @@ fn enforce_lamport_conservation(
     transactions: &[SanitizedTransaction],
     bob: &BOB,
     fee_payers: &HashSet<Pubkey>,
+    metrics: &SharedMetrics,
 ) {
     // Reused across transactions so the whole batch allocates at most once.
     let mut fabricated: Vec<usize> = Vec::new();
@@ -453,6 +454,15 @@ fn enforce_lamport_conservation(
         // lamport that went elsewhere. Hence no older account may grow while any
         // made-up money is missing.
         if shortfall > created || (shortfall > 0 && credited) {
+            // Nothing legitimate trips this, so every hit is worth an alert.
+            warn!(
+                sig = %tx.signature(),
+                shortfall,
+                created,
+                credited,
+                "execution: failing tx that does not account for its fabricated fee-payer lamports"
+            );
+            metrics.executor_conservation_rejected();
             // Fail the tx instead of taking the money back, which would mean
             // rewriting accounts it owns. Later stages skip failed txs.
             executed.execution_details.status = Err(TransactionError::UnbalancedTransaction);
@@ -732,6 +742,7 @@ pub async fn execute_batch(
             &regular_transactions,
             &execution_deps.bob,
             &fee_payers,
+            metrics,
         );
 
         // Update BOB's in-memory accounts with the execution results
@@ -1019,6 +1030,7 @@ mod tests {
             std::slice::from_ref(&tx),
             &bob,
             &fee_payers.iter().copied().collect(),
+            &(Arc::new(NoopMetrics) as SharedMetrics),
         );
         let Ok(ProcessedTransaction::Executed(executed)) = &output.processing_results[0] else {
             panic!("expected executed");
@@ -1217,6 +1229,42 @@ mod tests {
         assert_eq!(out.accounts[2], data_account(1010), "the credit stands");
     }
 
+    /// Routing the float through an account that ends where it started, so it
+    /// pays a new account's floor for it, is accepted. This is the allowance
+    /// doing its job, not a way around it: the relay ends no richer, and total
+    /// lamports still rise by exactly one per account created. Rejecting it
+    /// would also reject an ordinary creation, which spends the float the same
+    /// way in one hop instead of two.
+    #[tokio::test]
+    async fn float_relayed_through_a_flat_account_stays_within_the_allowance() {
+        let payer = Pubkey::new_unique();
+        let relay = Pubkey::new_unique();
+        let fresh = Pubkey::new_unique();
+        let out = run_conservation(
+            &[(relay, data_account(5000))],
+            vec![
+                // One lamport of the float is gone.
+                (payer, dataless_account(FLOAT - 1)),
+                // It passed through here and left again, so this ends flat.
+                (relay, data_account(5000)),
+                // And it came to rest as the new account's existence floor.
+                (fresh, data_account(1)),
+            ],
+            &[payer],
+        );
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(
+            out.accounts[1],
+            data_account(5000),
+            "the relay must end exactly where it started, so it gained nothing"
+        );
+        assert_eq!(
+            out.accounts[2],
+            data_account(1),
+            "the new account keeps the single lamport the allowance covers"
+        );
+    }
+
     /// An ordinary wallet (lamports, no data) is neither zeroed nor deleted.
     /// Force-deleting it was the documented divergence from Agave.
     #[tokio::test]
@@ -1315,6 +1363,7 @@ mod tests {
             std::slice::from_ref(&tx),
             &bob,
             &HashSet::from([payer]),
+            &(Arc::new(NoopMetrics) as SharedMetrics),
         );
         let Ok(ProcessedTransaction::Executed(executed)) = &output.processing_results[0] else {
             panic!("expected executed");

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -13,16 +13,16 @@ use {
         vm::{
             admin::AdminVm,
             clock::set_clock_now,
-            gasless_callback::{GaslessCallback, SnapshotCallback},
+            gasless_callback::{GaslessCallback, SnapshotCallback, DEFAULT_FEE_PAYER_LAMPORTS},
             gasless_rent_collector::GaslessRentCollector,
         },
     },
     solana_compute_budget::compute_budget::SVMTransactionExecutionBudget,
     solana_sdk::{
-        account::{ReadableAccount, WritableAccount},
+        account::{AccountSharedData, ReadableAccount},
         hash::Hash,
         pubkey::Pubkey,
-        transaction::SanitizedTransaction,
+        transaction::{SanitizedTransaction, TransactionError},
     },
     solana_svm::{
         transaction_error_metrics::TransactionErrorMetrics,
@@ -385,24 +385,25 @@ fn execute_parallel(
     merge_svm_outputs(chunk_outputs)
 }
 
-/// Cap each writable account's post-execution lamports so fabricated SOL never
-/// persists: a data account keeps at most its 1-lamport existence floor (0
-/// deallocates in the SVM, so the floor is 1, not 0); a dataless account keeps 0.
-/// The cap only ever reduces.
+/// The lamports the gasless callback invents for an unknown fee payer are the
+/// only lamports here that were never deposited. Treat them as a loan every
+/// successful transaction must repay, minus one lamport per account it creates.
 ///
-/// Enumeration-free — any leak (direct `Transfer`, park-then-`CloseAccount`,
-/// `RecoverNested`, swap close, any future program) ends with lamports rising
-/// above a floor, which the cap removes regardless of how. Legit flows are
-/// untouched: transfers don't move lamports; new mints/ATAs are floored at 1 so
-/// they persist; the dataless synthetic fee payer caps to 0 so it's deleted.
+/// The SVM already conserves lamports per instruction, so blocking that one
+/// source means every other balance is made of lamports that already existed
+/// and needs no checking. An unpaid loan fails the transaction instead of
+/// editing accounts, because editing accounts is what corrupts bystanders.
 ///
-/// Assumes no durable native lamports beyond existence floors (deposits mint
-/// tokens; no wrapped SOL) — revisit if native SOL is added. Regular path only
-/// (admin never fabricates fee payers).
-fn cap_lamports(
+/// Regular path only: admin execution never invents fee payers.
+fn enforce_lamport_conservation(
     output: &mut LoadAndExecuteSanitizedTransactionsOutput,
     transactions: &[SanitizedTransaction],
+    bob: &BOB,
+    fee_payers: &HashSet<Pubkey>,
 ) {
+    // Reused across transactions so the whole batch allocates at most once.
+    let mut fabricated: Vec<usize> = Vec::new();
+
     for (result, tx) in output
         .processing_results
         .iter_mut()
@@ -415,15 +416,44 @@ fn cap_lamports(
             // Failed executed txs commit no account writes downstream.
             continue;
         }
-        for (index, (_, acct)) in executed.loaded_transaction.accounts.iter_mut().enumerate() {
-            // Only writable accounts are persisted by the settler / BOB update.
-            if !tx.is_writable(index) {
+
+        fabricated.clear();
+        // How much of the invented float went missing, and how many brand new
+        // accounts exist to justify it.
+        let mut shortfall = 0u64;
+        let mut created = 0u64;
+        for (index, (pubkey, acct)) in executed.loaded_transaction.accounts.iter().enumerate() {
+            // Read-only accounts are never persisted, and anything BOB already
+            // knew is real money this check must not touch or count.
+            if !tx.is_writable(index) || bob.knows_account(pubkey) {
                 continue;
             }
-            let cap = if acct.data().is_empty() { 0 } else { 1 };
-            if acct.lamports() > cap {
-                acct.set_lamports(cap);
+            if fee_payers.contains(pubkey) {
+                // An invented payer: whatever it no longer holds has escaped.
+                // The set is batch-wide, so draining one payer into another
+                // still registers as a shortfall rather than as repayment.
+                fabricated.push(index);
+                shortfall += DEFAULT_FEE_PAYER_LAMPORTS.saturating_sub(acct.lamports());
+            } else if acct.lamports() > 0 {
+                // Unknown to BOB but funded, so this transaction created it.
+                created += 1;
             }
+        }
+
+        // Lamports against a count, because the rate is exactly one: the SVM
+        // deletes a 0-lamport account, and with rent at zero every creation
+        // path funds a single lamport. So `created` is also the allowance.
+        if shortfall > created {
+            // Reject rather than claw back, which would mean rewriting accounts
+            // the transaction legitimately owns. Downstream skips failed txs.
+            executed.execution_details.status = Err(TransactionError::UnbalancedTransaction);
+            continue;
+        }
+        // Loan settled. Erase the invented payers to the empty zero-lamport
+        // shape BOB and the settler already treat as deleted, and touch nothing
+        // else: an address that never existed must not become durable state.
+        for index in &fabricated {
+            executed.loaded_transaction.accounts[*index].1 = AccountSharedData::default();
         }
     }
 }
@@ -638,8 +668,11 @@ pub async fn execute_batch(
             // `accounts_to_preload` covers admin+regular keys; harmless
             // over-inclusion — admin keys in the snapshot just add a few
             // HashMap entries that regular-tx workers will never look up.
-            let snapshot =
-                SnapshotCallback::from_bob(&execution_deps.bob, &accounts_to_preload, fee_payers);
+            let snapshot = SnapshotCallback::from_bob(
+                &execution_deps.bob,
+                &accounts_to_preload,
+                fee_payers.clone(),
+            );
             // `execute_parallel` uses `std::thread::scope`, which parks this
             // OS thread until the worker threads join. Because we're on a
             // tokio worker, `block_in_place` lets tokio migrate other queued
@@ -654,7 +687,7 @@ pub async fn execute_batch(
             })
         } else {
             // Sequential path: direct BOB access, no snapshot cost.
-            let gasless_callback = GaslessCallback::new(&execution_deps.bob, fee_payers);
+            let gasless_callback = GaslessCallback::new(&execution_deps.bob, fee_payers.clone());
             execution_deps.vm.load_and_execute_sanitized_transactions(
                 &gasless_callback,
                 regular_transactions.as_slice(),
@@ -677,10 +710,15 @@ pub async fn execute_batch(
         );
         metrics.executor_svm_duration_ms("regular", t_svm_reg.as_secs_f64() * 1000.0);
 
-        // Cap writable lamports before either consumer reads the shared output:
-        // the in-memory BOB update below and the durable settler downstream. One
-        // mutation covers both consumers and both exec paths.
-        cap_lamports(&mut regular_results, &regular_transactions);
+        // Run the conservation check before either consumer reads the shared
+        // output: the in-memory BOB update below and the durable settler
+        // downstream. One pass covers both consumers and both exec paths.
+        enforce_lamport_conservation(
+            &mut regular_results,
+            &regular_transactions,
+            &execution_deps.bob,
+            &fee_payers,
+        );
 
         // Update BOB's in-memory accounts with the execution results
         let t_op = Instant::now();
@@ -840,12 +878,12 @@ mod tests {
         matches!(r, Ok(ProcessedTransaction::Executed(_)))
     }
 
-    // ── cap_lamports unit tests (cap math, tested directly) ──
+    // ── enforce_lamport_conservation unit tests (pure, no SVM) ──
     //
-    // cap_lamports is pure over (output, transactions). We build a 1-tx output
-    // whose loaded accounts we control, pair it with a tx whose writability we
-    // know (`transfer` → idx 0,1 writable, idx 2 system_program read-only),
-    // run the cap, and read the accounts back.
+    // The check is pure over (output, transactions, bob, fee_payers). We seed
+    // BOB with what existed before the transaction, hand the check a loaded
+    // account vector we control paired with a transaction whose writability we
+    // choose, and read the status and the accounts back.
 
     /// Build a single-tx Executed output carrying `accounts` with the given `status`.
     fn executed_with_status(
@@ -890,147 +928,427 @@ mod tests {
         AccountSharedData::new(lamports, 0, &solana_sdk_ids::system_program::ID)
     }
 
-    /// Run cap_lamports over one tx whose writable indices are 0 and 1.
-    /// Returns the post-cap accounts.
-    fn run_cap_one_tx(accounts: Vec<(Pubkey, AccountSharedData)>) -> Vec<AccountSharedData> {
-        // `transfer` yields exactly: [from(0,w), to(1,w), system_program(2,ro)].
-        let tx = transfer(&Keypair::new(), &Pubkey::new_unique(), 0);
+    /// A DvP-nonce-tombstone-shaped account: program-owned, no data, sitting on
+    /// the 1-lamport existence floor the SVM requires of a live account.
+    fn tombstone_account() -> AccountSharedData {
+        AccountSharedData::new(1, 0, &Pubkey::new_unique())
+    }
+
+    /// The float the gasless callback fabricates for an unknown fee payer.
+    const FLOAT: u64 = DEFAULT_FEE_PAYER_LAMPORTS;
+
+    /// Build a transaction over exactly `keys`, the first `writable` of them
+    /// writable, plus a trailing read-only program id. Signatures are dummies:
+    /// sanitization counts them, nothing here verifies them.
+    fn tx_over(keys: &[Pubkey], writable: usize) -> SanitizedTransaction {
+        use solana_sdk::{
+            instruction::CompiledInstruction, message::MessageHeader, signature::Signature,
+        };
+        let mut account_keys = keys.to_vec();
+        account_keys.push(solana_sdk_ids::system_program::ID);
+        let message = Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: (keys.len() - writable + 1) as u8,
+            },
+            account_keys,
+            recent_blockhash: Hash::default(),
+            instructions: vec![CompiledInstruction {
+                program_id_index: keys.len() as u8,
+                accounts: vec![],
+                data: vec![],
+            }],
+        };
+        let tx = Transaction {
+            signatures: vec![Signature::default()],
+            message,
+        };
+        SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new())
+            .expect("failed to build controlled-writability tx")
+    }
+
+    struct Outcome {
+        status: Result<(), solana_transaction_error::TransactionError>,
+        accounts: Vec<AccountSharedData>,
+    }
+
+    impl Outcome {
+        fn rejected(&self) -> bool {
+            self.status == Err(solana_transaction_error::TransactionError::UnbalancedTransaction)
+        }
+    }
+
+    /// Seed `pre` into BOB, run the check over one successful transaction whose
+    /// loaded accounts are `accounts` (the first `writable` writable), and
+    /// return the resulting status and accounts.
+    fn run_conservation_with(
+        pre: &[(Pubkey, AccountSharedData)],
+        accounts: Vec<(Pubkey, AccountSharedData)>,
+        writable: usize,
+        fee_payers: &[Pubkey],
+    ) -> Outcome {
+        let (mut bob, _settled_tx) = crate::test_helpers::create_test_bob();
+        for (pubkey, account) in pre {
+            bob.insert_account_for_test(*pubkey, account.clone());
+        }
+        let keys: Vec<Pubkey> = accounts.iter().map(|(pubkey, _)| *pubkey).collect();
+        let tx = tx_over(&keys, writable);
         let mut output = LoadAndExecuteSanitizedTransactionsOutput {
             processing_results: vec![executed_with(accounts)],
             error_metrics: TransactionErrorMetrics::default(),
             execute_timings: ExecuteTimings::default(),
             balance_collector: None,
         };
-        cap_lamports(&mut output, std::slice::from_ref(&tx));
+        enforce_lamport_conservation(
+            &mut output,
+            std::slice::from_ref(&tx),
+            &bob,
+            &fee_payers.iter().copied().collect(),
+        );
         let Ok(ProcessedTransaction::Executed(executed)) = &output.processing_results[0] else {
             panic!("expected executed");
         };
-        executed
-            .loaded_transaction
-            .accounts
-            .iter()
-            .map(|(_, a)| a.clone())
-            .collect()
+        Outcome {
+            status: executed.execution_details.status.clone(),
+            accounts: executed
+                .loaded_transaction
+                .accounts
+                .iter()
+                .map(|(_, account)| account.clone())
+                .collect(),
+        }
     }
 
-    /// Data account with excess lamports is floored to its 1-lamport existence
-    /// floor — parking fabricated lamports in a token account is neutralized.
-    #[test]
-    fn cap_data_account_excess_to_one() {
-        let out = run_cap_one_tx(vec![(Pubkey::new_unique(), data_account(11))]);
-        assert_eq!(out[0].lamports(), 1);
+    /// `run_conservation_with` with every loaded account writable.
+    fn run_conservation(
+        pre: &[(Pubkey, AccountSharedData)],
+        accounts: Vec<(Pubkey, AccountSharedData)>,
+        fee_payers: &[Pubkey],
+    ) -> Outcome {
+        let writable = accounts.len();
+        run_conservation_with(pre, accounts, writable, fee_payers)
     }
 
-    /// Data account already at the 1-lamport floor is untouched (ATA/mint floor
-    /// preserved — legit accounts persist).
-    #[test]
-    fn cap_data_account_one_is_noop() {
-        let out = run_cap_one_tx(vec![(Pubkey::new_unique(), data_account(1))]);
-        assert_eq!(out[0].lamports(), 1);
-    }
-
-    /// Data account being closed (0 lamports) stays at 0 — the cap only ever
-    /// reduces, never raises to the floor.
-    #[test]
-    fn cap_data_account_zero_stays_zero() {
-        let out = run_cap_one_tx(vec![(Pubkey::new_unique(), data_account(0))]);
-        assert_eq!(out[0].lamports(), 0);
-    }
-
-    /// Dataless account with excess lamports is zeroed — covers the direct
-    /// exploit recipient, a RecoverNested destination wallet, a swap close
-    /// destination: any dataless gainer.
-    #[test]
-    fn cap_dataless_account_excess_to_zero() {
-        let out = run_cap_one_tx(vec![(Pubkey::new_unique(), dataless_account(10))]);
-        assert_eq!(out[0].lamports(), 0);
-    }
-
-    /// Dataless account already at 0 is untouched.
-    #[test]
-    fn cap_dataless_account_zero_is_noop() {
-        let out = run_cap_one_tx(vec![(Pubkey::new_unique(), dataless_account(0))]);
-        assert_eq!(out[0].lamports(), 0);
-    }
-
-    /// Mixed surgical cap: in one result a data account (11 lamports) floors to
-    /// 1 while a dataless account (10 lamports) zeroes — per-account, not global.
-    #[test]
-    fn cap_mixed_per_account() {
-        let out = run_cap_one_tx(vec![
-            (Pubkey::new_unique(), data_account(11)),
-            (Pubkey::new_unique(), dataless_account(10)),
-        ]);
-        assert_eq!(out[0].lamports(), 1, "data account floored to 1");
-        assert!(!out[0].data().is_empty(), "data preserved");
-        assert_eq!(out[1].lamports(), 0, "dataless account zeroed");
-    }
-
-    /// Read-only accounts are not capped: only writable accounts are persisted,
-    /// so capping a read-only account would be pointless work (and could clobber
-    /// a shared input the settler never writes). idx 2 is the read-only
-    /// system_program slot in a `transfer`.
-    #[test]
-    fn cap_skips_readonly_account() {
-        let out = run_cap_one_tx(vec![
-            (Pubkey::new_unique(), dataless_account(0)), // idx 0, writable
-            (Pubkey::new_unique(), dataless_account(0)), // idx 1, writable
-            (Pubkey::new_unique(), dataless_account(99)), // idx 2, read-only
-        ]);
-        assert_eq!(
-            out[2].lamports(),
-            99,
-            "read-only account must not be capped"
-        );
-    }
-
-    /// A failed executed tx commits no account writes downstream, so cap_lamports leaves its loaded accounts untouched.
-    #[test]
-    fn cap_skips_failed_executed() {
-        let tx = transfer(&Keypair::new(), &Pubkey::new_unique(), 0);
-        let failed = executed_with_status(
-            Err(
-                solana_transaction_error::TransactionError::InstructionError(
-                    1,
-                    solana_sdk::instruction::InstructionError::Custom(0),
-                ),
-            ),
+    /// A repaid loan erases the fabricated payer and leaves everything else
+    /// exactly as the SVM produced it.
+    #[tokio::test]
+    async fn loan_repaid_erases_payer_and_touches_nothing_else() {
+        let payer = Pubkey::new_unique();
+        let existing = Pubkey::new_unique();
+        let out = run_conservation(
+            &[(existing, data_account(5000))],
             vec![
-                (Pubkey::new_unique(), data_account(11)),
-                (Pubkey::new_unique(), dataless_account(10)),
+                (payer, dataless_account(FLOAT)),
+                (existing, data_account(5000)),
             ],
+            &[payer],
         );
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(
+            out.accounts[0],
+            AccountSharedData::default(),
+            "fabricated payer must be erased"
+        );
+        assert_eq!(
+            out.accounts[1],
+            data_account(5000),
+            "a pre-existing account must be byte-identical after the check"
+        );
+    }
+
+    /// A payer that spent its float with nothing to show for it never repaid
+    /// the loan, so the transaction is rejected and no account is rewritten.
+    #[tokio::test]
+    async fn unrepaid_loan_rejects_transaction() {
+        let payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let out = run_conservation(
+            &[],
+            vec![
+                (payer, dataless_account(0)),
+                (recipient, dataless_account(FLOAT)),
+            ],
+            &[payer],
+        );
+        assert!(out.rejected(), "status was {:?}", out.status);
+        assert_eq!(out.accounts[0], dataless_account(0), "payer untouched");
+        assert_eq!(
+            out.accounts[1],
+            dataless_account(FLOAT),
+            "a rejected transaction must not trim the account that gained"
+        );
+    }
+
+    /// Each account the transaction creates consumes one lamport of the float,
+    /// because the SVM requires a live account to hold at least one.
+    #[tokio::test]
+    async fn creation_allowance_permits_one_lamport_per_new_account() {
+        let payer = Pubkey::new_unique();
+        let first = Pubkey::new_unique();
+        let second = Pubkey::new_unique();
+        let out = run_conservation(
+            &[],
+            vec![
+                (payer, dataless_account(FLOAT - 2)),
+                (first, data_account(1)),
+                (second, data_account(1)),
+            ],
+            &[payer],
+        );
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(out.accounts[0], AccountSharedData::default());
+        assert_eq!(out.accounts[1], data_account(1), "created account persists");
+        assert_eq!(out.accounts[2], data_account(1), "created account persists");
+    }
+
+    /// The allowance is exact: one created account does not cover a shortfall of two.
+    #[tokio::test]
+    async fn creation_allowance_is_exact() {
+        let payer = Pubkey::new_unique();
+        let created = Pubkey::new_unique();
+        let out = run_conservation(
+            &[],
+            vec![
+                (payer, dataless_account(FLOAT - 2)),
+                (created, data_account(1)),
+            ],
+            &[payer],
+        );
+        assert!(out.rejected(), "status was {:?}", out.status);
+    }
+
+    /// A pre-existing account credited by another pre-existing account keeps
+    /// the credit. This is the property whose absence drains a wSOL escrow.
+    #[tokio::test]
+    async fn pre_existing_account_that_gains_is_untouched() {
+        let payer = Pubkey::new_unique();
+        let source = Pubkey::new_unique();
+        let target = Pubkey::new_unique();
+        let out = run_conservation(
+            &[(source, data_account(5000)), (target, data_account(5000))],
+            vec![
+                (payer, dataless_account(FLOAT)),
+                (source, data_account(4000)),
+                (target, data_account(6000)),
+            ],
+            &[payer],
+        );
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(
+            out.accounts[1],
+            data_account(4000),
+            "the debited side keeps its balance"
+        );
+        assert_eq!(
+            out.accounts[2],
+            data_account(6000),
+            "the credited side keeps the credit"
+        );
+    }
+
+    /// An ordinary wallet (lamports, no data) is neither zeroed nor deleted.
+    /// Force-deleting it was the documented divergence from Agave.
+    #[tokio::test]
+    async fn pre_existing_dataless_account_keeps_lamports() {
+        let payer = Pubkey::new_unique();
+        let wallet = Pubkey::new_unique();
+        let out = run_conservation(
+            &[(wallet, dataless_account(7))],
+            vec![
+                (payer, dataless_account(FLOAT)),
+                (wallet, dataless_account(7)),
+            ],
+            &[payer],
+        );
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(out.accounts[1], dataless_account(7));
+    }
+
+    /// A program-owned dataless account the transaction created (the DvP nonce
+    /// tombstone) survives, and its existence floor is covered by the allowance.
+    #[tokio::test]
+    async fn created_program_owned_dataless_account_survives() {
+        let payer = Pubkey::new_unique();
+        let tombstone = Pubkey::new_unique();
+        let created = tombstone_account();
+        let out = run_conservation(
+            &[],
+            vec![
+                (payer, dataless_account(FLOAT - 1)),
+                (tombstone, created.clone()),
+            ],
+            &[payer],
+        );
+        assert!(
+            out.status.is_ok(),
+            "the tombstone's lamport is covered by the creation allowance, got {:?}",
+            out.status
+        );
+        assert_eq!(
+            out.accounts[1], created,
+            "the nonce tombstone must survive the batch that creates it"
+        );
+    }
+
+    /// Read-only accounts are never inspected: they are not persisted, and
+    /// erasing one would clobber a shared input. The read-only slot here is
+    /// also a batch fee payer, so an inspection would visibly erase it.
+    #[tokio::test]
+    async fn readonly_accounts_are_never_inspected() {
+        let payer = Pubkey::new_unique();
+        let writable = Pubkey::new_unique();
+        let readonly_payer = Pubkey::new_unique();
+        let out = run_conservation_with(
+            &[],
+            vec![
+                (payer, dataless_account(FLOAT)),
+                (writable, dataless_account(0)),
+                (readonly_payer, dataless_account(99)),
+            ],
+            2,
+            &[payer, readonly_payer],
+        );
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(
+            out.accounts[2],
+            dataless_account(99),
+            "a read-only account must not be inspected or rewritten"
+        );
+    }
+
+    /// A failed executed tx commits no account writes downstream, so the check
+    /// leaves both its accounts and its status alone.
+    #[tokio::test]
+    async fn failed_executed_transaction_is_skipped() {
+        let payer = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+        let original = Err(
+            solana_transaction_error::TransactionError::InstructionError(
+                1,
+                solana_sdk::instruction::InstructionError::Custom(0),
+            ),
+        );
+        let tx = tx_over(&[payer, other], 2);
         let mut output = LoadAndExecuteSanitizedTransactionsOutput {
-            processing_results: vec![failed],
+            processing_results: vec![executed_with_status(
+                original.clone(),
+                vec![(payer, dataless_account(0)), (other, data_account(11))],
+            )],
             error_metrics: TransactionErrorMetrics::default(),
             execute_timings: ExecuteTimings::default(),
             balance_collector: None,
         };
-        cap_lamports(&mut output, std::slice::from_ref(&tx));
+        let (bob, _settled_tx) = crate::test_helpers::create_test_bob();
+        enforce_lamport_conservation(
+            &mut output,
+            std::slice::from_ref(&tx),
+            &bob,
+            &HashSet::from([payer]),
+        );
         let Ok(ProcessedTransaction::Executed(executed)) = &output.processing_results[0] else {
             panic!("expected executed");
         };
-        let accts = &executed.loaded_transaction.accounts;
         assert_eq!(
-            accts[0].1.lamports(),
-            11,
-            "failed-tx data account must be left untouched"
+            executed.execution_details.status, original,
+            "a failed executed tx must not be re-judged"
         );
+        let accounts = &executed.loaded_transaction.accounts;
+        assert_eq!(accounts[0].1, dataless_account(0), "payer untouched");
+        assert_eq!(accounts[1].1, data_account(11), "account untouched");
+    }
+
+    /// A fee payer BOB already knows is real money, not a fabrication: no loan
+    /// is charged against it and it is not erased.
+    #[tokio::test]
+    async fn real_fee_payer_is_not_treated_as_fabricated() {
+        let payer = Pubkey::new_unique();
+        let out = run_conservation(
+            &[(payer, dataless_account(5000))],
+            vec![(payer, dataless_account(5000))],
+            &[payer],
+        );
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(out.accounts[0], dataless_account(5000));
+    }
+
+    /// A fabricated payer that allocated data still does not persist: the
+    /// address never existed, so no part of it may become durable state.
+    #[tokio::test]
+    async fn fabricated_payer_with_data_still_does_not_persist() {
+        let payer = Pubkey::new_unique();
+        let out = run_conservation(&[], vec![(payer, data_account(FLOAT))], &[payer]);
+        assert!(out.status.is_ok(), "status was {:?}", out.status);
+        assert_eq!(out.accounts[0], AccountSharedData::default());
+    }
+
+    /// A fabricated payer that gained lamports is still erased. Real lamports
+    /// sent to an address that never existed are burned, not persisted.
+    #[tokio::test]
+    async fn fabricated_payer_that_gains_is_erased() {
+        let payer = Pubkey::new_unique();
+        let source = Pubkey::new_unique();
+        let out = run_conservation(
+            &[(source, dataless_account(5000))],
+            vec![
+                (payer, dataless_account(FLOAT + 5)),
+                (source, dataless_account(4995)),
+            ],
+            &[payer],
+        );
+        assert!(
+            out.status.is_ok(),
+            "an over-repaid loan is not a shortfall, got {:?}",
+            out.status
+        );
+        assert_eq!(out.accounts[0], AccountSharedData::default());
         assert_eq!(
-            accts[1].1.lamports(),
-            10,
-            "failed-tx dataless account must be left untouched"
+            out.accounts[1],
+            dataless_account(4995),
+            "the sender's debit stands"
         );
     }
 
-    // ── execute_batch behavioral tests (system transfers, through the SVM) ──
+    /// Fabrication follows the batch-wide fee-payer set, not this transaction's
+    /// own payer, so draining one fabricated account into another is still a
+    /// shortfall and cannot smuggle the float out.
+    #[tokio::test]
+    async fn second_fabricated_account_cannot_absorb_the_loan() {
+        let payer = Pubkey::new_unique();
+        let other_payer = Pubkey::new_unique();
+        let out = run_conservation(
+            &[],
+            vec![
+                (payer, dataless_account(0)),
+                (other_payer, dataless_account(FLOAT * 2)),
+            ],
+            &[payer, other_payer],
+        );
+        assert!(out.rejected(), "status was {:?}", out.status);
+    }
 
-    /// Direct exploit, behavioral shift from the old reject model: a fresh `A`
-    /// transfers its fabricated 10 lamports to `R`. Under the cap the tx is NOT
-    /// rejected — it executes — but R (a dataless gainer) is capped to 0 and
-    /// nothing durable is created. A is dataless → capped to 0 → absent.
+    // ── execute_batch behavioral tests (through the real SVM) ──
+
+    /// The status a regular result carries after the conservation check.
+    fn regular_status(
+        result: &ExecutionResult,
+        i: usize,
+    ) -> Result<(), solana_transaction_error::TransactionError> {
+        let Ok(ProcessedTransaction::Executed(executed)) = regular_result(result, i) else {
+            panic!("expected an executed result at index {i}");
+        };
+        executed.execution_details.status.clone()
+    }
+
+    fn unbalanced() -> Result<(), solana_transaction_error::TransactionError> {
+        Err(solana_transaction_error::TransactionError::UnbalancedTransaction)
+    }
+
+    /// Direct exploit: a fabricated payer transfers its whole float to R. The
+    /// loan is unrepaid beyond the single lamport R's creation allows, so the
+    /// transaction is rejected and nothing persists.
     #[tokio::test(flavor = "multi_thread")]
-    async fn direct_exploit_executes_but_persists_nothing() {
+    async fn direct_exploit_is_rejected() {
         let (accounts_db, _pg) = start_test_postgres().await;
         let (_tx, rx) = mpsc::unbounded_channel();
         let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
@@ -1040,21 +1358,19 @@ mod tests {
         let r = Pubkey::new_unique();
         let result = run_batch(&mut deps, &metrics, vec![transfer(&a, &r, 10)]).await;
 
+        assert_eq!(regular_status(&result, 0), unbalanced());
         assert!(
-            is_executed(regular_result(&result, 0)),
-            "under the cap the exploit tx executes, it is not rejected"
-        );
-        assert!(
-            bob_balance(&deps.bob, &r).is_none_or(|l| l == 0),
+            bob_balance(&deps.bob, &r).is_none(),
             "R must gain nothing durable"
         );
         assert!(
-            bob_balance(&deps.bob, &a.pubkey()).is_none_or(|l| l == 0),
+            bob_balance(&deps.bob, &a.pubkey()).is_none(),
             "synthetic payer must not persist"
         );
     }
 
-    /// Partial spend (ends at 5 on R): R is a dataless gainer → capped to 0.
+    /// Partial spend (5 of the float lands on R): still short by more than the
+    /// one lamport R's creation allows, so it is rejected too.
     #[tokio::test(flavor = "multi_thread")]
     async fn partial_spend_persists_nothing() {
         let (accounts_db, _pg) = start_test_postgres().await;
@@ -1065,14 +1381,13 @@ mod tests {
         let a = Keypair::new();
         let r = Pubkey::new_unique();
         let result = run_batch(&mut deps, &metrics, vec![transfer(&a, &r, 5)]).await;
-        assert!(is_executed(regular_result(&result, 0)));
-        assert!(bob_balance(&deps.bob, &r).is_none_or(|l| l == 0));
+        assert_eq!(regular_status(&result, 0), unbalanced());
+        assert!(bob_balance(&deps.bob, &r).is_none());
     }
 
     /// 2-step re-use: a value-neutral setup tx (self-transfer of 0) cannot
-    /// graduate the synthetic payer — it is dataless → capped to 0 → not
-    /// persisted, so a later batch still treats `A` as synthetic and its spend
-    /// still persists nothing.
+    /// graduate the synthetic payer: it is erased and never persisted, so a
+    /// later batch still treats `A` as synthetic and its spend is rejected.
     #[tokio::test(flavor = "multi_thread")]
     async fn two_step_setup_does_not_graduate_payer() {
         let (accounts_db, _pg) = start_test_postgres().await;
@@ -1082,7 +1397,7 @@ mod tests {
 
         let a = Keypair::new();
         let setup = run_batch(&mut deps, &metrics, vec![transfer(&a, &a.pubkey(), 0)]).await;
-        assert!(is_executed(regular_result(&setup, 0)));
+        assert_eq!(regular_status(&setup, 0), Ok(()), "the setup tx conserves");
         assert!(
             bob_balance(&deps.bob, &a.pubkey()).is_none_or(|l| l == 0),
             "synthetic payer must not graduate"
@@ -1090,12 +1405,12 @@ mod tests {
 
         let r = Pubkey::new_unique();
         let spend = run_batch(&mut deps, &metrics, vec![transfer(&a, &r, 10)]).await;
-        assert!(is_executed(regular_result(&spend, 0)));
-        assert!(bob_balance(&deps.bob, &r).is_none_or(|l| l == 0));
+        assert_eq!(regular_status(&spend, 0), unbalanced());
+        assert!(bob_balance(&deps.bob, &r).is_none());
     }
 
-    /// Synthetic fee payer is dropped: any synthetic-payer system transfer →
-    /// the payer (dataless) is capped to 0 → not persisted in BOB.
+    /// Synthetic fee payer is dropped: any synthetic-payer transaction erases
+    /// the payer, so it is never persisted in BOB.
     #[tokio::test(flavor = "multi_thread")]
     async fn synthetic_fee_payer_dropped() {
         let (accounts_db, _pg) = start_test_postgres().await;
@@ -1115,10 +1430,10 @@ mod tests {
     // ── Legitimate flows still work ──
 
     /// Legit gasless sponsorship: a fresh `A` pays for a real `B`'s transfer
-    /// without sending or receiving value. The tx settles, `B→R` lands, and the
-    /// fabricated sponsor account is dropped (dataless → capped to 0).
+    /// without sending or receiving value. The transfer lands on both sides and
+    /// the fabricated sponsor is erased.
     #[tokio::test(flavor = "multi_thread")]
-    async fn legit_gasless_sponsor_succeeds_and_payer_dropped() {
+    async fn gasless_sponsor_succeeds_and_is_dropped() {
         let (accounts_db, _pg) = start_test_postgres().await;
         let (_tx, rx) = mpsc::unbounded_channel();
         let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
@@ -1135,30 +1450,20 @@ mod tests {
         )
         .await;
 
-        assert!(
-            is_executed(regular_result(&result, 0)),
-            "legit sponsored transfer must succeed"
-        );
-        // The sponsor pays no fee (gasless) and never touches value. All three
-        // accounts here are dataless system accounts: under the cap none persist
-        // durable native lamports (the channel has no native SOL). What matters
-        // for this test is that the gasless sponsorship EXECUTES (the SVM does
-        // not reject for a missing fee payer) and the synthetic sponsor is not
-        // graduated into BOB.
+        assert_eq!(regular_status(&result, 0), Ok(()));
         assert!(
             bob_balance(&deps.bob, &a.pubkey()).is_none_or(|l| l == 0),
             "sponsor must not be persisted"
         );
-        assert!(
-            bob_balance(&deps.bob, &r).is_none_or(|l| l == 0),
-            "dataless recipient is capped to 0"
-        );
+        assert_eq!(bob_balance(&deps.bob, &b.pubkey()), Some(4000));
+        assert_eq!(bob_balance(&deps.bob, &r), Some(1000));
     }
 
-    /// A pre-funded real payer settles normally — the cap is a no-op on accounts
-    /// whose lamports don't exceed their floor.
+    /// A transfer between accounts made of pre-existing lamports persists on
+    /// both sides. This is the clearest semantic change from the old cap, which
+    /// zeroed both.
     #[tokio::test(flavor = "multi_thread")]
-    async fn real_prefunded_payer_unaffected() {
+    async fn real_transfer_persists_both_sides() {
         let (accounts_db, _pg) = start_test_postgres().await;
         let (_tx, rx) = mpsc::unbounded_channel();
         let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
@@ -1169,13 +1474,113 @@ mod tests {
         let r = Pubkey::new_unique();
         let result = run_batch(&mut deps, &metrics, vec![transfer(&b, &r, 1000)]).await;
 
-        assert!(is_executed(regular_result(&result, 0)));
-        // B and R are dataless system accounts. Both are capped to 0 durably —
-        // a system-account-to-system-account transfer of plain lamports has no
-        // durable representation in this channel (there is no native SOL). The
-        // transfer still executes; nothing native persists.
-        assert!(bob_balance(&deps.bob, &r).is_none_or(|l| l == 0));
-        assert!(bob_balance(&deps.bob, &b.pubkey()).is_none_or(|l| l == 0));
+        assert_eq!(regular_status(&result, 0), Ok(()));
+        assert_eq!(bob_balance(&deps.bob, &b.pubkey()), Some(4000));
+        assert_eq!(bob_balance(&deps.bob, &r), Some(1000));
+    }
+
+    /// A gasless user creating an ATA: the payer's float covers the ATA's
+    /// 1-lamport existence floor, so the transaction is accepted and the ATA
+    /// persists. The admin InitializeMint shares the batch, and admin results land
+    /// in BOB before regular execution, so the mint is visible here.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ata_creation_under_fabricated_payer_succeeds() {
+        let (accounts_db, _pg) = start_test_postgres().await;
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
+        let metrics: SharedMetrics = Arc::new(NoopMetrics);
+
+        let (admin_tx, mint) = create_admin_initialize_mint_tx();
+        let payer = Keypair::new();
+        let wallet = Pubkey::new_unique();
+        let ata = spl_associated_token_account::get_associated_token_address(&wallet, &mint);
+        let ix = spl_associated_token_account::instruction::create_associated_token_account(
+            &payer.pubkey(),
+            &wallet,
+            &mint,
+            &spl_token::id(),
+        );
+        let msg = Message::new(&[ix], Some(&payer.pubkey()));
+        let raw = Transaction::new(&[&payer], msg, Hash::default());
+        let ata_tx = SanitizedTransaction::try_from_legacy_transaction(raw, &HashSet::new())
+            .expect("failed to build ATA-create tx");
+
+        let result = run_batch(&mut deps, &metrics, vec![admin_tx, ata_tx]).await;
+
+        assert_eq!(
+            regular_status(&result, 0),
+            Ok(()),
+            "gasless ATA creation must be accepted"
+        );
+        assert_eq!(
+            bob_balance(&deps.bob, &ata),
+            Some(1),
+            "the ATA must persist at its existence floor"
+        );
+        assert!(
+            bob_balance(&deps.bob, &payer.pubkey()).is_none_or(|l| l == 0),
+            "the fabricated payer must not persist"
+        );
+    }
+
+    /// A transaction may list accounts no instruction touches. The unrelated
+    /// writable account must come out byte-identical: rewriting it is what
+    /// would drain a third party's escrow.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unrelated_writable_account_is_untouched() {
+        use solana_sdk::{
+            account::WritableAccount, instruction::CompiledInstruction, message::MessageHeader,
+        };
+
+        let (accounts_db, _pg) = start_test_postgres().await;
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut deps = get_execution_deps(accounts_db, rx, 1, default_live_blockhashes()).await;
+        let metrics: SharedMetrics = Arc::new(NoopMetrics);
+
+        let payer = Keypair::new();
+        let unrelated = Pubkey::new_unique();
+        // rent_epoch is the SVM loader's rent-exempt marker, stamped on every
+        // account it loads; seed it so byte-identity is testable at all.
+        let mut seeded = data_account(5000);
+        seeded.set_rent_epoch(u64::MAX);
+        deps.bob.insert_account_for_test(unrelated, seeded.clone());
+
+        // A value-neutral self-transfer, with `unrelated` carried along as a
+        // writable key no instruction references.
+        let data =
+            solana_system_interface::instruction::transfer(&payer.pubkey(), &payer.pubkey(), 0)
+                .data;
+        let message = Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
+            },
+            account_keys: vec![
+                payer.pubkey(),
+                unrelated,
+                solana_sdk_ids::system_program::ID,
+            ],
+            recent_blockhash: Hash::default(),
+            instructions: vec![CompiledInstruction {
+                program_id_index: 2,
+                accounts: vec![0, 0],
+                data,
+            }],
+        };
+        let mut raw = Transaction::new_unsigned(message);
+        raw.sign(&[&payer], Hash::default());
+        let tx = SanitizedTransaction::try_from_legacy_transaction(raw, &HashSet::new())
+            .expect("failed to build carrier tx");
+
+        let result = run_batch(&mut deps, &metrics, vec![tx]).await;
+
+        assert_eq!(regular_status(&result, 0), Ok(()));
+        assert_eq!(
+            deps.bob.get_account_shared_data(&unrelated),
+            Some(seeded),
+            "an account no instruction touched must be byte-identical"
+        );
     }
 
     // Real-SVM premise: a mid-tx failure is Executed{Err} and persists nothing.
@@ -1184,9 +1589,7 @@ mod tests {
     /// insufficient funds. The SVM returns `Executed` with `status.is_err()`,
     /// proving the premise that a partial failure is not a top-level `Err`. The
     /// pre-funded payer must keep its pre-execution balance in BOB: its
-    /// rolled-back intermediate state must not be committed. The data-distinguishing
-    /// assertion is carried by the bob/settle unit tests; here both system
-    /// recipients are dataless so the cap would zero them regardless.
+    /// rolled-back intermediate state must not be committed.
     #[tokio::test(flavor = "multi_thread")]
     async fn partial_failure_through_svm_is_executed_err_and_persists_nothing() {
         let (accounts_db, _pg) = start_test_postgres().await;
@@ -1238,10 +1641,10 @@ mod tests {
 
     // ── Path parity & invariants ──
 
-    /// Parallel path (SnapshotCallback) must reach the same capped outcomes as
-    /// the sequential path for a batch of synthetic-payer transfers.
+    /// Parallel path (SnapshotCallback) must reach the same verdicts as the
+    /// sequential path for a batch of synthetic-payer spends.
     #[tokio::test(flavor = "multi_thread")]
-    async fn cap_parallel_path_parity() {
+    async fn conservation_parallel_path_parity() {
         let (accounts_db, _pg) = start_test_postgres().await;
         let (_tx, rx) = mpsc::unbounded_channel();
         let workers = 4;
@@ -1257,28 +1660,29 @@ mod tests {
         for _ in 0..n {
             let a = Keypair::new();
             let r = Pubkey::new_unique();
-            txs.push(transfer(&a, &r, 10)); // 1-step spend → capped
+            txs.push(transfer(&a, &r, 10)); // 1-step spend, unrepaid loan
             payers.push(a);
             recipients.push(r);
         }
         let result = run_batch(&mut deps, &metrics, txs).await;
 
         for i in 0..n {
-            assert!(
-                is_executed(regular_result(&result, i)),
-                "tx {i} must execute on the parallel path"
+            assert_eq!(
+                regular_status(&result, i),
+                unbalanced(),
+                "tx {i} must be rejected on the parallel path"
             );
         }
         for a in &payers {
             assert!(
-                bob_balance(&deps.bob, &a.pubkey()).is_none_or(|l| l == 0),
+                bob_balance(&deps.bob, &a.pubkey()).is_none(),
                 "synthetic payer must not persist on the parallel path"
             );
         }
         for r in &recipients {
             assert!(
-                bob_balance(&deps.bob, r).is_none_or(|l| l == 0),
-                "dataless recipient must be capped on the parallel path"
+                bob_balance(&deps.bob, r).is_none(),
+                "a rejected tx must persist nothing on the parallel path"
             );
         }
     }
@@ -1342,8 +1746,9 @@ mod tests {
         assert_eq!(results.processing_results.len(), n);
     }
 
-    /// Build a well-formed admin InitializeMint tx (single SPL Token ix, type=0).
-    fn create_admin_initialize_mint_tx() -> SanitizedTransaction {
+    /// Build a well-formed admin InitializeMint tx (single SPL Token ix,
+    /// type=0), returning it alongside the mint address it initializes.
+    fn create_admin_initialize_mint_tx() -> (SanitizedTransaction, Pubkey) {
         use solana_sdk::instruction::{AccountMeta, Instruction};
 
         let payer = Keypair::new();
@@ -1363,8 +1768,9 @@ mod tests {
         };
         let msg = Message::new(&[ix], Some(&payer.pubkey()));
         let tx = Transaction::new(&[&payer], msg, Hash::default());
-        SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new())
-            .expect("failed to create admin init-mint tx")
+        let sanitized = SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new())
+            .expect("failed to create admin init-mint tx");
+        (sanitized, mint)
     }
 
     /// Build a mixed tx: one admin instruction (InitializeMint) + one
@@ -1951,7 +2357,7 @@ mod tests {
         let (_tx, rx) = mpsc::unbounded_channel();
         let mut deps = get_execution_deps(accounts_db, rx, 4, default_live_blockhashes()).await;
 
-        let tx = create_admin_initialize_mint_tx();
+        let (tx, _mint) = create_admin_initialize_mint_tx();
         let batch = ConflictFreeBatch {
             transactions: vec![crate::scheduler::TransactionWithIndex {
                 transaction: Arc::new(tx),
@@ -2004,7 +2410,7 @@ mod tests {
         let (_tx, rx) = mpsc::unbounded_channel();
         let mut deps = get_execution_deps(accounts_db, rx, 4, default_live_blockhashes()).await;
 
-        let admin_tx = create_admin_initialize_mint_tx();
+        let (admin_tx, _mint) = create_admin_initialize_mint_tx();
         let regular_tx = create_test_transaction();
         let batch = ConflictFreeBatch {
             transactions: vec![

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -385,16 +385,16 @@ fn execute_parallel(
     merge_svm_outputs(chunk_outputs)
 }
 
-/// The lamports the gasless callback invents for an unknown fee payer are the
-/// only lamports here that were never deposited. Treat them as a loan every
-/// successful transaction must repay, minus one lamport per account it creates.
+/// The lamports the gasless callback makes up for an unknown fee payer are the
+/// only money here that nobody deposited. Treat them as a loan the transaction
+/// has to pay back, less one lamport for each account it creates.
 ///
-/// The SVM already conserves lamports per instruction, so blocking that one
-/// source means every other balance is made of lamports that already existed
-/// and needs no checking. An unpaid loan fails the transaction instead of
-/// editing accounts, because editing accounts is what corrupts bystanders.
+/// The SVM already makes every instruction balance, so once this one source is
+/// blocked, every other balance is made of money that was already here and does
+/// not need checking. A loan that is not paid back fails the transaction rather
+/// than editing accounts, because editing accounts is what corrupts bystanders.
 ///
-/// Regular path only: admin execution never invents fee payers.
+/// Regular path only: admin execution never makes up fee payers.
 fn enforce_lamport_conservation(
     output: &mut LoadAndExecuteSanitizedTransactionsOutput,
     transactions: &[SanitizedTransaction],
@@ -418,51 +418,54 @@ fn enforce_lamport_conservation(
         }
 
         fabricated.clear();
-        // How much of the invented float went missing, how many brand new
-        // accounts exist to justify it, and whether any account that already
-        // existed ended up richer than it started.
+        // How much of the made-up money is gone, how many new accounts exist to
+        // explain it, and whether any older account ended up richer.
         let mut shortfall = 0u64;
         let mut created = 0u64;
         let mut credited = false;
         for (index, (pubkey, acct)) in executed.loaded_transaction.accounts.iter().enumerate() {
-            // Read-only accounts are never persisted, so they are never touched
-            // or counted.
+            // Read-only accounts are never saved, so never touch or count them.
             if !tx.is_writable(index) {
                 continue;
             }
             if let Some(before) = bob.account_lamports(pubkey) {
-                // Already existed, so its balance is real money this check must
-                // never rewrite. Only note whether it grew.
+                // This account already existed, so its balance is real money we
+                // must never rewrite. Just note whether it grew.
                 credited |= acct.lamports() > before;
             } else if fee_payers.contains(pubkey) {
-                // An invented payer: whatever it no longer holds has escaped.
-                // The set is batch-wide, so draining one payer into another
-                // still registers as a shortfall rather than as repayment.
+                // A made-up payer, so anything it no longer holds has escaped.
+                // The set covers the whole batch, so moving money from one
+                // made-up payer to another still counts as escaped.
                 fabricated.push(index);
                 shortfall += DEFAULT_FEE_PAYER_LAMPORTS.saturating_sub(acct.lamports());
             } else if acct.lamports() > 0 {
-                // Unknown to BOB but funded, so this transaction created it.
+                // BOB never saw it, but it has money, so this tx just made it.
                 created += 1;
             }
         }
 
-        // Lamports against a count, because the rate is exactly one: the SVM
-        // deletes a 0-lamport account, and with rent at zero every creation
-        // path funds a single lamport. So `created` is also the allowance.
+        // Comparing money to a count works because the rate is one each: the SVM
+        // deletes an account holding nothing, and with no rent every way of
+        // making an account gives it exactly one lamport.
         //
-        // The second clause closes an attribution gap. Counting creations does
-        // not prove the float paid for them, so a creation funded by real money
-        // could licence a float lamport that actually landed somewhere durable.
-        // While any float is missing, no pre-existing balance may grow.
+        // Counting new accounts does not prove the made-up money paid for them,
+        // so a new account paid for with real money could excuse a made-up
+        // lamport that went elsewhere. Hence no older account may grow while any
+        // made-up money is missing.
         if shortfall > created || (shortfall > 0 && credited) {
-            // Reject rather than claw back, which would mean rewriting accounts
-            // the transaction legitimately owns. Downstream skips failed txs.
+            // Fail the tx instead of taking the money back, which would mean
+            // rewriting accounts it owns. Later stages skip failed txs.
             executed.execution_details.status = Err(TransactionError::UnbalancedTransaction);
             continue;
         }
-        // Loan settled. Erase the invented payers to the empty zero-lamport
-        // shape BOB and the settler already treat as deleted, and touch nothing
-        // else: an address that never existed must not become durable state.
+        // Nothing is missing, so wipe the made-up payers. BOB and the settler
+        // already read an empty account with no money as deleted, so wiping is
+        // how they disappear. Nothing else is touched.
+        //
+        // Always wipe, which burns any real money sent to the payer. Keeping it
+        // would turn an address we made up into a real one, paying the sender
+        // back would rewrite an innocent account, and failing the tx would break
+        // CancelDvp, which sends the closed escrows' leftover money here.
         for index in &fabricated {
             executed.loaded_transaction.accounts[*index].1 = AccountSharedData::default();
         }

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -1124,19 +1124,18 @@ mod tests {
         );
     }
 
-    /// Under the lamport cap, the executor zeroes a dataless gainer (e.g. the
-    /// synthetic fee payer) and floors a data account to its 1-lamport existence
-    /// floor. The settler must turn a capped dataless account (0 lamports, empty
-    /// data) into a `deleted` tombstone while persisting a capped data account.
+    /// The executor erases a fabricated fee payer to an empty, zero-lamport
+    /// account. The settler must turn that shape into a `deleted` tombstone
+    /// while persisting a live account sitting on its 1-lamport existence floor.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_settle_capped_dataless_deleted_data_persisted() {
+    async fn test_settle_erased_payer_deleted_data_persisted() {
         let (mut db, _pg) = start_test_postgres().await;
 
         let from = Keypair::new();
         let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 0);
 
-        // A capped dataless account (the zeroed synthetic payer) and a capped
-        // data account floored at its 1-lamport existence floor, both writable.
+        // An erased fabricated payer and a live account on its 1-lamport
+        // existence floor, both writable.
         let dataless = from.pubkey();
         let data_pk = Pubkey::new_unique();
         let data_acct = AccountSharedData::new(1, 8, &spl_token::id());
@@ -1165,7 +1164,7 @@ mod tests {
             .expect("dataless account must be emitted as a settlement");
         assert!(
             dataless_settlement.1.deleted,
-            "capped dataless account must settle as deleted"
+            "an erased fabricated payer must settle as deleted"
         );
 
         // Data account at the 1-lamport floor → persists, not deleted.
@@ -1176,7 +1175,7 @@ mod tests {
             .expect("data account must be emitted as a settlement");
         assert!(
             !data_settlement.1.deleted,
-            "capped data account at the 1-lamport floor must persist"
+            "a data account at the 1-lamport floor must persist"
         );
         assert_eq!(data_settlement.1.account.lamports(), 1);
     }

--- a/core/src/vm/gasless_callback.rs
+++ b/core/src/vm/gasless_callback.rs
@@ -6,7 +6,9 @@ use solana_sdk::{
 use solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback};
 use std::collections::{HashMap, HashSet};
 
-const DEFAULT_FEE_PAYER_LAMPORTS: u64 = 10;
+/// Lamports handed to an unknown fee payer so the SVM's fee-payer validation
+/// passes.
+pub(crate) const DEFAULT_FEE_PAYER_LAMPORTS: u64 = 10;
 
 /// A read-only, thread-safe snapshot of account state for parallel SVM execution.
 ///

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -111,7 +111,10 @@ These synthesized lamports are the only lamports in the channel that were never 
 
 - A synthesized fee payer must end holding the same amount it was handed. Whatever it is short by is the unrepaid part of the loan.
 - Each account the transaction created may keep one lamport of that shortfall, because the SVM requires a live account to hold at least one and, with rent at zero, every creation path funds exactly one.
-- If the shortfall exceeds that allowance the transaction is failed with `UnbalancedTransaction` and nothing it wrote is persisted. Otherwise the synthesized payers are erased and every other account is persisted exactly as executed.
+- While any of the float is missing, no account that already existed may end richer than it started. Counting creations does not prove the float paid for them, so without this a creation funded by real money could licence a fabricated lamport landing somewhere durable. With the float intact, pre-existing accounts move real lamports freely.
+- If the shortfall exceeds the allowance, or a pre-existing balance grew while the float was short, the transaction is failed with `UnbalancedTransaction` and nothing it wrote is persisted. Otherwise the synthesized payers are erased and every other account is persisted exactly as executed.
+
+Lamports sent *to* a synthesized payer are burned with it. Persisting the payer would graduate an address the channel invented into durable state, and returning them would mean rewriting the sender, so neither is safe. This is not a loss of deposited value: deposits mint tokens, never lamports, so every lamport in the channel began as a float or an admin mint's existence floor. It is also load-bearing for `CancelDvp`, where the settlement authority signs, pays, and receives the closed escrows' rent, ending above its float.
 
 Because the SVM already enforces per-instruction lamport conservation, blocking the fabricated lamports at their source means every other balance is made of lamports that already existed, so no other account needs inspecting. Accounts a transaction merely carries as writable keys are never rewritten.
 

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -105,6 +105,18 @@ This eliminates the operational overhead of funding user accounts for off-chain 
 
 **Location**: [`core/src/vm/gasless_callback.rs`](../core/src/vm/gasless_callback.rs)
 
+##### Lamport conservation
+
+These synthesized lamports are the only lamports in the channel that were never deposited, so the execution stage treats them as a loan the transaction must repay. After a successful regular transaction, every writable account the SVM loaded that BOB had never seen is examined:
+
+- A synthesized fee payer must end holding the same amount it was handed. Whatever it is short by is the unrepaid part of the loan.
+- Each account the transaction created may keep one lamport of that shortfall, because the SVM requires a live account to hold at least one and, with rent at zero, every creation path funds exactly one.
+- If the shortfall exceeds that allowance the transaction is failed with `UnbalancedTransaction` and nothing it wrote is persisted. Otherwise the synthesized payers are erased and every other account is persisted exactly as executed.
+
+Because the SVM already enforces per-instruction lamport conservation, blocking the fabricated lamports at their source means every other balance is made of lamports that already existed, so no other account needs inspecting. Accounts a transaction merely carries as writable keys are never rewritten.
+
+**Location**: [`enforce_lamport_conservation` in `core/src/stages/execution.rs`](../core/src/stages/execution.rs)
+
 #### GaslessRentCollector
 
 Intercepts rent collection to prevent the runtime from debiting lamports from synthesized fee payer accounts. Works alongside GaslessCallback to maintain the zero-fee model.

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -21,6 +21,7 @@ This document defines the safety and correctness invariants that Solana Private 
 | C11 | Solana Private Channels SHOULD support transaction/slot truncation | SHOULD | Done | #51 |
 | C12 | If truncation is supported, Solana Private Channels MUST have a valid cold storage backup before truncating DB rows | MUST | Done | #60 |
 | C13 | Solana Private Channels DB SHOULD use database backup and recovery | SHOULD | Done | #60 |
+| C14 | A regular transaction MUST NOT increase the durable lamport supply beyond one lamport per account it creates, and MUST NOT alter any account it did not touch | MUST | Done | #115, #131 |
 
 ## On-chain Programs
 


### PR DESCRIPTION
## Summary

Closes issues 115 and 131. To support gasless transactions, the callback fabricates 10 lamports for unknown fee payers so they pass SVM validation. Previously, `cap_lamports` reclaimed those fabricated lamports after execution by rewriting every writable account based solely on its shape, regardless of whether the transaction actually created it. This unintentionally modified legitimate accounts: it deleted the DvP nonce tombstone that enforces single-use nonces, allowing a closed trade to be recreated with different terms, and it drained any writable wrapped SOL (wSOL) escrow account because native token balances are stored as lamports.

This PR fixes the issue by enforcing **lamport conservation** instead of rewriting accounts after execution. The fabricated lamports are treated as a temporary loan that must be fully accounted for before the transaction commits. After execution, `enforce_lamport_conservation` checks only newly created writable accounts, allowing one lamport per created account as required by the SVM while ensuring no fabricated lamports escape into existing state. If the loan does not balance, the transaction fails with `UnbalancedTransaction` rather than mutating account balances. Once balanced, the temporary fee payer accounts are removed, leaving all legitimate accounts untouched. This preserves normal balance transfers while preventing fabricated funds from becoming durable.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 12,963 | 14,609 | 88.7% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30807745371) |
| Indexer | 32,527 | 35,947 | 90.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30807745371) |
| Gateway | 1,330 | 1,521 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30807745371) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30807745371) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,649 | 17,382 | 78.5% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30807745371) |
| **Total** | **61,254** | **70,362** | **87.1%** | |

> Last updated: 2026-08-03 11:56:14 UTC by E2E Integration