### PR TITLE
fix(core): bind settlement acknowledgements to executor account generations (issue-277)

### DIFF
--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -28,8 +28,8 @@
 /// have their `synced_since` updated frequently, so this is a good heuristic to
 /// evict less frequently accessed accounts.
 ///
-/// What decides whether `synced_since` may be set at all is the second field,
-/// `generation`. Every account BOB writes is stamped with the ordinal of that
+/// What decides whether `synced_since` may be set at all is `generation`. Every
+/// account BOB writes is stamped with the ordinal of that
 /// write, and settlement feedback carries a high-water generation meaning
 /// "everything up to here is durable". An entry is only ever marked
 /// synchronized, or dropped if it is a tombstone, when its own generation is
@@ -81,6 +81,12 @@ pub struct BobCacheStats {
     pub bytes: usize,
     /// Entries evicted (age + cap) since the previous read; drained on read.
     pub evicted: usize,
+    /// Settlement acknowledgements whose generation was covered but whose bytes
+    /// disagreed with the in-memory entry, since the previous read; drained on
+    /// read. Always zero unless BOB's and the settler's independent derivations
+    /// of account state have diverged, so any non-zero value is a bug worth
+    /// alerting on rather than a condition to tune.
+    pub settlement_divergences: usize,
 }
 
 struct AccountWithMeta {
@@ -123,6 +129,8 @@ pub struct BOB {
     dirty_entries: usize,
     /// Running sum of resident account-data bytes; maintained like dirty_entries.
     cache_bytes: usize,
+    /// Byte divergences seen since the last cache_stats read; drained on read.
+    settlement_divergences: usize,
     /// Ordinal of the next executor write. Needs no synchronization: the
     /// executor is a single task owning BOB through `&mut self`, so the
     /// counter is strictly monotonic.
@@ -147,6 +155,7 @@ impl BOB {
             evicted_delta: 0,
             dirty_entries: 0,
             cache_bytes: 0,
+            settlement_divergences: 0,
             next_generation: 0,
         }
     }
@@ -387,6 +396,9 @@ impl BOB {
                                 "Account {} settled under high-water generation {} but its bytes differ from in-memory (entry generation {:?}); leaving it dirty",
                                 pubkey, generation, entry_generation
                             );
+                            // Counted as well as logged so the divergence is
+                            // alertable, since a log line alone is not.
+                            self.settlement_divergences += 1;
                         }
                     }
                 } else {
@@ -500,8 +512,10 @@ impl BOB {
             dirty_entries: self.dirty_entries,
             bytes: self.cache_bytes,
             evicted: self.evicted_delta,
+            settlement_divergences: self.settlement_divergences,
         };
         self.evicted_delta = 0;
+        self.settlement_divergences = 0;
         stats
     }
 }
@@ -524,6 +538,7 @@ impl BOB {
             evicted_delta: 0,
             dirty_entries: 0,
             cache_bytes: 0,
+            settlement_divergences: 0,
             next_generation: 0,
         }
     }
