### PR TITLE
fix(rpc): reject transactions with duplicate account keys (ottersec-14)

### DIFF
--- a/core/src/rpc/send_transaction_impl.rs
+++ b/core/src/rpc/send_transaction_impl.rs
@@ -10,7 +10,7 @@ use solana_rpc_client_types::config::RpcSendTransactionConfig;
 use solana_runtime_transaction::runtime_transaction::RuntimeTransaction;
 use solana_sdk::{
     message::{v0::LoadedAddresses, SimpleAddressLoader},
-    transaction::{MessageHash, VersionedTransaction},
+    transaction::{MessageHash, SanitizedTransaction, VersionedTransaction, MAX_TX_ACCOUNT_LOCKS},
 };
 use std::collections::HashSet;
 use tokio::sync::mpsc;
@@ -68,6 +68,14 @@ pub async fn send_transaction_impl(
     )
     .map_err(|err| custom_error(INVALID_PARAMS_CODE, format!("invalid transaction: {err}")))?;
     let sanitized_tx = runtime_tx.into_inner_transaction();
+
+    // Sanitization never looks for repeated account keys, so this is the first
+    // and only place a transaction the scheduler cannot lock gets caught while
+    // there is still a caller to report a reason to. Passing the real limit
+    // instead of usize::MAX also keeps the account-count bound in force. Agave
+    // rejects the same shape when it admits packets into its banking buffer.
+    SanitizedTransaction::validate_account_locks(sanitized_tx.message(), MAX_TX_ACCOUNT_LOCKS)
+        .map_err(|err| custom_error(INVALID_PARAMS_CODE, format!("invalid transaction: {err}")))?;
 
     // Filter: only accept SPL token, ATA, System Program, Memo, Withdraw, and Swap Program transactions
     let is_allowed_transaction =
@@ -303,6 +311,27 @@ mod tests {
 
         let result = send_transaction_impl(&deps, encoded, None).await;
         assert!(result.is_ok(), "SPL token tx should pass allowlist");
+    }
+
+    // The rx assertion is load bearing: it proves the tx never entered the pipeline.
+    #[tokio::test]
+    async fn duplicate_account_keys_rejected() {
+        let payer = Keypair::new();
+        let tx = crate::test_helpers::duplicate_account_keys_transaction(&payer, Hash::default());
+        let (deps, rx) = make_write_deps();
+
+        let err = send_transaction_impl(&deps, encode_tx(&tx), None)
+            .await
+            .expect_err("duplicate account keys must be rejected");
+
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+        // TransactionError::AccountLoadedTwice renders as "Account loaded twice".
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Account loaded twice"),
+            "error must name the duplicate-key cause; got: {msg}"
+        );
+        assert_eq!(rx.len(), 0, "rejected tx must not reach the dedup stage");
     }
 
     #[tokio::test]

