### PR TITLE
fix(deploy): separate the escrow instance admin from the channel admin key

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -3,6 +3,7 @@
 
 # Instance
 ESCROW_INSTANCE_ID=
+# Channel admin service key, not the escrow instance admin. See .env.example.
 # Keep blank here: `make build-devnet` writes the live key to the gitignored `.env`.
 ADMIN_PRIVATE_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,15 @@ ESCROW_INSTANCE_ID=instance_pubkey
 # Created post-deploy via `create_instance`; compose interpolation needs it set,
 # so default to the all-1s placeholder until the real PDA is written back.
 COMMON_ESCROW_INSTANCE_ID=11111111111111111111111111111111
+# The channel admin service key: SPL mint+freeze authority on every receipt mint,
+# and the fee payer for the operator's own transactions.
+#
+# This is NOT the escrow instance admin. That is a separate offline keypair
+# (keypairs/escrow-admin.json) which no service ever loads, so it has no env var
+# here. Reusing one key for both roles defeats SetNewAdmin: the rotated-out key
+# keeps its receipt-mint authority and its Operator PDA, so it can still drain
+# escrow custody after the handover.
+#
 # Keep blank here: `make build-*` writes the live key to the gitignored `.env`.
 ADMIN_PRIVATE_KEY=
 
@@ -53,8 +62,9 @@ PRIVATE_CHANNEL_BATCH_DEADLINE_MS=10
 PRIVATE_CHANNEL_BATCH_CHANNEL_CAPACITY=16
 # Executor parallel SVM worker cap.
 PRIVATE_CHANNEL_MAX_SVM_WORKERS=8
-# Space-separated admin pubkey(s). `make build-localnet` fills this (and
-# ADMIN_PRIVATE_KEY) with a generated keypair; 
+# Space-separated channel admin pubkey(s): the write-node's InitializeMint gate.
+# `make build-localnet` fills this (and ADMIN_PRIVATE_KEY) with a generated keypair.
+# Must not list the escrow instance admin, which is a separate offline key.
 PRIVATE_CHANNEL_ADMIN_KEYS=admin_pubkey
 
 # Gateway

--- a/.env.local
+++ b/.env.local
@@ -3,6 +3,7 @@
 
 # Instance
 ESCROW_INSTANCE_ID=
+# Channel admin service key, not the escrow instance admin. See .env.example.
 # Keep blank here: `make build-localnet` writes the live key to the gitignored `.env`.
 ADMIN_PRIVATE_KEY=
 
@@ -28,7 +29,7 @@ PRIVATE_CHANNEL_MAX_TX_PER_BATCH=64
 PRIVATE_CHANNEL_BATCH_DEADLINE_MS=10
 PRIVATE_CHANNEL_BATCH_CHANNEL_CAPACITY=16
 PRIVATE_CHANNEL_MAX_SVM_WORKERS=8
-PRIVATE_CHANNEL_ADMIN_KEYS=your_admin_public_key # Public key of keypairs/admin.json
+PRIVATE_CHANNEL_ADMIN_KEYS=your_admin_public_key # Channel admin pubkey, not the escrow admin
 
 # Gateway
 GATEWAY_PORT=8899

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -404,6 +404,11 @@ services:
       - COMMON_RPC_URL=${GATEWAY_URL}
       - COMMON_SOURCE_RPC_URL=${DEVNET_RPC_URL}
       - COMMON_ESCROW_INSTANCE_ID=${ESCROW_INSTANCE_ID}
+      # Channel admin, not the escrow Instance.admin (a separate offline key that
+      # never reaches this stack). The operator alias is deliberate: both roles are
+      # the same hot service identity. Do not point OPERATOR_PRIVATE_KEY at a
+      # distinct key without also fixing feepayer_monitor.rs, which watches
+      # get_operator_pubkey() while the real fee payer is the admin key.
       - ADMIN_SIGNER=memory
       - ADMIN_PRIVATE_KEY=${ADMIN_PRIVATE_KEY}
       - OPERATOR_SIGNER=memory