@@ -754,10 +769,6 @@ mod tests {
     fn executed_output(
         accounts: Vec<(Pubkey, AccountSharedData)>,
     ) -> LoadAndExecuteSanitizedTransactionsOutput {
-        use solana_svm::{
-            account_loader::LoadedTransaction,
-            transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
-        };
         LoadAndExecuteSanitizedTransactionsOutput {
             processing_results: vec![Ok(ProcessedTransaction::Executed(Box::new(
                 ExecutedTransaction {
@@ -1075,6 +1086,18 @@ mod tests {
             bob.accounts.get(&pubkey).unwrap().synced_since.is_none(),
             "divergent bytes under a passing generation must leave the entry dirty"
         );
+
+        // The divergence is counted, not only logged, so it can be alerted on.
+        let stats = bob.cache_stats();
+        assert_eq!(
+            stats.settlement_divergences, 1,
+            "a byte divergence must be counted"
+        );
+        assert_eq!(
+            bob.cache_stats().settlement_divergences,
+            0,
+            "the counter drains on read, like the eviction counter"
+        );
     }
 
     /// Live feedback must never mark a tombstone synchronized, even when the
@@ -1228,8 +1251,6 @@ mod tests {
     /// and every account written in a call carries the returned generation.
     #[tokio::test]
     async fn update_accounts_returns_monotonic_generations_starting_at_one() {
-        use solana_sdk::signature::{Keypair, Signer};
-
         let (mut bob, _settled_tx) = create_test_bob();
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -27,10 +27,20 @@
 /// older than `OLDEST_SYNCED_ACCOUNT_AGE` seconds. Generally, hot accounts will
 /// have their `synced_since` updated frequently, so this is a good heuristic to
 /// evict less frequently accessed accounts.
+///
+/// What decides whether `synced_since` may be set at all is the second field,
+/// `generation`. Every account BOB writes is stamped with the ordinal of that
+/// write, and settlement feedback carries a high-water generation meaning
+/// "everything up to here is durable". An entry is only ever marked
+/// synchronized, or dropped if it is a tombstone, when its own generation is
+/// covered by that mark. Account bytes are never the deciding test: closed
+/// accounts are all byte-identical, and a live account can return to a value it
+/// held before, so bytes cannot tell an acknowledgement of this write apart from
+/// an acknowledgement of an older one.
 use {
     crate::{
         accounts::{precompiles::PRECOMPILES, AccountsDB},
-        stages::AccountSettlement,
+        stages::AccountSettlements,
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
@@ -80,6 +90,12 @@ struct AccountWithMeta {
     // HashMap while we keep it in-memory because it will fallback to the
     // AccountsDB.
     deleted: bool,
+    /// Generation of the last executor write to this account, or `None` when the
+    /// executor never wrote it (loaded from the AccountsDB, or injected by a
+    /// test). `Option` rather than a 0 sentinel so "never written" is
+    /// unrepresentable as a real generation and can never satisfy a settlement
+    /// comparison by accident.
+    generation: Option<u64>,
 }
 
 /// How often (in batches) to run the expensive eviction sweep in garbage_collect.
@@ -93,7 +109,7 @@ pub struct BOB {
     /// Precompiles that are always kept in memory (never garbage collected)
     precompiles: HashMap<Pubkey, AccountSharedData>,
     /// Accounts that are coming from settlement
-    settled_accounts_rx: mpsc::UnboundedReceiver<Vec<(Pubkey, AccountSettlement)>>,
+    settled_accounts_rx: mpsc::UnboundedReceiver<AccountSettlements>,
     /// AccountsDB account state
     pub accounts_db: AccountsDB,
     /// Counts preload calls since last eviction sweep
@@ -107,12 +123,16 @@ pub struct BOB {
     dirty_entries: usize,
     /// Running sum of resident account-data bytes; maintained like dirty_entries.
     cache_bytes: usize,
+    /// Ordinal of the next executor write. Needs no synchronization: the
+    /// executor is a single task owning BOB through `&mut self`, so the
+    /// counter is strictly monotonic.
+    next_generation: u64,
 }
 
 impl BOB {
     pub async fn new(
         accounts_db: AccountsDB,
-        settled_accounts_rx: mpsc::UnboundedReceiver<Vec<(Pubkey, AccountSettlement)>>,
+        settled_accounts_rx: mpsc::UnboundedReceiver<AccountSettlements>,
     ) -> Self {
         // Precompile ELFs are parsed once process-wide; see
         // `crate::accounts::precompiles`. Cloning the map is cheap, the
@@ -127,6 +147,7 @@ impl BOB {
             evicted_delta: 0,
             dirty_entries: 0,
             cache_bytes: 0,
+            next_generation: 0,
         }
     }
 
@@ -191,10 +212,13 @@ impl BOB {
                 // A DB-loaded account is byte-identical to the DB, so it is
                 // clean and belongs in the normally-evictable population.
                 // Reserve synced_since=None for execution-produced state.
+                // generation stays None for the same reason: the executor never
+                // wrote this, so no settlement acknowledgement can describe it.
                 let meta = AccountWithMeta {
                     account: account.clone(),
                     synced_since: Some(now),
                     deleted: false,
+                    generation: None,
                 };
                 self.note_added(&meta);
                 if let Some(old) = self.accounts.insert(miss_keys[index], meta) {
@@ -208,12 +232,21 @@ impl BOB {
     }
 
     // TODO: Merge this implementation with the one in the settlement stage
-    /// Called to update the accounts in memory
+    /// Called to update the accounts in memory.
+    ///
+    /// Returns the generation stamped on every account written by this call. Any
+    /// caller whose BOB outlives the batch must hand that generation to the
+    /// settler alongside the same execution output, otherwise the settlement
+    /// acknowledgement can never be matched and the entries stay dirty forever.
+    #[must_use]
     pub fn update_accounts(
         &mut self,
         svm_output: &LoadAndExecuteSanitizedTransactionsOutput,
         transactions: &[SanitizedTransaction],
-    ) {
+    ) -> u64 {
+        self.next_generation += 1;
+        let generation = self.next_generation;
+
         for (tx_index, tx) in svm_output.processing_results.iter().enumerate() {
             let sanitized_transaction = &transactions[tx_index];
             let signature = sanitized_transaction.signature();
@@ -243,6 +276,7 @@ impl BOB {
                                     account: account_data.clone(),
                                     deleted,
                                     synced_since: None,
+                                    generation: Some(generation),
                                 };
                                 self.note_added(&meta);
                                 if let Some(old) = self.accounts.insert(*pubkey, meta) {
@@ -260,6 +294,8 @@ impl BOB {
                 }
             }
         }
+
+        generation
     }
 
     /// Drain the settled accounts channel and periodically evict stale entries.
@@ -271,6 +307,14 @@ impl BOB {
     /// 2. **Eviction sweep** (every `GC_EVICTION_INTERVAL` batches): scan the
     ///    entire HashMap to evict entries that have been synced for longer than
     ///    `OLDEST_SYNCED_ACCOUNT_AGE`. This is O(N) so we avoid it on every batch.
+    ///
+    /// An entry is reconciled only when its generation is covered by the
+    /// acknowledgement's high-water mark, which is what makes the drain safe:
+    /// `entry.generation <= generation` means the database holds exactly the
+    /// value BOB holds, and a greater generation means the executor is ahead so
+    /// the entry must stay dirty. `<=` and not `==` because a tick acknowledges
+    /// every write up to its mark, and equality would strand any account whose
+    /// write was not the tick's last.
     fn garbage_collect(&mut self) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -278,32 +322,58 @@ impl BOB {
             .as_secs();
 
         // Phase 1: always drain the channel to keep dirty/clean state current.
-        while let Ok(account_settlements) = self.settled_accounts_rx.try_recv() {
-            for (pubkey, account_settlement) in account_settlements {
+        while let Ok(AccountSettlements {
+            generation,
+            accounts,
+        }) = self.settled_accounts_rx.try_recv()
+        {
+            for (pubkey, account_settlement) in accounts {
                 if account_settlement.deleted {
                     // We expect the account to exist in-memory because we only
                     // tombstone deleted accounts
-                    match self.accounts.get(&pubkey).map(|account| account.deleted) {
-                        Some(true) => {
+                    match self
+                        .accounts
+                        .get(&pubkey)
+                        .map(|account| (account.deleted, account.generation))
+                    {
+                        // Drop only a tombstone, and only the exact one now durable.
+                        // Closed accounts are byte-identical, so bytes cannot tell
+                        // one close apart from the next.
+                        Some((true, entry_generation))
+                            if entry_generation.is_some_and(|g| g <= generation) =>
+                        {
                             if let Some(old) = self.accounts.remove(&pubkey) {
                                 self.note_removed(&old);
                             }
                         }
-                        Some(false) => {}
+                        // A live entry, or a tombstone newer than this acknowledgement.
+                        Some(_) => {}
                         None => {
                             warn!("Account {} was deleted from in-memory, but we expected it to be tombstoned", pubkey);
                         }
                     }
                 } else if let Some(account) = self.accounts.get_mut(&pubkey) {
-                    if account.deleted || account.account != account_settlement.account {
-                        // In-memory is ahead of the AccountsDB
-                        continue;
-                    }
-                    // The settled bytes match, so this dirty entry is now clean.
-                    let was_dirty = account.synced_since.is_none();
-                    account.synced_since = Some(now);
-                    if was_dirty {
-                        self.dirty_entries = self.dirty_entries.saturating_sub(1);
+                    // A tombstone must never be marked clean: that would make it
+                    // evictable and let a later preload reload the stale row.
+                    if !account.deleted && account.generation.is_some_and(|g| g <= generation) {
+                        if account.account == account_settlement.account {
+                            // The settled bytes match, so this dirty entry is now clean.
+                            let was_dirty = account.synced_since.is_none();
+                            account.synced_since = Some(now);
+                            if was_dirty {
+                                self.dirty_entries = self.dirty_entries.saturating_sub(1);
+                            }
+                        } else {
+                            // A covered generation must imply matching bytes, so a
+                            // mismatch is a bug: BOB's and the settler's independent
+                            // derivations of account state have diverged. Leave the
+                            // entry dirty, which cannot be evicted or reloaded.
+                            let entry_generation = account.generation;
+                            warn!(
+                                "Account {} settled under high-water generation {} but its bytes differ from in-memory (entry generation {:?}); leaving it dirty",
+                                pubkey, generation, entry_generation
+                            );
+                        }
                     }
                 } else {
                     warn!(
@@ -427,7 +497,7 @@ impl BOB {
     /// Test-only constructor — needs private field access so it lives on the type.
     /// The actual test helper that sets up the dummy DB pool is in test_helpers.rs.
     pub(crate) fn new_test(
-        settled_accounts_rx: mpsc::UnboundedReceiver<Vec<(Pubkey, AccountSettlement)>>,
+        settled_accounts_rx: mpsc::UnboundedReceiver<AccountSettlements>,
         accounts_db: AccountsDB,
     ) -> Self {
         Self {
@@ -440,15 +510,21 @@ impl BOB {
             evicted_delta: 0,
             dirty_entries: 0,
             cache_bytes: 0,
+            next_generation: 0,
         }
     }
 
     /// Insert an account directly into BOB's cache (test-only).
+    ///
+    /// The entry gets `generation: None`, so settlement feedback can never
+    /// reconcile it. A test that needs an entry to be reconcilable must write it
+    /// through `update_accounts` or set the generation itself.
     pub(crate) fn insert_account_for_test(&mut self, pubkey: Pubkey, account: AccountSharedData) {
         let meta = AccountWithMeta {
             account,
             synced_since: None,
             deleted: false,
+            generation: None,
         };
         self.note_added(&meta);
         if let Some(old) = self.accounts.insert(pubkey, meta) {
@@ -485,8 +561,11 @@ impl TransactionProcessingCallback for BOB {
 
 #[cfg(test)]
 mod tests {
+    // `AccountSettlement` is imported here rather than at file scope because only
+    // test code names the type directly.
     use {
         super::*,
+        crate::stages::AccountSettlement,
         crate::test_helpers::create_test_sanitized_transaction,
         solana_sdk::account::Account,
         solana_sdk::signature::{Keypair, Signer},
@@ -499,7 +578,7 @@ mod tests {
         solana_timings::ExecuteTimings,
     };
 
-    fn create_test_bob() -> (BOB, mpsc::UnboundedSender<Vec<(Pubkey, AccountSettlement)>>) {
+    fn create_test_bob() -> (BOB, mpsc::UnboundedSender<AccountSettlements>) {
         crate::test_helpers::create_test_bob()
     }
 
@@ -575,7 +654,8 @@ mod tests {
             ),
             vec![(x, token_like(6)), (dest, token_like(4))],
         ));
-        bob.update_accounts(&output, std::slice::from_ref(&tx));
+        // These cases assert the write side effects, not the generation.
+        let _ = bob.update_accounts(&output, std::slice::from_ref(&tx));
 
         assert_eq!(
             token_balance(&bob.get_account_shared_data(&x).expect("X must remain")),
@@ -602,7 +682,8 @@ mod tests {
             Ok(()),
             vec![(x, token_like(6)), (dest, token_like(4))],
         ));
-        bob.update_accounts(&output, std::slice::from_ref(&tx));
+        // These cases assert the write side effects, not the generation.
+        let _ = bob.update_accounts(&output, std::slice::from_ref(&tx));
 
         assert_eq!(
             token_balance(&bob.get_account_shared_data(&x).expect("X present")),
@@ -634,7 +715,8 @@ mod tests {
             ),
             vec![],
         ));
-        bob.update_accounts(&output, std::slice::from_ref(&tx));
+        // These cases assert the write side effects, not the generation.
+        let _ = bob.update_accounts(&output, std::slice::from_ref(&tx));
 
         assert_eq!(
             token_balance(
@@ -653,6 +735,39 @@ mod tests {
             .as_secs()
     }
 
+    /// Single-transaction Executed output carrying `accounts` at the loaded
+    /// transaction's account positions, for driving `update_accounts` directly.
+    fn executed_output(
+        accounts: Vec<(Pubkey, AccountSharedData)>,
+    ) -> LoadAndExecuteSanitizedTransactionsOutput {
+        use solana_svm::{
+            account_loader::LoadedTransaction,
+            transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
+        };
+        LoadAndExecuteSanitizedTransactionsOutput {
+            processing_results: vec![Ok(ProcessedTransaction::Executed(Box::new(
+                ExecutedTransaction {
+                    loaded_transaction: LoadedTransaction {
+                        accounts,
+                        ..Default::default()
+                    },
+                    execution_details: TransactionExecutionDetails {
+                        status: Ok(()),
+                        log_messages: None,
+                        inner_instructions: None,
+                        return_data: None,
+                        executed_units: 0,
+                        accounts_data_len_delta: 0,
+                    },
+                    programs_modified_by_tx: HashMap::new(),
+                },
+            )))],
+            error_metrics: Default::default(),
+            execute_timings: Default::default(),
+            balance_collector: None,
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Invariant C2: BOB MUST be in sync or ahead of DB on disk
     // -----------------------------------------------------------------------
@@ -669,17 +784,21 @@ mod tests {
                 account: account.clone(),
                 synced_since: None,
                 deleted: false,
+                generation: Some(1),
             },
         );
 
         settled_tx
-            .send(vec![(
-                pubkey,
-                AccountSettlement {
-                    account: account.clone(),
-                    deleted: false,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: account.clone(),
+                        deleted: false,
+                    },
+                )],
+            })
             .unwrap();
 
         bob.garbage_collect();
@@ -705,18 +824,22 @@ mod tests {
                 account: newer.clone(),
                 synced_since: None,
                 deleted: false,
+                generation: Some(2),
             },
         );
 
         // Settler sends older (now-stale) feedback
         settled_tx
-            .send(vec![(
-                pubkey,
-                AccountSettlement {
-                    account: older,
-                    deleted: false,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: older,
+                        deleted: false,
+                    },
+                )],
+            })
             .unwrap();
 
         bob.garbage_collect();
@@ -745,18 +868,22 @@ mod tests {
                 account: account.clone(),
                 synced_since: None,
                 deleted: true,
+                generation: Some(2),
             },
         );
 
         // Settler sends non-deleted settlement (from before the delete)
         settled_tx
-            .send(vec![(
-                pubkey,
-                AccountSettlement {
-                    account,
-                    deleted: false,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account,
+                        deleted: false,
+                    },
+                )],
+            })
             .unwrap();
 
         bob.garbage_collect();
@@ -781,18 +908,22 @@ mod tests {
                 account: account.clone(),
                 synced_since: None,
                 deleted: true,
+                generation: Some(1),
             },
         );
 
         // Settler confirms deletion was persisted to DB
         settled_tx
-            .send(vec![(
-                pubkey,
-                AccountSettlement {
-                    account,
-                    deleted: true,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account,
+                        deleted: true,
+                    },
+                )],
+            })
             .unwrap();
 
         bob.garbage_collect();
@@ -801,6 +932,326 @@ mod tests {
             !bob.accounts.contains_key(&pubkey),
             "Tombstoned account must be removed once settler confirms deletion"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Generation-bound settlement feedback
+    // -----------------------------------------------------------------------
+
+    /// A delete acknowledgement whose high-water mark predates the tombstone
+    /// must not drop it. Every closed account is a byte-identical tombstone, so
+    /// only the generation can tell one close apart from the next.
+    #[tokio::test]
+    async fn gc_stale_delete_ack_does_not_remove_newer_tombstone() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+
+        // The tombstone from the second close of this account.
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(0, &[], &Pubkey::default()),
+                synced_since: None,
+                deleted: true,
+                generation: Some(3),
+            },
+        );
+
+        // Acknowledgement for the first close: durable only up to generation 1.
+        settled_tx
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: make_account(0, &[], &Pubkey::default()),
+                        deleted: true,
+                    },
+                )],
+            })
+            .unwrap();
+
+        bob.garbage_collect();
+
+        let meta = bob
+            .accounts
+            .get(&pubkey)
+            .expect("a stale delete ack must not remove the newer tombstone");
+        assert!(meta.deleted, "the entry must still be a tombstone");
+        assert!(
+            meta.synced_since.is_none(),
+            "a tombstone BOB is ahead on must stay non-evictable"
+        );
+    }
+
+    /// Bytes cannot be the gate: an account that went A to B and back to A lets
+    /// a stale acknowledgement match on bytes and wrongly mark BOB clean, which
+    /// makes an entry that is newer than the database evictable.
+    #[tokio::test]
+    async fn gc_stale_ack_with_identical_bytes_does_not_mark_synced() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        let bytes_a = make_account(1000, &[1, 2, 3], &Pubkey::default());
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: bytes_a.clone(),
+                synced_since: None,
+                deleted: false,
+                generation: Some(5),
+            },
+        );
+
+        settled_tx
+            .send(AccountSettlements {
+                generation: 3,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: bytes_a,
+                        deleted: false,
+                    },
+                )],
+            })
+            .unwrap();
+
+        bob.garbage_collect();
+
+        assert!(
+            bob.accounts.get(&pubkey).unwrap().synced_since.is_none(),
+            "an ack predating the entry's generation must not mark it synced, byte-identical or not"
+        );
+    }
+
+    /// The generation test passing while the bytes disagree means BOB and the
+    /// settler derived different state for the same write. Fail closed: leave
+    /// the entry dirty so it can be neither evicted nor reloaded.
+    #[tokio::test]
+    async fn gc_current_generation_with_divergent_bytes_leaves_entry_dirty() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(1000, &[1], &Pubkey::default()),
+                synced_since: None,
+                deleted: false,
+                generation: Some(2),
+            },
+        );
+
+        settled_tx
+            .send(AccountSettlements {
+                generation: 2,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: make_account(1000, &[2], &Pubkey::default()),
+                        deleted: false,
+                    },
+                )],
+            })
+            .unwrap();
+
+        bob.garbage_collect();
+
+        assert!(
+            bob.accounts.get(&pubkey).unwrap().synced_since.is_none(),
+            "divergent bytes under a passing generation must leave the entry dirty"
+        );
+    }
+
+    /// Live feedback must never mark a tombstone synchronized, even when the
+    /// high-water mark has caught up. A synchronized tombstone is evictable, and
+    /// the next preload would reload the stale database row.
+    #[tokio::test]
+    async fn gc_current_live_ack_does_not_mark_tombstone_synced() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        let tombstone = make_account(0, &[], &Pubkey::default());
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: tombstone.clone(),
+                synced_since: None,
+                deleted: true,
+                generation: Some(3),
+            },
+        );
+
+        settled_tx
+            .send(AccountSettlements {
+                generation: 4,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: tombstone,
+                        deleted: false,
+                    },
+                )],
+            })
+            .unwrap();
+
+        bob.garbage_collect();
+
+        let meta = bob.accounts.get(&pubkey).expect("tombstone must stay");
+        assert!(meta.deleted, "the entry must still be a tombstone");
+        assert!(
+            meta.synced_since.is_none(),
+            "a tombstone must stay non-evictable"
+        );
+    }
+
+    /// The mirror of `gc_current_live_ack_does_not_mark_tombstone_synced`: delete
+    /// feedback must never remove a live entry, even when the mark has caught up.
+    #[tokio::test]
+    async fn gc_current_delete_ack_does_not_remove_live_entry() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let pubkey = Pubkey::new_unique();
+        let live = make_account(1000, &[1, 2, 3], &Pubkey::default());
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: live.clone(),
+                synced_since: None,
+                deleted: false,
+                generation: Some(3),
+            },
+        );
+
+        settled_tx
+            .send(AccountSettlements {
+                generation: 4,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: make_account(0, &[], &Pubkey::default()),
+                        deleted: true,
+                    },
+                )],
+            })
+            .unwrap();
+
+        bob.garbage_collect();
+
+        let meta = bob
+            .accounts
+            .get(&pubkey)
+            .expect("a delete ack must not remove a live entry");
+        assert!(!meta.deleted, "the live entry must not become a tombstone");
+        assert_eq!(meta.account, live, "the live account must be unchanged");
+    }
+
+    /// The comparison is `<=`, not `==`: a tick acknowledges every write up to
+    /// its mark, so an entry whose write was not that tick's last must still
+    /// reconcile. Both halves of this test fail if the comparison narrows.
+    #[tokio::test]
+    async fn gc_reconciles_entry_older_than_high_water_mark() {
+        let (mut bob, settled_tx) = create_test_bob();
+        let live_key = Pubkey::new_unique();
+        let tombstone_key = Pubkey::new_unique();
+        let live = make_account(1000, &[1, 2, 3], &Pubkey::default());
+
+        bob.accounts.insert(
+            live_key,
+            AccountWithMeta {
+                account: live.clone(),
+                synced_since: None,
+                deleted: false,
+                generation: Some(2),
+            },
+        );
+        bob.accounts.insert(
+            tombstone_key,
+            AccountWithMeta {
+                account: make_account(0, &[], &Pubkey::default()),
+                synced_since: None,
+                deleted: true,
+                generation: Some(3),
+            },
+        );
+
+        // One tick made every generation up to 5 durable, so both entries are covered.
+        settled_tx
+            .send(AccountSettlements {
+                generation: 5,
+                accounts: vec![
+                    (
+                        live_key,
+                        AccountSettlement {
+                            account: live,
+                            deleted: false,
+                        },
+                    ),
+                    (
+                        tombstone_key,
+                        AccountSettlement {
+                            account: make_account(0, &[], &Pubkey::default()),
+                            deleted: true,
+                        },
+                    ),
+                ],
+            })
+            .unwrap();
+
+        bob.garbage_collect();
+
+        assert!(
+            bob.accounts.get(&live_key).unwrap().synced_since.is_some(),
+            "a live entry older than the high-water mark must be marked synced"
+        );
+        assert!(
+            !bob.accounts.contains_key(&tombstone_key),
+            "a tombstone older than the high-water mark must be dropped"
+        );
+    }
+
+    /// Generations start at 1 and increase by one per `update_accounts` call,
+    /// and every account written in a call carries the returned generation.
+    #[tokio::test]
+    async fn update_accounts_returns_monotonic_generations_starting_at_one() {
+        use solana_sdk::signature::{Keypair, Signer};
+
+        let (mut bob, _settled_tx) = create_test_bob();
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        // A system transfer has writable accounts at indices 0 and 1.
+        let tx = crate::test_helpers::create_test_sanitized_transaction(&payer, &recipient, 100);
+
+        let first = executed_output(vec![
+            (payer.pubkey(), make_account(900, &[9], &Pubkey::default())),
+            (recipient, make_account(100, &[1], &Pubkey::default())),
+        ]);
+        let first_generation = bob.update_accounts(&first, std::slice::from_ref(&tx));
+        assert_eq!(
+            first_generation, 1,
+            "the first executor write is generation 1"
+        );
+        for key in [payer.pubkey(), recipient] {
+            assert_eq!(
+                bob.accounts.get(&key).unwrap().generation,
+                Some(first_generation),
+                "every account written must carry the returned generation"
+            );
+        }
+
+        let second = executed_output(vec![
+            (payer.pubkey(), make_account(800, &[8], &Pubkey::default())),
+            (recipient, make_account(200, &[2], &Pubkey::default())),
+        ]);
+        let second_generation = bob.update_accounts(&second, std::slice::from_ref(&tx));
+        assert_eq!(second_generation, 2, "generations increase by one per call");
+        for key in [payer.pubkey(), recipient] {
+            assert_eq!(
+                bob.accounts.get(&key).unwrap().generation,
+                Some(second_generation),
+                "a rewrite must raise the account's generation"
+            );
+        }
     }
 
     #[tokio::test]