--- a/core/src/rpc/send_transaction_impl.rs
+++ b/core/src/rpc/send_transaction_impl.rs
@@ -69,11 +69,11 @@ pub async fn send_transaction_impl(
     .map_err(|err| custom_error(INVALID_PARAMS_CODE, format!("invalid transaction: {err}")))?;
     let sanitized_tx = runtime_tx.into_inner_transaction();
 
-    // Sanitization never looks for repeated account keys, so this is the first
-    // and only place a transaction the scheduler cannot lock gets caught while
-    // there is still a caller to report a reason to. Passing the real limit
-    // instead of usize::MAX also keeps the account-count bound in force. Agave
-    // rejects the same shape when it admits packets into its banking buffer.
+    // Sanitization never looks for repeated account keys, so a duplicate would
+    // otherwise reach the sequencer, which has no way to report a per-transaction
+    // error. Catching it here is what lets the caller be told why. Passing the
+    // real limit rather than usize::MAX also keeps the account-count bound in
+    // force. Agave rejects the same shape when admitting packets to its buffer.
     SanitizedTransaction::validate_account_locks(sanitized_tx.message(), MAX_TX_ACCOUNT_LOCKS)
         .map_err(|err| custom_error(INVALID_PARAMS_CODE, format!("invalid transaction: {err}")))?;
 

--- a/core/src/rpc/simulate_transaction_impl.rs
+++ b/core/src/rpc/simulate_transaction_impl.rs
@@ -21,7 +21,7 @@ use solana_runtime_transaction::runtime_transaction::RuntimeTransaction;
 use solana_sdk::{
     message::{v0::LoadedAddresses, SimpleAddressLoader},
     pubkey::Pubkey,
-    transaction::{MessageHash, VersionedTransaction},
+    transaction::{MessageHash, SanitizedTransaction, VersionedTransaction, MAX_TX_ACCOUNT_LOCKS},
 };
 use solana_svm::transaction_processing_result::ProcessedTransaction;
 use solana_svm_callback::TransactionProcessingCallback;
@@ -92,6 +92,10 @@ pub async fn simulate_transaction(
     )
     .map_err(|err| custom_error(INVALID_PARAMS_CODE, format!("invalid transaction: {err}")))?;
     let sanitized_tx = runtime_tx.into_inner_transaction();
+
+    // Refuse here what sendTransaction refuses, so preflight cannot bless a tx that will never land.
+    SanitizedTransaction::validate_account_locks(sanitized_tx.message(), MAX_TX_ACCOUNT_LOCKS)
+        .map_err(|err| custom_error(INVALID_PARAMS_CODE, format!("invalid transaction: {err}")))?;
 
     if config.sig_verify {
         let sigverify_result = sigverify_transaction(&sanitized_tx, &read_deps.admin_keys).await;

--- a/core/src/scheduler/dag.rs
+++ b/core/src/scheduler/dag.rs
@@ -53,8 +53,13 @@ impl DAGScheduler {
                     dependencies.insert(dependent_tx);
                 }
 
+                // Skip our own lock, as the read loop below already does. A key
+                // repeated in the writable set would otherwise make the
+                // transaction depend on itself, and it would never become ready.
                 if let Some(write_tx) = locks.write_lock {
-                    dependencies.insert(write_tx);
+                    if write_tx != tx_index {
+                        dependencies.insert(write_tx);
+                    }
                 }
 
                 locks.write_lock = Some(tx_index);

--- a/core/src/scheduler/types.rs
+++ b/core/src/scheduler/types.rs
@@ -80,6 +80,30 @@ mod tests {
         assert_eq!(read_accounts, vec![spl_memo::id(), spl_memo::id()]);
     }
 
+    // The write-lock path is the one a repeated key can actually corrupt, so prove
+    // extraction reports it and the scheduler still emits the transaction instead
+    // of dropping it or spinning on a dependency it can never satisfy.
+    #[test]
+    fn duplicate_writable_key_still_schedules() {
+        use crate::scheduler::{Scheduler, SchedulerTrait};
+
+        let payer = Keypair::new();
+        let tx = crate::test_helpers::duplicate_writable_account_keys_transaction(
+            &payer,
+            Hash::default(),
+        );
+        let sanitized = SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new())
+            .expect("a writable duplicate-key message still sanitizes");
+
+        let (read_accounts, write_accounts) = extract_accounts(&sanitized);
+        assert_eq!(write_accounts, vec![payer.pubkey(), payer.pubkey()]);
+        assert_eq!(read_accounts, vec![spl_memo::id()]);
+
+        let batches = Scheduler::new_dag().schedule(vec![sanitized]);
+        assert_eq!(batches.len(), 1, "the transaction must still be scheduled");
+        assert_eq!(batches[0].len(), 1);
+    }
+
     // Pins the read/write split so the unchecked accessor cannot quietly change what gets locked.
     #[test]
     fn extract_accounts_splits_read_and_write() {

--- a/core/src/scheduler/types.rs
+++ b/core/src/scheduler/types.rs
@@ -41,14 +41,55 @@ impl ConflictFreeBatch {
 }
 
 pub fn extract_accounts(transaction: &SanitizedTransaction) -> (Vec<Pubkey>, Vec<Pubkey>) {
-    // Use Solana's built-in account locking mechanism
-    // We use usize::MAX as the limit to avoid artificial restrictions
-    let account_locks = transaction
-        .get_account_locks(usize::MAX)
-        .expect("Failed to get account locks");
+    // The unchecked accessor is the same account_keys walk as the checked one,
+    // minus a validation step that can fail. Keeping the scheduler total means
+    // a malformed transaction can never abort the sequencer task; structural
+    // validation happens once at RPC ingress, where a rejection reason can
+    // actually be returned to the caller.
+    let account_locks = transaction.get_account_locks_unchecked();
 
     let read_accounts = account_locks.readonly.into_iter().copied().collect();
     let write_accounts = account_locks.writable.into_iter().copied().collect();
 
     (read_accounts, write_accounts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{
+        create_test_sanitized_transaction, duplicate_account_keys_transaction,
+    };
+    use solana_sdk::{
+        hash::Hash,
+        signature::{Keypair, Signer},
+    };
+    use std::collections::HashSet;
+
+    // A repeated account key is attacker reachable, so lock extraction must stay total.
+    #[test]
+    fn extract_accounts_handles_duplicate_keys() {
+        let payer = Keypair::new();
+        let tx = duplicate_account_keys_transaction(&payer, Hash::default());
+        let sanitized = SanitizedTransaction::try_from_legacy_transaction(tx, &HashSet::new())
+            .expect("a duplicate-key message still sanitizes");
+
+        let (read_accounts, write_accounts) = extract_accounts(&sanitized);
+
+        assert_eq!(write_accounts, vec![payer.pubkey()]);
+        assert_eq!(read_accounts, vec![spl_memo::id(), spl_memo::id()]);
+    }
+
+    // Pins the read/write split so the unchecked accessor cannot quietly change what gets locked.
+    #[test]
+    fn extract_accounts_splits_read_and_write() {
+        let from = Keypair::new();
+        let to = Pubkey::new_unique();
+        let sanitized = create_test_sanitized_transaction(&from, &to, 1_000);
+
+        let (read_accounts, write_accounts) = extract_accounts(&sanitized);
+
+        assert_eq!(write_accounts, vec![from.pubkey(), to]);
+        assert_eq!(read_accounts, vec![solana_sdk::system_program::id()]);
+    }
 }

--- a/core/src/test_helpers.rs
+++ b/core/src/test_helpers.rs
@@ -1,7 +1,8 @@
 use crate::accounts::traits::BlockInfo;
 use solana_sdk::{
     hash::Hash,
-    message::Message,
+    instruction::CompiledInstruction,
+    message::{Message, MessageHeader},
     signature::{Keypair, Signer},
     transaction::{SanitizedTransaction, Transaction},
 };
@@ -19,6 +20,27 @@ pub fn create_test_sanitized_transaction(
     let transaction = Transaction::new(&[from], message, Hash::default());
     SanitizedTransaction::try_from_legacy_transaction(transaction, &HashSet::new())
         .expect("failed to create SanitizedTransaction from test legacy transaction")
+}
+
+/// Legacy transaction with a repeated account key, built field by field because the SDK dedupes.
+pub fn duplicate_account_keys_transaction(payer: &Keypair, recent_blockhash: Hash) -> Transaction {
+    let message = Message {
+        header: MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 2,
+        },
+        account_keys: vec![payer.pubkey(), spl_memo::id(), spl_memo::id()],
+        recent_blockhash,
+        instructions: vec![CompiledInstruction {
+            program_id_index: 1,
+            accounts: vec![],
+            data: b"dup".to_vec(),
+        }],
+    };
+    let mut transaction = Transaction::new_unsigned(message);
+    transaction.sign(&[payer], recent_blockhash);
+    transaction
 }
 
 /// Create a BlockInfo with sensible defaults for a given slot.

--- a/core/src/test_helpers.rs
+++ b/core/src/test_helpers.rs
@@ -24,16 +24,48 @@ pub fn create_test_sanitized_transaction(
 
 /// Legacy transaction with a repeated account key, built field by field because the SDK dedupes.
 pub fn duplicate_account_keys_transaction(payer: &Keypair, recent_blockhash: Hash) -> Transaction {
+    // Both copies land in the readonly tail, which is the cheapest shape to submit.
+    duplicate_keys_transaction(
+        payer,
+        recent_blockhash,
+        vec![payer.pubkey(), spl_memo::id(), spl_memo::id()],
+        2,
+        1,
+    )
+}
+
+/// Same idea, but the repeated key is writable, which is the shape that stresses the write locks.
+pub fn duplicate_writable_account_keys_transaction(
+    payer: &Keypair,
+    recent_blockhash: Hash,
+) -> Transaction {
+    // Only the trailing program stays readonly, so the payer is locked writable twice.
+    duplicate_keys_transaction(
+        payer,
+        recent_blockhash,
+        vec![payer.pubkey(), payer.pubkey(), spl_memo::id()],
+        1,
+        2,
+    )
+}
+
+fn duplicate_keys_transaction(
+    payer: &Keypair,
+    recent_blockhash: Hash,
+    account_keys: Vec<solana_sdk::pubkey::Pubkey>,
+    num_readonly_unsigned_accounts: u8,
+    program_id_index: u8,
+) -> Transaction {
     let message = Message {
         header: MessageHeader {
             num_required_signatures: 1,
             num_readonly_signed_accounts: 0,
-            num_readonly_unsigned_accounts: 2,
+            num_readonly_unsigned_accounts,
         },
-        account_keys: vec![payer.pubkey(), spl_memo::id(), spl_memo::id()],
+        account_keys,
         recent_blockhash,
         instructions: vec![CompiledInstruction {
-            program_id_index: 1,
+            program_id_index,
             accounts: vec![],
             data: b"dup".to_vec(),
         }],

--- a/integration/tests/private-channel/rpc/test_send_transaction_errors.rs
+++ b/integration/tests/private-channel/rpc/test_send_transaction_errors.rs
@@ -17,17 +17,29 @@
 //!      server must reject with `INVALID_PARAMS_CODE` before the pipeline
 //!      is entered. Hits the size-check arm.
 //!
-//! Case C ("program not in allowlist") is out of scope here because the
-//! allowlist enforcement lives in a separate later stage and requires
-//! configuration plumbing not part of the default `PrivateChannelContext`. That
-//! branch can be a follow-up test when the context exposes a runtime
-//! allowlist toggle.
+//!   C. **Duplicate account keys**: a hand-assembled legacy message whose
+//!      `account_keys` repeat a pubkey. It clears sanitization, the allowlist
+//!      and sigverify, so without the ingress lock-validation guard it reaches
+//!      the sequencer and aborts the write node. Asserts the rejection and
+//!      then probes the write node for liveness.
+//!
+//! "Program not in allowlist" is out of scope here because the allowlist
+//! enforcement lives in a separate later stage and requires configuration
+//! plumbing not part of the default `PrivateChannelContext`. That branch can be
+//! a follow-up test when the context exposes a runtime allowlist toggle.
 
 use {
     super::test_context::PrivateChannelContext,
     base64::{engine::general_purpose::STANDARD, Engine as _},
+    private_channel_core::test_helpers::duplicate_account_keys_transaction,
     serde_json::json,
     solana_client::rpc_request::RpcRequest,
+    solana_sdk::{
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
+    solana_system_interface::instruction as system_instruction,
+    std::time::Duration,
 };
 
 const INVALID_PARAMS_CODE: i64 = -32_602;
@@ -37,8 +49,9 @@ pub async fn run_send_transaction_errors_test(ctx: &PrivateChannelContext) {
 
     case_a_base64_decode_failure(ctx).await;
     case_b_oversized_transaction(ctx).await;
+    case_c_duplicate_account_keys(ctx).await;
 
-    println!("✓ base64-decode + oversized branches passed");
+    println!("✓ base64-decode + oversized + duplicate-key branches passed");
 }
 
 // ── Case A ──────────────────────────────────────────────────────────────────
@@ -85,4 +98,56 @@ async fn case_b_oversized_transaction(ctx: &PrivateChannelContext) {
         msg.contains("too large") || msg.contains("1232") || msg.contains("1233"),
         "error must identify size as the cause; got: {msg}"
     );
+}
+
+// ── Case C ──────────────────────────────────────────────────────────────────
+async fn case_c_duplicate_account_keys(ctx: &PrivateChannelContext) {
+    // A live blockhash is mandatory here. With a stale one the dedup stage
+    // drops the transaction before the sequencer ever sees it, so the case
+    // would pass for a reason that has nothing to do with the guard under
+    // test, and it would keep passing if the guard were removed again.
+    let blockhash = ctx
+        .get_blockhash()
+        .await
+        .expect("live blockhash for the duplicate-key tx");
+    let payer = Keypair::new();
+    let tx = duplicate_account_keys_transaction(&payer, blockhash);
+    let encoded = STANDARD.encode(bincode::serialize(&tx).expect("serialize duplicate-key tx"));
+
+    let err = ctx
+        .write_client
+        .send::<serde_json::Value>(
+            RpcRequest::SendTransaction,
+            json!([encoded, {"skipPreflight": true, "encoding": "base64"}]),
+        )
+        .await
+        .expect_err("duplicate account keys must be rejected");
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("account loaded twice") || msg.contains(&INVALID_PARAMS_CODE.to_string()),
+        "error must name the duplicate-key cause or invalid-params; got: {msg}"
+    );
+
+    // Liveness probe. The sequencer runs inside the write node's process, so a
+    // transfer that is still accepted here proves the rejected transaction did
+    // not take the node down. It needs no funding; acceptance only requires the
+    // allowlist, sigverify and a live blockhash.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let probe_payer = Keypair::new();
+    let probe_blockhash = ctx
+        .get_blockhash()
+        .await
+        .expect("live blockhash for the liveness probe");
+    let ix = system_instruction::transfer(&probe_payer.pubkey(), &Keypair::new().pubkey(), 1);
+    let probe = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&probe_payer.pubkey()),
+        &[&probe_payer],
+        probe_blockhash,
+    );
+    ctx.write_client
+        .send_transaction(&probe)
+        .await
+        .expect("write node must still accept transactions after the rejection");
 }

--- a/integration/tests/private-channel/rpc/test_send_transaction_errors.rs
+++ b/integration/tests/private-channel/rpc/test_send_transaction_errors.rs
@@ -4,7 +4,7 @@
 //! Binary: `private_channel_integration` (existing).
 //! Fixture: reuses `PrivateChannelContext`.
 //!
-//! Covers the two non-SDK-duplication branches in `send_transaction_impl`:
+//! Covers the non-SDK-duplication branches in `send_transaction_impl`:
 //!
 //!   A. **Base64 decode failure** — SDK `send_transaction` does client-side
 //!      pre-encoding, so an entirely-invalid-base64 case doesn't reach the
@@ -20,8 +20,11 @@
 //!   C. **Duplicate account keys**: a hand-assembled legacy message whose
 //!      `account_keys` repeat a pubkey. It clears sanitization, the allowlist
 //!      and sigverify, so without the ingress lock-validation guard it reaches
-//!      the sequencer and aborts the write node. Asserts the rejection and
-//!      then probes the write node for liveness.
+//!      the sequencer and aborts the write node. The assertion names the
+//!      duplicate-key reason specifically, because every other rejection arm
+//!      in this handler also returns `INVALID_PARAMS_CODE` and would otherwise
+//!      satisfy it. A memo transaction must then land, which only happens if
+//!      the sequencer survived.
 //!
 //! "Program not in allowlist" is out of scope here because the allowlist
 //! enforcement lives in a separate later stage and requires configuration
@@ -35,14 +38,17 @@ use {
     serde_json::json,
     solana_client::rpc_request::RpcRequest,
     solana_sdk::{
+        instruction::Instruction,
         signature::{Keypair, Signer},
         transaction::Transaction,
     },
-    solana_system_interface::instruction as system_instruction,
     std::time::Duration,
 };
 
 const INVALID_PARAMS_CODE: i64 = -32_602;
+
+/// Generous because it only bounds the failure case; a healthy pipeline returns in well under a second.
+const LIVENESS_PROBE_SECONDS: u64 = 15;
 
 pub async fn run_send_transaction_errors_test(ctx: &PrivateChannelContext) {
     println!("\n=== sendTransaction — Error Classification ===");
@@ -102,10 +108,9 @@ async fn case_b_oversized_transaction(ctx: &PrivateChannelContext) {
 
 // ── Case C ──────────────────────────────────────────────────────────────────
 async fn case_c_duplicate_account_keys(ctx: &PrivateChannelContext) {
-    // A live blockhash is mandatory here. With a stale one the dedup stage
-    // drops the transaction before the sequencer ever sees it, so the case
-    // would pass for a reason that has nothing to do with the guard under
-    // test, and it would keep passing if the guard were removed again.
+    // A live blockhash keeps the transaction on the path the guard protects:
+    // without the guard a stale one would be dropped by dedup instead of
+    // reaching the sequencer, so the case would no longer describe the bug.
     let blockhash = ctx
         .get_blockhash()
         .await
@@ -123,31 +128,46 @@ async fn case_c_duplicate_account_keys(ctx: &PrivateChannelContext) {
         .await
         .expect_err("duplicate account keys must be rejected");
 
+    // Naming the reason matters: the base64, size, sanitize and allowlist arms
+    // all return the same code, so accepting a bare code would let this case
+    // stay green even if the guard under test were deleted.
     let msg = err.to_string().to_lowercase();
     assert!(
-        msg.contains("account loaded twice") || msg.contains(&INVALID_PARAMS_CODE.to_string()),
-        "error must name the duplicate-key cause or invalid-params; got: {msg}"
+        msg.contains("account loaded twice"),
+        "error must name the duplicate-key cause; got: {msg}"
+    );
+    assert!(
+        msg.contains(&INVALID_PARAMS_CODE.to_string()),
+        "duplicate keys are a client error; got: {msg}"
     );
 
-    // Liveness probe. The sequencer runs inside the write node's process, so a
-    // transfer that is still accepted here proves the rejected transaction did
-    // not take the node down. It needs no funding; acceptance only requires the
-    // allowlist, sigverify and a live blockhash.
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    let probe_payer = Keypair::new();
+    // The probe has to wait for the memo to land, not merely be accepted.
+    // sendTransaction returns as soon as the tx is queued, three stages ahead of
+    // the sequencer, and this harness never polls wait_for_any_worker_quit, so
+    // an acceptance-only check would still pass with the write pipeline dead.
+    // A landed transaction is proof the sequencer survived the rejected one.
     let probe_blockhash = ctx
         .get_blockhash()
         .await
         .expect("live blockhash for the liveness probe");
-    let ix = system_instruction::transfer(&probe_payer.pubkey(), &Keypair::new().pubkey(), 1);
-    let probe = Transaction::new_signed_with_payer(
-        &[ix],
-        Some(&probe_payer.pubkey()),
-        &[&probe_payer],
-        probe_blockhash,
-    );
-    ctx.write_client
-        .send_transaction(&probe)
+    let probe = memo_tx(probe_blockhash, "ottersec-14-liveness");
+    let landed = ctx
+        .send_and_check(&probe, Duration::from_secs(LIVENESS_PROBE_SECONDS))
         .await
-        .expect("write node must still accept transactions after the rejection");
+        .expect("liveness probe must not error");
+    assert!(
+        landed.is_some(),
+        "sequencer must still land transactions after the duplicate-key rejection"
+    );
+}
+
+/// Unique allowlisted memo tx; the memo program is loaded in the node VM so this lands.
+fn memo_tx(blockhash: solana_sdk::hash::Hash, tag: &str) -> Transaction {
+    let payer = Keypair::new();
+    let memo = Instruction {
+        program_id: spl_memo::id(),
+        accounts: vec![],
+        data: tag.as_bytes().to_vec(),
+    };
+    Transaction::new_signed_with_payer(&[memo], Some(&payer.pubkey()), &[&payer], blockhash)
 }

--- a/integration/tests/private-channel/rpc/test_simulate_transaction_preflight.rs
+++ b/integration/tests/private-channel/rpc/test_simulate_transaction_preflight.rs
@@ -10,6 +10,8 @@
 //!   B. **Invalid base64** in the tx parameter → RPC error `-32602`.
 //!   C. **Malformed bincode** (valid base64 but not a transaction) → RPC
 //!      error `-32602` with "Failed to deserialize transaction".
+//!   D. **Duplicate account keys**: RPC error `-32602`, keeping simulation
+//!      and `sendTransaction` in agreement about what a valid transaction is.
 //!
 //! `test_simulate_transaction_with_account_writes` covers the
 //! accounts-return / encoding / replaceRecentBlockhash branches separately.
@@ -17,6 +19,7 @@
 use {
     super::test_context::PrivateChannelContext,
     base64::{engine::general_purpose::STANDARD, Engine as _},
+    private_channel_core::test_helpers::duplicate_account_keys_transaction,
     serde_json::json,
     solana_client::rpc_request::RpcRequest,
     solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction},
@@ -29,8 +32,9 @@ pub async fn run_simulate_transaction_preflight_test(ctx: &PrivateChannelContext
     case_a_valid_simulation(ctx).await;
     case_b_invalid_base64(ctx).await;
     case_c_malformed_bincode(ctx).await;
+    case_d_duplicate_account_keys(ctx).await;
 
-    println!("✓ three preflight branches passed");
+    println!("✓ four preflight branches passed");
 }
 
 // ── Case A ──────────────────────────────────────────────────────────────────
@@ -103,5 +107,28 @@ async fn case_c_malformed_bincode(ctx: &PrivateChannelContext) {
     assert!(
         msg.contains("deserialize") || msg.contains("-32602"),
         "error must name deserialize failure or invalid-params; got {msg}"
+    );
+}
+
+// ── Case D ──────────────────────────────────────────────────────────────────
+async fn case_d_duplicate_account_keys(ctx: &PrivateChannelContext) {
+    // Simulation must refuse what sendTransaction refuses, or preflight blesses a doomed tx.
+    let payer = Keypair::new();
+    let blockhash = ctx.get_blockhash().await.expect("live blockhash");
+    let tx = duplicate_account_keys_transaction(&payer, blockhash);
+    let encoded = STANDARD.encode(bincode::serialize(&tx).expect("serialize duplicate-key tx"));
+
+    let err = ctx
+        .read_client
+        .send::<serde_json::Value>(
+            RpcRequest::SimulateTransaction,
+            json!([encoded, {"encoding": "base64", "sigVerify": false}]),
+        )
+        .await
+        .expect_err("duplicate account keys must be rejected by simulation");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("account loaded twice") || msg.contains("-32602"),
+        "error must name the duplicate cause or invalid-params; got {msg}"
     );
 }

--- a/integration/tests/private-channel/rpc/test_simulate_transaction_preflight.rs
+++ b/integration/tests/private-channel/rpc/test_simulate_transaction_preflight.rs
@@ -126,9 +126,10 @@ async fn case_d_duplicate_account_keys(ctx: &PrivateChannelContext) {
         )
         .await
         .expect_err("duplicate account keys must be rejected by simulation");
+    // Cases B and C already return this code, so only the reason pins this arm.
     let msg = err.to_string().to_lowercase();
     assert!(
-        msg.contains("account loaded twice") || msg.contains("-32602"),
-        "error must name the duplicate cause or invalid-params; got {msg}"
+        msg.contains("account loaded twice"),
+        "error must name the duplicate cause; got {msg}"
     );
 }


### PR DESCRIPTION
## Problem

`extract_accounts` used `get_account_locks(usize::MAX)`, which could panic on duplicate account keys. A crafted `sendTransaction` could therefore panic the sequencer task, and because any worker exit is treated as fatal, bring down the process.

## Fix

`send_transaction_impl` and `simulate_transaction` now validate account locks against the real `MAX_TX_ACCOUNT_LOCKS` limit and return `-32602` for invalid transactions. The scheduler now uses `get_account_locks_unchecked`, so invalid input is rejected at the RPC boundary and can no longer panic the sequencer.

The 128-account limit also restores the bound that was previously discarded. No valid transaction is affected because the 1232-byte packet limit currently caps account keys below this limit.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 12,065 | 13,690 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31184157099) |
| Indexer | 23,032 | 26,130 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31184157099) |
| Gateway | 1,055 | 1,230 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31184157099) |
| Auth | 830 | 949 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31184157099) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,237 | 15,287 | 80.0% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31184157099) |
| **Total** | **49,219** | **57,286** | **85.9%** | |

> Last updated: 2026-08-07 14:15:20 UTC by E2E Integration