### PR TITLE
fix(indexer): retry the PendingRemint handoff and read back its state before escalating (finding-274)

### DIFF
--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -419,7 +419,10 @@ async fn check_withdrawal(
 /// finality classifier. Shared by deposit and withdrawal recovery. A read error or a
 /// malformed stored signature returns a quarantine reason (uncertainty, never "dead"),
 /// so callers never demote a row whose signatures could not be read or parsed.
-async fn load_pending_sigs(storage: &Storage, id: i64) -> Result<Vec<PendingSig>, String> {
+pub(crate) async fn load_pending_sigs(
+    storage: &Storage,
+    id: i64,
+) -> Result<Vec<PendingSig>, String> {
     // Retry a transient DB blip before quarantining; matches the deposit gate so
     // a momentary read failure never pages ops for a healthy withdrawal.
     let stored = with_storage_backoff("journal read", id, || storage.get_release_signatures(id))

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -8,6 +8,7 @@ use crate::operator::tree_constants::MAX_TREE_LEAVES;
 use crate::operator::utils::instruction_util::{
     mint_extra_error_checks_policy, TransactionBuilder,
 };
+use crate::operator::utils::storage_util::with_storage_backoff;
 use crate::operator::utils::transaction_util::parse_program_error;
 use crate::operator::utils::transaction_util::{
     build_and_sign, check_transaction_status, send_signed, ConfirmationResult,
@@ -1020,6 +1021,8 @@ pub(super) async fn requeue_or_fail_prebroadcast(
 /// (which removes the nonce from SMT and builder caches), then queues a deferred
 /// remint that will execute after the Solana finality window passes. This prevents
 /// double-spend if the original withdrawal lands on-chain after our polling window.
+/// If the PendingRemint write cannot be confirmed, the cache entries go back and
+/// the row is left to recovery; only an undeterminable row goes to ManualReview.
 ///
 /// For non-withdrawal transactions: delegates to send_fatal_error.
 pub(super) async fn handle_permanent_failure(
@@ -1095,36 +1098,100 @@ pub(super) async fn handle_permanent_failure(
             .map(|pending_sig| pending_sig.last_valid_block_height as i64)
             .collect();
 
-        if let Err(e) = state
-            .storage
-            .set_pending_remint(transaction_id, sig_strings, lvbhs, deadline)
-            .await
-        {
-            error!(
-                "Failed to persist PendingRemint for transaction {} - sending to manual review: {}",
-                transaction_id, e
-            );
-            send_guaranteed(
-                storage_tx,
-                TransactionStatusUpdate {
+        // Retry the handoff: a statement timeout, deadlock or dropped connection
+        // is transient, and the compensation material is still held in the locals
+        // above, so nothing is given up while retrying.
+        let write_result =
+            with_storage_backoff("pending remint transition", transaction_id, || {
+                state.storage.set_pending_remint(
                     transaction_id,
-                    trace_id: ctx.trace_id.clone(),
-                    status: TransactionStatus::ManualReview,
-                    counterpart_signature: None,
-                    processed_at: Some(Utc::now()),
-                    error_message: Some(format!(
-                        "{} | failed to persist pending remint: {}",
-                        error_msg, e
-                    )),
-                    remint_signature: None,
-                    remint_attempted: false,
-                    release_signatures: None,
-                },
-                "transaction status update",
-            )
-            .await
-            .ok();
-            return;
+                    sig_strings.clone(),
+                    lvbhs.clone(),
+                    deadline,
+                )
+            })
+            .await;
+
+        if let Err(e) = write_result {
+            // The error is ambiguous: the write may or may not have committed.
+            // Read the row back; its status says who owns this withdrawal now.
+            let observed =
+                with_storage_backoff("pending remint status read", transaction_id, || {
+                    state.storage.get_transaction_status(transaction_id)
+                })
+                .await;
+
+            match observed {
+                // It committed and only the acknowledgement was lost, so this
+                // sender still owns the remint. Fall through and queue it.
+                Ok(Some(TransactionStatus::PendingRemint)) => {
+                    warn!(
+                        transaction_id,
+                        "set_pending_remint failed but the row is PendingRemint, treating the handoff as committed: {}",
+                        e
+                    );
+                }
+                // Nothing committed. Put the compensation material back and leave
+                // the row Processing for the recovery worker, which reloads the
+                // release signatures from the journal and completes, requeues or
+                // quarantines it. Queuing the remint here as well could pay twice.
+                Ok(Some(TransactionStatus::Processing)) => {
+                    error!(
+                        transaction_id,
+                        "Failed to persist PendingRemint, leaving the row to recovery: {}", e
+                    );
+                    if let Some(nonce) = ctx.withdrawal_nonce {
+                        state.remint_cache.insert(nonce, info);
+                        state.pending_signatures.insert(nonce, signatures);
+                    }
+                    metrics::OPERATOR_TRANSACTION_ERRORS
+                        .with_label_values(&[
+                            state.program_type.as_label(),
+                            "pending_remint_persist_failed",
+                        ])
+                        .inc();
+                    return;
+                }
+                // Another writer already moved the row, so it owns the outcome.
+                Ok(Some(status)) => {
+                    warn!(
+                        transaction_id,
+                        "Failed to persist PendingRemint and the row is already {:?}, leaving it alone: {}",
+                        status,
+                        e
+                    );
+                    return;
+                }
+                // Neither state can be established, so nothing automatic can be
+                // trusted to finish this. Escalate loudly instead.
+                unresolved => {
+                    error!(
+                        "Failed to persist PendingRemint for transaction {} and could not read it back ({:?}) - sending to manual review: {}",
+                        transaction_id, unresolved, e
+                    );
+                    send_guaranteed(
+                        storage_tx,
+                        TransactionStatusUpdate {
+                            transaction_id,
+                            trace_id: ctx.trace_id.clone(),
+                            status: TransactionStatus::ManualReview,
+                            counterpart_signature: None,
+                            processed_at: Some(Utc::now()),
+                            error_message: Some(format!(
+                                "{} | failed to persist pending remint: {}",
+                                error_msg, e
+                            )),
+                            remint_signature: None,
+                            remint_attempted: false,
+                            release_signatures: None,
+                        },
+                        "transaction status update",
+                    )
+                    .await
+                    .ok();
+                    return;
+                }
+            }
         }
     }
 
@@ -2029,6 +2096,14 @@ mod tests {
                 last_valid_block_height: 0,
             }],
         );
+        // The PendingRemint transition is guarded on a Processing row.
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(10, 5));
 
         let ctx = TransactionContext {
             transaction_id: Some(10),
@@ -2936,6 +3011,14 @@ mod tests {
                 last_valid_block_height: 0,
             }],
         );
+        // The PendingRemint transition is guarded on a Processing row.
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(txn_id, nonce));
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
         send_and_confirm(
@@ -3119,6 +3202,14 @@ mod tests {
                 },
             ],
         );
+        // The PendingRemint transition is guarded on a Processing row.
+        let Storage::Mock(ref seed) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        seed.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(10, 5));
 
         let ctx = TransactionContext {
             transaction_id: Some(10),
@@ -3195,29 +3286,30 @@ mod tests {
         );
     }
 
-    /// When the database write for `set_pending_remint` fails, the operator
-    /// cannot safely defer the remint — it has no guarantee the state will
-    /// survive a restart. Instead of silently losing the remint, it must
-    /// immediately escalate to ManualReview so an operator can intervene.
-    ///
-    /// Equally important: nothing should be queued in `pending_remints`.
-    /// Queuing in memory without the DB write would be a half-written state —
-    /// the entry would disappear on the next crash, violating the atomicity
-    /// invariant.
+    /// A failed `set_pending_remint` whose row still reads `Processing` proves
+    /// nothing committed. The row keeps that status so the recovery worker owns
+    /// it, and the compensation material goes back into the caches for a later
+    /// attempt on the same nonce. Escalating here would strand a row that
+    /// recovery resolves on its own.
     #[tokio::test]