@@ -812,8 +1263,9 @@ mod tests {
             pubkey,
             AccountWithMeta {
                 account: make_account(1000, &[1], &Pubkey::default()),
-                synced_since: None, // Ahead of DB — must never be evicted
+                synced_since: None, // Ahead of DB, must never be evicted
                 deleted: false,
+                generation: Some(1),
             },
         );
 
@@ -836,6 +1288,7 @@ mod tests {
                 account: make_account(1000, &[1], &Pubkey::default()),
                 synced_since: Some(now_secs() - OLDEST_SYNCED_ACCOUNT_AGE - 1),
                 deleted: false,
+                generation: Some(1),
             },
         );
 
@@ -860,6 +1313,7 @@ mod tests {
                 account: make_account(1000, &[1], &Pubkey::default()),
                 synced_since: Some(now_secs()),
                 deleted: false,
+                generation: Some(1),
             },
         );
 
@@ -868,40 +1322,6 @@ mod tests {
         assert!(
             bob.accounts.contains_key(&pubkey),
             "Recently synced accounts must not be evicted"
-        );
-    }
-
-    #[test]
-    fn preload_or_insert_preserves_inflight_state() {
-        // Directly tests the HashMap pattern used by preload_accounts.
-        // Verifies that entry().or_insert_with() does not overwrite
-        // an existing in-flight account with stale DB data.
-        let mut accounts: HashMap<Pubkey, AccountWithMeta> = HashMap::new();
-        let pubkey = Pubkey::new_unique();
-
-        let newer = make_account(2000, &[9, 9], &Pubkey::default());
-        let older_from_db = make_account(1000, &[1, 2], &Pubkey::default());
-
-        // Executor already wrote newer state
-        accounts.insert(
-            pubkey,
-            AccountWithMeta {
-                account: newer.clone(),
-                synced_since: None,
-                deleted: false,
-            },
-        );
-
-        // Simulate what preload_accounts does with DB results
-        accounts.entry(pubkey).or_insert_with(|| AccountWithMeta {
-            account: older_from_db,
-            synced_since: None,
-            deleted: false,
-        });
-
-        assert_eq!(
-            accounts[&pubkey].account, newer,
-            "or_insert_with must not overwrite existing in-flight state"
         );
     }
 
