### PR TITLE
fix(core): treat zero lamports as deallocation in BOB and settlement (issue-155)

### DIFF
--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -94,7 +94,7 @@ struct AccountWithMeta {
     synced_since: Option<u64>,
     // Whether we deleted this account. We can't remove an account from the
     // HashMap while we keep it in-memory because it will fallback to the
-    // AccountsDB.
+    // AccountsDB. Set at zero lamports, the SVM's own test for absence.
     deleted: bool,
     /// Generation of the last executor write to this account, or `None` when the
     /// executor never wrote it (loaded from the AccountsDB, or injected by a
@@ -290,11 +290,9 @@ impl BOB {
                             .enumerate()
                         {
                             if sanitized_transaction.is_writable(index) {
-                                // A zero-lamport, empty-data writable account is a
-                                // tombstone; either way the written state is ahead
-                                // of the DB, so it goes in as dirty.
-                                let deleted =
-                                    account_data.lamports() == 0 && account_data.data().is_empty();
+                                // Zero lamports means the SVM deallocated it, whatever the
+                                // data holds. Either way this write goes in dirty.
+                                let deleted = account_data.lamports() == 0;
                                 let meta = AccountWithMeta {
                                     account: account_data.clone(),
                                     deleted,
@@ -754,6 +752,33 @@ mod tests {
             ),
             10,
             "failed executed tx with empty accounts must not tombstone the fee payer"
+        );
+    }
+
+    /// A closed data account keeps its buffer, so only the lamports say it is
+    /// gone. Classifying on the data too leaves a dead account readable.
+    #[tokio::test]
+    async fn update_accounts_tombstones_zero_lamport_data_account() {
+        let (mut bob, _settled_tx) = create_test_bob();
+        let from = Keypair::new();
+        let closed = from.pubkey();
+        bob.insert_account_for_test(closed, token_like(10));
+
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 0);
+        // Drained to zero lamports with the data buffer still allocated.
+        let output = svm_output(executed_with_status(
+            Ok(()),
+            vec![(closed, make_account(0, &[7, 7, 7], &spl_token::id()))],
+        ));
+        let _ = bob.update_accounts(&output, std::slice::from_ref(&tx));
+
+        assert!(
+            bob.accounts.get(&closed).is_some_and(|meta| meta.deleted),
+            "a zero-lamport account must be tombstoned whatever its data holds"
+        );
+        assert!(
+            bob.get_account_shared_data(&closed).is_none(),
+            "a tombstoned account must not be readable by the SVM"
         );
     }
 
@@ -2147,6 +2172,47 @@ mod tests {
         );
     }
 
+    /// A zero-lamport row must never be read back in as a live entry. The
+    /// 1-lamport control proves the seed landed, so the miss is the filter.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preload_skips_zero_lamport_row() {
+        let (mut bob, _settled_tx, _pg) =
+            crate::test_helpers::create_test_bob_with_postgres().await;
+        let zero = Pubkey::new_unique();
+        let floor = Pubkey::new_unique();
+
+        bob.accounts_db
+            .set_account(zero, make_account(0, &[1, 2, 3], &spl_token::id()))
+            .await;
+        bob.accounts_db
+            .set_account(floor, make_account(1, &[1, 2, 3], &spl_token::id()))
+            .await;
+
+        let (fetched, cached) = bob.preload_accounts(&[zero, floor]).await;
+
+        assert_eq!(
+            (fetched, cached),
+            (1, 0),
+            "only the 1-lamport control is fetched; the zero-lamport row is not"
+        );
+        assert!(
+            !bob.accounts.contains_key(&zero),
+            "a zero-lamport row must not become a resident entry"
+        );
+        assert!(
+            bob.accounts.contains_key(&floor),
+            "the control must be resident, or the seed write never landed"
+        );
+        assert!(
+            TransactionProcessingCallback::get_account_shared_data(&bob, &zero).is_none(),
+            "a zero-lamport row must read as absent"
+        );
+        assert!(
+            TransactionProcessingCallback::get_account_shared_data(&bob, &floor).is_some(),
+            "an account on the 1-lamport floor must still load"
+        );
+    }
+
     /// `account_lamports` must report exactly what `get_account_shared_data`
     /// reports, for every entry shape: precompile, live, deleted, absent. The
     /// conservation check reads both "this account is new" and "this is what it