-    async fn permanent_failure_sends_manual_review_when_storage_fails() {
+    async fn permanent_failure_leaves_processing_row_to_recovery() {
+        let txn_id = 10;
+        let nonce = 5;
         let mut state = make_sender_state();
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
 
-        // Instruct the mock to fail on set_pending_remint.
         let Storage::Mock(ref mock) = *state.storage else {
             panic!("expected mock storage");
         };
         mock.set_should_fail("set_pending_remint", true);
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(txn_id, nonce));
 
-        state.remint_cache.insert(5, make_remint_info(10));
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
         state.pending_signatures.insert(
-            5,
+            nonce,
             vec![PendingSig {
                 signature: Signature::new_unique(),
                 last_valid_block_height: 0,
@@ -3225,25 +3317,126 @@ mod tests {
         );
 
         let ctx = TransactionContext {
-            transaction_id: Some(10),
-            withdrawal_nonce: Some(5),
-            trace_id: Some("trace-10".to_string()),
+            transaction_id: Some(txn_id),
+            withdrawal_nonce: Some(nonce),
+            trace_id: Some(format!("trace-{txn_id}")),
             deposit_claim_lease: None,
         };
 
         handle_permanent_failure(&mut state, &ctx, &storage_tx, "release_funds failed").await;
 
-        // Must escalate to ManualReview — human intervention is needed.
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "must not write a terminal status while the row is still Processing"
+        );
+        assert!(
+            state.pending_remints.is_empty(),
+            "must not queue a remint without a durable PendingRemint row"
+        );
+        assert!(
+            state.remint_cache.contains_key(&nonce),
+            "remint info must be restored for a later attempt"
+        );
+        assert!(
+            state.pending_signatures.contains_key(&nonce),
+            "release signatures must be restored for a later attempt"
+        );
+    }
+
+    /// The write can commit and still return an error when the acknowledgement
+    /// is lost. Reading the row back shows `PendingRemint`, so the handoff did
+    /// succeed and this sender keeps driving the remint instead of escalating
+    /// over a state that is already durable.
+    #[tokio::test]
+    async fn permanent_failure_adopts_committed_pending_remint_row() {
+        let txn_id = 11;
+        let nonce = 6;
+        let mut state = make_sender_state();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.set_should_fail("set_pending_remint", true);
+        let mut committed = processing_withdrawal_row(txn_id, nonce);
+        committed.status = TransactionStatus::PendingRemint;
+        mock.pending_transactions.lock().unwrap().push(committed);
+
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+        state.pending_signatures.insert(
+            nonce,
+            vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+        );
+
+        let ctx = TransactionContext {
+            transaction_id: Some(txn_id),
+            withdrawal_nonce: Some(nonce),
+            trace_id: Some(format!("trace-{txn_id}")),
+            deposit_claim_lease: None,
+        };
+
+        handle_permanent_failure(&mut state, &ctx, &storage_tx, "release_funds failed").await;
+
+        assert_eq!(
+            state.pending_remints.len(),
+            1,
+            "a committed PendingRemint row must be driven by this sender"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "must not overwrite a committed PendingRemint with a terminal status"
+        );
+    }
+
+    /// When neither the write nor the read-back establishes the row's state, no
+    /// automatic component can be trusted to finish the withdrawal, so it
+    /// escalates to ManualReview and queues nothing in memory.
+    #[tokio::test]
+    async fn permanent_failure_sends_manual_review_when_state_undeterminable() {
+        let txn_id = 12;
+        let nonce = 7;
+        let mut state = make_sender_state();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.set_should_fail("set_pending_remint", true);
+        mock.set_should_fail("get_transaction_status", true);
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(txn_id, nonce));
+
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+        state.pending_signatures.insert(
+            nonce,
+            vec![PendingSig {
+                signature: Signature::new_unique(),
+                last_valid_block_height: 0,
+            }],
+        );
+
+        let ctx = TransactionContext {
+            transaction_id: Some(txn_id),
+            withdrawal_nonce: Some(nonce),
+            trace_id: Some(format!("trace-{txn_id}")),
+            deposit_claim_lease: None,
+        };
+
+        handle_permanent_failure(&mut state, &ctx, &storage_tx, "release_funds failed").await;
+
         let update = storage_rx
             .try_recv()
             .expect("should receive ManualReview status");
-        assert_eq!(update.transaction_id, 10);
+        assert_eq!(update.transaction_id, txn_id);
         assert_eq!(update.status, TransactionStatus::ManualReview);
-
-        // Must not queue in memory — no DB write means no crash safety.
         assert!(
             state.pending_remints.is_empty(),
-            "should not queue pending remint when storage write failed"
+            "must not queue a remint when the row state is unknown"
         );
     }
 

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1022,7 +1022,8 @@ pub(super) async fn requeue_or_fail_prebroadcast(
 /// remint that will execute after the Solana finality window passes. This prevents
 /// double-spend if the original withdrawal lands on-chain after our polling window.
 /// If the PendingRemint write cannot be confirmed, the cache entries go back and
-/// the row is left to recovery; only an undeterminable row goes to ManualReview.
+/// the row is left to recovery; only a still-Processing undeterminable row goes to
+/// ManualReview, and a row that reads back PendingRemint is driven from here.
 ///
 /// For non-withdrawal transactions: delegates to send_fatal_error.
 pub(super) async fn handle_permanent_failure(
@@ -1203,8 +1204,8 @@ pub(super) async fn handle_permanent_failure(
             // write did commit and every read-back failed, and the generic status
             // writer accepts a `pending_remint` source, so an unguarded fallback
             // would overwrite that committed handoff and strand the withdrawal
-            // where no sweep looks. A guard miss leaves the row to the startup
-            // reload, which owns every PendingRemint row.
+            // where no sweep looks. A guard miss means the row left Processing,
+            // so read it back: only a committed PendingRemint is ours to drive.
             unresolved => {
                 error!(
                     "Failed to persist PendingRemint for transaction {} and could not read it back ({:?}): {}",
@@ -1242,17 +1243,37 @@ pub(super) async fn handle_permanent_failure(
                         )
                         .await
                         .ok();
+                        return;
                     }
-                    Ok(false) => warn!(
-                        transaction_id,
-                        "Row is no longer Processing, so the PendingRemint write did commit; leaving it to the startup reload"
-                    ),
-                    Err(escalate_err) => error!(
-                        transaction_id,
-                        "Could not escalate to ManualReview, leaving the row untouched: {escalate_err}"
-                    ),
+                    // The guard missed, so the row is not Processing. The escalation
+                    // reached the DB, so this read-back is the first reliable one on
+                    // this path: a PendingRemint row is the committed handoff and only
+                    // this queue drives it, since no sweep selects that status. Any
+                    // other status belongs to another writer, and queuing over it would
+                    // let the recovery GC drop the remint write-ahead rows and re-mint.
+                    Ok(false) => {
+                        match state.storage.get_transaction_status(transaction_id).await {
+                            Ok(Some(TransactionStatus::PendingRemint)) => warn!(
+                                transaction_id,
+                                "Row is PendingRemint, so the write did commit; driving the remint from this sender"
+                            ),
+                            observed => {
+                                warn!(
+                                    transaction_id,
+                                    "Row is no longer Processing ({:?}), leaving it alone", observed
+                                );
+                                return;
+                            }
+                        }
+                    }
+                    Err(escalate_err) => {
+                        error!(
+                            transaction_id,
+                            "Could not escalate to ManualReview, leaving the row untouched: {escalate_err}"
+                        );
+                        return;
+                    }
                 }
-                return;
             }
         }
     }
@@ -3548,11 +3569,12 @@ mod tests {
         );
     }
 
-    /// The write can commit while every read-back also fails. The escalation is
-    /// guarded on a Processing row, so it finds the committed PendingRemint,
-    /// writes nothing and leaves the withdrawal to the startup reload. An
-    /// unguarded fallback would be accepted by the status writer, whose source
-    /// set includes `pending_remint`, and strand a row no sweep selects.
+    /// The write can commit while the read-back also fails. The escalation is
+    /// guarded on a Processing row, so it finds the committed PendingRemint and
+    /// writes nothing. An unguarded fallback would be accepted by the status
+    /// writer, whose source set includes `pending_remint`, and strand a row no
+    /// sweep selects. The guard miss then reads the row back, and a PendingRemint
+    /// is adopted here: nothing else drives that status until a restart.
     #[tokio::test]
     async fn permanent_failure_does_not_escalate_over_committed_pending_remint() {
         let txn_id = 13;
@@ -3564,7 +3586,9 @@ mod tests {
             panic!("expected mock storage");
         };
         mock.set_should_fail("set_pending_remint", true);
-        mock.set_should_fail("get_transaction_status", true);
+        // The three read-back attempts fail; the read after the escalation, which
+        // proved the DB reachable, succeeds.
+        mock.set_fail_times("get_transaction_status", 3);
         // The handoff committed; only the acknowledgement and the read-backs were lost.
         let mut committed = processing_withdrawal_row(txn_id, nonce);
         committed.status = TransactionStatus::PendingRemint;
@@ -3596,6 +3620,11 @@ mod tests {
             storage_rx.try_recv().is_err(),
             "must not queue a terminal status the writer would apply to a committed PendingRemint"
         );
+        assert_eq!(
+            state.pending_remints.len(),
+            1,
+            "a committed PendingRemint has no other driver until a restart, so it must be queued here"
+        );
         let Storage::Mock(ref mock) = *state.storage else {
             panic!("expected mock storage");
         };
@@ -3604,6 +3633,70 @@ mod tests {
             rows[0].status,
             TransactionStatus::PendingRemint,
             "the committed handoff must survive"
+        );
+    }
+
+    /// The escalation guard can also miss because another writer moved the row:
+    /// a recovery demote leaves it Pending. Adopting it would drive a remint the
+    /// processor is about to re-release against, and the recovery GC drops the
+    /// remint write-ahead rows for any row that is not PendingRemint, so a
+    /// deferred attempt would re-mint. The read-back must leave it alone.
+    #[tokio::test]
+    async fn permanent_failure_does_not_adopt_row_moved_by_another_writer() {
+        let txn_id = 14;
+        let nonce = 9;
+        let mut state = make_sender_state();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.set_should_fail("set_pending_remint", true);
+        mock.set_fail_times("get_transaction_status", 3);
+        // Recovery demoted the row while the handoff was being retried, so the
+        // PendingRemint write never committed and the escalation guard misses.
+        let mut demoted = processing_withdrawal_row(txn_id, nonce);
+        demoted.status = TransactionStatus::Pending;
+        mock.pending_transactions.lock().unwrap().push(demoted);
+
+        let broadcast = Signature::new_unique();
+        mock.insert_release_signature(txn_id, broadcast.to_string(), 0)
+            .await
+            .unwrap();
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+        state.pending_signatures.insert(
+            nonce,
+            vec![PendingSig {
+                signature: broadcast,
+                last_valid_block_height: 0,
+            }],
+        );
+
+        let ctx = TransactionContext {
+            transaction_id: Some(txn_id),
+            withdrawal_nonce: Some(nonce),
+            trace_id: Some(format!("trace-{txn_id}")),
+            deposit_claim_lease: None,
+        };
+
+        handle_permanent_failure(&mut state, &ctx, &storage_tx, "release_funds failed").await;
+
+        assert!(
+            state.pending_remints.is_empty(),
+            "must not drive a remint for a row another writer owns"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "must not write a terminal status over another writer's row"
+        );
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let rows = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            rows[0].status,
+            TransactionStatus::Pending,
+            "the other writer's status must survive"
         );
     }
 

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -1198,32 +1198,60 @@ pub(super) async fn handle_permanent_failure(
                 return;
             }
             // Neither state can be established, so nothing automatic can be