@@ -922,18 +1342,22 @@ mod tests {
                 account: v1.clone(),
                 synced_since: None,
                 deleted: false,
+                generation: Some(1),
             },
         );
 
         // Step 2: Settler settles v1 and sends feedback
         settled_tx
-            .send(vec![(
-                pubkey,
-                AccountSettlement {
-                    account: v1,
-                    deleted: false,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: v1,
+                        deleted: false,
+                    },
+                )],
+            })
             .unwrap();
 
         // Step 3: Before GC runs, executor updates BOB to v2
@@ -943,6 +1367,7 @@ mod tests {
                 account: v2.clone(),
                 synced_since: None,
                 deleted: false,
+                generation: Some(2),
             },
         );
 
@@ -976,27 +1401,34 @@ mod tests {
                 account: v3.clone(),
                 synced_since: None,
                 deleted: false,
+                generation: Some(3),
             },
         );
 
         // Two settlement batches queue up before GC runs
         settled_tx
-            .send(vec![(
-                pubkey,
-                AccountSettlement {
-                    account: v1,
-                    deleted: false,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: v1,
+                        deleted: false,
+                    },
+                )],
+            })
             .unwrap();
         settled_tx
-            .send(vec![(
-                pubkey,
-                AccountSettlement {
-                    account: v2,
-                    deleted: false,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 2,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: v2,
+                        deleted: false,
+                    },
+                )],
+            })
             .unwrap();
 
         bob.garbage_collect();
@@ -1019,13 +1451,16 @@ mod tests {
 
         // Settler sends feedback for an account that was never in BOB
         settled_tx
-            .send(vec![(
-                missing_pubkey,
-                AccountSettlement {
-                    account: make_account(1000, &[1], &Pubkey::default()),
-                    deleted: false,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    missing_pubkey,
+                    AccountSettlement {
+                        account: make_account(1000, &[1], &Pubkey::default()),
+                        deleted: false,
+                    },
+                )],
+            })
             .unwrap();
 
         // Should not panic; just logs a warning
@@ -1052,6 +1487,7 @@ mod tests {
                 account: make_account(100, &[1], &Pubkey::default()),
                 synced_since: Some(now - OLDEST_SYNCED_ACCOUNT_AGE - 1),
                 deleted: false,
+                generation: Some(1),
             },
         );
         bob.accounts.insert(
@@ -1060,6 +1496,7 @@ mod tests {
                 account: make_account(200, &[2], &Pubkey::default()),
                 synced_since: Some(now),
                 deleted: false,
+                generation: Some(2),
             },
         );
         bob.accounts.insert(
@@ -1068,6 +1505,7 @@ mod tests {
                 account: make_account(300, &[3], &Pubkey::default()),
                 synced_since: None,
                 deleted: false,
+                generation: Some(3),
             },
         );
 
@@ -1094,13 +1532,14 @@ mod tests {
         let (mut bob, _settled_tx) = create_test_bob();
         let pubkey = Pubkey::new_unique();
 
-        // synced_since + OLDEST_SYNCED_ACCOUNT_AGE == now → should be kept (>= check)
+        // synced_since + OLDEST_SYNCED_ACCOUNT_AGE == now, so it should be kept (>= check)
         bob.accounts.insert(
             pubkey,
             AccountWithMeta {
                 account: make_account(1000, &[1], &Pubkey::default()),
                 synced_since: Some(now_secs() - OLDEST_SYNCED_ACCOUNT_AGE),
                 deleted: false,
+                generation: Some(1),
             },
         );
 
@@ -1122,6 +1561,7 @@ mod tests {
                 account: make_account(1000, &[1], &Pubkey::default()),
                 synced_since: None,
                 deleted: true,
+                generation: Some(1),
             },
         );
 
@@ -1143,6 +1583,7 @@ mod tests {
                 account: account.clone(),
                 synced_since: None,
                 deleted: false,
+                generation: Some(1),
             },
         );
 
@@ -1170,6 +1611,7 @@ mod tests {
                 account: make_account(1000, &[1], &Pubkey::default()),
                 synced_since: Some(now - 1800),
                 deleted: false,
+                generation: None,
             },
         );
 
@@ -1194,6 +1636,7 @@ mod tests {
                 account: make_account(1000, &[1], &Pubkey::default()),
                 synced_since: None,
                 deleted: false,
+                generation: None,
             },
         );
 
@@ -1222,6 +1665,7 @@ mod tests {
                     account: make_account(1, &[1], &Pubkey::default()),
                     synced_since: Some(now - 100 + i), // strictly increasing recency
                     deleted: false,
+                    generation: None,
                 },
             );
         }
@@ -1259,6 +1703,7 @@ mod tests {
                     account: make_account(1, &[1], &Pubkey::default()),
                     synced_since: None,
                     deleted: false,
+                    generation: None,
                 },
             );
         }
@@ -1288,6 +1733,7 @@ mod tests {
                     account: make_account(1, &[1], &Pubkey::default()),
                     synced_since: Some(stale),
                     deleted: false,
+                    generation: None,
                 },
             );
         }
@@ -1299,6 +1745,7 @@ mod tests {
                 account: make_account(1, &[1], &Pubkey::default()),
                 synced_since: Some(stale),
                 deleted: false,
+                generation: None,
             },
         );
 
@@ -1323,6 +1770,7 @@ mod tests {
                 account: make_account(1, &[0u8; 5], &Pubkey::default()),
                 synced_since: Some(now - OLDEST_SYNCED_ACCOUNT_AGE - 1),
                 deleted: false,
+                generation: None,
             },
         );
         // Two recent clean entries (kept), data lengths 3 and 7.
@@ -1332,6 +1780,7 @@ mod tests {
                 account: make_account(1, &[1u8; 3], &Pubkey::default()),
                 synced_since: Some(now),
                 deleted: false,
+                generation: None,
             },
         );
         bob.accounts.insert(
@@ -1340,6 +1789,7 @@ mod tests {
                 account: make_account(1, &[2u8; 7], &Pubkey::default()),
                 synced_since: Some(now),
                 deleted: false,
+                generation: None,
             },
         );
         // One dirty entry (kept), data length 4.
