### PR TITLE
fix(indexer): scope recovery sweeps to each operator role's transaction type (issue-1-ottersec)

### DIFF
--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -8,6 +8,7 @@ use crate::indexer::datasource::common::parser::{
     PRIVATE_CHANNEL_ESCROW_PROGRAM_ID, PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID,
 };
 use crate::operator::SignerUtil;
+use crate::storage::common::models::TransactionType;
 
 /// Program type to index
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum)]
@@ -37,6 +38,20 @@ impl ProgramType {
             ProgramType::Withdraw => {
                 Pubkey::from_str(PRIVATE_CHANNEL_WITHDRAW_PROGRAM_ID).expect("Invalid program ID")
             }
+        }
+    }
+
+    /// The one transaction type this role owns and may act on.
+    ///
+    /// Both operators share a single transactions table but point their RPC
+    /// clients at opposite chains: escrow mints deposits on PrivateChannel,
+    /// withdraw releases withdrawals on Solana. Every read that selects rows to
+    /// act on must be scoped through this mapping, or a role ends up checking
+    /// another role's signatures against a chain they were never sent to.
+    pub fn owned_transaction_type(&self) -> TransactionType {
+        match self {
+            ProgramType::Escrow => TransactionType::Deposit,
+            ProgramType::Withdraw => TransactionType::Withdrawal,
         }
     }
 }
@@ -399,6 +414,23 @@ mod tests {
         let config = create_common_config();
         let result = config.validate();
         assert!(result.is_ok());
+    }
+
+    // ============================================================================
+    // Role Ownership Tests
+    // ============================================================================
+
+    /// The single source of truth the fetcher and both recovery sweeps share.
+    #[test]
+    fn owned_transaction_type_maps_each_role() {
+        assert_eq!(
+            ProgramType::Escrow.owned_transaction_type(),
+            TransactionType::Deposit
+        );
+        assert_eq!(
+            ProgramType::Withdraw.owned_transaction_type(),
+            TransactionType::Withdrawal
+        );
     }
 
     // ============================================================================

--- a/indexer/src/operator/fetcher.rs
+++ b/indexer/src/operator/fetcher.rs
@@ -2,7 +2,7 @@ use crate::channel_utils::send_guaranteed;
 use crate::config::OperatorConfig;
 use crate::error::OperatorError;
 use crate::metrics;
-use crate::storage::common::models::{DbTransaction, TransactionType};
+use crate::storage::common::models::DbTransaction;
 use crate::storage::Storage;
 use crate::ProgramType;
 use private_channel_metrics::{HealthState, MetricLabel};