-            // trusted to finish this. Escalate loudly instead.
+            // trusted to finish this. Escalate loudly instead — but only a row
+            // that is provably still Processing. This branch also runs when the
+            // write did commit and every read-back failed, and the generic status
+            // writer accepts a `pending_remint` source, so an unguarded fallback
+            // would overwrite that committed handoff and strand the withdrawal
+            // where no sweep looks. A guard miss leaves the row to the startup
+            // reload, which owns every PendingRemint row.
             unresolved => {
                 error!(
-                    "Failed to persist PendingRemint for transaction {} and could not read it back ({:?}) - sending to manual review: {}",
+                    "Failed to persist PendingRemint for transaction {} and could not read it back ({:?}): {}",
                     transaction_id, unresolved, e
                 );
-                send_guaranteed(
-                    storage_tx,
-                    TransactionStatusUpdate {
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[
+                        state.program_type.as_label(),
+                        "pending_remint_state_unknown",
+                    ])
+                    .inc();
+                match state.storage.try_escalate_manual_review(transaction_id).await {
+                    // The row was still Processing, so nothing committed and this
+                    // escalation owns it. The status is already durable; the queued
+                    // update drives the webhook alert and no-ops on the row, whose
+                    // status is now outside the writer's source set.
+                    Ok(true) => {
+                        send_guaranteed(
+                            storage_tx,
+                            TransactionStatusUpdate {
+                                transaction_id,
+                                trace_id: ctx.trace_id.clone(),
+                                status: TransactionStatus::ManualReview,
+                                counterpart_signature: None,
+                                processed_at: Some(Utc::now()),
+                                error_message: Some(format!(
+                                    "{} | failed to persist pending remint: {}",
+                                    error_msg, e
+                                )),
+                                remint_signature: None,
+                                remint_attempted: false,
+                                release_signatures: None,
+                            },
+                            "transaction status update",
+                        )
+                        .await
+                        .ok();
+                    }
+                    Ok(false) => warn!(
                         transaction_id,
-                        trace_id: ctx.trace_id.clone(),
-                        status: TransactionStatus::ManualReview,
-                        counterpart_signature: None,
-                        processed_at: Some(Utc::now()),
-                        error_message: Some(format!(
-                            "{} | failed to persist pending remint: {}",
-                            error_msg, e
-                        )),
-                        remint_signature: None,
-                        remint_attempted: false,
-                        release_signatures: None,
-                    },
-                    "transaction status update",
-                )
-                .await
-                .ok();
+                        "Row is no longer Processing, so the PendingRemint write did commit; leaving it to the startup reload"
+                    ),
+                    Err(escalate_err) => error!(
+                        transaction_id,
+                        "Could not escalate to ManualReview, leaving the row untouched: {escalate_err}"
+                    ),
+                }
                 return;
             }
         }
@@ -3517,6 +3545,65 @@ mod tests {
         assert!(
             storage_rx.try_recv().is_err(),
             "must not overwrite a committed PendingRemint with a terminal status"
+        );
+    }
+
+    /// The write can commit while every read-back also fails. The escalation is
+    /// guarded on a Processing row, so it finds the committed PendingRemint,
+    /// writes nothing and leaves the withdrawal to the startup reload. An
+    /// unguarded fallback would be accepted by the status writer, whose source
+    /// set includes `pending_remint`, and strand a row no sweep selects.
+    #[tokio::test]
+    async fn permanent_failure_does_not_escalate_over_committed_pending_remint() {
+        let txn_id = 13;
+        let nonce = 8;
+        let mut state = make_sender_state();
+        let (storage_tx, mut storage_rx) = mpsc::channel(10);
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.set_should_fail("set_pending_remint", true);
+        mock.set_should_fail("get_transaction_status", true);
+        // The handoff committed; only the acknowledgement and the read-backs were lost.
+        let mut committed = processing_withdrawal_row(txn_id, nonce);
+        committed.status = TransactionStatus::PendingRemint;
+        mock.pending_transactions.lock().unwrap().push(committed);
+
+        let broadcast = Signature::new_unique();
+        mock.insert_release_signature(txn_id, broadcast.to_string(), 0)
+            .await
+            .unwrap();
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+        state.pending_signatures.insert(
+            nonce,
+            vec![PendingSig {
+                signature: broadcast,
+                last_valid_block_height: 0,
+            }],
+        );
+
+        let ctx = TransactionContext {
+            transaction_id: Some(txn_id),
+            withdrawal_nonce: Some(nonce),
+            trace_id: Some(format!("trace-{txn_id}")),
+            deposit_claim_lease: None,
+        };
+
+        handle_permanent_failure(&mut state, &ctx, &storage_tx, "release_funds failed").await;
+
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "must not queue a terminal status the writer would apply to a committed PendingRemint"
+        );
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let rows = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            rows[0].status,
+            TransactionStatus::PendingRemint,
+            "the committed handoff must survive"
         );
     }
 

--- a/indexer/src/operator/sender/transaction.rs
+++ b/indexer/src/operator/sender/transaction.rs
@@ -3,7 +3,7 @@ use crate::config::ProgramType;
 use crate::error::TransactionError;
 use crate::error::{AccountError, OperatorError, ProgramError};
 use crate::metrics;