@@ -2176,9 +2242,21 @@ mod tests {
         // This case asserts the write side effects, not the generation.
         let _ = bob.update_accounts(&output, std::slice::from_ref(&tx));
 
+        // Same, but closed with its data buffer left allocated. The conservation
+        // check must see this as absent, not as an account holding zero.
+        let ghost_payer = Keypair::new();
+        let ghost = ghost_payer.pubkey();
+        bob.insert_account_for_test(ghost, token_like(10));
+        let ghost_tx = create_test_sanitized_transaction(&ghost_payer, &Pubkey::new_unique(), 0);
+        let ghost_output = svm_output(executed_with_status(
+            Ok(()),
+            vec![(ghost, make_account(0, &[9, 9, 9], &spl_token::id()))],
+        ));
+        let _ = bob.update_accounts(&ghost_output, std::slice::from_ref(&ghost_tx));
+
         let absent = Pubkey::new_unique();
 
-        for pubkey in [precompile, live, deleted, absent] {
+        for pubkey in [precompile, live, deleted, ghost, absent] {
             assert_eq!(
                 bob.account_lamports(&pubkey),
                 bob.get_account_shared_data(&pubkey)
@@ -2191,6 +2269,7 @@ mod tests {
         assert_eq!(bob.account_lamports(&precompile), Some(1));
         assert_eq!(bob.account_lamports(&live), Some(1));
         assert_eq!(bob.account_lamports(&deleted), None);
+        assert_eq!(bob.account_lamports(&ghost), None);
         assert_eq!(bob.account_lamports(&absent), None);
     }
 }

--- a/core/src/accounts/bob.rs
+++ b/core/src/accounts/bob.rs
@@ -293,8 +293,15 @@ impl BOB {
                                 // Zero lamports means the SVM deallocated it, whatever the
                                 // data holds. Either way this write goes in dirty.
                                 let deleted = account_data.lamports() == 0;
+                                // A tombstone's bytes are never read, and it cannot be
+                                // evicted, so drop the buffer instead of pinning it.
+                                let account = if deleted {
+                                    AccountSharedData::default()
+                                } else {
+                                    account_data.clone()
+                                };
                                 let meta = AccountWithMeta {
-                                    account: account_data.clone(),
+                                    account,
                                     deleted,
                                     synced_since: None,
                                     generation: Some(generation),
@@ -779,6 +786,12 @@ mod tests {
         assert!(
             bob.get_account_shared_data(&closed).is_none(),
             "a tombstoned account must not be readable by the SVM"
+        );
+        assert!(
+            bob.accounts
+                .get(&closed)
+                .is_some_and(|meta| meta.account.data().is_empty()),
+            "a tombstone must not pin the closed account's data buffer"
         );
     }
 

--- a/core/src/accounts/get_account_shared_data.rs
+++ b/core/src/accounts/get_account_shared_data.rs
@@ -14,12 +14,14 @@ pub async fn get_account_shared_data(
     db: &AccountsDB,
     pubkey: &Pubkey,
 ) -> Option<AccountSharedData> {
-    match db {
+    let account = match db {
         AccountsDB::Postgres(postgres_db) => {
             get_account_shared_data_postgres(postgres_db, pubkey).await
         }
         AccountsDB::Redis(redis_db) => get_account_shared_data_redis(redis_db, pubkey).await,
-    }
+    };
+    // A stored row with no lamports describes an account that no longer exists.
+    account.filter(|account| account.lamports() != 0)
 }
 
 async fn get_account_shared_data_postgres(

--- a/core/src/accounts/get_accounts.rs
+++ b/core/src/accounts/get_accounts.rs
@@ -2,16 +2,27 @@ use {
     super::traits::AccountsDB,
     crate::accounts::{PostgresAccountsDB, RedisAccountsDB},
     redis::{AsyncCommands, RedisResult},
-    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        pubkey::Pubkey,
+    },
     sqlx::Row,
     std::sync::Arc,
 };
 
 pub async fn get_accounts(db: &AccountsDB, accounts: &[Pubkey]) -> Vec<Option<AccountSharedData>> {
-    match db {
+    let mut results = match db {
         AccountsDB::Postgres(postgres_db) => get_accounts_postgres(postgres_db, accounts).await,
         AccountsDB::Redis(redis_db) => get_accounts_redis(redis_db, accounts).await,
+    };
+    // A stored row with no lamports describes an account that no longer exists.
+    // Cleared in place so the result stays positionally aligned with `accounts`.
+    for slot in results.iter_mut() {
+        if slot.as_ref().is_some_and(|account| account.lamports() == 0) {
+            *slot = None;
+        }
     }
+    results
 }
 
 async fn get_accounts_postgres(

--- a/core/src/accounts/traits.rs
+++ b/core/src/accounts/traits.rs
@@ -251,6 +251,41 @@ mod tests {
         assert!(results[2].is_none(), "pk3 was never stored");
     }
 
+    /// Both read paths must report absence at zero lamports and still return the
+    /// 1-lamport floor. `get_accounts` is positional, so indices stay aligned.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_lamport_row_reads_as_absent() {
+        let (mut db, _pg) = start_test_postgres().await;
+
+        let zero = Pubkey::new_unique();
+        let floor = Pubkey::new_unique();
+        let never_stored = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        db.set_account(zero, AccountSharedData::new(0, 8, &owner))
+            .await;
+        db.set_account(floor, AccountSharedData::new(1, 8, &owner))
+            .await;
+
+        assert!(
+            db.get_account_shared_data(&zero).await.is_none(),
+            "a zero-lamport row must read as absent"
+        );
+        assert!(
+            db.get_account_shared_data(&floor).await.is_some(),
+            "an account on the 1-lamport floor must still read back"
+        );
+
+        let results = db.get_accounts(&[zero, floor, never_stored]).await;
+        assert_eq!(results.len(), 3);
+        assert!(results[0].is_none(), "the zero-lamport row is filtered out");
+        assert!(
+            results[1].is_some(),
+            "the floor account survives the filter"
+        );
+        assert!(results[2].is_none(), "never_stored was never written");
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn store_block_and_get_block_round_trip() {
         let (mut db, _pg) = start_test_postgres().await;

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -566,8 +566,9 @@ async fn settle_transactions(
                         executed_tx.loaded_transaction.accounts.iter().enumerate()
                     {
                         if sanitized_transaction.is_writable(index) {
-                            let deleted =
-                                account_data.lamports() == 0 && account_data.data().is_empty();
+                            // Zero lamports means the account is gone, whatever its data
+                            // holds. Must match BOB's rule or its entry never reconciles.
+                            let deleted = account_data.lamports() == 0;
                             final_accounts_actual.insert(
                                 *pubkey,
                                 AccountSettlement {
@@ -1206,6 +1207,163 @@ mod tests {
             "a data account at the 1-lamport floor must persist"
         );
         assert_eq!(data_settlement.1.account.lamports(), 1);
+    }
+
+    /// Count rows for this pubkey straight from the table. Reading through
+    /// `get_accounts` would pass on the filter alone, even if the row remained.
+    async fn raw_account_row_count(db: &PostgresAccountsDB, pubkey: &Pubkey) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM accounts WHERE pubkey = $1")
+            .bind(&pubkey.to_bytes()[..])
+            .fetch_one(db.pool.as_ref())
+            .await
+            .expect("count query must succeed")
+    }
+
+    /// A closed account keeps its data buffer, so the settler must still delete
+    /// its durable row rather than upserting a zero-lamport ghost.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_deletes_zero_lamport_data_row_from_postgres() {
+        let (mut db, _pg) = start_test_postgres().await;
+
+        let from = Keypair::new();
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 0);
+
+        // Index 0 closed with its buffer intact, index 1 live on the 1-lamport
+        // floor. Both writable, so both settle.
+        let closed = from.pubkey();
+        let floor = Pubkey::new_unique();
+        let processed = make_executed(vec![
+            (closed, AccountSharedData::new(0, 8, &spl_token::id())),
+            (floor, AccountSharedData::new(1, 8, &spl_token::id())),
+        ]);
+
+        // Seed the row the close is supposed to remove, so the delete has work
+        // to do and the assertion cannot pass vacuously.
+        db.set_account(closed, AccountSharedData::new(500, 8, &spl_token::id()))
+            .await;
+        let AccountsDB::Postgres(ref raw) = db else {
+            panic!("start_test_postgres must hand back a Postgres backend");
+        };
+        assert_eq!(
+            raw_account_row_count(raw, &closed).await,
+            1,
+            "the row must exist before settlement for this test to mean anything"
+        );
+
+        let results: Vec<(TransactionProcessingResult, _)> = vec![(Ok(processed), tx)];
+        let result = settle_transactions(
+            None,
+            &mut db,
+            None,
+            &results,
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let closed_settlement = result
+            .account_settlements
+            .iter()
+            .find(|(k, _)| *k == closed)
+            .expect("the closed account must be emitted as a settlement");
+        assert!(
+            closed_settlement.1.deleted,
+            "a zero-lamport account must settle as deleted whatever its data holds"
+        );
+
+        let floor_settlement = result
+            .account_settlements
+            .iter()
+            .find(|(k, _)| *k == floor)
+            .expect("the floor account must be emitted as a settlement");
+        assert!(
+            !floor_settlement.1.deleted,
+            "a data account on the 1-lamport floor must still persist"
+        );
+
+        let AccountsDB::Postgres(ref raw) = db else {
+            panic!("backend must not change across settlement");
+        };
+        assert_eq!(
+            raw_account_row_count(raw, &closed).await,
+            0,
+            "the closed account's row must be deleted, not upserted"
+        );
+        assert_eq!(
+            raw_account_row_count(raw, &floor).await,
+            1,
+            "the floor account's row must be written"
+        );
+    }
+
+    /// Both classifications must move together. Change one side only and the
+    /// entry is never reconciled and never leaves the cache.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn settle_then_preload_leaves_closed_account_absent() {
+        let (mut bob, settled_tx, _pg) = crate::test_helpers::create_test_bob_with_postgres().await;
+        let mut db = bob.accounts_db.clone();
+
+        let from = Keypair::new();
+        let closed = from.pubkey();
+        let tx = create_test_sanitized_transaction(&from, &Pubkey::new_unique(), 0);
+        let closed_account = AccountSharedData::new(0, 8, &spl_token::id());
+
+        db.set_account(closed, AccountSharedData::new(500, 8, &spl_token::id()))
+            .await;
+
+        // Both consumers see the same state so the generation lines up.
+        // `ProcessedTransaction` is not `Clone`, hence the rebuild below.
+        let output = LoadAndExecuteSanitizedTransactionsOutput {
+            processing_results: vec![Ok(make_executed(vec![(closed, closed_account.clone())]))],
+            error_metrics: Default::default(),
+            execute_timings: Default::default(),
+            balance_collector: None,
+        };
+        let generation = bob.update_accounts(&output, std::slice::from_ref(&tx));
+
+        let results: Vec<(TransactionProcessingResult, _)> =
+            vec![(Ok(make_executed(vec![(closed, closed_account)])), tx)];
+        let result = settle_transactions(
+            None,
+            &mut db,
+            None,
+            &results,
+            &(Arc::new(NoopMetrics) as SharedMetrics),
+            None,
+        )
+        .await
+        .unwrap();
+
+        settled_tx
+            .send(AccountSettlements {
+                generation,
+                accounts: result.account_settlements,
+            })
+            .unwrap();
+
+        // Drains the acknowledgement and drops the tombstone, then proves the
+        // now-absent key is not refilled from the database.
+        let (fetched, cached) = bob.preload_accounts(&[closed]).await;
+        assert_eq!(
+            (fetched, cached),
+            (0, 1),
+            "the tombstone is still resident when the hit/miss split runs"
+        );
+
+        let (fetched, cached) = bob.preload_accounts(&[closed]).await;
+        assert_eq!(
+            (fetched, cached),
+            (0, 0),
+            "the dropped tombstone leaves a miss that the database must not fill"
+        );
+        assert!(
+            solana_svm_callback::TransactionProcessingCallback::get_account_shared_data(
+                &bob, &closed
+            )
+            .is_none(),
+            "the closed account must stay unreadable"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/core/src/stages/settle.rs
+++ b/core/src/stages/settle.rs
@@ -569,13 +569,15 @@ async fn settle_transactions(
                             // Zero lamports means the account is gone, whatever its data
                             // holds. Must match BOB's rule or its entry never reconciles.
                             let deleted = account_data.lamports() == 0;
-                            final_accounts_actual.insert(
-                                *pubkey,
-                                AccountSettlement {
-                                    account: account_data.clone(),
-                                    deleted,
-                                },
-                            );
+                            // A delete carries no bytes to Postgres, Redis or BOB, so
+                            // don't pin the buffer in the unbounded feedback channel.
+                            let account = if deleted {
+                                AccountSharedData::default()
+                            } else {
+                                account_data.clone()
+                            };
+                            final_accounts_actual
+                                .insert(*pubkey, AccountSettlement { account, deleted });
                         }
                     }
                 }
@@ -1270,6 +1272,10 @@ mod tests {
         assert!(
             closed_settlement.1.deleted,
             "a zero-lamport account must settle as deleted whatever its data holds"
+        );
+        assert!(
+            closed_settlement.1.account.data().is_empty(),
+            "a delete settlement must not carry the closed account's buffer"
         );
 
         let floor_settlement = result


### PR DESCRIPTION
## Summary

BOB treated an account as deleted only when both its lamports and data were empty, while the SVM treats any zero-lamport account as deleted. This could leave closed accounts readable, block recreation, and prevent gasless fee-payer creation.

BOB and settlement now use `lamports() == 0`, and the `AccountsDB` read paths filter zero-lamport accounts consistently. No schema or serialization changes are needed; existing zero-lamport rows become invisible immediately.

Tests cover BOB tombstoning, DB reads, preload filtering, settlement deletion, and predicate consistency.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 13,783 | 15,483 | 89.0% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31481702016) |
| Indexer | 34,087 | 37,635 | 90.6% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31481702016) |
| Gateway | 1,330 | 1,521 | 87.4% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31481702016) |
| Auth | 785 | 903 | 86.9% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31481702016) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 14,106 | 17,934 | 78.7% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31481702016) |
| **Total** | **64,091** | **73,476** | **87.2%** | |

> Last updated: 2026-08-11 11:24:14 UTC by E2E Integration