@@ -457,6 +462,11 @@ services:
       # COMMON_RPC_URL above stays on devnet — that's where releases are sent.
       - COMMON_SOURCE_RPC_URL=${GATEWAY_READ_URL}
       - COMMON_ESCROW_INSTANCE_ID=${ESCROW_INSTANCE_ID}
+      # Channel admin, not the escrow Instance.admin (a separate offline key that
+      # never reaches this stack). The operator alias is deliberate: both roles are
+      # the same hot service identity. Do not point OPERATOR_PRIVATE_KEY at a
+      # distinct key without also fixing feepayer_monitor.rs, which watches
+      # get_operator_pubkey() while the real fee payer is the admin key.
       - ADMIN_SIGNER=memory
       - ADMIN_PRIVATE_KEY=${ADMIN_PRIVATE_KEY}
       - OPERATOR_SIGNER=memory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -530,6 +530,11 @@ services:
       # When absent (e.g. manual `docker compose up`), the TOML config's
       # escrow_instance_id is used — update that value to match your deployment.
       - COMMON_ESCROW_INSTANCE_ID
+      # Channel admin, not the escrow Instance.admin (a separate offline key that
+      # never reaches this stack). The operator alias is deliberate: both roles are
+      # the same hot service identity. Do not point OPERATOR_PRIVATE_KEY at a
+      # distinct key without also fixing feepayer_monitor.rs, which watches
+      # get_operator_pubkey() while the real fee payer is the admin key.
       - ADMIN_SIGNER=memory
       - ADMIN_PRIVATE_KEY=${ADMIN_PRIVATE_KEY}
       - OPERATOR_SIGNER=memory
@@ -583,6 +588,11 @@ services:
       - COMMON_FALLBACK_RPC_URL=http://validator-fallback:8899
       # source_rpc_url = Solana Private Channels gateway (source of withdrawal/burn state)
       - COMMON_SOURCE_RPC_URL=http://gateway:${GATEWAY_PORT}
+      # Channel admin, not the escrow Instance.admin (a separate offline key that
+      # never reaches this stack). The operator alias is deliberate: both roles are
+      # the same hot service identity. Do not point OPERATOR_PRIVATE_KEY at a
+      # distinct key without also fixing feepayer_monitor.rs, which watches
+      # get_operator_pubkey() while the real fee payer is the admin key.
       - ADMIN_SIGNER=memory
       - ADMIN_PRIVATE_KEY=${ADMIN_PRIVATE_KEY}
       - OPERATOR_SIGNER=memory

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -25,7 +25,7 @@ Reference for configuring, tuning, and operating Solana Private Channels service
 | `--max-connections` | `PRIVATE_CHANNEL_MAX_CONNECTIONS` | `100` | Max concurrent RPC connections |
 | `--blocktime-ms` | `PRIVATE_CHANNEL_BLOCKTIME_MS` | `100` | Settlement interval (ms) |
 | `--transaction-expiration-ms` | `PRIVATE_CHANNEL_TRANSACTION_EXPIRATION_MS` | `15000` | Transaction lifetime before dedup eviction |
-| `--admin-keys` | `PRIVATE_CHANNEL_ADMIN_KEYS` | — | Comma-separated base58 pubkeys for admin operations |
+| `--admin-keys` | `PRIVATE_CHANNEL_ADMIN_KEYS` | — | Comma-separated base58 channel admin pubkeys, gating SPL `InitializeMint`. Not the escrow `Instance.admin`, which is a separate offline key |
 | `--accountsdb-connection-url` | `PRIVATE_CHANNEL_ACCOUNTSDB_CONNECTION_URL` | — | PostgreSQL connection string |
 | `--log-level` | `PRIVATE_CHANNEL_LOG_LEVEL` | `info` | Log level: `trace`, `debug`, `info`, `warn`, `error` |
 | `--json-logs` | `PRIVATE_CHANNEL_JSON_LOGS` | `false` | Structured JSON log output |