@@ -1349,6 +1799,7 @@ mod tests {
                 account: make_account(1, &[3u8; 4], &Pubkey::default()),
                 synced_since: None,
                 deleted: false,
+                generation: None,
             },
         );
 
@@ -1377,7 +1828,16 @@ mod tests {
         let (mut bob, settled_tx) = create_test_bob();
         let a = Pubkey::new_unique();
         let account_a = make_account(1, &[0u8; 5], &Pubkey::default());
-        bob.insert_account_for_test(a, account_a.clone());
+        // Given a generation so settlement feedback can reconcile it;
+        // insert_account_for_test deliberately leaves the generation unset.
+        let meta = AccountWithMeta {
+            account: account_a.clone(),
+            synced_since: None,
+            deleted: false,
+            generation: Some(1),
+        };
+        bob.note_added(&meta);
+        bob.accounts.insert(a, meta);
         bob.insert_account_for_test(
             Pubkey::new_unique(),
             make_account(1, &[0u8; 3], &Pubkey::default()),
@@ -1391,13 +1851,16 @@ mod tests {
 
         // Settling `a` matches its in-memory bytes, flipping it clean with no sweep.
         settled_tx
-            .send(vec![(
-                a,
-                AccountSettlement {
-                    account: account_a,
-                    deleted: false,
-                },
-            )])
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    a,
+                    AccountSettlement {
+                        account: account_a,
+                        deleted: false,
+                    },
+                )],
+            })
             .unwrap();
         bob.garbage_collect();
 
@@ -1445,6 +1908,207 @@ mod tests {
         assert!(
             !bob.accounts.contains_key(&pubkey),
             "a clean DB-loaded account is age-evictable, no longer pinned in memory"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration: drain, cache-miss calculation and database read in one call
+    // -----------------------------------------------------------------------
+
+    /// The full resurrection path. A stale delete acknowledgement drops the
+    /// tombstone, and the database read that later fills the resulting cache
+    /// miss returns the row the close was supposed to remove. The drain runs
+    /// after this batch's hit/miss split, so an erased tombstone only becomes a
+    /// miss on the following batch; both batches are driven here so the whole
+    /// path is covered rather than only its first half.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preload_does_not_resurrect_account_after_stale_delete_ack() {
+        let (mut bob, settled_tx, _pg) = crate::test_helpers::create_test_bob_with_postgres().await;
+        let pubkey = Pubkey::new_unique();
+        let funded = make_account(1_000, &[7, 7, 7], &Pubkey::default());
+
+        // Premise: the database really does hold the stale funded row.
+        bob.accounts_db.set_account(pubkey, funded).await;
+        assert!(
+            bob.accounts_db
+                .get_account_shared_data(&pubkey)
+                .await
+                .is_some(),
+            "the stale funded row must be in the database for this test to mean anything"
+        );
+
+        // BOB holds the tombstone from the second close.
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(0, &[], &Pubkey::default()),
+                synced_since: None,
+                deleted: true,
+                generation: Some(3),
+            },
+        );
+
+        // Acknowledgement for the first close, durable only up to generation 1.
+        settled_tx
+            .send(AccountSettlements {
+                generation: 1,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: make_account(0, &[], &Pubkey::default()),
+                        deleted: true,
+                    },
+                )],
+            })
+            .unwrap();
+
+        let (fetched, cached) = bob.preload_accounts(&[pubkey]).await;
+        assert_eq!(
+            (fetched, cached),
+            (0, 1),
+            "the resident tombstone is a cache hit, so no database read happens"
+        );
+        assert!(
+            bob.accounts.get(&pubkey).is_some_and(|meta| meta.deleted),
+            "the tombstone must survive a stale delete acknowledgement"
+        );
+
+        // Had the tombstone been erased above, this is the batch where the
+        // funded row would be read back in.
+        let (fetched, cached) = bob.preload_accounts(&[pubkey]).await;
+        assert_eq!(
+            (fetched, cached),
+            (0, 1),
+            "the tombstone is still resident, so still no database read"
+        );
+        assert!(
+            bob.accounts.get(&pubkey).is_some_and(|meta| meta.deleted),
+            "the tombstone must still be there on the following batch"
+        );
+        assert!(
+            TransactionProcessingCallback::get_account_shared_data(&bob, &pubkey).is_none(),
+            "the closed account must never become readable again"
+        );
+    }
+
+    /// Legitimate cleanup still completes, so tombstones are not leaked: once the
+    /// high-water mark reaches the tombstone's generation the entry is dropped.
+    /// The drop happens after this batch's hit/miss split, so the key still
+    /// counts as a hit here and the database is not read.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preload_removes_tombstone_when_ack_is_current() {
+        let (mut bob, settled_tx, _pg) = crate::test_helpers::create_test_bob_with_postgres().await;
+        let pubkey = Pubkey::new_unique();
+
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: make_account(0, &[], &Pubkey::default()),
+                synced_since: None,
+                deleted: true,
+                generation: Some(3),
+            },
+        );
+
+        settled_tx
+            .send(AccountSettlements {
+                generation: 3,
+                accounts: vec![(
+                    pubkey,
+                    AccountSettlement {
+                        account: make_account(0, &[], &Pubkey::default()),
+                        deleted: true,
+                    },
+                )],
+            })
+            .unwrap();
+
+        let (fetched, cached) = bob.preload_accounts(&[pubkey]).await;
+
+        assert!(
+            !bob.accounts.contains_key(&pubkey),
+            "a tombstone the database has caught up with must be dropped"
+        );
+        assert_eq!(
+            (fetched, cached),
+            (0, 1),
+            "the tombstone was still resident when the split ran, so it counted as a hit"
+        );
+        assert!(
+            TransactionProcessingCallback::get_account_shared_data(&bob, &pubkey).is_none(),
+            "the closed account must stay unreadable"
+        );
+    }
+
+    /// The fetch path is unregressed and stamps `None`: rows loaded from the
+    /// database were never written by the executor, so they can never satisfy a
+    /// settlement comparison.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preload_stamps_fetched_accounts_with_no_generation() {
+        let (mut bob, _settled_tx, _pg) =
+            crate::test_helpers::create_test_bob_with_postgres().await;
+        let pubkey = Pubkey::new_unique();
+        let stored = make_account(1_000, &[4, 5, 6], &Pubkey::default());
+
+        bob.accounts_db.set_account(pubkey, stored.clone()).await;
+
+        let (fetched, cached) = bob.preload_accounts(&[pubkey]).await;
+
+        assert_eq!(
+            (fetched, cached),
+            (1, 0),
+            "the account must be a cache miss"
+        );
+        let meta = bob
+            .accounts
+            .get(&pubkey)
+            .expect("fetched account is cached");
+        assert_eq!(meta.account, stored);
+        assert_eq!(
+            meta.generation, None,
+            "a database-loaded entry has no executor generation"
+        );
+    }
+
+    /// A warm entry the executor is ahead on is never refetched and never
+    /// overwritten by the older database row. `preload_accounts` only reads keys
+    /// it has proven absent, and a clobbered entry would be worse than stale: it
+    /// would carry no generation, so no acknowledgement could ever correct it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preload_does_not_clobber_a_warm_entry_with_a_stale_row() {
+        let (mut bob, _settled_tx, _pg) =
+            crate::test_helpers::create_test_bob_with_postgres().await;
+        let pubkey = Pubkey::new_unique();
+        let older = make_account(1_000, &[1], &Pubkey::default());
+        let newer = make_account(2_000, &[9], &Pubkey::default());
+
+        bob.accounts_db.set_account(pubkey, older).await;
+        bob.accounts.insert(
+            pubkey,
+            AccountWithMeta {
+                account: newer.clone(),
+                synced_since: None,
+                deleted: false,
+                generation: Some(4),
+            },
+        );
+
+        let (fetched, cached) = bob.preload_accounts(&[pubkey]).await;
+
+        assert_eq!(
+            (fetched, cached),
+            (0, 1),
+            "a warm entry must be a cache hit, with no database read"
+        );
+        let meta = bob.accounts.get(&pubkey).expect("warm entry must survive");
+        assert_eq!(
+            meta.account, newer,
+            "the newer in-memory state must survive"
+        );
+        assert_eq!(meta.generation, Some(4), "the generation must survive");
+        assert!(
+            meta.synced_since.is_none(),
+            "an entry ahead of the database must stay dirty"
         );
     }
 }

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -14,13 +14,12 @@ use {
             sequencer::start_sequence_worker,
             settle::start_settle_worker,
             sigverify::start_sigverify_workerpool,
-            AccountSettlement,
+            AccountSettlements, ExecutedBatch,
         },
     },
     futures::future::FutureExt,
     solana_hash::Hash,
     solana_sdk::{pubkey::Pubkey, transaction::SanitizedTransaction},
-    solana_svm::transaction_processor::LoadAndExecuteSanitizedTransactionsOutput,
     std::{sync::Arc, time::Duration},
     tokio::{sync::mpsc, task::JoinHandle},
     tokio_util::sync::CancellationToken,