-use crate::operator::recovery::MAX_RECOVERY_REQUEUE_ATTEMPTS;
+use crate::operator::recovery::{load_pending_sigs, MAX_RECOVERY_REQUEUE_ATTEMPTS};
 use crate::operator::tree_constants::MAX_TREE_LEAVES;
 use crate::operator::utils::instruction_util::{
     mint_extra_error_checks_policy, TransactionBuilder,
@@ -1036,8 +1036,10 @@ pub(super) async fn handle_permanent_failure(
         .withdrawal_nonce
         .and_then(|nonce| state.remint_cache.remove(&nonce));
 
-    // Collect stashed signatures for finality check
-    let signatures = ctx
+    // Clear the per-nonce stash. It is no longer what the finality gate reads,
+    // so it is only in-memory bookkeeping here, restored below if this failure
+    // cannot be handed off.
+    let stashed = ctx
         .withdrawal_nonce
         .and_then(|nonce| state.pending_signatures.remove(&nonce))
         .unwrap_or_default();
@@ -1050,35 +1052,71 @@ pub(super) async fn handle_permanent_failure(
         return;
     };
 
-    // Zero signatures means no broadcast succeeded for this nonce, but the RPC
-    // may still have broadcast one before erroring, so blind remint is unsafe.
+    // Guard before the journal read below, which is keyed by transaction_id.
+    // `transaction_id` is always `Some` for a withdrawal — only `ReleaseFunds`
+    // transactions populate `remint_cache`, and `ReleaseFunds` always carries a DB
+    // transaction_id (see `TransactionBuilder::transaction_id` in instruction_util.rs).
+    // `InitializeMint` and `ResetSmtRoot` return `None` there and exited above via
+    // `send_fatal_error`. This prevents silently enqueuing a `PendingRemint` with no
+    // DB record, which would be lost on restart since recovery reads from the DB.
+    let Some(transaction_id) = ctx.transaction_id else {
+        error!(
+            "Cannot defer remint for nonce {:?} — no transaction_id, entry would be unrecoverable on restart",
+            ctx.withdrawal_nonce,
+        );
+        return;
+    };
+
+    // Every attempt is journaled before its send, so the journal is the only
+    // complete record of what may still land: a send that errored ambiguously
+    // never reaches the in-memory stash. Classifying the stash alone can call a
+    // live release dead and remint on top of it. Recovery reads the same table.
+    let journaled = load_pending_sigs(&state.storage, transaction_id).await;
+    let signatures = match journaled {
+        Ok(sigs) => sigs,
+        // Without the broadcast set there is nothing to prove the release dead
+        // against. Put the compensation material back and leave the row
+        // Processing for recovery, which reads the same journal.
+        Err(reason) => {
+            error!(
+                transaction_id,
+                "Cannot read the release-signature journal, leaving the row to recovery: {reason}"
+            );
+            if let Some(nonce) = ctx.withdrawal_nonce {
+                state.remint_cache.insert(nonce, info);
+                state.pending_signatures.insert(nonce, stashed);
+            }
+            return;
+        }
+    };
+
+    // An empty journal means no release was broadcast, but the persist itself may
+    // have failed after reaching Postgres, so a blind remint is still unsafe.
     if signatures.is_empty() {
         error!(
             "No signatures to verify for nonce {:?} — cannot safely remint, sending to ManualReview",
             ctx.withdrawal_nonce,
         );
-        if let Some(transaction_id) = ctx.transaction_id {
-            send_guaranteed(
-                storage_tx,
-                TransactionStatusUpdate {
-                    transaction_id,
-                    trace_id: ctx.trace_id.clone(),
-                    status: TransactionStatus::ManualReview,
-                    counterpart_signature: None,
-                    processed_at: Some(Utc::now()),
-                    error_message: Some(format!(
-                        "{} | no signatures to verify — remint unsafe",
-                        error_msg
-                    )),
-                    remint_signature: None,
-                    remint_attempted: false,
-                    release_signatures: None,
-                },
-                "transaction status update",
-            )
-            .await
-            .ok();
-        }
+        send_guaranteed(
+            storage_tx,
+            TransactionStatusUpdate {
+                transaction_id,
+                trace_id: ctx.trace_id.clone(),
+                status: TransactionStatus::ManualReview,
+                counterpart_signature: None,
+                processed_at: Some(Utc::now()),
+                error_message: Some(format!(
+                    "{} | no signatures to verify — remint unsafe",
+                    error_msg
+                )),
+                remint_signature: None,
+                remint_attempted: false,
+                release_signatures: None,
+            },
+            "transaction status update",
+        )
+        .await
+        .ok();
         return;
     }
 
@@ -1088,126 +1126,107 @@ pub(super) async fn handle_permanent_failure(
     // needed for the finality check. This replaces the previous Failed write —
     // keeping status as Processing until the remint resolves avoids partial state
     // if the operator crashes during the finality window.
-    if let Some(transaction_id) = ctx.transaction_id {
-        let sig_strings: Vec<String> = signatures
-            .iter()
-            .map(|pending_sig| pending_sig.signature.to_string())
-            .collect();
-        let lvbhs: Vec<i64> = signatures
-            .iter()
-            .map(|pending_sig| pending_sig.last_valid_block_height as i64)
-            .collect();
+    let sig_strings: Vec<String> = signatures
+        .iter()
+        .map(|pending_sig| pending_sig.signature.to_string())
+        .collect();
+    let lvbhs: Vec<i64> = signatures
+        .iter()
+        .map(|pending_sig| pending_sig.last_valid_block_height as i64)
+        .collect();
 
-        // Retry the handoff: a statement timeout, deadlock or dropped connection
-        // is transient, and the compensation material is still held in the locals
-        // above, so nothing is given up while retrying.
-        let write_result =
-            with_storage_backoff("pending remint transition", transaction_id, || {
-                state.storage.set_pending_remint(
+    // Retry the handoff: a statement timeout, deadlock or dropped connection
+    // is transient, and the compensation material is still held in the locals
+    // above, so nothing is given up while retrying.
+    let write_result = with_storage_backoff("pending remint transition", transaction_id, || {
+        state.storage.set_pending_remint(
+            transaction_id,
+            sig_strings.clone(),
+            lvbhs.clone(),
+            deadline,
+        )
+    })
+    .await;
+
+    if let Err(e) = write_result {
+        // The error is ambiguous: the write may or may not have committed.
+        // Read the row back; its status says who owns this withdrawal now.
+        let observed = with_storage_backoff("pending remint status read", transaction_id, || {
+            state.storage.get_transaction_status(transaction_id)
+        })
+        .await;
+
+        match observed {
+            // It committed and only the acknowledgement was lost, so this
+            // sender still owns the remint. Fall through and queue it.
+            Ok(Some(TransactionStatus::PendingRemint)) => {
+                warn!(
                     transaction_id,
-                    sig_strings.clone(),
-                    lvbhs.clone(),
-                    deadline,
+                    "set_pending_remint failed but the row is PendingRemint, treating the handoff as committed: {}",
+                    e
+                );
+            }
+            // Nothing committed. Put the compensation material back and leave
+            // the row Processing for the recovery worker, which reloads the
+            // release signatures from the journal and completes, requeues or
+            // quarantines it. Queuing the remint here as well could pay twice.
+            Ok(Some(TransactionStatus::Processing)) => {
+                error!(
+                    transaction_id,
+                    "Failed to persist PendingRemint, leaving the row to recovery: {}", e
+                );
+                if let Some(nonce) = ctx.withdrawal_nonce {
+                    state.remint_cache.insert(nonce, info);
+                    state.pending_signatures.insert(nonce, stashed);
+                }
+                metrics::OPERATOR_TRANSACTION_ERRORS
+                    .with_label_values(&[
+                        state.program_type.as_label(),
+                        "pending_remint_persist_failed",
+                    ])
+                    .inc();
+                return;
+            }
+            // Another writer already moved the row, so it owns the outcome.
+            Ok(Some(status)) => {
+                warn!(
+                    transaction_id,
+                    "Failed to persist PendingRemint and the row is already {:?}, leaving it alone: {}",
+                    status,
+                    e
+                );
+                return;
+            }
+            // Neither state can be established, so nothing automatic can be
+            // trusted to finish this. Escalate loudly instead.
+            unresolved => {
+                error!(
+                    "Failed to persist PendingRemint for transaction {} and could not read it back ({:?}) - sending to manual review: {}",
+                    transaction_id, unresolved, e
+                );
+                send_guaranteed(
+                    storage_tx,
+                    TransactionStatusUpdate {
+                        transaction_id,
+                        trace_id: ctx.trace_id.clone(),
+                        status: TransactionStatus::ManualReview,
+                        counterpart_signature: None,
+                        processed_at: Some(Utc::now()),
+                        error_message: Some(format!(
+                            "{} | failed to persist pending remint: {}",
+                            error_msg, e
+                        )),
+                        remint_signature: None,
+                        remint_attempted: false,
+                        release_signatures: None,
+                    },
+                    "transaction status update",
                 )
-            })
-            .await;
-
-        if let Err(e) = write_result {
-            // The error is ambiguous: the write may or may not have committed.
-            // Read the row back; its status says who owns this withdrawal now.
-            let observed =
-                with_storage_backoff("pending remint status read", transaction_id, || {
-                    state.storage.get_transaction_status(transaction_id)
-                })
-                .await;
-
-            match observed {
-                // It committed and only the acknowledgement was lost, so this
-                // sender still owns the remint. Fall through and queue it.
-                Ok(Some(TransactionStatus::PendingRemint)) => {
-                    warn!(
-                        transaction_id,
-                        "set_pending_remint failed but the row is PendingRemint, treating the handoff as committed: {}",
-                        e
-                    );
-                }
-                // Nothing committed. Put the compensation material back and leave
-                // the row Processing for the recovery worker, which reloads the
-                // release signatures from the journal and completes, requeues or
-                // quarantines it. Queuing the remint here as well could pay twice.
-                Ok(Some(TransactionStatus::Processing)) => {
-                    error!(
-                        transaction_id,
-                        "Failed to persist PendingRemint, leaving the row to recovery: {}", e
-                    );
-                    if let Some(nonce) = ctx.withdrawal_nonce {
-                        state.remint_cache.insert(nonce, info);
-                        state.pending_signatures.insert(nonce, signatures);
-                    }
-                    metrics::OPERATOR_TRANSACTION_ERRORS
-                        .with_label_values(&[
-                            state.program_type.as_label(),
-                            "pending_remint_persist_failed",
-                        ])
-                        .inc();
-                    return;
-                }
-                // Another writer already moved the row, so it owns the outcome.
-                Ok(Some(status)) => {
-                    warn!(
-                        transaction_id,
-                        "Failed to persist PendingRemint and the row is already {:?}, leaving it alone: {}",
-                        status,
-                        e
-                    );
-                    return;
-                }
-                // Neither state can be established, so nothing automatic can be
-                // trusted to finish this. Escalate loudly instead.
-                unresolved => {
-                    error!(
-                        "Failed to persist PendingRemint for transaction {} and could not read it back ({:?}) - sending to manual review: {}",
-                        transaction_id, unresolved, e
-                    );
-                    send_guaranteed(
-                        storage_tx,
-                        TransactionStatusUpdate {
-                            transaction_id,
-                            trace_id: ctx.trace_id.clone(),
-                            status: TransactionStatus::ManualReview,
-                            counterpart_signature: None,
-                            processed_at: Some(Utc::now()),
-                            error_message: Some(format!(
-                                "{} | failed to persist pending remint: {}",
-                                error_msg, e
-                            )),
-                            remint_signature: None,
-                            remint_attempted: false,
-                            release_signatures: None,
-                        },
-                        "transaction status update",
-                    )
-                    .await
-                    .ok();
-                    return;
-                }
+                .await
+                .ok();
+                return;
             }
         }
-    }
-
-    // `transaction_id` is always `Some` at this point in practice — only
-    // `ReleaseFunds` transactions populate `remint_cache`, and `ReleaseFunds`
-    // always carries a DB transaction_id (see `TransactionBuilder::transaction_id`
-    // in instruction_util.rs). `InitializeMint` and `ResetSmtRoot` return `None`
-    // there and would have exited early above via `send_fatal_error`. This guard
-    // exists to prevent silently enqueuing a `PendingRemint` with no DB record,
-    // which would be lost on restart since recovery reads from the DB.
-    if ctx.transaction_id.is_none() {
-        error!(
-            "Cannot defer remint for nonce {:?} — no transaction_id, entry would be unrecoverable on restart",
-            ctx.withdrawal_nonce,
-        );
-        return;
     }
 
     info!(
@@ -2096,7 +2115,8 @@ mod tests {
                 last_valid_block_height: 0,
             }],
         );
-        // The PendingRemint transition is guarded on a Processing row.
+        // The PendingRemint transition is guarded on a Processing row, and the
+        // finality gate reads the journal the broadcast wrote.
         let Storage::Mock(ref mock) = *state.storage else {
             panic!("expected mock storage");
         };
@@ -2104,6 +2124,9 @@ mod tests {
             .lock()
             .unwrap()
             .push(processing_withdrawal_row(10, 5));
+        mock.insert_release_signature(10, sig.to_string(), 0)
+            .await
+            .unwrap();
 
         let ctx = TransactionContext {
             transaction_id: Some(10),
@@ -2825,12 +2848,13 @@ mod tests {
         assert_eq!(update.status, TransactionStatus::Completed);
     }
 
-    /// The in-memory stash happens only after a successful broadcast, so a send that
-    /// never reached the network leaves no signature to verify and routes to
-    /// ManualReview, not a deferred remint. The write-ahead DB persist (for crash
-    /// recovery) does not change this.
+    /// The node answered the send with an error, so the release may still have
+    /// reached the network. The in-memory stash is only written after a successful
+    /// send and so knows nothing about this attempt, but the write-ahead journal
+    /// does: the withdrawal takes the finality-checked remint path carrying that
+    /// signature, instead of being escalated as if nothing had been broadcast.
     #[tokio::test]
-    async fn send_failure_routes_to_manual_review() {
+    async fn send_failure_defers_remint_on_journaled_signature() {
         let mut server = mockito::Server::new_async().await;
         let _hash = mock_blockhash(&mut server);
         let _send = server
@@ -2849,11 +2873,21 @@ mod tests {
             )
             .create();
 
+        let txn_id = 10;
+        let nonce = 5;
         let mut state = make_sender_state_with_server(&server.url());
-        state.remint_cache.insert(5, make_remint_info(10));
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+        // The PendingRemint transition is guarded on a Processing row.
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(txn_id, nonce));
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
-        let ctx = withdrawal_ctx(10, 5);
+        let ctx = withdrawal_ctx(txn_id, nonce);
 
         send_and_confirm(
             &mut state,
@@ -2867,13 +2901,28 @@ mod tests {
         .await;
 
         assert!(
-            state.pending_remints.is_empty(),
-            "a never-broadcast send must not defer a remint"
+            storage_rx.try_recv().is_err(),
+            "an ambiguously-sent release must not be terminalized"
         );
-        let update = storage_rx
-            .try_recv()
-            .expect("send failure must surface a status update");
-        assert_eq!(update.status, TransactionStatus::ManualReview);
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let journaled = mock.get_release_signatures(txn_id).await.unwrap();
+        assert_eq!(
+            journaled.len(),
+            1,
+            "the send was preceded by a write-ahead persist"
+        );
+        assert!(
+            !state.pending_signatures.contains_key(&nonce),
+            "the failed send never stashed its signature"
+        );
+        assert_eq!(state.pending_remints.len(), 1);
+        assert_eq!(
+            state.pending_remints[0].signatures[0].signature.to_string(),
+            journaled[0].0,
+            "the gate must carry the journaled signature"
+        );
     }
 
     // ── pre-broadcast build/sign failure requeues withdrawals ────────
@@ -3011,7 +3060,8 @@ mod tests {
                 last_valid_block_height: 0,
             }],
         );
-        // The PendingRemint transition is guarded on a Processing row.
+        // The PendingRemint transition is guarded on a Processing row, and the
+        // earlier broadcast journaled its signature before sending.
         let Storage::Mock(ref mock) = *state.storage else {
             panic!("expected mock storage");
         };
@@ -3019,6 +3069,9 @@ mod tests {
             .lock()
             .unwrap()
             .push(processing_withdrawal_row(txn_id, nonce));
+        mock.insert_release_signature(txn_id, prior_sig.to_string(), 0)
+            .await
+            .unwrap();
 
         let (storage_tx, mut storage_rx) = mpsc::channel(10);
         send_and_confirm(
@@ -3189,20 +3242,8 @@ mod tests {
         let sig1_lvbh: u64 = 100;
         let sig2_lvbh: u64 = 200;
         state.remint_cache.insert(5, make_remint_info(10));
-        state.pending_signatures.insert(
-            5,
-            vec![
-                PendingSig {
-                    signature: sig1,
-                    last_valid_block_height: sig1_lvbh,
-                },
-                PendingSig {
-                    signature: sig2,
-                    last_valid_block_height: sig2_lvbh,
-                },
-            ],
-        );
-        // The PendingRemint transition is guarded on a Processing row.
+        // The PendingRemint transition is guarded on a Processing row, and both
+        // attempts were journaled write-ahead before their sends.
         let Storage::Mock(ref seed) = *state.storage else {
             panic!("expected mock storage");
         };
@@ -3210,6 +3251,12 @@ mod tests {
             .lock()
             .unwrap()
             .push(processing_withdrawal_row(10, 5));
+        seed.insert_release_signature(10, sig1.to_string(), sig1_lvbh as i64)
+            .await
+            .unwrap();
+        seed.insert_release_signature(10, sig2.to_string(), sig2_lvbh as i64)
+            .await
+            .unwrap();
 
         let ctx = TransactionContext {
             transaction_id: Some(10),
@@ -3286,6 +3333,80 @@ mod tests {
         );
     }
 
+    /// Attempt 1 broadcast and stashed its signature; attempt 2 was journaled
+    /// write-ahead and then its send errored ambiguously, so it never reached the
+    /// stash while its release can still land. The finality gate must be fed from
+    /// the journal, or it classifies attempt 1 alone, calls the release dead and
+    /// remints tokens the user may still be paid for on-chain.
+    #[tokio::test]
+    async fn permanent_failure_gate_includes_ambiguously_sent_attempt() {
+        let txn_id = 77;
+        let nonce = 21;
+        let stashed_attempt = Signature::new_unique();
+        let ambiguous_attempt = Signature::new_unique();
+        let mut state = make_sender_state();
+        let (storage_tx, _storage_rx) = mpsc::channel(10);
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(processing_withdrawal_row(txn_id, nonce));
+        // Both attempts are journaled write-ahead, each before its own send.
+        mock.insert_release_signature(txn_id, stashed_attempt.to_string(), 100)
+            .await
+            .unwrap();
+        mock.insert_release_signature(txn_id, ambiguous_attempt.to_string(), 200)
+            .await
+            .unwrap();
+
+        // Only attempt 1 reached the stash: the push runs in send_signed's Ok arm.
+        state.remint_cache.insert(nonce, make_remint_info(txn_id));
+        state.pending_signatures.insert(
+            nonce,
+            vec![PendingSig {
+                signature: stashed_attempt,
+                last_valid_block_height: 100,
+            }],
+        );
+
+        let ctx = TransactionContext {
+            transaction_id: Some(txn_id),
+            withdrawal_nonce: Some(nonce),
+            trace_id: Some(format!("trace-{txn_id}")),
+            deposit_claim_lease: None,
+        };
+
+        handle_permanent_failure(&mut state, &ctx, &storage_tx, "release_funds failed").await;
+
+        let Storage::Mock(ref mock) = *state.storage else {
+            panic!("expected mock storage");
+        };
+        let (_, persisted_sigs, persisted_lvbhs, _) =
+            mock.pending_remint_signatures.lock().unwrap()[0].clone();
+        assert!(
+            persisted_sigs.contains(&ambiguous_attempt.to_string()),
+            "the ambiguously-sent attempt must be persisted for the finality check: {persisted_sigs:?}"
+        );
+        assert_eq!(
+            persisted_lvbhs.iter().max(),
+            Some(&200),
+            "the deadline bound must cover the ambiguously-sent attempt"
+        );
+
+        let queued: Vec<Signature> = state.pending_remints[0]
+            .signatures
+            .iter()
+            .map(|pending_sig| pending_sig.signature)
+            .collect();
+        assert!(
+            queued.contains(&ambiguous_attempt),
+            "the in-process gate must classify the ambiguously-sent attempt too: {queued:?}"
+        );
+    }
+
     /// A failed `set_pending_remint` whose row still reads `Processing` proves
     /// nothing committed. The row keeps that status so the recovery worker owns
     /// it, and the compensation material goes back into the caches for a later
@@ -3307,11 +3428,15 @@ mod tests {
             .unwrap()
             .push(processing_withdrawal_row(txn_id, nonce));
 
+        let broadcast = Signature::new_unique();
+        mock.insert_release_signature(txn_id, broadcast.to_string(), 0)
+            .await
+            .unwrap();
         state.remint_cache.insert(nonce, make_remint_info(txn_id));
         state.pending_signatures.insert(
             nonce,
             vec![PendingSig {
-                signature: Signature::new_unique(),
+                signature: broadcast,
                 last_valid_block_height: 0,
             }],
         );
@@ -3362,11 +3487,15 @@ mod tests {
         committed.status = TransactionStatus::PendingRemint;
         mock.pending_transactions.lock().unwrap().push(committed);
 
+        let broadcast = Signature::new_unique();
+        mock.insert_release_signature(txn_id, broadcast.to_string(), 0)
+            .await
+            .unwrap();
         state.remint_cache.insert(nonce, make_remint_info(txn_id));
         state.pending_signatures.insert(
             nonce,
             vec![PendingSig {
-                signature: Signature::new_unique(),
+                signature: broadcast,
                 last_valid_block_height: 0,
             }],
         );
@@ -3411,11 +3540,15 @@ mod tests {
             .unwrap()
             .push(processing_withdrawal_row(txn_id, nonce));
 
+        let broadcast = Signature::new_unique();
+        mock.insert_release_signature(txn_id, broadcast.to_string(), 0)
+            .await
+            .unwrap();
         state.remint_cache.insert(nonce, make_remint_info(txn_id));
         state.pending_signatures.insert(
             nonce,
             vec![PendingSig {
-                signature: Signature::new_unique(),
+                signature: broadcast,
                 last_valid_block_height: 0,
             }],
         );

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -26,6 +26,7 @@ pub mod get_release_signatures;
 pub mod get_remint_signatures;
 pub mod get_stale_parked_transactions;
 pub mod get_stale_processing_transactions;
+pub mod get_transaction_status;
 pub mod has_active_withdrawal_below;
 pub mod init_schema;
 pub mod insert_db_transaction;
@@ -350,6 +351,15 @@ impl Storage {
         &self,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         get_pending_remint_transactions::get_pending_remint_transactions(self).await
+    }
+
+    /// Current status of one row, or `None` if it does not exist. Used to
+    /// resolve which state a guarded write committed when its result was lost.
+    pub async fn get_transaction_status(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Option<TransactionStatus>, StorageError> {
+        get_transaction_status::get_transaction_status(self, transaction_id).await
     }
 
     /// Try to acquire the singleton sender lock for `key`. `Ok(None)` means

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -42,6 +42,7 @@ pub mod set_mint_extension_flags;
 pub mod set_pending_remint;
 pub mod sync_mint_status;
 pub mod try_complete_processing;
+pub mod try_escalate_manual_review;
 pub mod try_park_processing;
 pub mod try_quarantine_processing;
 pub mod try_requeue_parked;
@@ -360,6 +361,17 @@ impl Storage {
         transaction_id: i64,
     ) -> Result<Option<TransactionStatus>, StorageError> {
         get_transaction_status::get_transaction_status(self, transaction_id).await
+    }
+
+    /// Escalate a still-`Processing` row to ManualReview. `Ok(false)` means the
+    /// row moved on, so the caller's escalation does not own it and must not be
+    /// written through the generic status writer, which would accept a
+    /// `pending_remint` source and overwrite a committed handoff.
+    pub async fn try_escalate_manual_review(
+        &self,
+        transaction_id: i64,
+    ) -> Result<bool, StorageError> {
+        try_escalate_manual_review::try_escalate_manual_review(self, transaction_id).await
     }
 
     /// Try to acquire the singleton sender lock for `key`. `Ok(None)` means

--- a/indexer/src/storage/common/storage/get_transaction_status.rs
+++ b/indexer/src/storage/common/storage/get_transaction_status.rs
@@ -1,0 +1,20 @@
+use crate::{
+    error::StorageError,
+    storage::common::{models::TransactionStatus, storage::Storage},
+};
+
+/// Read a row's current status. `Ok(None)` means no such row.
+pub async fn get_transaction_status(
+    storage: &Storage,
+    transaction_id: i64,
+) -> Result<Option<TransactionStatus>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => {
+            let status = db.get_transaction_status_internal(transaction_id).await?;
+
+            Ok(status)
+        }
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.get_transaction_status(transaction_id).await,
+    }
+}

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -697,6 +697,27 @@ impl MockStorage {
         Ok(())
     }
 
+    /// Mirror `try_escalate_manual_review_internal`: flip a Processing row to
+    /// ManualReview, returning whether it matched. Any other status is a guard
+    /// miss that writes nothing. Honors `should_fail("try_escalate_manual_review")`.
+    pub async fn try_escalate_manual_review(
+        &self,
+        transaction_id: i64,
+    ) -> Result<bool, StorageError> {
+        self.check_should_fail("try_escalate_manual_review")?;
+        let mut rows = self.pending_transactions.lock().unwrap();
+        let Some(row) = rows
+            .iter_mut()
+            .find(|t| t.id == transaction_id && t.status == TransactionStatus::Processing)
+        else {
+            return Ok(false);
+        };
+        row.status = TransactionStatus::ManualReview;
+        row.processed_at = Some(Utc::now());
+        row.updated_at = Utc::now();
+        Ok(true)
+    }
+
     /// Status of one row. `pending_transactions` is the live mirror of the
     /// table, so it wins; `pending_remint_transactions` is the fallback for
     /// tests that only seeded the rehydration list.

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -629,6 +629,11 @@ impl MockStorage {
         Ok(nonces)
     }
 
+    /// Mirror `set_pending_remint_internal`: transition a Processing row to
+    /// PendingRemint and store the finality-check payload. Replaying an
+    /// identical payload on an already-PendingRemint row succeeds; any other
+    /// status, a different payload, or a missing row is a guard miss, matching
+    /// the Postgres semantics. Honors `should_fail("set_pending_remint")`.
     pub async fn set_pending_remint(
         &self,
         transaction_id: i64,
@@ -648,6 +653,41 @@ impl MockStorage {
                 message: "Simulated set_pending_remint failure".to_string(),
             });
         }
+
+        {
+            let mut rows = self.pending_transactions.lock().unwrap();
+            let row = rows
+                .iter_mut()
+                .find(|t| t.id == transaction_id)
+                .ok_or_else(|| StorageError::DatabaseError {
+                    message: format!("no row for id {transaction_id}"),
+                })?;
+            let replay = row.status == TransactionStatus::PendingRemint
+                && row.remint_signatures.as_ref() == Some(&remint_signatures);
+            if row.status != TransactionStatus::Processing && !replay {
+                return Err(StorageError::DatabaseError {
+                    message: format!(
+                        "id {transaction_id} is {:?}, not a PendingRemint transition",
+                        row.status
+                    ),
+                });
+            }
+            row.status = TransactionStatus::PendingRemint;
+            row.remint_signatures = Some(remint_signatures.clone());
+            row.remint_last_valid_block_heights = Some(remint_last_valid_block_heights.clone());
+            row.pending_remint_deadline_at = Some(deadline_at);
+            row.updated_at = Utc::now();
+
+            // Keep the rehydration list in step, so `get_pending_remint_transactions`
+            // sees the row exactly as a restart would.
+            let transitioned = row.clone();
+            let mut rehydrate = self.pending_remint_transactions.lock().unwrap();
+            match rehydrate.iter_mut().find(|t| t.id == transaction_id) {
+                Some(existing) => *existing = transitioned,
+                None => rehydrate.push(transitioned),
+            }
+        }
+
         self.pending_remint_signatures.lock().unwrap().push((
             transaction_id,
             remint_signatures,
@@ -655,6 +695,32 @@ impl MockStorage {
             deadline_at,
         ));
         Ok(())
+    }
+
+    /// Status of one row. `pending_transactions` is the live mirror of the
+    /// table, so it wins; `pending_remint_transactions` is the fallback for
+    /// tests that only seeded the rehydration list.
+    pub async fn get_transaction_status(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Option<TransactionStatus>, StorageError> {
+        self.check_should_fail("get_transaction_status")?;
+        if let Some(txn) = self
+            .pending_transactions
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|t| t.id == transaction_id)
+        {
+            return Ok(Some(txn.status));
+        }
+        Ok(self
+            .pending_remint_transactions
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|t| t.id == transaction_id)
+            .map(|t| t.status))
     }
 
     /// Update the in-memory pending_remint row for `transaction_id` with the

--- a/indexer/src/storage/common/storage/try_escalate_manual_review.rs
+++ b/indexer/src/storage/common/storage/try_escalate_manual_review.rs
@@ -1,0 +1,20 @@
+use crate::{error::StorageError, storage::common::storage::Storage};
+
+/// Escalate a still-`Processing` row to ManualReview. `Ok(false)` means the row
+/// is no longer Processing, so this escalation does not own it.
+pub async fn try_escalate_manual_review(
+    storage: &Storage,
+    transaction_id: i64,
+) -> Result<bool, StorageError> {
+    match storage {
+        Storage::Postgres(db) => {
+            let escalated = db
+                .try_escalate_manual_review_internal(transaction_id)
+                .await?;
+
+            Ok(escalated)
+        }
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => mock_db.try_escalate_manual_review(transaction_id).await,
+    }
+}

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1662,6 +1662,33 @@ impl PostgresDb {
             .await
     }
 
+    /// Escalate a row to ManualReview, but only while it is still `processing`.
+    /// `Ok(false)` means the row moved on and this escalation must not apply:
+    /// the generic status writer accepts `pending_remint` as a source, so an
+    /// unguarded fallback could overwrite a committed PendingRemint handoff and
+    /// strand the withdrawal, which no sweep would pick up again.
+    pub async fn try_escalate_manual_review_internal(
+        &self,
+        transaction_id: i64,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET
+                status = $2,
+                processed_at = NOW()
+            WHERE id = $1
+                AND status = 'processing'
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(TransactionStatus::ManualReview)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
     /// Durably record a confirmed remint: flip status to FailedReminted and
     /// store the signature in one UPDATE, before the async writer runs. The
     /// `pending_remint` guard makes it a no-op on an already-terminal row, so

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1578,6 +1578,10 @@ impl PostgresDb {
 
     /// Transitions a withdrawal to PendingRemint status, storing the
     /// withdrawal signatures needed for the finality check on restart.
+    ///
+    /// Idempotent for an identical payload: a row already PendingRemint with the
+    /// same signatures is re-written, so a retry after a lost acknowledgement
+    /// succeeds. A different payload still fails, and no other status matches.
     pub async fn set_pending_remint_internal(
         &self,
         transaction_id: i64,
@@ -1595,7 +1599,8 @@ impl PostgresDb {
                 pending_remint_deadline_at = $5,
                 updated_at = NOW()
             WHERE id = $1
-                AND status = 'processing'
+                AND (status = 'processing'
+                     OR (status = 'pending_remint' AND remint_signatures = $3))
             "#,
         )
         .bind(transaction_id)
@@ -1646,6 +1651,17 @@ impl PostgresDb {
         Ok(())
     }
 
+    /// Current status of one row, or `None` if it does not exist.
+    pub async fn get_transaction_status_internal(
+        &self,
+        transaction_id: i64,
+    ) -> Result<Option<TransactionStatus>, sqlx::Error> {
+        sqlx::query_scalar::<_, TransactionStatus>("SELECT status FROM transactions WHERE id = $1")
+            .bind(transaction_id)
+            .fetch_optional(&self.pool)
+            .await
+    }
+
     /// Durably record a confirmed remint: flip status to FailedReminted and
     /// store the signature in one UPDATE, before the async writer runs. The
     /// `pending_remint` guard makes it a no-op on an already-terminal row, so
@@ -1679,16 +1695,11 @@ impl PostgresDb {
             // PendingRemint row), a non-pending_remint status is expected on an
             // idempotent replay. Both still signal RowNotFound so the caller
             // falls back to the async writer.
-            let current: Option<String> =
-                sqlx::query_scalar("SELECT status::text FROM transactions WHERE id = $1")
-                    .bind(transaction_id)
-                    .fetch_optional(&self.pool)
-                    .await?;
-            match current.as_deref() {
+            match self.get_transaction_status_internal(transaction_id).await? {
                 None => warn!("record_remint_result: transaction {transaction_id} not found"),
                 Some(status) => info!(
                     "record_remint_result: transaction {transaction_id} not pending_remint \
-                     (status {status}); skipping"
+                     (status {status:?}); skipping"
                 ),
             }
             return Err(sqlx::Error::RowNotFound);

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -825,8 +825,12 @@ async fn try_escalate_manual_review_spares_pending_remint() -> Result<(), Box<dy
 {
     let (pool, storage, _pg) = start_postgres().await?;
 
+    // One dequeue has to lock both rows: once the first is PendingRemint its
+    // nonce is the frontier, and the higher nonce stays Pending.
     let txn = make_db_transaction("escalate_guard", TransactionType::Withdrawal);
     let id = storage.insert_db_transaction(&txn).await?;
+    let other = make_db_transaction("escalate_processing", TransactionType::Withdrawal);
+    let other_id = storage.insert_db_transaction(&other).await?;
     storage
         .get_and_lock_pending_transactions(TransactionType::Withdrawal, 100)
         .await?;
@@ -840,27 +844,18 @@ async fn try_escalate_manual_review_spares_pending_remint() -> Result<(), Box<dy
         !storage.try_escalate_manual_review(id).await?,
         "a PendingRemint row must not be escalated"
     );
-    let status: String = sqlx::query_scalar("SELECT status::text FROM transactions WHERE id = $1")
-        .bind(id)
-        .fetch_one(&pool)
-        .await?;
-    assert_eq!(status, "pending_remint", "the handoff must survive");
+    assert_eq!(
+        status_of(&pool, id).await,
+        "pending_remint",
+        "the handoff must survive"
+    );
 
     // A row that never left Processing is the escalation's to take.
-    let other = make_db_transaction("escalate_processing", TransactionType::Withdrawal);
-    let other_id = storage.insert_db_transaction(&other).await?;
-    storage
-        .get_and_lock_pending_transactions(TransactionType::Withdrawal, 100)
-        .await?;
     assert!(
         storage.try_escalate_manual_review(other_id).await?,
         "a Processing row must be escalated"
     );
-    let status: String = sqlx::query_scalar("SELECT status::text FROM transactions WHERE id = $1")
-        .bind(other_id)
-        .fetch_one(&pool)
-        .await?;
-    assert_eq!(status, "manual_review");
+    assert_eq!(status_of(&pool, other_id).await, "manual_review");
     Ok(())
 }
 

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -816,6 +816,59 @@ async fn set_pending_remint_fails_when_not_processing() -> Result<(), Box<dyn st
     Ok(())
 }
 
+/// A retry whose first attempt committed but whose acknowledgement was lost must
+/// succeed, so the sender can tell a durable handoff from a failed one. Replaying
+/// the same payload is accepted; a different payload is not, so a second caller
+/// can never silently overwrite the signatures a live remint depends on.
+#[tokio::test(flavor = "multi_thread")]
+async fn set_pending_remint_replays_identical_payload_only(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    let txn = make_db_transaction("remint_replay", TransactionType::Withdrawal);
+    let id = storage.insert_db_transaction(&txn).await?;
+    storage
+        .get_and_lock_pending_transactions(TransactionType::Withdrawal, 100)
+        .await?;
+
+    let deadline = Utc::now() + chrono::Duration::seconds(32);
+    let signatures = vec!["sig1".to_string(), "sig2".to_string()];
+    storage
+        .set_pending_remint(id, signatures.clone(), vec![10, 20], deadline)
+        .await?;
+
+    // The row is already PendingRemint; the same payload must still be accepted.
+    storage
+        .set_pending_remint(id, signatures.clone(), vec![10, 20], deadline)
+        .await?;
+
+    let stored: Vec<String> =
+        sqlx::query_scalar("SELECT remint_signatures FROM transactions WHERE id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(stored, signatures, "replay must preserve the signatures");
+
+    let other = storage
+        .set_pending_remint(id, vec!["different".to_string()], vec![30], deadline)
+        .await;
+    assert!(
+        other.is_err(),
+        "a different payload must not overwrite a live PendingRemint"
+    );
+
+    let stored: Vec<String> =
+        sqlx::query_scalar("SELECT remint_signatures FROM transactions WHERE id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(
+        stored, signatures,
+        "the rejected payload must leave the signatures untouched"
+    );
+    Ok(())
+}
+
 // ── set_mint_extension_flags row-exists guard ────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread")]

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -816,6 +816,54 @@ async fn set_pending_remint_fails_when_not_processing() -> Result<(), Box<dyn st
     Ok(())
 }
 
+/// The ManualReview fallback must only terminalize a row it can prove is still
+/// Processing. A committed PendingRemint has to survive it: the generic status
+/// writer accepts `pending_remint` as a source, so an unguarded escalation would
+/// overwrite the handoff and leave the withdrawal in a status no sweep selects.
+#[tokio::test(flavor = "multi_thread")]
+async fn try_escalate_manual_review_spares_pending_remint() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    let txn = make_db_transaction("escalate_guard", TransactionType::Withdrawal);
+    let id = storage.insert_db_transaction(&txn).await?;
+    storage
+        .get_and_lock_pending_transactions(TransactionType::Withdrawal, 100)
+        .await?;
+
+    let deadline = Utc::now() + chrono::Duration::seconds(32);
+    storage
+        .set_pending_remint(id, vec!["sig1".to_string()], vec![10], deadline)
+        .await?;
+
+    assert!(
+        !storage.try_escalate_manual_review(id).await?,
+        "a PendingRemint row must not be escalated"
+    );
+    let status: String = sqlx::query_scalar("SELECT status::text FROM transactions WHERE id = $1")
+        .bind(id)
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(status, "pending_remint", "the handoff must survive");
+
+    // A row that never left Processing is the escalation's to take.
+    let other = make_db_transaction("escalate_processing", TransactionType::Withdrawal);
+    let other_id = storage.insert_db_transaction(&other).await?;
+    storage
+        .get_and_lock_pending_transactions(TransactionType::Withdrawal, 100)
+        .await?;
+    assert!(
+        storage.try_escalate_manual_review(other_id).await?,
+        "a Processing row must be escalated"
+    );
+    let status: String = sqlx::query_scalar("SELECT status::text FROM transactions WHERE id = $1")
+        .bind(other_id)
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(status, "manual_review");
+    Ok(())
+}
+
 /// A retry whose first attempt committed but whose acknowledgement was lost must
 /// succeed, so the sender can tell a durable handoff from a failed one. Replaying
 /// the same payload is accepted; a different payload is not, so a second caller

--- a/integration/tests/indexer/operator_lifecycle.rs
+++ b/integration/tests/indexer/operator_lifecycle.rs
@@ -220,6 +220,31 @@ async fn wait_for_transaction_status(
     .into())
 }
 
+/// Poll until the row reaches one of `expected_statuses`, returning the one it
+/// reached. A permanently-failed withdrawal is resolved by the deferred-remint
+/// gate, which can land on either a completed remint or an escalation, so the
+/// caller must accept both.
+async fn wait_for_any_transaction_status(
+    pool: &sqlx::PgPool,
+    signature: &str,
+    expected_statuses: &[&str],
+    timeout_secs: u64,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let start = std::time::Instant::now();
+    while start.elapsed().as_secs() < timeout_secs {
+        if let Some(tx) = db::get_transaction(pool, signature).await? {
+            if expected_statuses.contains(&tx.status.as_str()) {
+                return Ok(tx.status);
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Err(format!(
+        "Transaction {signature} did not reach any of {expected_statuses:?} within {timeout_secs}s"
+    )
+    .into())
+}
+
 /// Poll until the deposit's write-ahead mint signature is journaled in
 /// `pending_release_signatures`. The journal is written right before broadcast,
 /// so a non-empty journal proves the mint reached the send step.
@@ -575,15 +600,14 @@ async fn test_withdrawal_operator_prevents_double_withdrawal(
 }
 
 /// Triggers one preflight-failing mint (wrong-authority `mint_to`) and one bad
-/// withdrawal (mint not whitelisted on the instance, escalated to `ManualReview`
-/// because the burn never produced a verifiable signature).
+/// withdrawal (mint not whitelisted on the instance).
 ///
-/// A write-ahead-persisted mint is never terminalized in the sender: on a send
-/// error it is left Processing for recovery, so it journals its signature and
-/// stays Processing rather than reaching Failed, and fires no alert. Only the
-/// withdrawal's `ManualReview` disposition fires a webhook, so the configured
-/// `alert_webhook_url` receives exactly one POST via
-/// `db_transaction_writer::send_webhook_alert`.
+/// Neither is terminalized by the sender on the send error, because both journal
+/// their signature write-ahead: the mint is left Processing for recovery and fires
+/// no alert, and the withdrawal is handed to the deferred-remint gate, which
+/// resolves it once the journaled signature can no longer land. Only that final
+/// withdrawal disposition fires a webhook, so the configured `alert_webhook_url`
+/// receives exactly one POST via `db_transaction_writer::send_webhook_alert`.
 ///
 /// Uses a `mockito` HTTP server as the webhook endpoint so no external service
 /// is required.
@@ -739,13 +763,26 @@ async fn test_failed_withdrawal_alerts_and_preflight_mint_defers_to_recovery(
     .await?;
 
     // The bad withdrawal preflights with `invalid account data for instruction`
-    // from the escrow program (the mint isn't whitelisted on the instance), so
-    // `sign_and_send` errors before any signature is broadcast. With no
-    // signatures to verify, the sender's "cannot safely remint" branch
-    // (`indexer/src/operator/sender/transaction.rs`) routes the row to
-    // `ManualReview`, NOT `Failed` — reverting that to `Failed` would risk
-    // double-reminting if the broadcast had succeeded silently.
-    wait_for_transaction_status(&pool, &withdrawal_sig, "manual_review", 180).await?;
+    // from the escrow program (the mint isn't whitelisted on the instance), so the
+    // send fails — but only after the write-ahead journal recorded its signature.
+    // The sender cannot tell a preflight rejection from an ambiguous transport
+    // error, so it hands the row to the deferred-remint gate instead of
+    // terminalizing it as never-broadcast.
+    wait_for_transaction_status(&pool, &withdrawal_sig, "pending_remint", 180).await?;
+
+    // Once the tip passes the journaled signature's blockhash validity the gate
+    // proves it dead and remints the burned tokens; if it exhausts its deferral
+    // budget first it escalates instead. Both are terminal and fire exactly one
+    // webhook, which is what this test asserts. The env-aware timeout keeps
+    // coverage-instrumented runs off the uninstrumented ceiling.
+    let disposition = wait_for_any_transaction_status(
+        &pool,
+        &withdrawal_sig,
+        &["failed_reminted", "manual_review"],
+        *WAIT_TIMEOUT_SECS,
+    )
+    .await?;
+    println!("bad withdrawal settled as {disposition}");
 
     alert_mock.assert();
 

--- a/integration/tests/indexer/sender_max_retries.rs
+++ b/integration/tests/indexer/sender_max_retries.rs
@@ -31,13 +31,16 @@ use {
             },
             utils::instruction_util::{ExtraErrorCheckPolicy, RetryPolicy},
         },
-        storage::{common::storage::mock::MockStorage, Storage, TransactionStatus},
+        storage::{
+            common::{models::DbTransactionBuilder, storage::mock::MockStorage},
+            Storage, TransactionStatus, TransactionType,
+        },
     },
     sender_fixtures::{
         blockhash_reply, ensure_admin_signer_env, make_config, make_instruction, make_remint_info,
         withdrawal_ctx,
     },
-    solana_sdk::{commitment_config::CommitmentLevel, signature::Signature},
+    solana_sdk::{commitment_config::CommitmentLevel, pubkey::Pubkey, signature::Signature},
     std::sync::Arc,
     test_utils::mock_rpc::{MockRpcServer, Reply},
     tokio::sync::mpsc,
@@ -85,6 +88,27 @@ fn seed_remint_cache(state: &mut SenderState, transaction_id: i64, nonce: u64) {
     state
         .remint_cache
         .insert(nonce, make_remint_info(transaction_id));
+}
+
+/// Seed the Processing withdrawal row that the PendingRemint transition is
+/// guarded on, so `set_pending_remint` can commit against the mock store the
+/// way it does against Postgres.
+fn seed_processing_withdrawal_row(storage: &MockStorage, transaction_id: i64, nonce: u64) {
+    let owner = Pubkey::new_unique().to_string();
+    let mut tx = DbTransactionBuilder::new(
+        format!("sig-{transaction_id}"),
+        1,
+        Pubkey::new_unique().to_string(),
+        1,
+    )
+    .initiator(owner.clone())
+    .recipient(owner)
+    .transaction_type(TransactionType::Withdrawal)
+    .build();
+    tx.id = transaction_id;
+    tx.status = TransactionStatus::Processing;
+    tx.withdrawal_nonce = Some(nonce as i64);
+    storage.pending_transactions.lock().unwrap().push(tx);
 }
 
 /// Helper: enqueue one (`getLatestBlockhash`, `sendTransaction`-error)
@@ -233,20 +257,21 @@ async fn idempotent_send_loops_capped_at_higher_budget() {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Withdrawal deferral — zero stashed signatures → ManualReview.
+// Withdrawal deferral — ambiguous send, nothing stashed → gated remint.
 // ─────────────────────────────────────────────────────────────────────
 //
-// `remint_cache[nonce]` is seeded so `handle_permanent_failure` enters
-// the deferred-remint branch instead of falling through to
-// `send_fatal_error`. `pending_signatures[nonce]` is left empty: the
-// production code treats this as "the RPC may have broadcast the tx
-// before erroring — blind remint is unsafe" and routes to
-// `ManualReview` with the "no signatures to verify" label.
+// `pending_signatures[nonce]` is left empty because the stash is only
+// written after a successful send, and this send failed. The signature
+// was still journaled write-ahead before the send, and the node answered
+// it with an error, so the release may have reached the network. The
+// deferral is therefore gated on that journaled signature rather than
+// escalated as if nothing had been broadcast.
 #[tokio::test]
-async fn deferral_with_zero_stashed_signatures_routes_to_manual_review() {
-    let (mut state, mut storage_rx, storage_tx, mock, _mock_storage) = build_fixture(3).await;
+async fn deferral_with_ambiguous_send_gates_on_journaled_signature() {
+    let (mut state, mut storage_rx, storage_tx, mock, mock_storage) = build_fixture(3).await;
     let ctx = withdrawal_ctx(601, 21);
     seed_remint_cache(&mut state, 601, 21);
+    seed_processing_withdrawal_row(&mock_storage, 601, 21);
     // pending_signatures intentionally NOT seeded.
 
     enqueue_failing_send(&mock, "permanent send error");
@@ -262,24 +287,29 @@ async fn deferral_with_zero_stashed_signatures_routes_to_manual_review() {
     )
     .await;
 
-    let update = storage_rx
-        .recv()
+    assert!(
+        storage_rx.try_recv().is_err(),
+        "an ambiguously-sent release must not be terminalized; the row stays Processing until the deferred check runs"
+    );
+    let journaled = mock_storage
+        .get_release_signatures(601)
         .await
-        .expect("zero-sigs deferral arm must emit a ManualReview update");
-    assert_eq!(update.transaction_id, 601);
-    assert_eq!(update.status, TransactionStatus::ManualReview);
-    let msg = update.error_message.unwrap_or_default();
-    assert!(
-        msg.contains("no signatures to verify"),
-        "zero-sigs arm must surface the 'no signatures to verify' label; got {msg:?}"
+        .expect("journal read");
+    assert_eq!(
+        journaled.len(),
+        1,
+        "the send was preceded by a write-ahead persist"
     );
     assert!(
-        !update.remint_attempted,
-        "zero-sigs arm must NOT mark remint_attempted (no remint was scheduled)"
+        !state.pending_signatures.contains_key(&21),
+        "the failed send never stashed its signature"
     );
-    // Entry was NOT pushed to pending_remints — the unsafe-remint guard
-    // returned ManualReview directly.
-    assert!(state.pending_remints.is_empty());
+    assert_eq!(state.pending_remints.len(), 1);
+    assert_eq!(
+        state.pending_remints[0].signatures[0].signature.to_string(),
+        journaled[0].0,
+        "the gate must carry the journaled signature"
+    );
     mock.shutdown().await;
 }
 
@@ -287,21 +317,28 @@ async fn deferral_with_zero_stashed_signatures_routes_to_manual_review() {
 // Withdrawal deferral — set_pending_remint succeeds → push to queue.
 // ─────────────────────────────────────────────────────────────────────
 //
-// Pre-seed `pending_signatures[nonce]` with one fake signature so the
-// non-zero-sigs branch fires, calls `storage.set_pending_remint`
-// (succeeds under default `MockStorage`), and pushes a `PendingRemint`
-// entry into `state.pending_remints` for the deferred-finality-check
-// loop to pick up later. No status update is emitted on this path —
-// the row stays Processing until the remint resolves.
+// The multi-attempt shape: an earlier attempt broadcast and stashed its
+// signature, then this attempt was journaled write-ahead and its send
+// errored ambiguously. `set_pending_remint` commits and a `PendingRemint`
+// is pushed for the deferred-finality-check loop, carrying BOTH attempts —
+// either one may still land, so classifying only the stashed one could
+// remint on top of a release that lands afterwards. No status update is
+// emitted: the row stays Processing until the remint resolves.
 #[tokio::test]
 async fn deferral_with_stashed_signatures_pushes_pending_remint() {
-    let (mut state, mut storage_rx, storage_tx, mock, _mock_storage) = build_fixture(3).await;
+    let (mut state, mut storage_rx, storage_tx, mock, mock_storage) = build_fixture(3).await;
     let ctx = withdrawal_ctx(602, 22);
     seed_remint_cache(&mut state, 602, 22);
+    seed_processing_withdrawal_row(&mock_storage, 602, 22);
+    let prior_attempt = Signature::new_unique();
+    mock_storage
+        .insert_release_signature(602, prior_attempt.to_string(), 0)
+        .await
+        .expect("journal the earlier broadcast");
     state.pending_signatures.insert(
         22,
         vec![PendingSig {
-            signature: Signature::new_unique(),
+            signature: prior_attempt,
             last_valid_block_height: 0,
         }],
     );
@@ -332,10 +369,19 @@ async fn deferral_with_stashed_signatures_pushes_pending_remint() {
     let entry = &state.pending_remints[0];
     assert_eq!(entry.ctx.transaction_id, Some(602));
     assert_eq!(entry.ctx.withdrawal_nonce, Some(22));
+    let gated: Vec<String> = entry
+        .signatures
+        .iter()
+        .map(|pending_sig| pending_sig.signature.to_string())
+        .collect();
     assert_eq!(
-        entry.signatures.len(),
-        1,
-        "the seeded stashed signature must be carried over to the PendingRemint entry"
+        gated.len(),
+        2,
+        "both the earlier broadcast and this ambiguously-sent attempt must be gated; got {gated:?}"
+    );
+    assert!(
+        gated.contains(&prior_attempt.to_string()),
+        "the earlier broadcast must still be classified; got {gated:?}"
     );
     mock.shutdown().await;
 }
@@ -344,24 +390,33 @@ async fn deferral_with_stashed_signatures_pushes_pending_remint() {
 // Withdrawal deferral — set_pending_remint fails → ManualReview.
 // ─────────────────────────────────────────────────────────────────────
 //
-// Same setup as the success scenario above, but
-// `MockStorage::set_should_fail("set_pending_remint", true)` makes the
-// storage call fail. The arm catches the error and routes to
-// `ManualReview` with a `"failed to persist pending remint"` label
-// instead of leaving the row in a broken half-state.
+// Same setup as the success scenario above, but neither the write nor the
+// read-back can establish which state was committed: `set_pending_remint`
+// and `get_transaction_status` both fail. With the row's owner unknown, no
+// automatic component can be trusted to finish the withdrawal, so it routes
+// to `ManualReview` with a `"failed to persist pending remint"` label. (A
+// write failure whose row still reads Processing is left to recovery
+// instead — covered by the unit tests in transaction.rs.)
 #[tokio::test]
-async fn deferral_set_pending_remint_storage_failure_routes_to_manual_review() {
+async fn deferral_undeterminable_state_routes_to_manual_review() {
     let (mut state, mut storage_rx, storage_tx, mock, mock_storage) = build_fixture(3).await;
     let ctx = withdrawal_ctx(603, 23);
     seed_remint_cache(&mut state, 603, 23);
+    seed_processing_withdrawal_row(&mock_storage, 603, 23);
+    let prior_attempt = Signature::new_unique();
+    mock_storage
+        .insert_release_signature(603, prior_attempt.to_string(), 0)
+        .await
+        .expect("journal the earlier broadcast");
     state.pending_signatures.insert(
         23,
         vec![PendingSig {
-            signature: Signature::new_unique(),
+            signature: prior_attempt,
             last_valid_block_height: 0,
         }],
     );
     mock_storage.set_should_fail("set_pending_remint", true);
+    mock_storage.set_should_fail("get_transaction_status", true);
 
     enqueue_failing_send(&mock, "permanent send error");
 


### PR DESCRIPTION
## Problem

  A permanently-failed withdrawal could lose its compensating remint two ways:

  1. **The handoff was not durable.** `handle_permanent_failure` discarded the remint info and
  release signatures, then called `set_pending_remint`. Any error wrote `ManualReview` and
  returned. If the write had actually committed and only the ack was lost, that overwrote a
  valid recovery state — the status writer accepts `pending_remint` as a source. And no sweep
  selects `manual_review`, so the row left every automatic path while blocking the dequeue
  frontier behind its nonce. A statement timeout was enough.

  2. **The finality gate read the wrong source.** Signatures are journaled *before* each send;
  the in-memory stash is only written after a successful one. So the attempt whose send errored
  ambiguously — the one most likely still in flight — was the one the gate never saw. It
  classified the earlier finalized-failed attempt, called the release dead, and reminted. The
  SMT gate doesn't catch it: `max_lvbh` comes from the same truncated set, so the non-inclusion
  proof runs while the missing signature can still land.

  ## Changes

  - `set_pending_remint` is idempotent for an identical payload, so a retry after a lost ack
  succeeds. A different payload is still rejected.
  - The write retries with `with_storage_backoff`; the compensation material stays in its
  locals.
  - On exhausted retries the row is read back and its status decides ownership: `PendingRemint`
  → this sender keeps driving it; `Processing` → restore the caches and leave it to recovery;
  anything else → another writer owns it; unreadable → escalate.
  - That escalation goes through a new `try_escalate_manual_review`, guarded on `status =
  'processing'`. A guard miss means the write did commit, so the row is left for the startup
  reload instead of being clobbered.
  - The gate now loads signatures with `load_pending_sigs`, the same journal read recovery
  uses, so the in-process and post-restart gates classify the same set. An unreadable journal
  restores the caches and leaves the row `Processing`.
  - Added `Storage::get_transaction_status`; `record_remint_result_internal` uses it instead of
  its own inline query.
  - Mock storage enforces the same guards as the SQL, which exposed several tests transitioning
  rows that never existed
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 12,498 | 14,129 | 88.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30836960965) |
| Indexer | 32,942 | 36,441 | 90.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30836960965) |
| Gateway | 1,330 | 1,521 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30836960965) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30836960965) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,714 | 17,436 | 78.7% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/30836960965) |
| **Total** | **61,269** | **70,430** | **87.0%** | |

> Last updated: 2026-08-03 18:34:45 UTC by E2E Integration