--- a/docs/DEVNET_QUICKSTART.md
+++ b/docs/DEVNET_QUICKSTART.md
@@ -135,6 +135,8 @@ Open [http://localhost:5173](http://localhost:5173) in your browser.
 
 The operator keypair signs transactions for minting on the Solana Private Channels payment channel and releasing from escrow.
 
+Generate a **new** keypair here. It must not be the wallet that created the instance in Step 3, which is the escrow `Instance.admin`. `SetNewAdmin` only rewrites `Instance.admin`, so a key that is also the operator keeps its receipt-mint authority and its Operator PDA after a handover and can still drain escrow custody.
+
 ```shell
 # Generate a new keypair
 solana-keygen new -o operator-keypair.json -s --no-bip39-passphrase

--- a/docs/ESCROW_INTERACTION_GUIDE.md
+++ b/docs/ESCROW_INTERACTION_GUIDE.md
@@ -226,7 +226,9 @@ const setAdminIx = getSetNewAdminInstruction({
 **Important:**
 - Both current admin and new admin must sign the transaction
 - Change is immediate and irreversible
-- Old admin loses all privileges once confirmed
+- Old admin loses its `Instance.admin` privileges once confirmed. It does **not** lose anything else: this instruction rewrites one field and nothing more
+- Operator PDAs survive the handover. Any wallet added via `AddOperator` can still sign `ReleaseFunds` and `ResetSmtRoot` until the new admin calls `RemoveOperator` for it, including the old admin itself if it was ever registered
+- If the old admin was also used as the channel admin, it keeps SPL mint and freeze authority over every already-initialized receipt mint. Migrate those with SPL `SetAuthority` before treating the rotation as complete. Keeping the two keys separate from the start avoids this entirely
 - Verify new admin address carefully (typos = permanent loss of control)
 
 

--- a/docs/runbooks/reconciliation_halt_runbook.md
+++ b/docs/runbooks/reconciliation_halt_runbook.md
@@ -106,6 +106,13 @@ a custody shortfall). Escalate per [`_escalation.md`](_escalation.md); rotate th
 operator/admin key if over-issuance is suspected, and do **not** resume the
 pipelines.
 
+Rotating the channel admin means migrating every receipt mint's authority to the
+new key with SPL `SetAuthority` first. The old key stays the on-chain
+`mint_authority` until you do, so deposits fail with `OwnerMismatch`
+(see [`deposit_failed.md`](deposit_failed.md)) and the old key keeps the ability to
+mint. This is separate from the escrow `Instance.admin`, which `SetNewAdmin`
+rotates on its own.
+
 ## Recover (only after backing is confirmed)
 
 Once you have verified that custody genuinely backs the minted supply (e.g. the

--- a/private-channel-deploy/templates/env.j2
+++ b/private-channel-deploy/templates/env.j2
@@ -53,8 +53,9 @@ PRIVATE_CHANNEL_MAX_TX_PER_BATCH=64
 PRIVATE_CHANNEL_BATCH_DEADLINE_MS=10
 PRIVATE_CHANNEL_BATCH_CHANNEL_CAPACITY=16
 PRIVATE_CHANNEL_MAX_SVM_WORKERS=8
-# Admin pubkey + private key. In single-host self-test mode these come from
-# the on-disk keypair at {{ admin_keypair_path | default('keypairs/admin.json') }}.
+# Channel admin pubkey + private key, NOT the escrow Instance.admin (which is a
+# separate offline key that never reaches this host). In single-host self-test mode
+# these come from the on-disk keypair at {{ admin_keypair_path | default('keypairs/admin.json') }}.
 # The pipeline phase computes them and writes them back into the rendered .env
 # before bringing up the operator services. Until then the placeholders below
 # satisfy compose variable interpolation; the operators don't actually start

--- a/private-channel-deploy/vars/dev.yml
+++ b/private-channel-deploy/vars/dev.yml
@@ -77,10 +77,18 @@ withdraw_program_id: J231K9UEpS4y4KAPwGc4gsMNCjKFRMYcQBcjVW7vBhVi
 # crash the indexer's Pubkey::from_str at boot.)
 # escrow_instance_id: "<your_instance_address>"
 
-# === Admin keypair ==========================================================
+# === Channel admin keypair ==================================================
 # Path on the control node to a funded Solana keypair (JSON byte array).
-# Used to derive the operator services' ADMIN_PRIVATE_KEY at runtime, and by
-# any post-deploy admin tooling that signs on-chain transactions.
+# Used to derive the operator services' ADMIN_PRIVATE_KEY and
+# PRIVATE_CHANNEL_ADMIN_KEYS at runtime. This is the channel admin: SPL
+# mint+freeze authority on every receipt mint, and the operator fee payer.
+#
+# It is NOT the escrow Instance.admin. That key signs CreateInstance, AllowMint,
+# Add/RemoveOperator and SetNewAdmin, is never rendered into any env file and
+# never reaches the target host. Keep it a separate offline keypair: SetNewAdmin
+# only rewrites Instance.admin, so a rotated-out key that is also the channel
+# admin keeps its receipt-mint authority and its Operator PDA, and can still
+# drain escrow custody after the handover.
 admin_keypair_path: "{{ repo_root }}/keypairs/admin.json"
 
 # === Public surface ========================================================

--- a/scripts/devnet/README.md
+++ b/scripts/devnet/README.md
@@ -9,20 +9,29 @@ cp .env.example .env
 # Generate strong values with: openssl rand -hex 32
 ```
 
+## Two admin keys
+
+Steps 1-3 below are escrow governance and are signed by `keypairs/escrow-admin.json`,
+the `Instance.admin` key. The services run as a *different* key, the channel admin in
+`ADMIN_PRIVATE_KEY`, which holds receipt-mint authority and is what step 2 registers as
+the operator. Keep them separate: `SetNewAdmin` only rewrites `Instance.admin`, so a key
+that is also the channel admin keeps its receipt-mint authority and its Operator PDA
+after a handover and can still drain escrow custody.
+
 Run all commands from project root:
 
 ## 1. Create Instance
 ```bash
 cargo run --bin create_instance -- \
   https://api.devnet.solana.com \
-  ./keypairs/admin.json
+  ./keypairs/escrow-admin.json
 ```
 
 ## 2. Add Operator
 ```bash
 cargo run --bin add_operator -- \
   https://api.devnet.solana.com \
-  ./keypairs/admin.json \
+  ./keypairs/escrow-admin.json \
   <INSTANCE_ID> \
   <OPERATOR_PUBKEY>
 ```
@@ -31,7 +40,7 @@ cargo run --bin add_operator -- \
 ```bash
 cargo run --bin allow_mint -- \
   https://api.devnet.solana.com \
-  ./keypairs/admin.json \
+  ./keypairs/escrow-admin.json \
   <INSTANCE_ID> \
   <MINT_ADDRESS>
 ```

--- a/scripts/devnet/devnet-test.sh
+++ b/scripts/devnet/devnet-test.sh
@@ -3,15 +3,18 @@
 #
 # Required env vars:
 #   DEVNET_RPC_URL          - Solana devnet RPC URL (e.g. https://api.devnet.solana.com)
+#   ADMIN_PRIVATE_KEY       - Channel admin key, read from the .env sourced below
 #
 # Two separate admin keys, which must never be the same keypair:
 #
 #   ESCROW_ADMIN_KEYPAIR  Instance.admin on Solana. Signs CreateInstance, AddOperator
 #                         and AllowMint here, plus SetNewAdmin in production. Needs SOL
 #                         to pay for those three transactions. Never loaded by a service.
-#   ADMIN_KEYPAIR         The channel admin the containers run as: SPL mint+freeze
+#   ADMIN_PRIVATE_KEY     The channel admin the containers run as: SPL mint+freeze
 #                         authority on receipt mints, operator fee payer, and the wallet
-#                         registered as the escrow Operator by step 2.
+#                         registered as the escrow Operator by step 2. Read from the same
+#                         .env the containers load, so the Operator registered here is
+#                         always the key they sign with.
 #
 # Sharing one keypair across both roles means SetNewAdmin does not revoke anything:
 # the rotated-out key keeps its receipt-mint authority and its Operator PDA, and can
@@ -20,7 +23,6 @@
 # Optional env vars:
 #   PRIVATE_CHANNEL_GATEWAY_URL      - Solana Private Channels gateway URL (default: http://localhost:8899)
 #   ESCROW_ADMIN_KEYPAIR    - Path to escrow admin keypair (default: ./keypairs/escrow-admin.json)
-#   ADMIN_KEYPAIR           - Path to channel admin keypair (default: ./keypairs/admin.json)
 #   MINT_KEYPAIR            - Path to mint keypair (default: ./keypairs/mint.json)
 #   USER_KEYPAIR            - Path to user keypair (default: ./keypairs/user.json)
 
@@ -36,13 +38,13 @@ fi
 RPC_URL="${DEVNET_RPC_URL:?DEVNET_RPC_URL is required}"
 PRIVATE_CHANNEL_GATEWAY_URL="${PRIVATE_CHANNEL_GATEWAY_URL:-http://localhost:8899}"
 ESCROW_ADMIN_KEYPAIR="${ESCROW_ADMIN_KEYPAIR:-./keypairs/escrow-admin.json}"
-ADMIN_KEYPAIR="${ADMIN_KEYPAIR:-./keypairs/admin.json}"
 MINT_KEYPAIR="${MINT_KEYPAIR:-./keypairs/mint.json}"
 USER_KEYPAIR="${USER_KEYPAIR:-./keypairs/user.json}"
+: "${ADMIN_PRIVATE_KEY:?ADMIN_PRIVATE_KEY is required; \`make build-devnet\` writes it to .env}"
 
 if [ ! -f "$ESCROW_ADMIN_KEYPAIR" ]; then
   echo "ERROR: escrow admin keypair not found: $ESCROW_ADMIN_KEYPAIR" >&2
-  echo "       It must be a different keypair from ADMIN_KEYPAIR ($ADMIN_KEYPAIR)." >&2
+  echo "       It must be a different keypair from the channel admin in ADMIN_PRIVATE_KEY." >&2
   echo "       Create one: solana-keygen new --no-bip39-passphrase -o $ESCROW_ADMIN_KEYPAIR" >&2
   echo "       Then fund it on devnet so it can pay for CreateInstance/AddOperator/AllowMint." >&2
   exit 1
@@ -59,8 +61,16 @@ sedi() {
 
 MINT=$(solana-keygen pubkey "$MINT_KEYPAIR")
 ESCROW_ADMIN=$(solana-keygen pubkey "$ESCROW_ADMIN_KEYPAIR")
-OPERATOR=$(solana-keygen pubkey "$ADMIN_KEYPAIR")
 USER=$(solana-keygen pubkey "$USER_KEYPAIR")
+
+# Derived from the secret itself, not from a keypair path: a path could name a key the
+# containers never load, which would both defeat the check below and register an Operator
+# that cannot sign ReleaseFunds.
+if ! OPERATOR=$(printf '%s\n' "$ADMIN_PRIVATE_KEY" | solana-keygen pubkey -); then
+  echo "ERROR: could not derive a pubkey from ADMIN_PRIVATE_KEY." >&2
+  echo "       Expected the JSON byte array that \`make build-devnet\` writes to .env." >&2
+  exit 1
+fi
 
 # Fail closed on the collapsed-key configuration this script used to ship with.
 if [ "$ESCROW_ADMIN" = "$OPERATOR" ]; then

--- a/scripts/devnet/devnet-test.sh
+++ b/scripts/devnet/devnet-test.sh
@@ -4,9 +4,23 @@
 # Required env vars:
 #   DEVNET_RPC_URL          - Solana devnet RPC URL (e.g. https://api.devnet.solana.com)
 #
+# Two separate admin keys, which must never be the same keypair:
+#
+#   ESCROW_ADMIN_KEYPAIR  Instance.admin on Solana. Signs CreateInstance, AddOperator
+#                         and AllowMint here, plus SetNewAdmin in production. Needs SOL
+#                         to pay for those three transactions. Never loaded by a service.
+#   ADMIN_KEYPAIR         The channel admin the containers run as: SPL mint+freeze
+#                         authority on receipt mints, operator fee payer, and the wallet
+#                         registered as the escrow Operator by step 2.
+#
+# Sharing one keypair across both roles means SetNewAdmin does not revoke anything:
+# the rotated-out key keeps its receipt-mint authority and its Operator PDA, and can
+# still drain escrow custody afterwards.
+#
 # Optional env vars:
 #   PRIVATE_CHANNEL_GATEWAY_URL      - Solana Private Channels gateway URL (default: http://localhost:8899)
-#   ADMIN_KEYPAIR           - Path to admin keypair (default: ./keypairs/admin.json)
+#   ESCROW_ADMIN_KEYPAIR    - Path to escrow admin keypair (default: ./keypairs/escrow-admin.json)
+#   ADMIN_KEYPAIR           - Path to channel admin keypair (default: ./keypairs/admin.json)
 #   MINT_KEYPAIR            - Path to mint keypair (default: ./keypairs/mint.json)
 #   USER_KEYPAIR            - Path to user keypair (default: ./keypairs/user.json)
 
@@ -21,9 +35,18 @@ fi
 
 RPC_URL="${DEVNET_RPC_URL:?DEVNET_RPC_URL is required}"
 PRIVATE_CHANNEL_GATEWAY_URL="${PRIVATE_CHANNEL_GATEWAY_URL:-http://localhost:8899}"
+ESCROW_ADMIN_KEYPAIR="${ESCROW_ADMIN_KEYPAIR:-./keypairs/escrow-admin.json}"
 ADMIN_KEYPAIR="${ADMIN_KEYPAIR:-./keypairs/admin.json}"
 MINT_KEYPAIR="${MINT_KEYPAIR:-./keypairs/mint.json}"
 USER_KEYPAIR="${USER_KEYPAIR:-./keypairs/user.json}"
+
+if [ ! -f "$ESCROW_ADMIN_KEYPAIR" ]; then
+  echo "ERROR: escrow admin keypair not found: $ESCROW_ADMIN_KEYPAIR" >&2
+  echo "       It must be a different keypair from ADMIN_KEYPAIR ($ADMIN_KEYPAIR)." >&2
+  echo "       Create one: solana-keygen new --no-bip39-passphrase -o $ESCROW_ADMIN_KEYPAIR" >&2
+  echo "       Then fund it on devnet so it can pay for CreateInstance/AddOperator/AllowMint." >&2
+  exit 1
+fi
 
 # Portable sed -i (macOS vs Linux)
 sedi() {
@@ -35,8 +58,17 @@ sedi() {
 }
 
 MINT=$(solana-keygen pubkey "$MINT_KEYPAIR")
+ESCROW_ADMIN=$(solana-keygen pubkey "$ESCROW_ADMIN_KEYPAIR")
 OPERATOR=$(solana-keygen pubkey "$ADMIN_KEYPAIR")
 USER=$(solana-keygen pubkey "$USER_KEYPAIR")
+
+# Fail closed on the collapsed-key configuration this script used to ship with.
+if [ "$ESCROW_ADMIN" = "$OPERATOR" ]; then
+  echo "ERROR: the escrow admin and the channel admin are the same key ($ESCROW_ADMIN)." >&2
+  echo "       SetNewAdmin cannot revoke a key that also holds receipt-mint authority" >&2
+  echo "       and an Operator PDA. Use two distinct keypairs." >&2
+  exit 1
+fi
 
 # Function to get token balance for a wallet (raw amount, no decimals)
 get_token_balance() {
@@ -45,7 +77,8 @@ get_token_balance() {
   spl-token balance --owner "$wallet" "$mint" -u "$RPC_URL" --output json 2>/dev/null | jq -r '.amount' || echo "0"
 }
 
-echo "Admin/Operator: $OPERATOR"
+echo "Escrow admin (Instance.admin): $ESCROW_ADMIN"
+echo "Channel admin / operator: $OPERATOR"
 echo "Mint: $MINT"
 echo "User: $USER"
 
@@ -61,7 +94,7 @@ echo "User token balance (before): $USER_BALANCE_BEFORE"
 echo "=== Step 1: Create Instance ==="
 OUTPUT=$(cargo run --quiet --manifest-path scripts/devnet/Cargo.toml --bin create_instance -- \
   "$RPC_URL" \
-  "$ADMIN_KEYPAIR")
+  "$ESCROW_ADMIN_KEYPAIR")
 echo "$OUTPUT"
 
 # Parse instance ID from output (line: escrow_instance_id = "...")
@@ -80,7 +113,7 @@ echo ""
 echo "=== Step 2: Add Operator ==="
 cargo run --quiet --manifest-path scripts/devnet/Cargo.toml --bin add_operator -- \
   "$RPC_URL" \
-  "$ADMIN_KEYPAIR" \
+  "$ESCROW_ADMIN_KEYPAIR" \
   "$INSTANCE_ID" \
   "$OPERATOR"
 
@@ -88,7 +121,7 @@ echo ""
 echo "=== Step 3: Allow Mint ==="
 cargo run --quiet --manifest-path scripts/devnet/Cargo.toml --bin allow_mint -- \
   "$RPC_URL" \
-  "$ADMIN_KEYPAIR" \
+  "$ESCROW_ADMIN_KEYPAIR" \
   "$INSTANCE_ID" \
   "$MINT"
 

--- a/scripts/devnet/src/bin/add_operator.rs
+++ b/scripts/devnet/src/bin/add_operator.rs
@@ -32,10 +32,10 @@ fn main() -> Result<()> {
 
     if args.len() < 5 {
         eprintln!(
-            "Usage: {} <rpc-url> <admin-keypair-path> <instance-id> <operator-pubkey>",
+            "Usage: {} <rpc-url> <escrow-admin-keypair-path> <instance-id> <operator-pubkey>",
             args[0]
         );
-        eprintln!("Example: {} https://api.devnet.solana.com ./keypairs/admin.json 9F2CJEevdBVaPJwr1iCayZMT9Acvg7twG4JnjYf9G2zv 5s3eemaoNZ4mW39w6ACBuy84EGo4UKMvXTTZxBkur6ma", args[0]);
+        eprintln!("Example: {} https://api.devnet.solana.com ./keypairs/escrow-admin.json 9F2CJEevdBVaPJwr1iCayZMT9Acvg7twG4JnjYf9G2zv 5s3eemaoNZ4mW39w6ACBuy84EGo4UKMvXTTZxBkur6ma", args[0]);
         std::process::exit(1);
     }
 

--- a/scripts/devnet/src/bin/allow_mint.rs
+++ b/scripts/devnet/src/bin/allow_mint.rs
@@ -33,10 +33,10 @@ fn main() -> Result<()> {
 
     if args.len() < 5 {
         eprintln!(
-            "Usage: {} <rpc-url> <admin-keypair-path> <instance-id> <mint-address>",
+            "Usage: {} <rpc-url> <escrow-admin-keypair-path> <instance-id> <mint-address>",
             args[0]
         );
-        eprintln!("Example: {} https://api.devnet.solana.com ./keypairs/admin.json 9F2CJEevdBVaPJwr1iCayZMT9Acvg7twG4JnjYf9G2zv So11111111111111111111111111111111111111112", args[0]);
+        eprintln!("Example: {} https://api.devnet.solana.com ./keypairs/escrow-admin.json 9F2CJEevdBVaPJwr1iCayZMT9Acvg7twG4JnjYf9G2zv So11111111111111111111111111111111111111112", args[0]);
         std::process::exit(1);
     }
 

--- a/scripts/devnet/src/bin/create_instance.rs
+++ b/scripts/devnet/src/bin/create_instance.rs
@@ -30,9 +30,9 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 3 {
-        eprintln!("Usage: {} <rpc-url> <admin-keypair-path>", args[0]);
+        eprintln!("Usage: {} <rpc-url> <escrow-admin-keypair-path>", args[0]);
         eprintln!(
-            "Example: {} https://api.devnet.solana.com ./keypairs/admin.json",
+            "Example: {} https://api.devnet.solana.com ./keypairs/escrow-admin.json",
             args[0]
         );
         std::process::exit(1);

--- a/scripts/update-admin-env.sh
+++ b/scripts/update-admin-env.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Takes the CHANNEL admin keypair, the service identity the containers run as.
+# Never pass the escrow Instance.admin keypair here: sharing one key across both
+# roles means SetNewAdmin revokes nothing, because the rotated-out key keeps its
+# receipt-mint authority and its Operator PDA.
+#
 # Public admin key goes to the tracked template; the private key goes only to a
 # gitignored runtime env file, so `make build-*` never puts a live key in git.
 
 if [[ $# -lt 2 || $# -gt 3 ]]; then
-  echo "Usage: $0 <env-file> <admin-keypair-path> [runtime-env-file]" >&2
+  echo "Usage: $0 <env-file> <channel-admin-keypair-path> [runtime-env-file]" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What

Splits the two admins that the shipped deployment collapsed into one keypair.

  - Escrow `Instance.admin` is now its own keypair (`keypairs/escrow-admin.json`). It signs `CreateInstance`, `AllowMint`, `AddOperator` and `SetNewAdmin`, and no service ever loads it.
  - The channel admin (`ADMIN_PRIVATE_KEY` / `PRIVATE_CHANNEL_ADMIN_KEYS`) stays the hot service identity: receipt-mint authority, operator fee payer, and the registered escrow Operator.
  - `devnet-test.sh` fails closed if the two pubkeys match. Env files, ansible vars, compose and the CLI help text now name which key is which.

## Why this instead of the proposed changes

The finding recommends `pending_admin`, an admin epoch, and binding releases on-chain to a registered mint authority. None of that is needed to close it. The vulnerability is entirely that the key `SetNewAdmin` rotates was also a service key. Once the escrow admin is separate, it never becomes an SPL mint authority and never gets an `AddOperator` registration, so both drain paths (atomic mint-and-burn, and direct `ReleaseFunds` via a surviving Operator PDA) are gone. The indexer never signs an escrow admin instruction, so this is config only, no program change.

The two-phase transition and epoch binding remain reasonable hardening. Not in this PR.

## Docs

`SetNewAdmin` no longer claims the old admin loses all privileges. It rewrites one field: Operator PDAs survive until `RemoveOperator`, and a shared key keeps mint and freeze authority. The reconciliation halt runbook now requires SPL `SetAuthority` migration before a channel admin rotation.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | - | - | - | - |
| Indexer | - | - | - | - |
| Gateway | - | - | - | - |
| Auth | - | - | - | - |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | - | - | - | - |
| **Total** | **-** | **-** | **-** | |

> Coverage runs in progress...