@@ -184,14 +183,11 @@ pub async fn run_node(config: NodeConfig) -> Result<NodeHandles, Box<dyn std::er
 
             // Create execution results channel between executor and settler (bounded for back-pressure)
             let (execution_results_tx, execution_results_rx) =
-                mpsc::channel::<(
-                    LoadAndExecuteSanitizedTransactionsOutput,
-                    Vec<SanitizedTransaction>,
-                )>(config.execution_results_capacity);
+                mpsc::channel::<ExecutedBatch>(config.execution_results_capacity);
 
             // Create settled accounts channel between settler and executor
             let (settled_accounts_tx, settled_accounts_rx) =
-                mpsc::unbounded_channel::<Vec<(Pubkey, AccountSettlement)>>();
+                mpsc::unbounded_channel::<AccountSettlements>();
 
             // Create settled blockhashes channel between settler and dedup
             let (settled_blockhashes_tx, settled_blockhashes_rx) =

--- a/core/src/stage_metrics.rs
+++ b/core/src/stage_metrics.rs
@@ -38,6 +38,9 @@ pub trait StageMetrics: Send + Sync {
     fn bob_cache_dirty_entries(&self, count: usize);
     fn bob_cache_bytes(&self, bytes: usize);
     fn bob_cache_evicted(&self, count: usize);
+    /// Settlement acknowledgements whose generation matched but whose bytes did
+    /// not. Non-zero means BOB and the settler have diverged; alert on any.
+    fn bob_settlement_divergences(&self, count: usize);
 
     // Settler
     fn settler_txs_settled(&self, count: usize);
@@ -127,6 +130,9 @@ impl StageMetrics for NoopMetrics {
     }
     fn bob_cache_evicted(&self, count: usize) {
         debug!("bob: cache_evicted={}", count);
+    }
+    fn bob_settlement_divergences(&self, count: usize) {
+        debug!("bob: settlement_divergences={}", count);
     }
     fn settler_txs_settled(&self, n: usize) {
         debug!("settler: settled {}", n);
@@ -276,6 +282,12 @@ counter_vec!(
     BOB_CACHE_EVICTED,
     "private_channel_bob_cache_evicted_total",
     "BOB account-cache entries evicted (age sweep + hard cap)",
+    &[]
+);
+counter_vec!(
+    BOB_SETTLEMENT_DIVERGENCES,
+    "private_channel_bob_settlement_divergences_total",
+    "Settled accounts whose generation was covered but whose bytes differed from BOB (always 0 unless the executor and settler have diverged)",
     &[]
 );
 gauge_vec!(
@@ -451,6 +463,11 @@ impl StageMetrics for PrometheusMetrics {
     }
     fn bob_cache_evicted(&self, count: usize) {
         BOB_CACHE_EVICTED
+            .with_label_values(&[] as &[&str])
+            .inc_by(count as f64);
+    }
+    fn bob_settlement_divergences(&self, count: usize) {
+        BOB_SETTLEMENT_DIVERGENCES
             .with_label_values(&[] as &[&str])
             .inc_by(count as f64);
     }

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -600,6 +600,7 @@ pub async fn execute_batch(
     metrics.bob_cache_dirty_entries(cache_stats.dirty_entries);
     metrics.bob_cache_bytes(cache_stats.bytes);
     metrics.bob_cache_evicted(cache_stats.evicted);
+    metrics.bob_settlement_divergences(cache_stats.settlement_divergences);
 
     // Refresh the SVM's cached Clock sysvar from wall time. Contra has no
     // real Clock source (see `crate::vm::clock`); without this, programs

--- a/core/src/stages/execution.rs
+++ b/core/src/stages/execution.rs
@@ -8,7 +8,7 @@ use {
         },
         scheduler::ConflictFreeBatch,
         stage_metrics::SharedMetrics,
-        stages::AccountSettlement,
+        stages::{AccountSettlements, ExecutedBatch},
         transactions::is_admin_instruction,
         vm::{
             admin::AdminVm,
@@ -21,7 +21,6 @@ use {
     solana_sdk::{
         account::{ReadableAccount, WritableAccount},
         hash::Hash,
-        pubkey::Pubkey,
         transaction::SanitizedTransaction,
     },
     solana_svm::{
@@ -54,11 +53,8 @@ const MIN_PARALLEL_BATCH_FACTOR: usize = 4;
 
 pub struct ExecutionArgs {
     pub batch_rx: mpsc::Receiver<ConflictFreeBatch>,
-    pub settled_accounts_rx: mpsc::UnboundedReceiver<Vec<(Pubkey, AccountSettlement)>>,
-    pub execution_results_tx: mpsc::Sender<(
-        LoadAndExecuteSanitizedTransactionsOutput,
-        Vec<SanitizedTransaction>,
-    )>,
+    pub settled_accounts_rx: mpsc::UnboundedReceiver<AccountSettlements>,
+    pub execution_results_tx: mpsc::Sender<ExecutedBatch>,
     pub accountsdb_connection_url: String,
     pub shutdown_token: CancellationToken,
     pub metrics: SharedMetrics,
@@ -91,6 +87,13 @@ pub struct ExecutionResult {
     pub regular_transactions: Vec<SanitizedTransaction>,
     pub admin_results: Option<LoadAndExecuteSanitizedTransactionsOutput>,
     pub regular_results: Option<LoadAndExecuteSanitizedTransactionsOutput>,
+    /// BOB generation stamped on the admin path's account writes, 0 when the
+    /// path was skipped. A plain field rather than part of `admin_results` so
+    /// that reading the results does not force callers to unwrap a pair.
+    pub admin_generation: u64,
+    /// BOB generation stamped on the regular path's account writes, 0 when the
+    /// path was skipped.
+    pub regular_generation: u64,
 }
 
 pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
@@ -150,7 +153,7 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                                     // settler queue never wedges executor exit. Owned values only,
                                     // no lock guard is held across this await.
                                     tokio::select! {
-                                        send_result = execution_results_tx.send((admin_results, execution_result.admin_transactions)) => {
+                                        send_result = execution_results_tx.send((admin_results, execution_result.admin_transactions, execution_result.admin_generation)) => {
                                             if let Err(e) = send_result {
                                                 metrics.executor_results_send_failed("admin");
                                                 error!("Failed to send admin results: {:?}", e);
@@ -173,7 +176,7 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
                                 if let Some(regular_results) = execution_result.regular_results {
                                     let len = execution_result.regular_transactions.len();
                                     tokio::select! {
-                                        send_result = execution_results_tx.send((regular_results, execution_result.regular_transactions)) => {
+                                        send_result = execution_results_tx.send((regular_results, execution_result.regular_transactions, execution_result.regular_generation)) => {
                                             if let Err(e) = send_result {
                                                 metrics.executor_results_send_failed("regular");
                                                 error!("Failed to send regular results: {:?}", e);
@@ -224,7 +227,7 @@ pub async fn start_execution_worker(args: ExecutionArgs) -> WorkerHandle {
 
 pub async fn get_execution_deps(
     accounts_db: AccountsDB,
-    settled_accounts_rx: mpsc::UnboundedReceiver<Vec<(Pubkey, AccountSettlement)>>,
+    settled_accounts_rx: mpsc::UnboundedReceiver<AccountSettlements>,
     max_svm_workers: usize,
     live_blockhashes: Arc<RwLock<LinkedList<Hash>>>,
 ) -> ExecutionDeps {
@@ -581,6 +584,12 @@ pub async fn execute_batch(
     let mut t_svm_reg = Duration::ZERO;
     let mut t_bob_reg = Duration::ZERO;
 
+    // Generations stamped by each path's BOB update. They stay 0 when that path
+    // is skipped, which the settler's max() fold and BOB's high-water comparison
+    // both treat as "acknowledges nothing".
+    let mut admin_generation = 0u64;
+    let mut regular_generation = 0u64;
+
     // Settle admin transactions immediately so regular transactions see the updates
     let admin_results = if !admin_transactions.is_empty() {
         let t_op = Instant::now();
@@ -602,7 +611,7 @@ pub async fn execute_batch(
 
         // Update BOB's in-memory accounts with the execution results
         let t_op = Instant::now();
-        execution_deps
+        admin_generation = execution_deps
             .bob
             .update_accounts(&admin_results, &admin_transactions);
         t_bob_admin = t_op.elapsed();
@@ -684,7 +693,7 @@ pub async fn execute_batch(
 
         // Update BOB's in-memory accounts with the execution results
         let t_op = Instant::now();
-        execution_deps
+        regular_generation = execution_deps
             .bob
             .update_accounts(&regular_results, &regular_transactions);
         t_bob_reg = t_op.elapsed();
@@ -718,6 +727,8 @@ pub async fn execute_batch(
         regular_transactions,
         admin_results,
         regular_results,
+        admin_generation,
+        regular_generation,
     }
 }
 
@@ -1092,6 +1103,15 @@ mod tests {
         let spend = run_batch(&mut deps, &metrics, vec![transfer(&a, &r, 10)]).await;
         assert!(is_executed(regular_result(&spend, 0)));
         assert!(bob_balance(&deps.bob, &r).is_none_or(|l| l == 0));
+
+        // Monotonicity survives the trip through ExecutionResult: a later batch
+        // always reports a strictly higher generation than an earlier one.
+        assert!(
+            spend.regular_generation > setup.regular_generation,
+            "generation must strictly increase across batches ({} then {})",
+            setup.regular_generation,
+            spend.regular_generation
+        );
     }
 
     /// Synthetic fee payer is dropped: any synthetic-payer system transfer →
@@ -1585,10 +1605,8 @@ mod tests {
 
         let (_batch_tx, batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
         let (_settled_tx, settled_rx) = mpsc::unbounded_channel();
-        let (execution_results_tx, _execution_results_rx) = mpsc::channel::<(
-            LoadAndExecuteSanitizedTransactionsOutput,
-            Vec<SanitizedTransaction>,
-        )>(RESULTS_CAP);
+        let (execution_results_tx, _execution_results_rx) =
+            mpsc::channel::<ExecutedBatch>(RESULTS_CAP);
         let shutdown = CancellationToken::new();
 
         let handle = start_execution_worker(ExecutionArgs {
@@ -1913,10 +1931,8 @@ mod tests {
 
         let (batch_tx, batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
         let (_settled_tx, settled_rx) = mpsc::unbounded_channel();
-        let (execution_results_tx, _execution_results_rx) = mpsc::channel::<(
-            LoadAndExecuteSanitizedTransactionsOutput,
-            Vec<SanitizedTransaction>,
-        )>(RESULTS_CAP);
+        let (execution_results_tx, _execution_results_rx) =
+            mpsc::channel::<ExecutedBatch>(RESULTS_CAP);
         let shutdown = CancellationToken::new();
 
         let handle = start_execution_worker(ExecutionArgs {
@@ -2025,6 +2041,17 @@ mod tests {
         assert_eq!(result.regular_transactions.len(), 1);
         assert!(result.admin_results.is_some());
         assert!(result.regular_results.is_some());
+        // Each path gets its own BOB write, so each gets its own generation.
+        // Exact values, because the admin path must be settled before the
+        // regular path so regular transactions observe the admin updates.
+        assert_eq!(
+            result.admin_generation, 1,
+            "the admin BOB update must come first"
+        );
+        assert_eq!(
+            result.regular_generation, 2,
+            "the regular BOB update must follow the admin one"
+        );
     }
 
     // A full results channel blocks the executor's send (backpressure) without
@@ -2037,10 +2064,7 @@ mod tests {
 
         let (batch_tx, batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
         let (_settled_tx, settled_rx) = mpsc::unbounded_channel();
-        let (execution_results_tx, mut execution_results_rx) = mpsc::channel::<(
-            LoadAndExecuteSanitizedTransactionsOutput,
-            Vec<SanitizedTransaction>,
-        )>(1);
+        let (execution_results_tx, mut execution_results_rx) = mpsc::channel::<ExecutedBatch>(1);
         let shutdown = CancellationToken::new();
 
         let _handle = start_execution_worker(ExecutionArgs {
@@ -2090,10 +2114,7 @@ mod tests {
 
         let (batch_tx, batch_rx) = mpsc::channel::<ConflictFreeBatch>(16);
         let (_settled_tx, settled_rx) = mpsc::unbounded_channel();
-        let (execution_results_tx, execution_results_rx) = mpsc::channel::<(
-            LoadAndExecuteSanitizedTransactionsOutput,
-            Vec<SanitizedTransaction>,
-        )>(1);
+        let (execution_results_tx, execution_results_rx) = mpsc::channel::<ExecutedBatch>(1);
         let shutdown = CancellationToken::new();
 
         let handle = start_execution_worker(ExecutionArgs {

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -42,6 +42,24 @@ pub struct AccountSettlement {
     pub deleted: bool,
 }
 
+/// One executed batch on its way from the executor to the settler. The third
+/// element is the executor's generation for the account writes in this batch.
+pub type ExecutedBatch = (
+    LoadAndExecuteSanitizedTransactionsOutput,
+    Vec<SanitizedTransaction>,
+    u64,
+);
+
+/// Settlement acknowledgement sent back to BOB after a commit.
+///
+/// `generation` is a high-water mark: every executor write with a generation
+/// <= this one is now durable in the accounts database. One number describes
+/// the whole tick because the settler commits its buffer atomically.
+pub struct AccountSettlements {
+    pub generation: u64,
+    pub accounts: Vec<(Pubkey, AccountSettlement)>,
+}
+
 struct SettleResult {
     slot: u64,
     blockhash: Hash,
@@ -138,11 +156,8 @@ pub async fn warm_redis_cache(
 }
 
 pub struct SettleArgs {
-    pub execution_results_rx: mpsc::Receiver<(
-        LoadAndExecuteSanitizedTransactionsOutput,
-        Vec<SanitizedTransaction>,
-    )>,
-    pub settled_accounts_tx: mpsc::UnboundedSender<Vec<(Pubkey, AccountSettlement)>>,
+    pub execution_results_rx: mpsc::Receiver<ExecutedBatch>,
+    pub settled_accounts_tx: mpsc::UnboundedSender<AccountSettlements>,
     pub settled_blockhashes_tx: mpsc::UnboundedSender<Hash>,
     /// Bounded channel to the background `address_index_writer`.
     pub address_signatures_tx: mpsc::Sender<Vec<AddressSignatureRow>>,
@@ -170,11 +185,8 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
     let handle = tokio::spawn(async move {
         #[allow(clippy::too_many_arguments)]
         async fn run_settle_worker(
-            mut execution_results_rx: mpsc::Receiver<(
-                LoadAndExecuteSanitizedTransactionsOutput,
-                Vec<SanitizedTransaction>,
-            )>,
-            settled_accounts_tx: mpsc::UnboundedSender<Vec<(Pubkey, AccountSettlement)>>,
+            mut execution_results_rx: mpsc::Receiver<ExecutedBatch>,
+            settled_accounts_tx: mpsc::UnboundedSender<AccountSettlements>,
             settled_blockhashes_tx: mpsc::UnboundedSender<Hash>,
             address_signatures_tx: mpsc::Sender<Vec<AddressSignatureRow>>,
             accountsdb_connection_url: String,
@@ -247,6 +259,11 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                 _ => None,
             };
             let mut processing_results = Vec::new();
+
+            // High-water mark of executor generations buffered so far. It is
+            // worker-loop state rather than settle state because it describes
+            // what the next commit will make durable, not one settle call.
+            let mut highest_generation = 0u64;
 
             // Tick-driven block production: the blocktime tick is the sole
             // trigger for producing blocks.  Between ticks, execution results
@@ -321,7 +338,10 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                                     settle_result.blockhash
                                 );
                                 if let Err(e) =
-                                    settled_accounts_tx.send(settle_result.account_settlements)
+                                    settled_accounts_tx.send(AccountSettlements {
+                                        generation: highest_generation,
+                                        accounts: settle_result.account_settlements,
+                                    })
                                 {
                                     warn!("Failed to send settled accounts: {:?}", e);
                                     break;
@@ -376,7 +396,7 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                     // Accumulate execution results — never flush here, just buffer.
                     result = execution_results_rx.recv() => {
                         match result {
-                            Some((svm_output, transactions)) => {
+                            Some((svm_output, transactions, generation)) => {
                                 heartbeat.record_input();
                                 debug!("Settle worker received output with {} transactions", transactions.len());
                                 if svm_output.processing_results.len() != transactions.len() {
@@ -385,6 +405,11 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                                 }
                                 debug!("Extending {} processing results", svm_output.processing_results.len());
                                 processing_results.extend(svm_output.processing_results.into_iter().zip(transactions.into_iter()));
+                                // Fold only once the batch is buffered, so the watermark can
+                                // never cover a batch that was rejected above and therefore
+                                // never committed. max() and not assignment so a producer
+                                // that ever regresses cannot pull the watermark backwards.
+                                highest_generation = highest_generation.max(generation);
                             }
                             None => {
                                 info!("Settle worker stopped - channel closed");
@@ -414,7 +439,10 @@ pub async fn start_settle_worker(args: SettleArgs) -> WorkerHandle {
                         if num_results > 0 {
                             metrics.settler_txs_settled(num_results);
                         }
-                        let _ = settled_accounts_tx.send(settle_result.account_settlements);
+                        let _ = settled_accounts_tx.send(AccountSettlements {
+                            generation: highest_generation,
+                            accounts: settle_result.account_settlements,
+                        });
                         let _ = settled_blockhashes_tx.send(settle_result.blockhash);
                         info!(
                             "Final flush settled {} buffered transactions in slot {}",
@@ -1485,7 +1513,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx])).await.unwrap();
+        exec_tx.send((output, vec![tx], 1)).await.unwrap();
 
         // Wait for the blocktime tick to process and emit settlements
         let settlements =
@@ -1498,6 +1526,137 @@ mod tests {
         let blockhash =
             tokio::time::timeout(Duration::from_secs(1), settled_blockhashes_rx.recv()).await;
         assert!(blockhash.is_ok(), "should receive blockhash within timeout");
+
+        shutdown.cancel();
+    }
+
+    /// Drain feedback until a message actually carries settled accounts. The
+    /// settler emits feedback on every blocktime tick, including ticks with an
+    /// empty buffer, so a single `recv()` can legitimately return generation 0.
+    async fn recv_nonempty_settlements(
+        rx: &mut mpsc::UnboundedReceiver<AccountSettlements>,
+    ) -> AccountSettlements {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let settlements = rx.recv().await.expect("settler feedback channel closed");
+                if !settlements.accounts.is_empty() {
+                    return settlements;
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for non-empty settler feedback")
+    }
+
+    /// Build a one-transaction execution output writing a fresh account. The
+    /// caller supplies the generation, so this returns the output and the
+    /// transactions rather than a whole `ExecutedBatch`.
+    fn one_account_batch() -> (
+        LoadAndExecuteSanitizedTransactionsOutput,
+        Vec<SanitizedTransaction>,
+    ) {
+        let tx = create_test_sanitized_transaction(&Keypair::new(), &Pubkey::new_unique(), 100);
+        let executed = make_executed(vec![(
+            Pubkey::new_unique(),
+            AccountSharedData::new(500, 0, &Pubkey::new_unique()),
+        )]);
+        let output = LoadAndExecuteSanitizedTransactionsOutput {
+            processing_results: vec![Ok(executed)],
+            error_metrics: Default::default(),
+            execute_timings: Default::default(),
+            balance_collector: None,
+        };
+        (output, vec![tx])
+    }
+
+    /// The generation the executor sent must come back on the acknowledgement,
+    /// alongside the accounts the tick made durable.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_worker_feedback_carries_received_generation() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+
+        let (exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
+        let (settled_accounts_tx, mut settled_accounts_rx) = mpsc::unbounded_channel();
+        let (settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
+        let (address_signatures_tx, _address_signatures_rx) = mpsc::channel(64);
+        let shutdown = CancellationToken::new();
+
+        let _handle = start_settle_worker(SettleArgs {
+            execution_results_rx: exec_rx,
+            settled_accounts_tx,
+            settled_blockhashes_tx,
+            address_signatures_tx,
+            accountsdb_connection_url: url,
+            blocktime_ms: 50,
+            perf_sample_period_secs: 3600,
+            shutdown_token: shutdown.clone(),
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: crate::health::StageHeartbeat::new(),
+        })
+        .await;
+
+        let (output, transactions) = one_account_batch();
+        exec_tx.send((output, transactions, 7)).await.unwrap();
+
+        let settlements = recv_nonempty_settlements(&mut settled_accounts_rx).await;
+        assert_eq!(
+            settlements.generation, 7,
+            "feedback must report the generation the executor sent"
+        );
+
+        shutdown.cancel();
+    }
+
+    /// The high-water mark folds with max(), so a producer that regresses cannot
+    /// pull the durable watermark backwards.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_worker_feedback_generation_never_regresses() {
+        let (_db, _pg) = start_test_postgres().await;
+        let url = crate::test_helpers::postgres_container_url(&_pg, "test_db").await;
+
+        let (exec_tx, exec_rx) = mpsc::channel(RESULTS_CAP);
+        let (settled_accounts_tx, mut settled_accounts_rx) = mpsc::unbounded_channel();
+        let (settled_blockhashes_tx, _settled_blockhashes_rx) = mpsc::unbounded_channel();
+        let (address_signatures_tx, _address_signatures_rx) = mpsc::channel(64);
+        let shutdown = CancellationToken::new();
+
+        let _handle = start_settle_worker(SettleArgs {
+            execution_results_rx: exec_rx,
+            settled_accounts_tx,
+            settled_blockhashes_tx,
+            address_signatures_tx,
+            accountsdb_connection_url: url,
+            blocktime_ms: 50,
+            perf_sample_period_secs: 3600,
+            shutdown_token: shutdown.clone(),
+            metrics: Arc::new(NoopMetrics),
+            heartbeat: crate::health::StageHeartbeat::new(),
+        })
+        .await;
+
+        let (output_a, transactions_a) = one_account_batch();
+        exec_tx.send((output_a, transactions_a, 9)).await.unwrap();
+        let (output_b, transactions_b) = one_account_batch();
+        exec_tx.send((output_b, transactions_b, 7)).await.unwrap();
+
+        let settlements = recv_nonempty_settlements(&mut settled_accounts_rx).await;
+        assert_eq!(
+            settlements.generation, 9,
+            "a stale generation must not lower the high-water mark"
+        );
+
+        // Assert a later tick too. Under plain assignment the stale 7 shows up in
+        // whichever tick receives it, so checking only the first non-empty
+        // acknowledgement would pass even without the max() fold.
+        let later = tokio::time::timeout(Duration::from_secs(10), settled_accounts_rx.recv())
+            .await
+            .expect("timed out waiting for a later acknowledgement")
+            .expect("settler feedback channel closed");
+        assert_eq!(
+            later.generation, 9,
+            "the high-water mark must stay at 9 on every later tick"
+        );
 
         shutdown.cancel();
     }
@@ -1936,7 +2095,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx])).await.unwrap();
+        exec_tx.send((output, vec![tx], 1)).await.unwrap();
 
         // Poll for perf sample with deadline instead of fixed sleep.
         // Perf tick fires after ~1s; poll every 100ms for up to 5s.
@@ -2000,7 +2159,7 @@ mod tests {
             execute_timings: Default::default(),
             balance_collector: None,
         };
-        exec_tx.send((output, vec![tx])).await.unwrap();
+        exec_tx.send((output, vec![tx], 1)).await.unwrap();
 
         let result = tokio::time::timeout(Duration::from_secs(10), handle.handle).await;
         assert!(

--- a/core/src/test_helpers.rs
+++ b/core/src/test_helpers.rs
@@ -177,9 +177,7 @@ pub(crate) async fn start_test_redis() -> (
 #[cfg(test)]
 pub(crate) fn create_test_bob() -> (
     crate::accounts::bob::BOB,
-    tokio::sync::mpsc::UnboundedSender<
-        Vec<(solana_sdk::pubkey::Pubkey, crate::stages::AccountSettlement)>,
-    >,
+    tokio::sync::mpsc::UnboundedSender<crate::stages::AccountSettlements>,
 ) {
     use crate::accounts::{AccountsDB, PostgresAccountsDB};
     use sqlx::postgres::PgPoolOptions;
@@ -195,4 +193,19 @@ pub(crate) fn create_test_bob() -> (
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let bob = crate::accounts::bob::BOB::new_test(rx, db);
     (bob, tx)
+}
+
+/// Same as `create_test_bob` but backed by a real throwaway Postgres container,
+/// so tests can exercise BOB's cache-miss path against an actual database.
+/// The container handle is returned so the caller keeps it alive.
+#[cfg(test)]
+pub(crate) async fn create_test_bob_with_postgres() -> (
+    crate::accounts::bob::BOB,
+    tokio::sync::mpsc::UnboundedSender<crate::stages::AccountSettlements>,
+    testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+) {
+    let (db, container) = start_test_postgres().await;
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let bob = crate::accounts::bob::BOB::new_test(rx, db);
+    (bob, tx, container)
 }

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -9,7 +9,7 @@ This document defines the safety and correctness invariants that Solana Private 
 | ID | Invariant | Level | Status | Ref |
 |----|-----------|-------|--------|-----|
 | C1 | A slot and all of its transactions + account changes MUST be written to DB as a single transaction | MUST | Done | #16 |
-| C2 | The in-memory accounts DB MUST be in sync or ahead of the accounts DB on disk | MUST | Done | #20 |
+| C2 | The in-memory accounts DB MUST be in sync or ahead of the accounts DB on disk | MUST | Done | #20, #277 |
 | C3 | Solana Private Channels MUST NOT allow two transactions with the same signature to both execute | MUST | Done | #15 |
 | C4 | Solana Private Channels MUST NOT allow a transaction with an expired blockhash to execute | MUST | Done | #22 |
 | C5 | Solana Private Channels MUST require all transactions to be signed | MUST | Done | #22 |


### PR DESCRIPTION
## Summary

Closes the stale-settlement issue. The settler acknowledged committed accounts back to BOB using only `{pubkey, account, deleted}`, without identifying which execution the acknowledgement belonged to. For updates, BOB could compare account bytes, but for deletions every closed account becomes the same tombstone, so stale acknowledgements were indistinguishable from current ones. As a result, an old delete acknowledgement could remove a newer tombstone from the cache, allowing `preload_accounts` to reload the deleted account from Postgres. This could resurrect a closed ATA and make its funds withdrawable a second time.

The fix adds a monotonic generation number to every account update. BOB stamps each write with a generation, the executor propagates it, and the settler acknowledges the highest durable generation for each tick. An entry is reconciled only if its generation is less than or equal to the acknowledged generation, making stale acknowledgements harmless for both updates and deletions. Byte equality is retained as a fail-closed consistency check: mismatches leave the entry dirty instead of reconciling it. Since generations are process-local, the change requires no schema, wire format, or deployment changes.

The implementation is intentionally narrow. Settlement APIs remain unchanged, `ExecutionResult` gains two generation fields, and the existing settlement pipeline is preserved. Tests cover the stale-acknowledgement regression, cache resurrection path, and the new reconciliation guards.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 13,574 | 15,249 | 89.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31002721747) |
| Indexer | 32,951 | 36,441 | 90.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31002721747) |
| Gateway | 1,330 | 1,521 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31002721747) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31002721747) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 13,774 | 17,513 | 78.7% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31002721747) |
| **Total** | **62,414** | **71,627** | **87.1%** | |

> Last updated: 2026-08-05 12:40:40 UTC by E2E Integration