@@ -25,10 +25,7 @@ pub async fn run_fetcher(
 ) -> Result<(), OperatorError> {
     info!("Starting fetcher");
 
-    let transaction_type = match program_type {
-        ProgramType::Escrow => TransactionType::Deposit,
-        ProgramType::Withdraw => TransactionType::Withdrawal,
-    };
+    let transaction_type = program_type.owned_transaction_type();
 
     loop {
         // Check for cancellation
@@ -108,7 +105,7 @@ pub async fn run_fetcher(
 mod tests {
     use super::*;
     use crate::storage::common::amount::TokenAmount;
-    use crate::storage::common::models::{DbTransaction, TransactionStatus};
+    use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
     use crate::storage::common::storage::mock::MockStorage;
     use chrono::Utc;
     use std::time::Duration;

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -119,8 +119,10 @@ async fn recover_once(
         Err(e) => warn!("Recovery release-signature GC failed: {}", e),
     }
 
+    let owned_type = program_type.owned_transaction_type();
+
     let stale = storage
-        .get_stale_processing_transactions(threshold, RECOVERY_BATCH_LIMIT)
+        .get_stale_processing_transactions(threshold, RECOVERY_BATCH_LIMIT, owned_type)
         .await?;
 
     if !stale.is_empty() {
@@ -136,6 +138,9 @@ async fn recover_once(
             info!("Recovery sweep cancelled; remaining rows deferred");
             return Ok(());
         }
+        if !role_owns(program_type, &row) {
+            continue;
+        }
         // Capture `updated_at` before the RPC so the write below CAS-checks it.
         let captured = row.updated_at;
         let action = decide_action(&row, storage, rpc_client).await;
@@ -146,16 +151,39 @@ async fn recover_once(
     // these itself, so anything stale here lost its in-memory driver. Parked
     // rows were never sent on-chain, so requeue them without verifying finality.
     let stale_parked = storage
-        .get_stale_parked_transactions(threshold, RECOVERY_BATCH_LIMIT)
+        .get_stale_parked_transactions(threshold, RECOVERY_BATCH_LIMIT, owned_type)
         .await?;
     for row in stale_parked {
         if cancellation_token.is_cancelled() {
             info!("Recovery sweep cancelled; remaining parked rows deferred");
             return Ok(());
         }
+        if !role_owns(program_type, &row) {
+            continue;
+        }
         requeue_parked(storage, &row, program_type).await;
     }
     Ok(())
+}
+
+/// Whether this operator role owns the row, and may therefore act on it.
+///
+/// The sweep queries already filter by type, so in production this is always
+/// true. It is kept as a second, in-process gate because the consequence of a
+/// miss is severe and silent: the two roles share one database but hold RPC
+/// clients pointed at opposite chains, so acting on a foreign row classifies
+/// its signatures against a chain they were never broadcast to. Guarding here,
+/// ahead of every storage read and RPC, means any future unfiltered query
+/// cannot reach the wrong chain.
+fn role_owns(program_type: ProgramType, row: &DbTransaction) -> bool {
+    let owned = row.transaction_type == program_type.owned_transaction_type();
+    if !owned {
+        warn!(
+            transaction_id = row.id,
+            "Recovery skipped a row owned by the other operator role"
+        );
+    }
+    owned
 }
 
 async fn decide_action(
@@ -443,7 +471,8 @@ async fn route_outcome(
 
 /// Synchronous boot pre-flight reconcile: repeatedly run `recover_once` with a
 /// `Duration::ZERO` threshold (so even a fresh crash row is reconciled) until no
-/// `Processing` rows remain, bounded by `max_passes`. A withdraw operator is
+/// `Processing` rows of this role's type remain, bounded by `max_passes`. Rows
+/// belonging to the other role are never counted or touched. A withdraw operator is
 /// single-active (SMT nonce ordering forbids a second sender), so at boot there
 /// is no live sibling whose not-yet-stale work this could disrupt. Exhausting
 /// `max_passes` with rows still `Processing` returns `Ok`: the caller's
@@ -467,8 +496,14 @@ pub async fn boot_reconcile_processing(
         )
         .await?;
 
+        // Same type scope as the sweep above, or the loop could never converge
+        // while a sibling role has Processing rows of its own.
         let remaining = storage
-            .get_stale_processing_transactions(Duration::ZERO, RECOVERY_BATCH_LIMIT)
+            .get_stale_processing_transactions(
+                Duration::ZERO,
+                RECOVERY_BATCH_LIMIT,
+                program_type.owned_transaction_type(),
+            )
             .await?;
         if remaining.is_empty() {
             return Ok(());
@@ -1086,6 +1121,96 @@ mod tests {
             mock.pending_transactions.lock().unwrap()[0].status,
             TransactionStatus::Parked,
             "fresh parked row must be left alone"
+        );
+    }
+
+    // ── role ownership ───────────────────────────────────────────────
+
+    /// A withdraw operator must leave escrow deposits alone. Its RPC client points
+    /// at the withdrawal destination chain, so classifying a deposit's mint
+    /// signature there reads a chain the signature was never sent to.
+    #[tokio::test]
+    async fn withdraw_sweep_ignores_processing_deposit() {
+        let mock = MockStorage::new();
+        let mut row = make_deposit_row(80);
+        row.status = TransactionStatus::Processing;
+        // Backdate past STALE_THRESHOLD so only ownership can keep the sweep off it.
+        row.updated_at = Utc::now() - chrono::Duration::minutes(10);
+        mock.pending_transactions.lock().unwrap().push(row.clone());
+        // A persisted signature is what an unowned sweep would classify cross-chain.
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
+            .await
+            .unwrap();
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client("http://localhost:1");
+        let (storage_tx, mut storage_rx) = mpsc::channel(8);
+
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+            .await
+            .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::Processing,
+            "a deposit is not the withdraw role's row to recover"
+        );
+        assert_eq!(
+            after[0].recovery_requeue_attempts, 0,
+            "a foreign row must not burn the requeue cap"
+        );
+        drop(after);
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "skipping a foreign row must not alert"
+        );
+    }
+
+    /// `role_owns` exhaustively, over all four role/row-type pairs. Called directly
+    /// on purpose: the SQL and mock reads are both type-scoped, so a cross-role row
+    /// can no longer reach the guard through storage.
+    #[test]
+    fn role_owns_rejects_cross_role_rows() {
+        let deposit = make_deposit_row(1);
+        let withdrawal = make_withdrawal_row(2, Some(1));
+        let cases = [
+            (ProgramType::Escrow, &deposit, true),
+            (ProgramType::Escrow, &withdrawal, false),
+            (ProgramType::Withdraw, &withdrawal, true),
+            (ProgramType::Withdraw, &deposit, false),
+        ];
+        for (program_type, row, expected) in cases {
+            assert_eq!(
+                role_owns(program_type, row),
+                expected,
+                "{program_type:?} vs {:?}",
+                row.transaction_type
+            );
+        }
+    }
+
+    /// The parked mirror: an escrow operator must not unpark a withdrawal a
+    /// withdraw sender still owns. This path issues no RPC, so ownership is the
+    /// only thing standing between it and a cross-role write.
+    #[tokio::test]
+    async fn escrow_sweep_ignores_parked_withdrawal() {
+        let mock = MockStorage::new();
+        let mut row = make_withdrawal_row(81, Some(9));
+        row.status = TransactionStatus::Parked;
+        row.updated_at = Utc::now() - chrono::Duration::minutes(10);
+        mock.pending_transactions.lock().unwrap().push(row);
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client("http://localhost:1");
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Escrow, &storage_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Parked,
+            "a withdrawal is not the escrow role's row to unpark"
         );
     }
 

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -336,14 +336,20 @@ impl Storage {
         quarantine_all_active_withdrawals::quarantine_all_active_withdrawals(self, exclude_id).await
     }
 
-    /// Stale `Processing` rows past the threshold (used by recovery).
+    /// Stale `Processing` rows of one type past the threshold (used by recovery).
     pub async fn get_stale_processing_transactions(
         &self,
         threshold: std::time::Duration,
         limit: i64,
+        transaction_type: TransactionType,
     ) -> Result<Vec<DbTransaction>, StorageError> {
-        get_stale_processing_transactions::get_stale_processing_transactions(self, threshold, limit)
-            .await
+        get_stale_processing_transactions::get_stale_processing_transactions(
+            self,
+            threshold,
+            limit,
+            transaction_type,
+        )
+        .await
     }
 
     /// CAS `Processing` → `Pending` on `updated_at`; `Ok(false)` if stale.
@@ -369,13 +375,20 @@ impl Storage {
         try_unpark_to_processing::try_unpark_to_processing(self, transaction_id).await
     }
 
-    /// Stale `Parked` rows older than the threshold, oldest-first.
+    /// Stale `Parked` rows of one type, oldest-first.
     pub async fn get_stale_parked_transactions(
         &self,
         threshold: std::time::Duration,
         limit: i64,
+        transaction_type: TransactionType,
     ) -> Result<Vec<DbTransaction>, StorageError> {
-        get_stale_parked_transactions::get_stale_parked_transactions(self, threshold, limit).await
+        get_stale_parked_transactions::get_stale_parked_transactions(
+            self,
+            threshold,
+            limit,
+            transaction_type,
+        )
+        .await
     }
 
     /// CAS `Parked` → `Pending` on `updated_at`; `Ok(false)` if stale.

--- a/indexer/src/storage/common/storage/get_stale_parked_transactions.rs
+++ b/indexer/src/storage/common/storage/get_stale_parked_transactions.rs
@@ -1,22 +1,26 @@
 use crate::{
     error::StorageError,
-    storage::common::{models::DbTransaction, storage::Storage},
+    storage::common::{
+        models::{DbTransaction, TransactionType},
+        storage::Storage,
+    },
 };
 
-/// Stale `Parked` rows older than the threshold, oldest-first.
+/// Stale `Parked` rows of one type older than the threshold, oldest-first.
 pub async fn get_stale_parked_transactions(
     storage: &Storage,
     threshold: std::time::Duration,
     limit: i64,
+    transaction_type: TransactionType,
 ) -> Result<Vec<DbTransaction>, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
-            .get_stale_parked_transactions_internal(threshold, limit)
+            .get_stale_parked_transactions_internal(threshold, limit, transaction_type)
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .get_stale_parked_transactions(threshold, limit)
+                .get_stale_parked_transactions(threshold, limit, transaction_type)
                 .await
         }
     }

--- a/indexer/src/storage/common/storage/get_stale_processing_transactions.rs
+++ b/indexer/src/storage/common/storage/get_stale_processing_transactions.rs
@@ -1,23 +1,27 @@
 use crate::{
     error::StorageError,
-    storage::common::{models::DbTransaction, storage::Storage},
+    storage::common::{
+        models::{DbTransaction, TransactionType},
+        storage::Storage,
+    },
 };
 use std::time::Duration;
 
-/// Stale `Processing` rows past the threshold, oldest-first.
+/// Stale `Processing` rows of one type past the threshold, oldest-first.
 pub async fn get_stale_processing_transactions(
     storage: &Storage,
     threshold: Duration,
     limit: i64,
+    transaction_type: TransactionType,
 ) -> Result<Vec<DbTransaction>, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
-            .get_stale_processing_transactions_internal(threshold, limit)
+            .get_stale_processing_transactions_internal(threshold, limit, transaction_type)
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .get_stale_processing_transactions(threshold, limit)
+                .get_stale_processing_transactions(threshold, limit, transaction_type)
                 .await
         }
     }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -541,6 +541,7 @@ impl MockStorage {
         &self,
         threshold: std::time::Duration,
         limit: i64,
+        transaction_type: TransactionType,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         self.check_should_fail("get_stale_processing_transactions")?;
         let threshold_chrono = chrono::Duration::from_std(threshold)
@@ -548,9 +549,15 @@ impl MockStorage {
             .unwrap_or_else(|_| chrono::Duration::days(1));
         let cutoff = Utc::now() - threshold_chrono;
         let pending = self.pending_transactions.lock().unwrap();
+        // Mirrors the Postgres type predicate so the mock cannot hand a caller a
+        // row its role does not own.
         let mut matched: Vec<DbTransaction> = pending
             .iter()
-            .filter(|t| t.status == TransactionStatus::Processing && t.updated_at < cutoff)
+            .filter(|t| {
+                t.status == TransactionStatus::Processing
+                    && t.updated_at < cutoff
+                    && t.transaction_type == transaction_type
+            })
             .cloned()
             .collect();
         matched.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
@@ -617,6 +624,7 @@ impl MockStorage {
         &self,
         threshold: std::time::Duration,
         limit: i64,
+        transaction_type: TransactionType,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         self.check_should_fail("get_stale_parked_transactions")?;
         let threshold_chrono = chrono::Duration::from_std(threshold)
@@ -624,9 +632,14 @@ impl MockStorage {
             .unwrap_or_else(|_| chrono::Duration::days(1));
         let cutoff = Utc::now() - threshold_chrono;
         let pending = self.pending_transactions.lock().unwrap();
+        // Same type predicate as Postgres; see the stale Processing read.
         let mut matched: Vec<DbTransaction> = pending
             .iter()
-            .filter(|t| t.status == TransactionStatus::Parked && t.updated_at < cutoff)
+            .filter(|t| {
+                t.status == TransactionStatus::Parked
+                    && t.updated_at < cutoff
+                    && t.transaction_type == transaction_type
+            })
             .cloned()
             .collect();
         matched.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1148,11 +1148,15 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
-    /// Stale `Processing` rows older than the threshold, oldest-first.
+    /// Stale `Processing` rows of one transaction type, oldest-first.
+    ///
+    /// Scoped by type because both operator roles share this table: the sweep
+    /// must only return rows the caller's role owns.
     pub async fn get_stale_processing_transactions_internal(
         &self,
         threshold: Duration,
         limit: i64,
+        transaction_type: TransactionType,
     ) -> Result<Vec<DbTransaction>, sqlx::Error> {
         let threshold_secs = threshold.as_secs() as f64;
         sqlx::query_as::<_, DbTransaction>(&format!(
@@ -1163,6 +1167,7 @@ impl PostgresDb {
             FROM transactions
             WHERE {} = 'processing'
               AND {} < NOW() - make_interval(secs => $1)
+              AND {} = $3
             ORDER BY {} ASC
             LIMIT $2
             "#,
@@ -1193,11 +1198,13 @@ impl PostgresDb {
             // Filters
             transaction_cols::STATUS,
             transaction_cols::UPDATED_AT,
+            transaction_cols::TRANSACTION_TYPE,
             // Ordering (FIFO over stale)
             transaction_cols::UPDATED_AT,
         ))
         .bind(threshold_secs)
         .bind(limit)
+        .bind(transaction_type)
         .fetch_all(&self.pool)
         .await
     }
@@ -1269,11 +1276,16 @@ impl PostgresDb {
         Ok(result.rows_affected() == 1)
     }
 
-    /// Stale `Parked` rows older than the threshold, oldest-first.
+    /// Stale `Parked` rows of one transaction type, oldest-first.
+    ///
+    /// Type-scoped for the same reason as the stale `Processing` read: the
+    /// parked sweep unparks rows unconditionally, so a cross-role hit would
+    /// hand back a row another operator still owns.
     pub async fn get_stale_parked_transactions_internal(
         &self,
         threshold: Duration,
         limit: i64,
+        transaction_type: TransactionType,
     ) -> Result<Vec<DbTransaction>, sqlx::Error> {
         let threshold_secs = threshold.as_secs() as f64;
         sqlx::query_as::<_, DbTransaction>(&format!(
@@ -1284,6 +1296,7 @@ impl PostgresDb {
             FROM transactions
             WHERE {} = 'parked'
               AND {} < NOW() - make_interval(secs => $1)
+              AND {} = $3
             ORDER BY {} ASC
             LIMIT $2
             "#,
@@ -1314,11 +1327,13 @@ impl PostgresDb {
             // Filters
             transaction_cols::STATUS,
             transaction_cols::UPDATED_AT,
+            transaction_cols::TRANSACTION_TYPE,
             // Ordering (FIFO over stale)
             transaction_cols::UPDATED_AT,
         ))
         .bind(threshold_secs)
         .bind(limit)
+        .bind(transaction_type)
         .fetch_all(&self.pool)
         .await
     }

--- a/integration/tests/indexer/parked_withdrawal_recovery.rs
+++ b/integration/tests/indexer/parked_withdrawal_recovery.rs
@@ -277,7 +277,11 @@ async fn get_stale_parked_filters_and_orders() {
 
     // Stale parked only, oldest updated_at first.
     let stale = storage
-        .get_stale_parked_transactions(Duration::from_secs(5 * 60), 100)
+        .get_stale_parked_transactions(
+            Duration::from_secs(5 * 60),
+            100,
+            TransactionType::Withdrawal,
+        )
         .await
         .unwrap();
     let ids: Vec<i64> = stale.iter().map(|t| t.id).collect();
@@ -285,7 +289,7 @@ async fn get_stale_parked_filters_and_orders() {
 
     // Limit is honored (FIFO over stale → the oldest).
     let limited = storage
-        .get_stale_parked_transactions(Duration::from_secs(5 * 60), 1)
+        .get_stale_parked_transactions(Duration::from_secs(5 * 60), 1, TransactionType::Withdrawal)
         .await
         .unwrap();
     assert_eq!(limited.len(), 1);
@@ -342,6 +346,41 @@ async fn recovery_requeues_stale_parked_to_pending() {
     assert!(
         storage_rx.try_recv().is_err(),
         "parked rescue is routine cleanup — no webhook alert"
+    );
+}
+
+/// An escrow operator shares this database but owns only deposits. Parking is
+/// withdrawal-only, so its parked sweep must find nothing: unparking a withdrawal
+/// would hand a row a withdraw sender still owns back to the pending queue.
+#[tokio::test(flavor = "multi_thread")]
+async fn escrow_recovery_never_unparks_withdrawal() {
+    let (db, url, _c) = start_pg("role_scope_parked").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let id = db
+        .insert_transaction_internal(&make_withdrawal(&Signature::new_unique().to_string(), 22))
+        .await
+        .unwrap();
+    set_status(&pool, id, "parked").await;
+    // Stale enough that only ownership keeps the escrow sweep off it.
+    backdate(&pool, id, ChronoDuration::minutes(10)).await;
+
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+    test_hooks::run_recovery_once(&storage, &dead_client(), ProgramType::Escrow, &storage_tx)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        status_of(&pool, id).await,
+        "parked",
+        "a withdrawal is not the escrow role's row to unpark"
+    );
+    assert_eq!(
+        requeue_attempts_of(&pool, id).await,
+        0,
+        "a foreign row must not be written at all"
     );
 }
 

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -6,7 +6,7 @@ use {
         config::ProgramType,
         metrics::OPERATOR_STALE_PROCESSING_RECOVERED,
         operator::{
-            recovery::test_hooks,
+            recovery::{boot_reconcile_processing, test_hooks},
             utils::rpc_util::{RetryConfig, RpcClientWithRetry},
             TransactionStatusUpdate,
         },
@@ -18,6 +18,7 @@ use {
     std::{sync::Arc, time::Duration},
     test_utils::mock_rpc::{MockRpcServer, Reply},
     tokio::sync::mpsc,
+    tokio_util::sync::CancellationToken,
 };
 
 /// Pre-test reading of a recovery-metric cell; assert `>snapshot` after.
@@ -1105,6 +1106,195 @@ async fn it13_recovery_requeue_cap_quarantines_after_max() {
     mock.shutdown().await;
 }
 
+// I1: the stale-Processing read is scoped to one transaction type. Only this can
+// prove the SQL predicate, including that renumbering the placeholders left the
+// threshold and limit binds intact.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_queries_filter_by_transaction_type() {
+    let (db, url, _container) = start_pg("role_scope_query").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let deposit = make_deposit(
+        &Signature::new_unique().to_string(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        1_000,
+    );
+    let deposit_id = db.insert_transaction_internal(&deposit).await.unwrap();
+    seed_backdated_processing(&pool, deposit_id, ChronoDuration::minutes(10)).await;
+
+    let withdrawal = make_withdrawal(&Signature::new_unique().to_string(), 55);
+    let withdrawal_id = db.insert_transaction_internal(&withdrawal).await.unwrap();
+    seed_backdated_processing(&pool, withdrawal_id, ChronoDuration::minutes(10)).await;
+
+    let deposits = db
+        .get_stale_processing_transactions_internal(
+            Duration::from_secs(5 * 60),
+            100,
+            TransactionType::Deposit,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        deposits.iter().map(|r| r.id).collect::<Vec<_>>(),
+        vec![deposit_id],
+        "asking for deposits must not return the withdrawal"
+    );
+
+    let withdrawals = db
+        .get_stale_processing_transactions_internal(
+            Duration::from_secs(5 * 60),
+            100,
+            TransactionType::Withdrawal,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        withdrawals.iter().map(|r| r.id).collect::<Vec<_>>(),
+        vec![withdrawal_id],
+        "asking for withdrawals must not return the deposit"
+    );
+
+    // The type bind must not have displaced the threshold bind: a threshold
+    // wider than the rows' age still excludes them.
+    let too_young = db
+        .get_stale_processing_transactions_internal(
+            Duration::from_secs(60 * 60),
+            100,
+            TransactionType::Deposit,
+        )
+        .await
+        .unwrap();
+    assert!(too_young.is_empty(), "threshold bind must still be $1");
+
+    // Nor the limit bind.
+    let capped = db
+        .get_stale_processing_transactions_internal(
+            Duration::from_secs(5 * 60),
+            0,
+            TransactionType::Deposit,
+        )
+        .await
+        .unwrap();
+    assert!(capped.is_empty(), "limit bind must still be $2");
+}
+
+// I2: a withdraw operator must never sweep an escrow deposit row. Its RPC client
+// points at the withdrawal destination chain, so classifying a deposit's mint
+// signature there reads a chain the signature was never sent to. Ownership is
+// checked before any request leaves the process, which the zero call counts pin.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn withdraw_recovery_never_touches_escrow_deposit() {
+    let (db, url, _container) = start_pg("role_scope_processing").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_deposit(
+        &Signature::new_unique().to_string(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        4_242,
+    );
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    // The persisted mint signature is what a cross-role sweep would classify.
+    db.insert_release_signature_internal(tx_id, Signature::new_unique().to_string(), 100)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, mut storage_rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        mock.call_count("getSignatureStatuses"),
+        0,
+        "ownership must be verified before any RPC to the wrong chain"
+    );
+    assert_eq!(
+        mock.call_count("getBlockHeight"),
+        0,
+        "no height comparison may run against a foreign chain"
+    );
+    assert_eq!(
+        status_of(&pool, tx_id).await,
+        "processing",
+        "a deposit is not the withdraw role's row to recover"
+    );
+    assert!(
+        updated_at_of(&pool, tx_id).await < Utc::now() - ChronoDuration::minutes(5),
+        "no write means updated_at stays backdated"
+    );
+    assert!(
+        storage_rx.try_recv().is_err(),
+        "skipping a foreign row must not alert"
+    );
+    mock.shutdown().await;
+}
+
+// I4: the boot reconcile sweeps with a ZERO threshold, so age protects nothing.
+// A withdraw operator booting beside a live escrow operator must still leave every
+// deposit alone, including ones actively being minted.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn withdraw_boot_reconcile_ignores_foreign_processing_rows() {
+    let (db, url, _container) = start_pg("role_scope_boot").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let mut ids = Vec::new();
+    for amount in [10u64, 20, 30] {
+        let tx = make_deposit(
+            &Signature::new_unique().to_string(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            amount,
+        );
+        let id = db.insert_transaction_internal(&tx).await.unwrap();
+        seed_backdated_processing(&pool, id, ChronoDuration::minutes(10)).await;
+        db.insert_release_signature_internal(id, Signature::new_unique().to_string(), 100)
+            .await
+            .unwrap();
+        ids.push(id);
+    }
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    boot_reconcile_processing(
+        &storage,
+        &client,
+        ProgramType::Withdraw,
+        &storage_tx,
+        &CancellationToken::new(),
+        2,
+    )
+    .await
+    .unwrap();
+
+    for id in ids {
+        assert_eq!(
+            status_of(&pool, id).await,
+            "processing",
+            "boot reconcile must leave foreign deposits untouched"
+        );
+    }
+    assert_eq!(mock.call_count("getSignatureStatuses"), 0);
+    assert_eq!(mock.call_count("getBlockHeight"), 0);
+    mock.shutdown().await;
+}
+
 // Threshold boundary: three rows at -4:59 / -5:00 / -5:01, expect the two older returned.
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1152,7 +1342,11 @@ async fn threshold_boundary_returns_only_strictly_older_rows() {
         .unwrap();
 
     let stale = db
-        .get_stale_processing_transactions_internal(Duration::from_secs(5 * 60), 100)
+        .get_stale_processing_transactions_internal(
+            Duration::from_secs(5 * 60),
+            100,
+            TransactionType::Deposit,
+        )
         .await
         .unwrap();
     // 4:59 excluded; 5:00 is timing-dependent (Postgres `<` is strict).


### PR DESCRIPTION
## Summary

Both operator roles share the same transactions table, but they operate on different chains: escrow handles deposits on PrivateChannel, while withdraw handles releases on Solana. The recovery sweep only checked status and age, so a withdraw operator could incorrectly pick up an escrow deposit, query its PrivateChannel signature on Solana, mark it `Pending`, and cause the deposit to be minted again.

Recovery queries are now also filtered by `transaction_type`, with the role-to-type mapping centralized in `ProgramType::owned_transaction_type`. A `role_owns` guard also prevents a role from reading or processing rows it does not own. `MockStorage` uses the same ownership check.

This also prevents one role's backlog from consuming the shared 100-row batch limit and fixes boot reconciliation from getting stuck. No database migration is required, and mixed-version operators remain safe.

Four unit tests and four Postgres integration tests cover the recovery sweeps, SQL filtering, ownership checks, and boot reconciliation.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 11,994 | 13,619 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31173145739) |
| Indexer | 23,146 | 26,259 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31173145739) |
| Gateway | 1,055 | 1,230 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31173145739) |
| Auth | 830 | 949 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31173145739) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,273 | 15,326 | 80.1% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31173145739) |
| **Total** | **49,298** | **57,383** | **85.9%** | |

> Last updated: 2026-08-07 11:37:25 UTC by E2E Integration