### PR TITLE
fix(indexer): clear stalled withdrawals proven landed on-chain (issue-20-ottersec)

### DIFF
--- a/docs/runbooks/_glossary.md
+++ b/docs/runbooks/_glossary.md
@@ -18,7 +18,7 @@ DB type `transaction_status`.
 | `completed` | yes | no | Withdrawal release or deposit mint confirmed on-chain. |
 | `failed` | yes | yes | Terminal failure with no on-chain proof. **Primary alert for deposits** (sender-side failures terminate here since there is no remint path). Rare for withdrawals - those go through `pending_remint`. |
 | `failed_reminted` | yes | yes | **Withdrawal-only.** Original withdrawal failed, remint of burned private channel tokens succeeded. Deposits do not have a remint path. |
-| `manual_review` | yes | yes | Operator stopped acting on this row. Requires human triage. Withdrawals: six triggers (build error → halt, pre-flight bail → no halt, four sender-side ambiguities). Deposits: build error, sender-side post-JIT mint failure, or processor-side allowlist-gate rejection (no halt, no sweep). |
+| `manual_review` | conditional | yes | Operator stopped acting on this row. Requires human triage. Withdrawals: six triggers (build error → halt, pre-flight bail → no halt, four sender-side ambiguities). Deposits: build error, sender-side post-JIT mint failure, or processor-side allowlist-gate rejection (no halt, no sweep). **Conditionally terminal:** a withdrawal row that carries release signatures in `remint_signatures` is re-checked every recovery tick and at boot; if those signatures are proven finalized on-chain it self-clears to `completed`. Every other `manual_review` row, including all deposits, is terminal and needs a human. |
 
 Webhook receivers should treat `failed`, `failed_reminted`, `manual_review` as
 the alertable set. Source: `indexer/src/operator/db_transaction_writer.rs`,

--- a/docs/runbooks/withdrawal_manual_review.md
+++ b/docs/runbooks/withdrawal_manual_review.md
@@ -215,6 +215,23 @@ committing the row to manual review. Sub-triggers below; same recovery.
 > appended). Both land here in Path C — verify on-chain and act on the
 > verdict; never blindly re-arm a row whose release may already be on-chain.
 
+> **Some Path C rows resolve themselves; check before you act.** The
+> quarantine now copies the broadcast signatures onto the row
+> (`remint_signatures`), and every recovery tick plus each operator boot
+> re-classifies them. A row quarantined with `could not verify release
+> landed (...)` was quarantined because the RPC was unreachable, not because
+> the release failed, so once the RPC catches up that row promotes itself to
+> `completed` with the landed signature. A row quarantined with `no broadcast
+> signatures recorded ...` has nothing to re-check and will never self-clear.
+> Re-read the row's status before starting the steps below: if it is already
+> `completed`, the sweep resolved the bookkeeping and the alert can be closed
+> against that signature. One caveat: if the row reached `manual_review` by way
+> of `pending_remint`, the running sender had already dropped that nonce from
+> its in-memory SMT, and the promotion does not put it back. That sender keeps
+> proving against a tree the chain disagrees with until it is restarted, so if
+> withdrawals stopped completing, restart the withdraw operator - it will now
+> pass the boot check rather than refuse to start.
+
 1. **Verify on-chain.** Run
    [`_verify_onchain_release.md`](_verify_onchain_release.md). This is
    the entire decision.

--- a/docs/runbooks/withdrawal_pipeline_halt_runbook.md
+++ b/docs/runbooks/withdrawal_pipeline_halt_runbook.md
@@ -34,8 +34,16 @@ On boot, before any withdrawal is fetched, locked, or processed, the operator:
    landed but never reached `Completed` is detected by an on-chain finality
    check and promoted to `Completed` - re-recording the nonce. A row with no
    recorded signature, or one the RPC cannot classify, is quarantined to
-   `manual_review` (never `failed`).
-2. **Validates** the rebuilt local SMT root against the on-chain root.
+   `manual_review` (never `failed`). Quarantining is not the end of the story:
+   the signatures are copied onto the row, so a row quarantined only because
+   the RPC was unreachable is re-classified on every recovery tick and at each
+   boot, and promotes itself once the release is proven finalized.
+2. **Reconciles stalled rows.** Withdrawals sitting in `manual_review` or
+   `pending_remint` that still carry release signatures are classified the same
+   way and promoted to `completed` on proof. A landed-but-unrecorded nonce
+   parked in either status no longer wedges the gate below. Rows carrying no
+   signatures are skipped entirely and stay for a human.
+3. **Validates** the rebuilt local SMT root against the on-chain root.
 
 If validation passes, the pipeline starts normally
 (`SMT root verification passed` in the logs). A residual mismatch the reconcile
@@ -44,6 +52,11 @@ error and exits without consuming nonces against a tree it cannot reason about.
 This should never fire under the known cause (the write-ahead signature plus the
 boot reconcile close that gap); it guards an unforeseen divergence such as a
 program bug or a manual on-chain admin operation.
+
+Reaching the rest of this runbook therefore means something stronger than it
+used to: the divergence is **not provable from any evidence the operator
+stored**. Either the row that consumed the nonce has no recorded signature, or
+no row in the tree window corresponds to it at all.
 
 ### Symptom
 
@@ -95,7 +108,11 @@ it, so identify the nonce by hand.
 
    A row in `manual_review` whose alert `error_message` was
    `no broadcast signatures recorded; cannot verify release landed`
-   (recovery-worker quarantine) is the prime suspect.
+   (recovery-worker quarantine) is the prime suspect, and now essentially the
+   only one: a row quarantined with `could not verify release landed (...)`
+   kept its signatures and would have cleared itself before the gate ran.
+   Confirm with `SELECT remint_signatures FROM transactions WHERE id = :id` -
+   a NULL or empty array is the shape that reaches this runbook.
 3. For each candidate, run
    [`_verify_onchain_release.md`](_verify_onchain_release.md). Exactly
    one verdict resolves the mismatch: a `LANDED <sig>` whose

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -167,6 +167,11 @@ counter_vec!(
 // stuck-row recovery worker.  `outcome` ∈ {completed, requeued, quarantined};
 // `type` ∈ {deposit, withdrawal}.  All values 0 in steady state — any
 // sustained nonzero is concrete evidence of operator crash-window activity.
+//
+// The same counter also reports withdrawals cleared out of a stalled status by
+// the reconcile sweep: `manual_review_cleared` and `pending_remint_cleared`.
+// Those two are withdrawal-only, and each one means a row that had stopped
+// moving was proven landed on-chain and promoted to Completed.
 counter_vec!(
     OPERATOR_STALE_PROCESSING_RECOVERED,
     "private_channel_operator_stale_processing_recovered_total",
@@ -250,6 +255,16 @@ pub fn init_labels(program_type: &str) {
                 txn_type,
             ]);
         }
+    }
+
+    // Stalled-row clears exist only on the withdraw side; pairing them with
+    // `deposit` would register a series that can never increment.
+    for outcome in &["manual_review_cleared", "pending_remint_cleared"] {
+        OPERATOR_STALE_PROCESSING_RECOVERED.with_label_values(&[
+            program_type,
+            outcome,
+            "withdrawal",
+        ]);
     }
 }
 

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -376,6 +376,26 @@ async fn run_withdraw_preflight(
         warn!("Boot reconcile failed, proceeding to SMT validation: {}", e);
     }
 
+    // Boot is the only safe window for the pending_remint pass. Once run_sender
+    // starts it rehydrates every such row into its in-memory queue and may put a
+    // remint in flight; completing one from underneath it would pay the
+    // withdrawal and remint the burn. This returns before the sender is spawned.
+    // Best-effort for the same reason as the reconcile above: validation is the
+    // gate, and a transient error here must not crash-loop the operator.
+    if let Err(e) = recovery::reconcile_landed_withdrawals(
+        storage,
+        rpc_client,
+        crate::storage::common::models::TransactionStatus::PendingRemint,
+        cancellation_token,
+    )
+    .await
+    {
+        warn!(
+            "Pending-remint reconcile failed, proceeding to SMT validation: {}",
+            e
+        );
+    }
+
     // Only a genuine root mismatch is a refuse-to-start. Any other error (instance
     // not yet on-chain, RPC failure, DB read failure) means we could not run the
     // check; start anyway and let the sender's lazy init plus the recovery worker
@@ -422,6 +442,8 @@ mod tests {
     use super::*;
     use crate::operator::utils::rpc_util::RetryConfig;
     use crate::operator::utils::smt_util::SmtState;
+    use crate::storage::common::amount::TokenAmount;
+    use crate::storage::common::models::{DbTransaction, TransactionStatus, TransactionType};
     use crate::storage::common::storage::mock::MockStorage;
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine;
@@ -493,8 +515,11 @@ mod tests {
             .create()
     }
 
-    async fn run_preflight(client: RpcClientWithRetry) -> Result<(), OperatorError> {
-        let storage = Arc::new(Storage::Mock(MockStorage::new()));
+    async fn run_preflight(
+        client: RpcClientWithRetry,
+        mock: MockStorage,
+    ) -> Result<(), OperatorError> {
+        let storage = Arc::new(Storage::Mock(mock));
         let client = Arc::new(client);
         let (storage_tx, _rx) = mpsc::channel::<sender::TransactionStatusUpdate>(8);
         let token = CancellationToken::new();
@@ -507,7 +532,7 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         // Empty DB rebuilds an empty tree, so the on-chain root must be the empty-tree root.
         let _account = mock_instance_account(&mut server, SmtState::new(0).current_root());
-        let result = run_preflight(make_rpc_client(&server.url())).await;
+        let result = run_preflight(make_rpc_client(&server.url()), MockStorage::new()).await;
         assert!(result.is_ok(), "matching root must start: {result:?}");
     }
 
@@ -518,7 +543,7 @@ mod tests {
     async fn preflight_starts_when_instance_not_found() {
         let mut server = mockito::Server::new_async().await;
         let _account = mock_instance_not_found(&mut server);
-        let result = run_preflight(make_rpc_client(&server.url())).await;
+        let result = run_preflight(make_rpc_client(&server.url()), MockStorage::new()).await;
         assert!(
             result.is_ok(),
             "AccountNotFound must start anyway, not refuse: {result:?}"
@@ -534,7 +559,7 @@ mod tests {
         let mut onchain = SmtState::new(0);
         onchain.insert_nonce(7);
         let _account = mock_instance_account(&mut server, onchain.current_root());
-        let result = run_preflight(make_rpc_client(&server.url())).await;
+        let result = run_preflight(make_rpc_client(&server.url()), MockStorage::new()).await;
         assert!(
             matches!(
                 result,
@@ -543,6 +568,115 @@ mod tests {
                 ))
             ),
             "a real mismatch must refuse to start: {result:?}"
+        );
+    }
+
+    /// A withdraw operator whose only unrecorded nonce sits in a `PendingRemint`
+    /// row carrying its release signature, plus the on-chain root that includes
+    /// that nonce. This is the exact shape that used to wedge the boot gate.
+    fn preflight_fixture(nonce: i64, signature: &str) -> (MockStorage, [u8; 32]) {
+        let mut onchain = SmtState::new(0);
+        onchain.insert_nonce(nonce as u64);
+
+        let now = chrono::Utc::now();
+        let row = DbTransaction {
+            id: 1,
+            signature: "burn-sig".to_string(),
+            trace_id: "trace-1".to_string(),
+            slot: 100,
+            initiator: Pubkey::new_unique().to_string(),
+            recipient: Pubkey::new_unique().to_string(),
+            mint: Pubkey::new_unique().to_string(),
+            amount: TokenAmount(1_000),
+            memo: None,
+            transaction_type: TransactionType::Withdrawal,
+            withdrawal_nonce: Some(nonce),
+            status: TransactionStatus::PendingRemint,
+            created_at: now,
+            updated_at: now,
+            processed_at: None,
+            counterpart_signature: None,
+            remint_signatures: Some(vec![signature.to_string()]),
+            remint_last_valid_block_heights: Some(vec![100]),
+            pending_remint_deadline_at: None,
+            finality_check_attempts: 0,
+            recovery_requeue_attempts: 0,
+            instruction_index: 0,
+            inner_index: None,
+            landed_remint_signature: None,
+        };
+        let mock = MockStorage::new();
+        mock.pending_transactions.lock().unwrap().push(row);
+        (mock, onchain.current_root())
+    }
+
+    fn mock_signature_statuses(
+        server: &mut mockito::ServerGuard,
+        status: usize,
+        body: &str,
+    ) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(status)
+            .with_body(body)
+            .create()
+    }
+
+    const FINALIZED_SUCCESS: &str = r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":null,"status":{"Ok":null},"confirmationStatus":"finalized"}]},"id":1}"#;
+
+    /// The regression test for the whole issue: a landed-but-unrecorded release
+    /// held in `pending_remint` is reconciled by the pre-flight, so the root now
+    /// agrees and the operator starts instead of crash-looping.
+    #[tokio::test]
+    async fn preflight_completes_landed_pending_remint_and_starts() {
+        let landed_sig = solana_sdk::signature::Signature::new_unique().to_string();
+        let (mock, root) = preflight_fixture(7, &landed_sig);
+        let mut server = mockito::Server::new_async().await;
+        let _account = mock_instance_account(&mut server, root);
+        let _status = mock_signature_statuses(&mut server, 200, FINALIZED_SUCCESS);
+
+        let result = run_preflight(make_rpc_client(&server.url()), mock.clone()).await;
+
+        assert!(
+            result.is_ok(),
+            "a reconcilable divergence must start: {result:?}"
+        );
+        let rows = mock.pending_transactions.lock().unwrap();
+        assert_eq!(rows[0].status, TransactionStatus::Completed);
+        assert_eq!(
+            rows[0].counterpart_signature.as_deref(),
+            Some(landed_sig.as_str())
+        );
+    }
+
+    /// The halt is narrowed, not weakened: an unprovable divergence still
+    /// refuses to start and leaves the row where a human can see it.
+    #[tokio::test]
+    async fn preflight_still_refuses_when_mismatch_survives_reconcile() {
+        let landed_sig = solana_sdk::signature::Signature::new_unique().to_string();
+        let (mock, root) = preflight_fixture(7, &landed_sig);
+        let mut server = mockito::Server::new_async().await;
+        let _account = mock_instance_account(&mut server, root);
+        let _status = mock_signature_statuses(&mut server, 500, "internal server error");
+
+        let result = run_preflight(make_rpc_client(&server.url()), mock.clone()).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(OperatorError::Program(
+                    crate::error::ProgramError::SmtRootMismatch { .. }
+                ))
+            ),
+            "an unprovable divergence must still refuse to start: {result:?}"
+        );
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::PendingRemint,
+            "an uncertain verdict must leave the row for the runbook"
         );
     }
 }

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -382,10 +382,13 @@ async fn run_withdraw_preflight(
     // withdrawal and remint the burn. This returns before the sender is spawned.
     // Best-effort for the same reason as the reconcile above: validation is the
     // gate, and a transient error here must not crash-loop the operator.
+    // Time-bounded because startup waits on it: an unbounded pass over a large
+    // backlog on a degraded RPC would hold withdrawals down indefinitely.
     if let Err(e) = recovery::reconcile_landed_withdrawals(
         storage,
         rpc_client,
         crate::storage::common::models::TransactionStatus::PendingRemint,
+        Some(recovery::BOOT_RECONCILE_BUDGET),
         cancellation_token,
     )
     .await

--- a/indexer/src/operator/operator.rs
+++ b/indexer/src/operator/operator.rs
@@ -388,7 +388,10 @@ async fn run_withdraw_preflight(
         storage,
         rpc_client,
         crate::storage::common::models::TransactionStatus::PendingRemint,
-        Some(recovery::BOOT_RECONCILE_BUDGET),
+        recovery::BOOT_RECONCILE_BUDGET,
+        // Boot runs once, so the cursor has nowhere to resume to. If the budget
+        // is spent the SMT check below decides whether the operator may start.
+        &mut 0,
         cancellation_token,
     )
     .await

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Utc};
 use solana_sdk::signature::Signature;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -31,6 +31,16 @@ pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 /// Stalled withdrawals examined in one sweep before the depth is worth a warning.
 /// Purely an observability threshold: the sweep never stops early on it.
 const RECONCILE_BACKLOG_WARN_AT: usize = 1_000;
+
+/// Wall-clock ceiling on the boot pre-flight's reconcile.
+///
+/// Startup waits on this sweep, and a degraded RPC turns each row into five
+/// retries, so an unbounded pass can hold withdrawals down for the better part
+/// of an hour with nothing paged. Giving up early costs nothing in that case:
+/// an RPC that cannot classify cannot promote either, so the sweep would not
+/// have cleared the row anyway. The SMT check still runs, and a mismatch that
+/// survives is the designed refuse-to-start, which is loud and has a runbook.
+pub(crate) const BOOT_RECONCILE_BUDGET: Duration = Duration::from_secs(120);
 
 /// Max durable Demote requeues before a stuck row is quarantined (paged).
 const MAX_RECOVERY_REQUEUE_ATTEMPTS: i32 = 3;
@@ -181,6 +191,9 @@ async fn recover_once(
             storage,
             rpc_client,
             TransactionStatus::ManualReview,
+            // Blocks nothing, so it runs to exhaustion: only an exhaustive sweep
+            // guarantees no row is permanently hidden behind unclearable ones.
+            None,
             cancellation_token,
         )
         .await
@@ -218,10 +231,18 @@ fn role_owns(program_type: ProgramType, row: &DbTransaction) -> bool {
 /// carry no signatures, are filtered out by the query, and stay for a human;
 /// rows quarantined on a transient one clear themselves once the chain catches
 /// up. That asymmetry is the whole reason this is safe to run unattended.
+///
+/// `budget` bounds the sweep in wall-clock time. The periodic worker passes
+/// `None` and runs to exhaustion: it blocks nothing, and only an exhaustive
+/// sweep guarantees a row is never permanently hidden behind rows that can
+/// never clear. The boot pre-flight passes `Some`, because it holds up startup
+/// and every row costs an RPC round trip that retries five times against a
+/// degraded endpoint.
 pub(crate) async fn reconcile_landed_withdrawals(
     storage: &Storage,
     rpc_client: &RpcClientWithRetry,
     from_status: TransactionStatus,
+    budget: Option<Duration>,
     cancellation_token: &CancellationToken,
 ) -> Result<(), OperatorError> {
     let outcome_label = match from_status {
@@ -236,16 +257,15 @@ pub(crate) async fn reconcile_landed_withdrawals(
         }
     };
 
-    // Page forward by id to exhaustion, in batches only to bound each query.
+    // Page forward by id, in batches only to bound each query.
     //
-    // Deliberately uncapped. Rows that do not classify are left untouched by
-    // design, so nothing ever drains this set on its own; any per-sweep cap is
-    // a permanent blind spot for every row behind it, and the cursor restarts
-    // at zero on the next sweep so the same prefix is rescanned forever. The
-    // one row that matters most, a landed release still wedging the boot gate,
-    // is exactly the row a cap would hide. Work is proportional to the stalled
-    // backlog, which is empty in steady state and is precisely the set that
-    // needs examining when it is not.
+    // There is no row-count cap. Rows that do not classify are left untouched
+    // by design, so nothing drains this set on its own; a count cap would be a
+    // permanent blind spot for every row behind it, since the cursor restarts
+    // at zero each sweep and rescans the same prefix forever. The one row that
+    // matters most, a landed release still wedging the boot gate, is exactly
+    // the row such a cap would hide.
+    let deadline = budget.map(|b| Instant::now() + b);
     let mut after_id = 0i64;
     let mut scanned = 0usize;
     loop {
@@ -267,6 +287,17 @@ pub(crate) async fn reconcile_landed_withdrawals(
         for row in batch {
             if cancellation_token.is_cancelled() {
                 info!("Reconcile sweep cancelled; remaining stalled rows deferred");
+                return Ok(());
+            }
+            // Checked per row, not per batch: one row against a degraded RPC
+            // costs five retries, so a batch can overrun the budget on its own.
+            if deadline.is_some_and(|d| Instant::now() >= d) {
+                warn!(
+                    scanned,
+                    ?from_status,
+                    "Reconcile sweep hit its time budget; \
+                     the SMT check below decides whether the operator can start"
+                );
                 return Ok(());
             }
             // The cursor advances even when a row is skipped, which is what stops
@@ -799,7 +830,7 @@ pub mod test_hooks {
         from_status: TransactionStatus,
     ) -> Result<(), OperatorError> {
         let token = CancellationToken::new();
-        reconcile_landed_withdrawals(storage, rpc_client, from_status, &token).await
+        reconcile_landed_withdrawals(storage, rpc_client, from_status, None, &token).await
     }
 }
 
@@ -1418,6 +1449,7 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
+            None,
             &CancellationToken::new(),
         )
         .await
@@ -1436,6 +1468,62 @@ mod tests {
                 .filter(|t| t.id <= 1_200)
                 .all(|t| t.status == TransactionStatus::ManualReview),
             "rows that cannot classify stay exactly where they are"
+        );
+    }
+
+    /// Startup waits on the boot sweep, so a backlog it cannot get through must
+    /// hand control back rather than hold withdrawals down. The SMT check after
+    /// it is what decides whether the operator may start.
+    #[tokio::test]
+    #[serial_test::serial(manual_review_cleared_metric)]
+    async fn reconcile_returns_when_the_boot_budget_is_spent() {
+        let mut server = mockito::Server::new_async().await;
+        // Every classification stalls, so the budget expires before the backlog does.
+        let _slow = server
+            .mock("POST", "/")
+            .with_status(500)
+            .with_chunked_body(|_| {
+                std::thread::sleep(std::time::Duration::from_millis(60));
+                Ok(())
+            })
+            .expect_at_least(1)
+            .create();
+
+        let mock = MockStorage::new();
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            for id in 1..=200 {
+                db.push(stalled_withdrawal(
+                    id,
+                    TransactionStatus::PendingRemint,
+                    &[Signature::new_unique().to_string()],
+                ));
+            }
+        }
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+
+        let started = Instant::now();
+        reconcile_landed_withdrawals(
+            &storage,
+            &client,
+            TransactionStatus::PendingRemint,
+            Some(Duration::from_millis(150)),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the boot sweep must return on its budget, not grind through the backlog"
+        );
+        let after = mock.pending_transactions.lock().unwrap();
+        assert!(
+            after
+                .iter()
+                .all(|t| t.status == TransactionStatus::PendingRemint),
+            "giving up on time must never promote a row"
         );
     }
 
@@ -1485,6 +1573,7 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
+            None,
             &CancellationToken::new(),
         )
         .await
@@ -1527,6 +1616,7 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
+            None,
             &CancellationToken::new(),
         )
         .await
@@ -1602,6 +1692,7 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
+            None,
             &CancellationToken::new(),
         )
         .await
@@ -1637,6 +1728,7 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
+            None,
             &CancellationToken::new(),
         )
         .await

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -28,9 +28,9 @@ pub(crate) const STALE_THRESHOLD: Duration = Duration::from_secs(5 * 60);
 /// Per-tick batch cap; leftovers are picked up next tick.
 pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 
-/// Batches of `RECOVERY_BATCH_LIMIT` the stalled-withdrawal sweep will page
-/// through in one pass before deferring the rest to the next tick.
-const MAX_RECONCILE_BATCHES: usize = 10;
+/// Stalled withdrawals examined in one sweep before the depth is worth a warning.
+/// Purely an observability threshold: the sweep never stops early on it.
+const RECONCILE_BACKLOG_WARN_AT: usize = 1_000;
 
 /// Max durable Demote requeues before a stuck row is quarantined (paged).
 const MAX_RECOVERY_REQUEUE_ATTEMPTS: i32 = 3;
@@ -236,18 +236,24 @@ pub(crate) async fn reconcile_landed_withdrawals(
         }
     };
 
-    // Page forward by id instead of taking one capped batch. A row that does not
-    // classify is deliberately left untouched, so it stays in this set for good;
-    // a fixed window would hand back the same blocked rows every sweep and hide
-    // every row behind them, including a landed one still wedging the boot gate.
+    // Page forward by id to exhaustion, in batches only to bound each query.
+    //
+    // Deliberately uncapped. Rows that do not classify are left untouched by
+    // design, so nothing ever drains this set on its own; any per-sweep cap is
+    // a permanent blind spot for every row behind it, and the cursor restarts
+    // at zero on the next sweep so the same prefix is rescanned forever. The
+    // one row that matters most, a landed release still wedging the boot gate,
+    // is exactly the row a cap would hide. Work is proportional to the stalled
+    // backlog, which is empty in steady state and is precisely the set that
+    // needs examining when it is not.
     let mut after_id = 0i64;
     let mut scanned = 0usize;
-    for _ in 0..MAX_RECONCILE_BATCHES {
+    loop {
         let batch = storage
             .get_stalled_withdrawals_with_signatures(from_status, after_id, RECOVERY_BATCH_LIMIT)
             .await?;
         if batch.is_empty() {
-            return Ok(());
+            break;
         }
         debug!(
             count = batch.len(),
@@ -255,8 +261,8 @@ pub(crate) async fn reconcile_landed_withdrawals(
             ?from_status,
             "Reconcile sweep found stalled withdrawals with stored signatures"
         );
-        scanned += batch.len();
         let exhausted = batch.len() < RECOVERY_BATCH_LIMIT as usize;
+        scanned += batch.len();
 
         for row in batch {
             if cancellation_token.is_cancelled() {
@@ -283,17 +289,20 @@ pub(crate) async fn reconcile_landed_withdrawals(
         }
 
         if exhausted {
-            return Ok(());
+            break;
         }
     }
 
-    // Never truncate silently: at this depth the backlog is an incident of its
-    // own, and the operator needs to know the tail went unexamined this tick.
-    warn!(
-        scanned,
-        ?from_status,
-        "Reconcile sweep hit its batch budget; remaining stalled rows deferred to the next tick"
-    );
+    // A backlog this deep is an incident of its own: every row in it is a
+    // withdrawal that failed and could not be resolved, and each costs an RPC
+    // round trip per sweep. Surface it rather than let the cost stay invisible.
+    if scanned >= RECONCILE_BACKLOG_WARN_AT {
+        warn!(
+            scanned,
+            ?from_status,
+            "Reconcile sweep examined an unusually deep stalled-withdrawal backlog"
+        );
+    }
     Ok(())
 }
 
@@ -1371,6 +1380,63 @@ mod tests {
         row.remint_last_valid_block_heights = Some(vec![100; sigs.len()]);
         row.remint_signatures = Some(sigs.to_vec());
         row
+    }
+
+    /// A backlog of rows that can never classify must not hide the rows behind
+    /// it, at any depth. Nothing writes to them, so they stay in the set for
+    /// good and the cursor restarts at zero every sweep; a per-sweep cap would
+    /// leave the landed row below permanently unreachable.
+    #[tokio::test]
+    #[serial_test::serial(manual_review_cleared_metric)]
+    async fn reconcile_pages_past_a_backlog_larger_than_any_batch_budget() {
+        let landed_sig = Signature::new_unique().to_string();
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_finalized_status(&mut server);
+
+        let mock = MockStorage::new();
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            // Well past ten batches of RECOVERY_BATCH_LIMIT. Each parses to
+            // nothing, so it is fetched, skipped, and never costs an RPC.
+            for id in 1..=1_200 {
+                db.push(stalled_withdrawal(
+                    id,
+                    TransactionStatus::ManualReview,
+                    &["not-a-signature".to_string()],
+                ));
+            }
+            db.push(stalled_withdrawal(
+                9_999,
+                TransactionStatus::ManualReview,
+                std::slice::from_ref(&landed_sig),
+            ));
+        }
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+
+        reconcile_landed_withdrawals(
+            &storage,
+            &client,
+            TransactionStatus::ManualReview,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        let target = after.iter().find(|t| t.id == 9_999).unwrap();
+        assert_eq!(
+            target.status,
+            TransactionStatus::Completed,
+            "the landed row must be reached however deep the unclearable backlog is"
+        );
+        assert!(
+            after
+                .iter()
+                .filter(|t| t.id <= 1_200)
+                .all(|t| t.status == TransactionStatus::ManualReview),
+            "rows that cannot classify stay exactly where they are"
+        );
     }
 
     fn cleared_metric(outcome: &str) -> f64 {

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -28,6 +28,10 @@ pub(crate) const STALE_THRESHOLD: Duration = Duration::from_secs(5 * 60);
 /// Per-tick batch cap; leftovers are picked up next tick.
 pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 
+/// Batches of `RECOVERY_BATCH_LIMIT` the stalled-withdrawal sweep will page
+/// through in one pass before deferring the rest to the next tick.
+const MAX_RECONCILE_BATCHES: usize = 10;
+
 /// Max durable Demote requeues before a stuck row is quarantined (paged).
 const MAX_RECOVERY_REQUEUE_ATTEMPTS: i32 = 3;
 
@@ -232,38 +236,64 @@ pub(crate) async fn reconcile_landed_withdrawals(
         }
     };
 
-    let stalled = storage
-        .get_stalled_withdrawals_with_signatures(from_status, RECOVERY_BATCH_LIMIT)
-        .await?;
-    if stalled.is_empty() {
-        return Ok(());
-    }
-    debug!(
-        count = stalled.len(),
-        ?from_status,
-        "Reconcile sweep found stalled withdrawals with stored signatures"
-    );
-
-    for row in stalled {
-        if cancellation_token.is_cancelled() {
-            info!("Reconcile sweep cancelled; remaining stalled rows deferred");
+    // Page forward by id instead of taking one capped batch. A row that does not
+    // classify is deliberately left untouched, so it stays in this set for good;
+    // a fixed window would hand back the same blocked rows every sweep and hide
+    // every row behind them, including a landed one still wedging the boot gate.
+    let mut after_id = 0i64;
+    let mut scanned = 0usize;
+    for _ in 0..MAX_RECONCILE_BATCHES {
+        let batch = storage
+            .get_stalled_withdrawals_with_signatures(from_status, after_id, RECOVERY_BATCH_LIMIT)
+            .await?;
+        if batch.is_empty() {
             return Ok(());
         }
-        // The query is withdrawal-only, so this is the same belt-and-braces gate
-        // the other sweeps use: never classify a row against the wrong chain.
-        if !role_owns(ProgramType::Withdraw, &row) {
-            continue;
+        debug!(
+            count = batch.len(),
+            after_id,
+            ?from_status,
+            "Reconcile sweep found stalled withdrawals with stored signatures"
+        );
+        scanned += batch.len();
+        let exhausted = batch.len() < RECOVERY_BATCH_LIMIT as usize;
+
+        for row in batch {
+            if cancellation_token.is_cancelled() {
+                info!("Reconcile sweep cancelled; remaining stalled rows deferred");
+                return Ok(());
+            }
+            // The cursor advances even when a row is skipped, which is what stops
+            // an unclearable row from being re-fetched ahead of everything else.
+            after_id = row.id;
+            // The query is withdrawal-only, so this is the same belt-and-braces gate
+            // the other sweeps use: never classify a row against the wrong chain.
+            if !role_owns(ProgramType::Withdraw, &row) {
+                continue;
+            }
+            let Some(pending) = row_pending_sigs(&row) else {
+                continue;
+            };
+            let SigFinality::Landed(signature) =
+                classify_release_signatures(rpc_client, &pending).await
+            else {
+                continue;
+            };
+            promote_stalled_row(storage, &row, from_status, outcome_label, signature).await;
         }
-        let Some(pending) = row_pending_sigs(&row) else {
-            continue;
-        };
-        let SigFinality::Landed(signature) =
-            classify_release_signatures(rpc_client, &pending).await
-        else {
-            continue;
-        };
-        promote_stalled_row(storage, &row, from_status, outcome_label, signature).await;
+
+        if exhausted {
+            return Ok(());
+        }
     }
+
+    // Never truncate silently: at this depth the backlog is an incident of its
+    // own, and the operator needs to know the tail went unexamined this tick.
+    warn!(
+        scanned,
+        ?from_status,
+        "Reconcile sweep hit its batch budget; remaining stalled rows deferred to the next tick"
+    );
     Ok(())
 }
 

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -750,6 +750,18 @@ pub mod test_hooks {
         )
         .await
     }
+
+    /// Drive one stalled-withdrawal reconcile pass, exactly as the boot
+    /// pre-flight does for `PendingRemint` and the periodic tick does for
+    /// `ManualReview`.
+    pub async fn reconcile_stalled_withdrawals_once(
+        storage: &Storage,
+        rpc_client: &RpcClientWithRetry,
+        from_status: TransactionStatus,
+    ) -> Result<(), OperatorError> {
+        let token = CancellationToken::new();
+        reconcile_landed_withdrawals(storage, rpc_client, from_status, &token).await
+    }
 }
 
 #[cfg(test)]

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -163,6 +163,27 @@ async fn recover_once(
         }
         requeue_parked(storage, &row, program_type).await;
     }
+
+    // `manual_review` has no owner, so re-checking it every tick is free of
+    // contention. `pending_remint` is deliberately absent here: the sender owns
+    // those rows and may have a remint in flight, so they are reconciled once at
+    // boot, before the sender exists.
+    //
+    // Best-effort: this runs at the tail of every tick, including inside the
+    // bounded boot-reconcile loop, so propagating an error here would cost the
+    // remaining passes of Processing reconciliation over a transient DB blip.
+    if program_type == ProgramType::Withdraw {
+        if let Err(e) = reconcile_landed_withdrawals(
+            storage,
+            rpc_client,
+            TransactionStatus::ManualReview,
+            cancellation_token,
+        )
+        .await
+        {
+            warn!("Stalled-withdrawal reconcile failed: {}", e);
+        }
+    }
     Ok(())
 }
 
@@ -184,6 +205,148 @@ fn role_owns(program_type: ProgramType, row: &DbTransaction) -> bool {
         );
     }
     owned
+}
+
+/// Clear withdrawals stalled in `from_status` whose stored release signatures
+/// prove the release finalized on-chain.
+///
+/// Only `SigFinality::Landed` writes. Rows quarantined on a structural problem
+/// carry no signatures, are filtered out by the query, and stay for a human;
+/// rows quarantined on a transient one clear themselves once the chain catches
+/// up. That asymmetry is the whole reason this is safe to run unattended.
+pub(crate) async fn reconcile_landed_withdrawals(
+    storage: &Storage,
+    rpc_client: &RpcClientWithRetry,
+    from_status: TransactionStatus,
+    cancellation_token: &CancellationToken,
+) -> Result<(), OperatorError> {
+    let outcome_label = match from_status {
+        TransactionStatus::ManualReview => "manual_review_cleared",
+        TransactionStatus::PendingRemint => "pending_remint_cleared",
+        other => {
+            warn!(
+                ?other,
+                "Stalled-withdrawal reconcile called with an unsupported status"
+            );
+            return Ok(());
+        }
+    };
+
+    let stalled = storage
+        .get_stalled_withdrawals_with_signatures(from_status, RECOVERY_BATCH_LIMIT)
+        .await?;
+    if stalled.is_empty() {
+        return Ok(());
+    }
+    debug!(
+        count = stalled.len(),
+        ?from_status,
+        "Reconcile sweep found stalled withdrawals with stored signatures"
+    );
+
+    for row in stalled {
+        if cancellation_token.is_cancelled() {
+            info!("Reconcile sweep cancelled; remaining stalled rows deferred");
+            return Ok(());
+        }
+        // The query is withdrawal-only, so this is the same belt-and-braces gate
+        // the other sweeps use: never classify a row against the wrong chain.
+        if !role_owns(ProgramType::Withdraw, &row) {
+            continue;
+        }
+        let Some(pending) = row_pending_sigs(&row) else {
+            continue;
+        };
+        let SigFinality::Landed(signature) =
+            classify_release_signatures(rpc_client, &pending).await
+        else {
+            continue;
+        };
+        promote_stalled_row(storage, &row, from_status, outcome_label, signature).await;
+    }
+    Ok(())
+}
+
+/// Parse a stalled row's stored signatures into `PendingSig`s. Corrupt or
+/// misaligned columns yield `None` so the row is skipped rather than promoted.
+fn row_pending_sigs(row: &DbTransaction) -> Option<Vec<PendingSig>> {
+    let sigs = row.remint_signatures.as_ref()?;
+    let heights = row.remint_last_valid_block_heights.as_ref()?;
+    if sigs.len() != heights.len() {
+        warn!(
+            transaction_id = row.id,
+            "Stalled withdrawal has mismatched signature and block-height columns; skipping"
+        );
+        return None;
+    }
+    let mut pending = Vec::with_capacity(sigs.len());
+    for (sig_str, lvbh) in sigs.iter().zip(heights) {
+        let signature = match Signature::from_str(sig_str) {
+            Ok(signature) => signature,
+            Err(e) => {
+                warn!(
+                    transaction_id = row.id,
+                    "Stalled withdrawal has a malformed stored signature {sig_str}: {e}"
+                );
+                return None;
+            }
+        };
+        // A negative height is corrupt, not a very large one; casting would
+        // wrap it into a height no chain ever reaches.
+        let Ok(last_valid_block_height) = u64::try_from(*lvbh) else {
+            warn!(
+                transaction_id = row.id,
+                "Stalled withdrawal has a negative stored block height {lvbh}; skipping"
+            );
+            return None;
+        };
+        pending.push(PendingSig {
+            signature,
+            last_valid_block_height,
+        });
+    }
+    Some(pending)
+}
+
+/// CAS a proven-landed stalled row to `Completed`, then log and count it.
+async fn promote_stalled_row(
+    storage: &Storage,
+    row: &DbTransaction,
+    from_status: TransactionStatus,
+    outcome_label: &str,
+    signature: Signature,
+) {
+    let signature = signature.to_string();
+    match storage
+        .try_complete_stalled_withdrawal(
+            row.id,
+            row.updated_at,
+            from_status,
+            Some(signature.clone()),
+        )
+        .await
+    {
+        // Loud on purpose: a status that means "a human decided this needs
+        // eyes" just cleared itself, and the on-call should see why.
+        Ok(true) => {
+            warn!(
+                transaction_id = row.id,
+                ?from_status,
+                signature,
+                "Reconcile promoted a stalled withdrawal to Completed on finalized on-chain proof"
+            );
+            // Both call sites gate on the withdraw operator, so the
+            // program-type label is fixed rather than threaded through.
+            OPERATOR_STALE_PROCESSING_RECOVERED
+                .with_label_values(&[pt_label(ProgramType::Withdraw), outcome_label, "withdrawal"])
+                .inc();
+        }
+        Ok(false) => debug!(
+            id = row.id,
+            "reconcile skipped, another writer touched the row first"
+        ),
+        Err(e) => warn!(id = row.id, "reconcile write error: {}", e),
+    }
 }
 
 async fn decide_action(
@@ -324,6 +487,34 @@ async fn load_pending_sigs(storage: &Storage, id: i64) -> Result<Vec<PendingSig>
     Ok(pending)
 }
 
+/// Split a row's journalled release signatures into the two parallel arrays the
+/// quarantine CAS stores. The inner `(None, None)` means there was nothing worth
+/// recording, which leaves the columns untouched.
+///
+/// An outer `None` means the read failed and the caller must defer. Quarantining
+/// blind is irreversible: the journal is GC'd as soon as the row leaves
+/// `Processing`, so a transient read error would otherwise destroy the row's only
+/// evidence and make it permanently unreconcilable.
+async fn stored_release_signatures(
+    storage: &Storage,
+    id: i64,
+) -> Option<(Option<Vec<String>>, Option<Vec<i64>>)> {
+    match storage.get_release_signatures(id).await {
+        Ok(stored) if stored.is_empty() => Some((None, None)),
+        Ok(stored) => {
+            let (sigs, heights): (Vec<String>, Vec<i64>) = stored.into_iter().unzip();
+            Some((Some(sigs), Some(heights)))
+        }
+        Err(e) => {
+            warn!(
+                id,
+                "deferring quarantine, release signature read failed: {}", e
+            );
+            None
+        }
+    }
+}
+
 fn pt_label(program_type: ProgramType) -> &'static str {
     match program_type {
         ProgramType::Escrow => "escrow",
@@ -422,9 +613,22 @@ async fn route_outcome(
             );
         }
         RecoveryAction::Quarantine { reason } => {
+            // The journal these came from is GC'd as soon as the row leaves
+            // Processing, so a quarantined withdrawal keeps its own copy or the
+            // evidence is gone before anything can re-check it.
+            let (sigs, heights) = match row.transaction_type {
+                TransactionType::Withdrawal => {
+                    match stored_release_signatures(storage, row.id).await {
+                        Some(columns) => columns,
+                        // Retry next tick rather than spend the row's evidence.
+                        None => return,
+                    }
+                }
+                TransactionType::Deposit => (None, None),
+            };
             // Noisy by design — page on uncertainty, never silently demote.
             match storage
-                .try_quarantine_processing(row.id, captured_updated_at)
+                .try_quarantine_processing(row.id, captured_updated_at, sigs, heights)
                 .await
             {
                 Ok(true) => {
@@ -1059,6 +1263,347 @@ mod tests {
         assert_eq!(
             update.error_message.as_deref(),
             Some("withdrawal row missing nonce")
+        );
+    }
+
+    /// A quarantined withdrawal must keep its release signatures on the row,
+    /// because the journal they came from is GC'd on the next sweep. Deposits
+    /// have no such reader, so their columns stay untouched.
+    #[tokio::test]
+    async fn quarantine_persists_release_signatures_for_withdrawals_only() {
+        let mock = MockStorage::new();
+        let mut withdrawal = make_withdrawal_row(10, Some(5));
+        withdrawal.status = TransactionStatus::Processing;
+        let mut deposit = make_deposit_row(11);
+        deposit.status = TransactionStatus::Processing;
+        let w_captured = seed_processing_row(&mock, withdrawal.clone()).await;
+        let d_captured = seed_processing_row(&mock, deposit.clone()).await;
+        let w_sig = Signature::new_unique().to_string();
+        mock.insert_release_signature(withdrawal.id, w_sig.clone(), 4242)
+            .await
+            .unwrap();
+        mock.insert_release_signature(deposit.id, Signature::new_unique().to_string(), 99)
+            .await
+            .unwrap();
+
+        let storage = Storage::Mock(mock.clone());
+        let (storage_tx, _rx) = mpsc::channel(8);
+        for (row, captured) in [(&withdrawal, w_captured), (&deposit, d_captured)] {
+            route_outcome(
+                &storage,
+                row,
+                captured,
+                RecoveryAction::Quarantine {
+                    reason: "could not verify release landed (rpc down)".to_string(),
+                },
+                ProgramType::Withdraw,
+                &storage_tx,
+            )
+            .await;
+        }
+
+        let after = mock.pending_transactions.lock().unwrap();
+        let stored = after.iter().find(|t| t.id == withdrawal.id).unwrap();
+        assert_eq!(stored.status, TransactionStatus::ManualReview);
+        assert_eq!(stored.remint_signatures.as_deref(), Some(&[w_sig][..]));
+        assert_eq!(
+            stored.remint_last_valid_block_heights.as_deref(),
+            Some(&[4242i64][..])
+        );
+
+        let deposit_row = after.iter().find(|t| t.id == deposit.id).unwrap();
+        assert_eq!(deposit_row.status, TransactionStatus::ManualReview);
+        assert!(
+            deposit_row.remint_signatures.is_none()
+                && deposit_row.remint_last_valid_block_heights.is_none(),
+            "the deposit path must not start writing withdrawal remint columns"
+        );
+    }
+
+    // ── stalled-withdrawal reconcile ─────────────────────────────────
+
+    /// A withdrawal stalled in `status` with its release signatures on the row.
+    fn stalled_withdrawal(id: i64, status: TransactionStatus, sigs: &[String]) -> DbTransaction {
+        let mut row = make_withdrawal_row(id, Some(id));
+        row.status = status;
+        row.remint_last_valid_block_heights = Some(vec![100; sigs.len()]);
+        row.remint_signatures = Some(sigs.to_vec());
+        row
+    }
+
+    fn cleared_metric(outcome: &str) -> f64 {
+        OPERATOR_STALE_PROCESSING_RECOVERED
+            .with_label_values(&["withdraw", outcome, "withdrawal"])
+            .get()
+    }
+
+    /// Mock a finalized-but-failed `getSignatureStatuses`, the only shape that
+    /// classifies `Dead` without a block-height round trip.
+    fn mock_finalized_failure(server: &mut mockito::ServerGuard) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[{"slot":100,"confirmations":null,"err":{"InstructionError":[0,{"Custom":1}]},"status":{"Err":{"InstructionError":[0,{"Custom":1}]}},"confirmationStatus":"finalized"}]},"id":1}"#,
+            )
+            .create()
+    }
+
+    /// Proven-landed evidence promotes the row and records the landed signature.
+    #[tokio::test]
+    #[serial_test::serial(manual_review_cleared_metric)]
+    async fn reconcile_landed_promotes_manual_review_on_finalized_success() {
+        let landed_sig = Signature::new_unique().to_string();
+        let mut server = mockito::Server::new_async().await;
+        let _status = mock_finalized_status(&mut server);
+
+        let mock = MockStorage::new();
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(stalled_withdrawal(
+                1,
+                TransactionStatus::ManualReview,
+                std::slice::from_ref(&landed_sig),
+            ));
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+        let before = cleared_metric("manual_review_cleared");
+
+        reconcile_landed_withdrawals(
+            &storage,
+            &client,
+            TransactionStatus::ManualReview,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(after[0].status, TransactionStatus::Completed);
+        assert_eq!(
+            after[0].counterpart_signature.as_deref(),
+            Some(landed_sig.as_str())
+        );
+        assert_eq!(
+            cleared_metric("manual_review_cleared"),
+            before + 1.0,
+            "a cleared row must be visible as its own metric series"
+        );
+    }
+
+    /// Seed one stalled row, serve `setup`'s RPC shape, and assert nothing moved.
+    async fn assert_not_promoted(
+        label: &str,
+        setup: impl FnOnce(&mut mockito::ServerGuard) -> Vec<mockito::Mock>,
+    ) {
+        let mut server = mockito::Server::new_async().await;
+        let _mocks = setup(&mut server);
+
+        let mock = MockStorage::new();
+        let row = stalled_withdrawal(
+            1,
+            TransactionStatus::ManualReview,
+            &[Signature::new_unique().to_string()],
+        );
+        let seeded_updated_at = row.updated_at;
+        mock.pending_transactions.lock().unwrap().push(row);
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+        let before = cleared_metric("manual_review_cleared");
+
+        reconcile_landed_withdrawals(
+            &storage,
+            &client,
+            TransactionStatus::ManualReview,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let after = mock.pending_transactions.lock().unwrap();
+        assert_eq!(
+            after[0].status,
+            TransactionStatus::ManualReview,
+            "{label}: only proven-landed evidence may clear a quarantine"
+        );
+        assert_eq!(
+            after[0].updated_at, seeded_updated_at,
+            "{label}: a non-landed verdict must not write to the row at all"
+        );
+        assert_eq!(
+            cleared_metric("manual_review_cleared"),
+            before,
+            "{label}: no write means no metric"
+        );
+    }
+
+    /// The load-bearing safety property: everything short of proof is a no-op.
+    #[tokio::test]
+    #[serial_test::serial(manual_review_cleared_metric)]
+    async fn reconcile_landed_leaves_row_on_every_non_landed_verdict() {
+        // Live: no status entry yet and the blockhash has not expired.
+        assert_not_promoted("live", |server| {
+            vec![mock_null_status(server), mock_block_height(server, 0)]
+        })
+        .await;
+        assert_not_promoted("dead", |server| vec![mock_finalized_failure(server)]).await;
+        assert_not_promoted("uncertain", |server| {
+            vec![server
+                .mock("POST", "/")
+                .with_status(500)
+                .with_body("internal server error")
+                .create()]
+        })
+        .await;
+    }
+
+    /// Corrupt evidence must be inert: no panic, no RPC, and no promotion.
+    #[tokio::test]
+    #[serial_test::serial(manual_review_cleared_metric)]
+    async fn reconcile_landed_skips_unparseable_stored_signature() {
+        let mut server = mockito::Server::new_async().await;
+        let status = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(
+                r#""method"\s*:\s*"getSignatureStatuses""#.into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"jsonrpc":"2.0","result":{"context":{"slot":200},"value":[null]},"id":1}"#,
+            )
+            .expect(0)
+            .create();
+
+        let mock = MockStorage::new();
+        mock.pending_transactions
+            .lock()
+            .unwrap()
+            .push(stalled_withdrawal(
+                1,
+                TransactionStatus::ManualReview,
+                &["not-a-valid-base58-signature".to_string()],
+            ));
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+
+        reconcile_landed_withdrawals(
+            &storage,
+            &client,
+            TransactionStatus::ManualReview,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::ManualReview
+        );
+        status.assert();
+    }
+
+    /// A negative stored block height cannot be a real one, so the row is
+    /// skipped rather than sign-wrapped into a height no chain will reach.
+    #[tokio::test]
+    #[serial_test::serial(manual_review_cleared_metric)]
+    async fn reconcile_landed_skips_negative_block_height() {
+        let mut server = mockito::Server::new_async().await;
+        let status = mock_finalized_status(&mut server).expect(0);
+
+        let mock = MockStorage::new();
+        let mut row = stalled_withdrawal(
+            1,
+            TransactionStatus::ManualReview,
+            &[Signature::new_unique().to_string()],
+        );
+        row.remint_last_valid_block_heights = Some(vec![-1]);
+        mock.pending_transactions.lock().unwrap().push(row);
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+
+        reconcile_landed_withdrawals(
+            &storage,
+            &client,
+            TransactionStatus::ManualReview,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::ManualReview
+        );
+        status.assert();
+    }
+
+    /// The sweep runs at the tail of every tick, including inside the bounded
+    /// boot-reconcile loop. A failure there must not abort the tick and cost
+    /// the remaining passes of Processing reconciliation.
+    #[tokio::test]
+    async fn recover_once_tolerates_reconcile_query_failure() {
+        let mock = MockStorage::new();
+        mock.set_should_fail("get_stalled_withdrawals_with_signatures", true);
+        let storage = Storage::Mock(mock);
+        let client = make_rpc_client("http://localhost:1");
+        let (storage_tx, _rx) = mpsc::channel(8);
+
+        let result = recover_once(
+            &storage,
+            &client,
+            ProgramType::Withdraw,
+            &storage_tx,
+            &CancellationToken::new(),
+            Duration::ZERO,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "a reconcile query failure must not abort the tick: {result:?}"
+        );
+    }
+
+    /// Quarantining without the evidence is irreversible: the journal is GC'd
+    /// on the next tick, so the row could never be auto-reconciled again.
+    /// A read failure must defer the quarantine, not spend the row's evidence.
+    #[tokio::test]
+    async fn quarantine_defers_when_release_signature_read_fails() {
+        let mock = MockStorage::new();
+        let mut row = make_withdrawal_row(12, Some(6));
+        row.status = TransactionStatus::Processing;
+        let captured = seed_processing_row(&mock, row.clone()).await;
+        mock.insert_release_signature(row.id, Signature::new_unique().to_string(), 100)
+            .await
+            .unwrap();
+        mock.set_should_fail("get_release_signatures", true);
+        let storage = Storage::Mock(mock.clone());
+        let (storage_tx, mut storage_rx) = mpsc::channel(8);
+
+        route_outcome(
+            &storage,
+            &row,
+            captured,
+            RecoveryAction::Quarantine {
+                reason: "could not verify release landed (rpc down)".to_string(),
+            },
+            ProgramType::Withdraw,
+            &storage_tx,
+        )
+        .await;
+
+        assert_eq!(
+            mock.pending_transactions.lock().unwrap()[0].status,
+            TransactionStatus::Processing,
+            "the row must stay Processing so the next tick can retry with evidence"
+        );
+        assert!(
+            storage_rx.try_recv().is_err(),
+            "a deferred quarantine must not fire the manual-review alert"
         );
     }
 

--- a/indexer/src/operator/recovery.rs
+++ b/indexer/src/operator/recovery.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Utc};
 use solana_sdk::signature::Signature;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -31,6 +31,15 @@ pub(crate) const RECOVERY_BATCH_LIMIT: i64 = 100;
 /// Stalled withdrawals examined in one sweep before the depth is worth a warning.
 /// Purely an observability threshold: the sweep never stops early on it.
 const RECONCILE_BACKLOG_WARN_AT: usize = 1_000;
+
+/// Wall-clock ceiling on the periodic reconcile.
+///
+/// Held below `RECOVERY_INTERVAL` so the worker still idles between ticks. The
+/// tick interval bursts on a missed deadline, so a sweep that outran it would
+/// leave the worker permanently busy and push the stale-`Processing` recovery
+/// at the top of the next tick behind it. The cursor makes stopping early cost
+/// nothing: the next sweep resumes rather than restarts.
+pub(crate) const RECONCILE_SWEEP_BUDGET: Duration = Duration::from_secs(45);
 
 /// Wall-clock ceiling on the boot pre-flight's reconcile.
 ///
@@ -92,6 +101,9 @@ pub async fn run_recovery_worker(
 ) -> Result<(), OperatorError> {
     info!("Starting recovery worker");
     let mut interval = tokio::time::interval(RECOVERY_INTERVAL);
+    // Lives across ticks so a sweep that stops on its budget resumes where it
+    // left off, rather than rescanning the same prefix every minute.
+    let mut reconcile_cursor = 0i64;
     loop {
         tokio::select! {
             _ = cancellation_token.cancelled() => {
@@ -106,6 +118,7 @@ pub async fn run_recovery_worker(
                     &storage_tx,
                     &cancellation_token,
                     STALE_THRESHOLD,
+                    &mut reconcile_cursor,
                 )
                 .await
                 {
@@ -125,6 +138,7 @@ async fn recover_once(
     storage_tx: &mpsc::Sender<TransactionStatusUpdate>,
     cancellation_token: &CancellationToken,
     threshold: Duration,
+    reconcile_cursor: &mut i64,
 ) -> Result<(), OperatorError> {
     // Best-effort GC of release signatures whose parent is no longer Processing;
     // a failure here must not block recovery.
@@ -191,9 +205,8 @@ async fn recover_once(
             storage,
             rpc_client,
             TransactionStatus::ManualReview,
-            // Blocks nothing, so it runs to exhaustion: only an exhaustive sweep
-            // guarantees no row is permanently hidden behind unclearable ones.
-            None,
+            RECONCILE_SWEEP_BUDGET,
+            reconcile_cursor,
             cancellation_token,
         )
         .await
@@ -242,7 +255,42 @@ pub(crate) async fn reconcile_landed_withdrawals(
     storage: &Storage,
     rpc_client: &RpcClientWithRetry,
     from_status: TransactionStatus,
-    budget: Option<Duration>,
+    budget: Duration,
+    cursor: &mut i64,
+    cancellation_token: &CancellationToken,
+) -> Result<(), OperatorError> {
+    // The ceiling has to wrap the whole sweep, not gate entry to each row. A
+    // single classification retries five times, so a deadline consulted only
+    // between rows is overrun by whatever is already in flight when it passes.
+    // Dropping the future mid-flight is safe: the sole write is one CAS
+    // statement, so it either committed or it did not.
+    match tokio::time::timeout(
+        budget,
+        reconcile_sweep(storage, rpc_client, from_status, cursor, cancellation_token),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            // The cursor keeps its position, so the next sweep resumes here
+            // instead of rescanning the prefix that just used up the budget.
+            warn!(
+                resume_after_id = *cursor,
+                ?from_status,
+                "Reconcile sweep hit its time budget; remainder deferred to the next sweep"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// The sweep itself. Split out so the caller can impose a hard wall-clock
+/// ceiling on it as a whole.
+async fn reconcile_sweep(
+    storage: &Storage,
+    rpc_client: &RpcClientWithRetry,
+    from_status: TransactionStatus,
+    cursor: &mut i64,
     cancellation_token: &CancellationToken,
 ) -> Result<(), OperatorError> {
     let outcome_label = match from_status {
@@ -257,27 +305,25 @@ pub(crate) async fn reconcile_landed_withdrawals(
         }
     };
 
-    // Page forward by id, in batches only to bound each query.
+    // Page forward by id from wherever the last sweep stopped.
     //
-    // There is no row-count cap. Rows that do not classify are left untouched
-    // by design, so nothing drains this set on its own; a count cap would be a
-    // permanent blind spot for every row behind it, since the cursor restarts
-    // at zero each sweep and rescans the same prefix forever. The one row that
-    // matters most, a landed release still wedging the boot gate, is exactly
-    // the row such a cap would hide.
-    let deadline = budget.map(|b| Instant::now() + b);
-    let mut after_id = 0i64;
+    // There is no row-count cap. Rows that do not classify are left untouched by
+    // design, so nothing drains this set on its own; a cap paired with a cursor
+    // that restarts at zero would rescan the same prefix forever and hide every
+    // row behind it, including a landed release still wedging the boot gate.
+    // The time ceiling bounds the work instead, and the cursor is what keeps
+    // that bound from turning into a permanent blind spot.
     let mut scanned = 0usize;
     loop {
         let batch = storage
-            .get_stalled_withdrawals_with_signatures(from_status, after_id, RECOVERY_BATCH_LIMIT)
+            .get_stalled_withdrawals_with_signatures(from_status, *cursor, RECOVERY_BATCH_LIMIT)
             .await?;
         if batch.is_empty() {
             break;
         }
         debug!(
             count = batch.len(),
-            after_id,
+            after_id = *cursor,
             ?from_status,
             "Reconcile sweep found stalled withdrawals with stored signatures"
         );
@@ -289,20 +335,9 @@ pub(crate) async fn reconcile_landed_withdrawals(
                 info!("Reconcile sweep cancelled; remaining stalled rows deferred");
                 return Ok(());
             }
-            // Checked per row, not per batch: one row against a degraded RPC
-            // costs five retries, so a batch can overrun the budget on its own.
-            if deadline.is_some_and(|d| Instant::now() >= d) {
-                warn!(
-                    scanned,
-                    ?from_status,
-                    "Reconcile sweep hit its time budget; \
-                     the SMT check below decides whether the operator can start"
-                );
-                return Ok(());
-            }
-            // The cursor advances even when a row is skipped, which is what stops
-            // an unclearable row from being re-fetched ahead of everything else.
-            after_id = row.id;
+            // Advances even when a row is skipped, which is what stops an
+            // unclearable row from being re-fetched ahead of everything else.
+            *cursor = row.id;
             // The query is withdrawal-only, so this is the same belt-and-braces gate
             // the other sweeps use: never classify a row against the wrong chain.
             if !role_owns(ProgramType::Withdraw, &row) {
@@ -323,6 +358,10 @@ pub(crate) async fn reconcile_landed_withdrawals(
             break;
         }
     }
+
+    // Reaching the end means every row was seen, so the next sweep starts over
+    // and picks up whatever stalled in the meantime.
+    *cursor = 0;
 
     // A backlog this deep is an incident of its own: every row in it is a
     // withdrawal that failed and could not be resolved, and each costs an RPC
@@ -759,6 +798,7 @@ pub async fn boot_reconcile_processing(
     cancellation_token: &CancellationToken,
     max_passes: u32,
 ) -> Result<(), OperatorError> {
+    let mut reconcile_cursor = 0i64;
     for pass in 0..max_passes {
         recover_once(
             storage,
@@ -767,6 +807,7 @@ pub async fn boot_reconcile_processing(
             storage_tx,
             cancellation_token,
             Duration::ZERO,
+            &mut reconcile_cursor,
         )
         .await?;
 
@@ -817,6 +858,7 @@ pub mod test_hooks {
             storage_tx,
             &token,
             STALE_THRESHOLD,
+            &mut 0,
         )
         .await
     }
@@ -830,7 +872,15 @@ pub mod test_hooks {
         from_status: TransactionStatus,
     ) -> Result<(), OperatorError> {
         let token = CancellationToken::new();
-        reconcile_landed_withdrawals(storage, rpc_client, from_status, None, &token).await
+        reconcile_landed_withdrawals(
+            storage,
+            rpc_client,
+            from_status,
+            RECONCILE_SWEEP_BUDGET,
+            &mut 0,
+            &token,
+        )
+        .await
     }
 }
 
@@ -1449,7 +1499,8 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
-            None,
+            RECONCILE_SWEEP_BUDGET,
+            &mut 0,
             &CancellationToken::new(),
         )
         .await
@@ -1503,20 +1554,25 @@ mod tests {
         let storage = Storage::Mock(mock.clone());
         let client = make_rpc_client(&server.url());
 
-        let started = Instant::now();
+        let started = std::time::Instant::now();
         reconcile_landed_withdrawals(
             &storage,
             &client,
             TransactionStatus::PendingRemint,
-            Some(Duration::from_millis(150)),
+            Duration::from_millis(150),
+            &mut 0,
             &CancellationToken::new(),
         )
         .await
         .unwrap();
 
+        // The ceiling must hold even though a classification is mid-retry when it
+        // passes: a deadline consulted only between rows would overshoot by the
+        // whole in-flight retry chain, which is what the wrapping timeout stops.
         assert!(
-            started.elapsed() < Duration::from_secs(10),
-            "the boot sweep must return on its budget, not grind through the backlog"
+            started.elapsed() < Duration::from_secs(1),
+            "the boot sweep must return on its budget even mid-retry, took {:?}",
+            started.elapsed()
         );
         let after = mock.pending_transactions.lock().unwrap();
         assert!(
@@ -1524,6 +1580,72 @@ mod tests {
                 .iter()
                 .all(|t| t.status == TransactionStatus::PendingRemint),
             "giving up on time must never promote a row"
+        );
+    }
+
+    /// A sweep that stops on its budget must resume, not restart. Without a
+    /// cursor that survives the call, every sweep would rescan the same prefix
+    /// and the rows behind it would never be reached.
+    #[tokio::test]
+    #[serial_test::serial(manual_review_cleared_metric)]
+    async fn reconcile_cursor_resumes_after_a_spent_budget() {
+        let mut server = mockito::Server::new_async().await;
+        let _slow = server
+            .mock("POST", "/")
+            .with_status(500)
+            .with_chunked_body(|_| {
+                std::thread::sleep(std::time::Duration::from_millis(60));
+                Ok(())
+            })
+            .expect_at_least(1)
+            .create();
+
+        let mock = MockStorage::new();
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            for id in 1..=200 {
+                db.push(stalled_withdrawal(
+                    id,
+                    TransactionStatus::ManualReview,
+                    &[Signature::new_unique().to_string()],
+                ));
+            }
+        }
+        let storage = Storage::Mock(mock.clone());
+        let client = make_rpc_client(&server.url());
+        let mut cursor = 0i64;
+
+        reconcile_landed_withdrawals(
+            &storage,
+            &client,
+            TransactionStatus::ManualReview,
+            Duration::from_millis(200),
+            &mut cursor,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            cursor > 0,
+            "a sweep stopped by its budget must leave the cursor where it got to"
+        );
+        let first_stop = cursor;
+
+        reconcile_landed_withdrawals(
+            &storage,
+            &client,
+            TransactionStatus::ManualReview,
+            Duration::from_millis(200),
+            &mut cursor,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            cursor > first_stop,
+            "the next sweep must carry on past {first_stop}, not restart at zero"
         );
     }
 
@@ -1573,7 +1695,8 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
-            None,
+            RECONCILE_SWEEP_BUDGET,
+            &mut 0,
             &CancellationToken::new(),
         )
         .await
@@ -1616,7 +1739,8 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
-            None,
+            RECONCILE_SWEEP_BUDGET,
+            &mut 0,
             &CancellationToken::new(),
         )
         .await
@@ -1692,7 +1816,8 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
-            None,
+            RECONCILE_SWEEP_BUDGET,
+            &mut 0,
             &CancellationToken::new(),
         )
         .await
@@ -1728,7 +1853,8 @@ mod tests {
             &storage,
             &client,
             TransactionStatus::ManualReview,
-            None,
+            RECONCILE_SWEEP_BUDGET,
+            &mut 0,
             &CancellationToken::new(),
         )
         .await
@@ -1759,6 +1885,7 @@ mod tests {
             &storage_tx,
             &CancellationToken::new(),
             Duration::ZERO,
+            &mut 0,
         )
         .await;
 
@@ -2178,6 +2305,7 @@ mod tests {
             &storage_tx,
             &CancellationToken::new(),
             Duration::ZERO,
+            &mut 0,
         )
         .await
         .unwrap();

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -398,10 +398,11 @@ impl Storage {
     pub async fn get_stalled_withdrawals_with_signatures(
         &self,
         status: TransactionStatus,
+        after_id: i64,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         get_stalled_withdrawals_with_signatures::get_stalled_withdrawals_with_signatures(
-            self, status, limit,
+            self, status, after_id, limit,
         )
         .await
     }
@@ -1518,7 +1519,7 @@ mod tests {
         }
 
         let found = storage
-            .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 100)
+            .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 0, 100)
             .await
             .unwrap();
 

--- a/indexer/src/storage/common/storage.rs
+++ b/indexer/src/storage/common/storage.rs
@@ -20,6 +20,7 @@ pub mod get_pending_remint_transactions;
 pub mod get_release_signatures;
 pub mod get_stale_parked_transactions;
 pub mod get_stale_processing_transactions;
+pub mod get_stalled_withdrawals_with_signatures;
 pub mod init_schema;
 pub mod insert_db_transaction;
 pub mod insert_db_transactions_batch;
@@ -32,6 +33,7 @@ pub mod set_mint_extension_flags;
 pub mod set_pending_remint;
 pub mod sync_mint_status;
 pub mod try_complete_processing;
+pub mod try_complete_stalled_withdrawal;
 pub mod try_park_processing;
 pub mod try_quarantine_processing;
 pub mod try_requeue_parked;
@@ -391,6 +393,19 @@ impl Storage {
         .await
     }
 
+    /// Withdrawals stalled in `status` that still carry stored release
+    /// signatures, oldest-first. Rows with no usable evidence are excluded.
+    pub async fn get_stalled_withdrawals_with_signatures(
+        &self,
+        status: TransactionStatus,
+        limit: i64,
+    ) -> Result<Vec<DbTransaction>, StorageError> {
+        get_stalled_withdrawals_with_signatures::get_stalled_withdrawals_with_signatures(
+            self, status, limit,
+        )
+        .await
+    }
+
     /// CAS `Parked` → `Pending` on `updated_at`; `Ok(false)` if stale.
     pub async fn try_requeue_parked(
         &self,
@@ -416,16 +431,41 @@ impl Storage {
         .await
     }
 
+    /// CAS a stalled withdrawal (`ManualReview` or `PendingRemint`) to
+    /// `Completed` on `updated_at`; `Ok(false)` if stale or guard-rejected.
+    pub async fn try_complete_stalled_withdrawal(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+        from_status: TransactionStatus,
+        counterpart_signature: Option<String>,
+    ) -> Result<bool, StorageError> {
+        try_complete_stalled_withdrawal::try_complete_stalled_withdrawal(
+            self,
+            transaction_id,
+            expected_updated_at,
+            from_status,
+            counterpart_signature,
+        )
+        .await
+    }
+
     /// CAS `Processing` → `ManualReview`; reason rides on the webhook, not DB.
+    /// The optional signature arrays are recorded on the row in the same write;
+    /// `None` leaves both columns untouched.
     pub async fn try_quarantine_processing(
         &self,
         transaction_id: i64,
         expected_updated_at: chrono::DateTime<chrono::Utc>,
+        remint_signatures: Option<Vec<String>>,
+        remint_last_valid_block_heights: Option<Vec<i64>>,
     ) -> Result<bool, StorageError> {
         try_quarantine_processing::try_quarantine_processing(
             self,
             transaction_id,
             expected_updated_at,
+            remint_signatures,
+            remint_last_valid_block_heights,
         )
         .await
     }
@@ -1433,5 +1473,59 @@ mod tests {
         assert_eq!(poison.status, TransactionStatus::Processing);
         let sibling = rows.iter().find(|t| t.id == 43).unwrap();
         assert_eq!(sibling.status, TransactionStatus::ManualReview);
+    }
+
+    /// The mock must reject exactly what the SQL rejects, otherwise every
+    /// mock-backed test of the reconcile sweep rests on a filter that does not
+    /// exist in production.
+    #[tokio::test]
+    async fn stalled_withdrawal_query_filters_match_sql() {
+        let (storage, mock) = make_mock_storage();
+        let stalled = |id: i64, sigs: Option<Vec<String>>| {
+            let mut row = make_db_transaction();
+            row.id = id;
+            row.transaction_type = TransactionType::Withdrawal;
+            row.status = TransactionStatus::ManualReview;
+            row.withdrawal_nonce = Some(id);
+            row.remint_last_valid_block_heights = sigs.as_ref().map(|s| vec![0i64; s.len()]);
+            row.remint_signatures = sigs;
+            row
+        };
+        {
+            let mut db = mock.pending_transactions.lock().unwrap();
+            db.push(stalled(1, Some(vec!["sig-a".to_string()])));
+
+            let mut wrong_status = stalled(2, Some(vec!["sig-b".to_string()]));
+            wrong_status.status = TransactionStatus::PendingRemint;
+            db.push(wrong_status);
+
+            let mut deposit = stalled(3, Some(vec!["sig-c".to_string()]));
+            deposit.transaction_type = TransactionType::Deposit;
+            db.push(deposit);
+
+            let mut no_nonce = stalled(4, Some(vec!["sig-d".to_string()]));
+            no_nonce.withdrawal_nonce = None;
+            db.push(no_nonce);
+
+            db.push(stalled(5, Some(Vec::new())));
+            db.push(stalled(6, None));
+
+            // Reachable on a database upgraded between the two column
+            // migrations: signatures present, heights never backfilled.
+            let mut no_heights = stalled(7, Some(vec!["sig-e".to_string()]));
+            no_heights.remint_last_valid_block_heights = None;
+            db.push(no_heights);
+        }
+
+        let found = storage
+            .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 100)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            found.iter().map(|t| t.id).collect::<Vec<_>>(),
+            vec![1],
+            "only the row with a usable signature set may be returned"
+        );
     }
 }

--- a/indexer/src/storage/common/storage/get_stalled_withdrawals_with_signatures.rs
+++ b/indexer/src/storage/common/storage/get_stalled_withdrawals_with_signatures.rs
@@ -1,0 +1,27 @@
+use crate::{
+    error::StorageError,
+    storage::common::{
+        models::{DbTransaction, TransactionStatus},
+        storage::Storage,
+    },
+};
+
+/// Withdrawals stalled in `status` that still carry stored release signatures,
+/// oldest-first. Rows with no usable evidence are filtered out by the query.
+pub async fn get_stalled_withdrawals_with_signatures(
+    storage: &Storage,
+    status: TransactionStatus,
+    limit: i64,
+) -> Result<Vec<DbTransaction>, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .get_stalled_withdrawals_with_signatures_internal(status, limit)
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .get_stalled_withdrawals_with_signatures(status, limit)
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/get_stalled_withdrawals_with_signatures.rs
+++ b/indexer/src/storage/common/storage/get_stalled_withdrawals_with_signatures.rs
@@ -7,20 +7,22 @@ use crate::{
 };
 
 /// Withdrawals stalled in `status` that still carry stored release signatures,
-/// oldest-first. Rows with no usable evidence are filtered out by the query.
+/// keyed forward from `after_id`. Rows with no usable evidence are filtered out
+/// by the query.
 pub async fn get_stalled_withdrawals_with_signatures(
     storage: &Storage,
     status: TransactionStatus,
+    after_id: i64,
     limit: i64,
 ) -> Result<Vec<DbTransaction>, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
-            .get_stalled_withdrawals_with_signatures_internal(status, limit)
+            .get_stalled_withdrawals_with_signatures_internal(status, after_id, limit)
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .get_stalled_withdrawals_with_signatures(status, limit)
+                .get_stalled_withdrawals_with_signatures(status, after_id, limit)
                 .await
         }
     }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -700,6 +700,7 @@ impl MockStorage {
     pub async fn get_stalled_withdrawals_with_signatures(
         &self,
         status: TransactionStatus,
+        after_id: i64,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, StorageError> {
         self.check_should_fail("get_stalled_withdrawals_with_signatures")?;
@@ -710,9 +711,10 @@ impl MockStorage {
             .filter(|t| t.withdrawal_nonce.is_some())
             .filter(|t| t.remint_signatures.as_ref().is_some_and(|s| !s.is_empty()))
             .filter(|t| t.remint_last_valid_block_heights.is_some())
+            .filter(|t| t.id > after_id)
             .cloned()
             .collect();
-        matched.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
+        matched.sort_by_key(|t| t.id);
         matched.truncate(limit as usize);
         Ok(matched)
     }

--- a/indexer/src/storage/common/storage/mock.rs
+++ b/indexer/src/storage/common/storage/mock.rs
@@ -693,10 +693,74 @@ impl MockStorage {
         Ok(false)
     }
 
+    /// Mirror `get_stalled_withdrawals_with_signatures_internal`, including the
+    /// evidence predicates: a missing nonce, an absent/empty signature array, or
+    /// a missing heights array makes the row unclassifiable, so it is not
+    /// returned.
+    pub async fn get_stalled_withdrawals_with_signatures(
+        &self,
+        status: TransactionStatus,
+        limit: i64,
+    ) -> Result<Vec<DbTransaction>, StorageError> {
+        self.check_should_fail("get_stalled_withdrawals_with_signatures")?;
+        let pending = self.pending_transactions.lock().unwrap();
+        let mut matched: Vec<DbTransaction> = pending
+            .iter()
+            .filter(|t| t.transaction_type == TransactionType::Withdrawal && t.status == status)
+            .filter(|t| t.withdrawal_nonce.is_some())
+            .filter(|t| t.remint_signatures.as_ref().is_some_and(|s| !s.is_empty()))
+            .filter(|t| t.remint_last_valid_block_heights.is_some())
+            .cloned()
+            .collect();
+        matched.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
+        matched.truncate(limit as usize);
+        Ok(matched)
+    }
+
+    /// Mirror `try_complete_stalled_withdrawal_internal`: the source status is
+    /// pinned to the two stalled statuses regardless of what the caller binds.
+    pub async fn try_complete_stalled_withdrawal(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: DateTime<Utc>,
+        from_status: TransactionStatus,
+        counterpart_signature: Option<String>,
+    ) -> Result<bool, StorageError> {
+        self.check_should_fail("try_complete_stalled_withdrawal")?;
+        if !matches!(
+            from_status,
+            TransactionStatus::ManualReview | TransactionStatus::PendingRemint
+        ) {
+            return Ok(false);
+        }
+        let mut pending = self.pending_transactions.lock().unwrap();
+        for txn in pending.iter_mut() {
+            if txn.id == transaction_id
+                && txn.transaction_type == TransactionType::Withdrawal
+                && txn.status == from_status
+                && txn.updated_at == expected_updated_at
+            {
+                txn.status = TransactionStatus::Completed;
+                if counterpart_signature.is_some() {
+                    txn.counterpart_signature = counterpart_signature;
+                }
+                let now = Utc::now();
+                txn.processed_at = Some(now);
+                txn.updated_at = now;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Mirror `try_quarantine_processing_internal`, `COALESCE` included: a
+    /// `None` argument leaves the existing column value in place.
     pub async fn try_quarantine_processing(
         &self,
         transaction_id: i64,
         expected_updated_at: DateTime<Utc>,
+        remint_signatures: Option<Vec<String>>,
+        remint_last_valid_block_heights: Option<Vec<i64>>,
     ) -> Result<bool, StorageError> {
         self.check_should_fail("try_quarantine_processing")?;
         let mut pending = self.pending_transactions.lock().unwrap();
@@ -706,6 +770,12 @@ impl MockStorage {
                 && txn.updated_at == expected_updated_at
             {
                 txn.status = TransactionStatus::ManualReview;
+                if remint_signatures.is_some() {
+                    txn.remint_signatures = remint_signatures;
+                }
+                if remint_last_valid_block_heights.is_some() {
+                    txn.remint_last_valid_block_heights = remint_last_valid_block_heights;
+                }
                 let now = Utc::now();
                 txn.processed_at = Some(now);
                 txn.updated_at = now;

--- a/indexer/src/storage/common/storage/try_complete_stalled_withdrawal.rs
+++ b/indexer/src/storage/common/storage/try_complete_stalled_withdrawal.rs
@@ -1,0 +1,36 @@
+use crate::{
+    error::StorageError,
+    storage::common::{models::TransactionStatus, storage::Storage},
+};
+
+/// CAS a stalled withdrawal (`ManualReview` or `PendingRemint`) to `Completed`
+/// on `updated_at`; `Ok(false)` if stale or the guard rejects the row.
+pub async fn try_complete_stalled_withdrawal(
+    storage: &Storage,
+    transaction_id: i64,
+    expected_updated_at: chrono::DateTime<chrono::Utc>,
+    from_status: TransactionStatus,
+    counterpart_signature: Option<String>,
+) -> Result<bool, StorageError> {
+    match storage {
+        Storage::Postgres(db) => Ok(db
+            .try_complete_stalled_withdrawal_internal(
+                transaction_id,
+                expected_updated_at,
+                from_status,
+                counterpart_signature,
+            )
+            .await?),
+        #[cfg(any(test, feature = "test-mock-storage"))]
+        Storage::Mock(mock_db) => {
+            mock_db
+                .try_complete_stalled_withdrawal(
+                    transaction_id,
+                    expected_updated_at,
+                    from_status,
+                    counterpart_signature,
+                )
+                .await
+        }
+    }
+}

--- a/indexer/src/storage/common/storage/try_quarantine_processing.rs
+++ b/indexer/src/storage/common/storage/try_quarantine_processing.rs
@@ -1,19 +1,34 @@
 use crate::{error::StorageError, storage::common::storage::Storage};
 
 /// CAS `Processing` → `ManualReview`; reason rides on the webhook, not DB.
+/// The optional signature arrays are recorded on the row in the same write, so
+/// the evidence outlives the release-signature journal's GC. `None` leaves both
+/// columns untouched.
 pub async fn try_quarantine_processing(
     storage: &Storage,
     transaction_id: i64,
     expected_updated_at: chrono::DateTime<chrono::Utc>,
+    remint_signatures: Option<Vec<String>>,
+    remint_last_valid_block_heights: Option<Vec<i64>>,
 ) -> Result<bool, StorageError> {
     match storage {
         Storage::Postgres(db) => Ok(db
-            .try_quarantine_processing_internal(transaction_id, expected_updated_at)
+            .try_quarantine_processing_internal(
+                transaction_id,
+                expected_updated_at,
+                remint_signatures,
+                remint_last_valid_block_heights,
+            )
             .await?),
         #[cfg(any(test, feature = "test-mock-storage"))]
         Storage::Mock(mock_db) => {
             mock_db
-                .try_quarantine_processing(transaction_id, expected_updated_at)
+                .try_quarantine_processing(
+                    transaction_id,
+                    expected_updated_at,
+                    remint_signatures,
+                    remint_last_valid_block_heights,
+                )
                 .await
         }
     }

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1389,15 +1389,26 @@ impl PostgresDb {
     }
 
     /// CAS `Processing` → `ManualReview`; reason rides on the webhook, not DB.
+    ///
+    /// The optional signature arrays are persisted by the same statement rather
+    /// than a preceding one. Splitting them is not merely slower, it cannot
+    /// work: the `updated_at` trigger fires on the first write, after which this
+    /// statement's `updated_at` compare can never match and the row would be
+    /// stranded in `processing` forever. `COALESCE` keeps a `None` call inert,
+    /// so callers with no evidence to record leave both columns as they were.
     pub async fn try_quarantine_processing_internal(
         &self,
         transaction_id: i64,
         expected_updated_at: chrono::DateTime<chrono::Utc>,
+        remint_signatures: Option<Vec<String>>,
+        remint_last_valid_block_heights: Option<Vec<i64>>,
     ) -> Result<bool, sqlx::Error> {
         let result = sqlx::query(
             r#"
             UPDATE transactions
             SET status = 'manual_review',
+                remint_signatures = COALESCE($3, remint_signatures),
+                remint_last_valid_block_heights = COALESCE($4, remint_last_valid_block_heights),
                 processed_at = NOW()
             WHERE id = $1
               AND status = 'processing'
@@ -1406,6 +1417,115 @@ impl PostgresDb {
         )
         .bind(transaction_id)
         .bind(expected_updated_at)
+        .bind(remint_signatures)
+        .bind(remint_last_valid_block_heights)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Withdrawals stalled in `status` that still carry stored release
+    /// signatures, oldest-first.
+    ///
+    /// The evidence predicates are in SQL so a row that can never be classified
+    /// (structurally corrupt, or quarantined before anything was broadcast) is
+    /// never fetched and never costs an RPC round trip. A NULL nonce is excluded
+    /// for the same reason: no nonce means no release was ever built, so the row
+    /// cannot be the missing leaf the on-chain tree is holding. The two arrays
+    /// are index-paired, and they arrived in separate migrations, so a row can
+    /// legitimately carry signatures with no heights; that is unclassifiable too.
+    pub async fn get_stalled_withdrawals_with_signatures_internal(
+        &self,
+        status: TransactionStatus,
+        limit: i64,
+    ) -> Result<Vec<DbTransaction>, sqlx::Error> {
+        sqlx::query_as::<_, DbTransaction>(&format!(
+            r#"
+            SELECT
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+                {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+            FROM transactions
+            WHERE {} = 'withdrawal'
+              AND {} = $1
+              AND {} IS NOT NULL
+              AND {} IS NOT NULL
+              AND array_length({}, 1) > 0
+              AND {} IS NOT NULL
+            ORDER BY {} ASC
+            LIMIT $2
+            "#,
+            transaction_cols::ID,
+            transaction_cols::SIGNATURE,
+            transaction_cols::TRACE_ID,
+            transaction_cols::SLOT,
+            transaction_cols::INITIATOR,
+            transaction_cols::RECIPIENT,
+            transaction_cols::MINT,
+            transaction_cols::AMOUNT,
+            transaction_cols::MEMO,
+            transaction_cols::TRANSACTION_TYPE,
+            transaction_cols::WITHDRAWAL_NONCE,
+            transaction_cols::STATUS,
+            transaction_cols::CREATED_AT,
+            transaction_cols::UPDATED_AT,
+            transaction_cols::PROCESSED_AT,
+            transaction_cols::COUNTERPART_SIGNATURE,
+            transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
+            transaction_cols::PENDING_REMINT_DEADLINE_AT,
+            transaction_cols::FINALITY_CHECK_ATTEMPTS,
+            transaction_cols::RECOVERY_REQUEUE_ATTEMPTS,
+            transaction_cols::INSTRUCTION_INDEX,
+            transaction_cols::INNER_INDEX,
+            transaction_cols::LANDED_REMINT_SIGNATURE,
+            // Filters
+            transaction_cols::TRANSACTION_TYPE,
+            transaction_cols::STATUS,
+            transaction_cols::WITHDRAWAL_NONCE,
+            transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::REMINT_SIGNATURES,
+            transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
+            // Ordering (oldest stall first, so progress is deterministic under LIMIT)
+            transaction_cols::UPDATED_AT,
+        ))
+        .bind(status)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// CAS a stalled withdrawal to `Completed` once its release is proven landed.
+    ///
+    /// `from_status` is bound by the caller, but the statement additionally pins
+    /// the allowed source statuses inline. That redundancy is deliberate: the
+    /// guard is what stops this from resurrecting a terminal row or stealing a
+    /// `processing` row from a live sender, and it belongs in the SQL rather
+    /// than resting on every present and future caller binding the right value.
+    pub async fn try_complete_stalled_withdrawal_internal(
+        &self,
+        transaction_id: i64,
+        expected_updated_at: chrono::DateTime<chrono::Utc>,
+        from_status: TransactionStatus,
+        counterpart_signature: Option<String>,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'completed',
+                counterpart_signature = COALESCE($4, counterpart_signature),
+                processed_at = NOW()
+            WHERE id = $1
+              AND updated_at = $2
+              AND status = $3
+              AND status IN ('manual_review', 'pending_remint')
+              AND transaction_type = 'withdrawal'
+            "#,
+        )
+        .bind(transaction_id)
+        .bind(expected_updated_at)
+        .bind(from_status)
+        .bind(counterpart_signature)
         .execute(&self.pool)
         .await?;
 

--- a/indexer/src/storage/postgres/db.rs
+++ b/indexer/src/storage/postgres/db.rs
@@ -1426,7 +1426,7 @@ impl PostgresDb {
     }
 
     /// Withdrawals stalled in `status` that still carry stored release
-    /// signatures, oldest-first.
+    /// signatures, keyed forward from `after_id`.
     ///
     /// The evidence predicates are in SQL so a row that can never be classified
     /// (structurally corrupt, or quarantined before anything was broadcast) is
@@ -1435,9 +1435,16 @@ impl PostgresDb {
     /// cannot be the missing leaf the on-chain tree is holding. The two arrays
     /// are index-paired, and they arrived in separate migrations, so a row can
     /// legitimately carry signatures with no heights; that is unclassifiable too.
+    ///
+    /// Paging is keyed on `id` rather than offset by `updated_at`. A row that
+    /// does not classify is left untouched by design, so its `updated_at` never
+    /// moves; ordering on it would return the same blocked rows on every sweep
+    /// and starve everything behind them. `id` gives the caller a cursor that
+    /// always advances.
     pub async fn get_stalled_withdrawals_with_signatures_internal(
         &self,
         status: TransactionStatus,
+        after_id: i64,
         limit: i64,
     ) -> Result<Vec<DbTransaction>, sqlx::Error> {
         sqlx::query_as::<_, DbTransaction>(&format!(
@@ -1452,8 +1459,9 @@ impl PostgresDb {
               AND {} IS NOT NULL
               AND array_length({}, 1) > 0
               AND {} IS NOT NULL
+              AND {} > $2
             ORDER BY {} ASC
-            LIMIT $2
+            LIMIT $3
             "#,
             transaction_cols::ID,
             transaction_cols::SIGNATURE,
@@ -1486,10 +1494,13 @@ impl PostgresDb {
             transaction_cols::REMINT_SIGNATURES,
             transaction_cols::REMINT_SIGNATURES,
             transaction_cols::REMINT_LAST_VALID_BLOCK_HEIGHTS,
-            // Ordering (oldest stall first, so progress is deterministic under LIMIT)
-            transaction_cols::UPDATED_AT,
+            // Keyset cursor
+            transaction_cols::ID,
+            // Ordering must match the cursor so paging cannot repeat or skip
+            transaction_cols::ID,
         ))
         .bind(status)
+        .bind(after_id)
         .bind(limit)
         .fetch_all(&self.pool)
         .await

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -1171,3 +1171,396 @@ async fn try_requeue_processing_stale_cas_leaves_counter_unchanged(
     );
     Ok(())
 }
+
+// ── stalled-withdrawal reconciliation ────────────────────────────────────────
+
+/// Insert a row and force it into `status` without going through the operator.
+async fn seed_with_status(
+    pool: &PgPool,
+    storage: &Storage,
+    sig: &str,
+    txn_type: TransactionType,
+    status: &str,
+) -> Result<i64, Box<dyn std::error::Error>> {
+    let id = storage
+        .insert_db_transaction(&make_db_transaction(sig, txn_type))
+        .await?;
+    sqlx::query("UPDATE transactions SET status = $2::transaction_status WHERE id = $1")
+        .bind(id)
+        .bind(status)
+        .execute(pool)
+        .await?;
+    Ok(id)
+}
+
+/// I1: the promote CAS refuses every source status but `manual_review` and
+/// `pending_remint`, refuses deposits, and honours the `updated_at` compare.
+#[tokio::test(flavor = "multi_thread")]
+async fn try_complete_stalled_withdrawal_guard_matrix() -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+
+    // (label, seeded status, bound from-status, transaction type, use a stale CAS, expected)
+    let cases: &[(&str, &str, TransactionStatus, TransactionType, bool, bool)] = &[
+        (
+            "manual_review fresh",
+            "manual_review",
+            TransactionStatus::ManualReview,
+            TransactionType::Withdrawal,
+            false,
+            true,
+        ),
+        (
+            "pending_remint fresh",
+            "pending_remint",
+            TransactionStatus::PendingRemint,
+            TransactionType::Withdrawal,
+            false,
+            true,
+        ),
+        (
+            "processing fresh",
+            "processing",
+            TransactionStatus::Processing,
+            TransactionType::Withdrawal,
+            false,
+            false,
+        ),
+        (
+            "completed fresh",
+            "completed",
+            TransactionStatus::Completed,
+            TransactionType::Withdrawal,
+            false,
+            false,
+        ),
+        (
+            "manual_review stale cas",
+            "manual_review",
+            TransactionStatus::ManualReview,
+            TransactionType::Withdrawal,
+            true,
+            false,
+        ),
+        (
+            "deposit manual_review",
+            "manual_review",
+            TransactionStatus::ManualReview,
+            TransactionType::Deposit,
+            false,
+            false,
+        ),
+    ];
+
+    for (i, (label, seeded, from_status, txn_type, stale, expected)) in cases.iter().enumerate() {
+        let id = seed_with_status(&pool, &storage, &format!("cas_{i}"), *txn_type, seeded).await?;
+        let mut captured = updated_at_of(&pool, id).await;
+        if *stale {
+            captured -= chrono::Duration::seconds(60);
+        }
+
+        let promoted = storage
+            .try_complete_stalled_withdrawal(id, captured, *from_status, Some(format!("sig-{i}")))
+            .await?;
+        assert_eq!(promoted, *expected, "{label}: unexpected CAS result");
+
+        if *expected {
+            assert_eq!(status_of(&pool, id).await, "completed", "{label}");
+            let sig: Option<String> =
+                sqlx::query_scalar("SELECT counterpart_signature FROM transactions WHERE id = $1")
+                    .bind(id)
+                    .fetch_one(&pool)
+                    .await?;
+            assert_eq!(sig.as_deref(), Some(format!("sig-{i}").as_str()), "{label}");
+        } else {
+            assert_eq!(
+                status_of(&pool, id).await,
+                *seeded,
+                "{label}: a refused CAS must leave the row exactly as it was"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Backdate `updated_at` past the trigger that would otherwise stamp NOW().
+async fn force_updated_at(
+    pool: &PgPool,
+    id: i64,
+    ts: chrono::DateTime<Utc>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    sqlx::query("ALTER TABLE transactions DISABLE TRIGGER update_transactions_updated_at")
+        .execute(pool)
+        .await?;
+    sqlx::query("UPDATE transactions SET updated_at = $2 WHERE id = $1")
+        .bind(id)
+        .bind(ts)
+        .execute(pool)
+        .await?;
+    sqlx::query("ALTER TABLE transactions ENABLE TRIGGER update_transactions_updated_at")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn set_remint_signatures(
+    pool: &PgPool,
+    id: i64,
+    sigs: Option<Vec<String>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let heights: Option<Vec<i64>> = sigs.as_ref().map(|s| vec![0i64; s.len()]);
+    sqlx::query(
+        "UPDATE transactions SET remint_signatures = $2, remint_last_valid_block_heights = $3
+         WHERE id = $1",
+    )
+    .bind(id)
+    .bind(sigs)
+    .bind(heights)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// I2: the fetch predicates and ordering, which the mock cannot verify
+/// (`array_length` and the NULL-nonce filter are SQL-only).
+#[tokio::test(flavor = "multi_thread")]
+async fn stalled_withdrawal_query_predicates_and_ordering() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (pool, storage, _pg) = start_postgres().await?;
+    let base = Utc::now() - chrono::Duration::hours(1);
+    let sigs = || Some(vec!["sig-a".to_string()]);
+
+    // Three matching manual_review rows, seeded out of `updated_at` order.
+    let newest = seed_with_status(
+        &pool,
+        &storage,
+        "q_new",
+        TransactionType::Withdrawal,
+        "manual_review",
+    )
+    .await?;
+    let oldest = seed_with_status(
+        &pool,
+        &storage,
+        "q_old",
+        TransactionType::Withdrawal,
+        "manual_review",
+    )
+    .await?;
+    let middle = seed_with_status(
+        &pool,
+        &storage,
+        "q_mid",
+        TransactionType::Withdrawal,
+        "manual_review",
+    )
+    .await?;
+    for (id, offset) in [(newest, 30i64), (oldest, 10), (middle, 20)] {
+        set_remint_signatures(&pool, id, sigs()).await?;
+        force_updated_at(&pool, id, base + chrono::Duration::seconds(offset)).await?;
+    }
+
+    // One pending_remint row: visible only to the PendingRemint query.
+    let remint = seed_with_status(
+        &pool,
+        &storage,
+        "q_pr",
+        TransactionType::Withdrawal,
+        "pending_remint",
+    )
+    .await?;
+    set_remint_signatures(&pool, remint, sigs()).await?;
+
+    // Every shape the predicates must exclude.
+    let wrong_status = seed_with_status(
+        &pool,
+        &storage,
+        "q_done",
+        TransactionType::Withdrawal,
+        "completed",
+    )
+    .await?;
+    set_remint_signatures(&pool, wrong_status, sigs()).await?;
+    let deposit = seed_with_status(
+        &pool,
+        &storage,
+        "q_dep",
+        TransactionType::Deposit,
+        "manual_review",
+    )
+    .await?;
+    set_remint_signatures(&pool, deposit, sigs()).await?;
+    let null_nonce = seed_with_status(
+        &pool,
+        &storage,
+        "q_nonce",
+        TransactionType::Withdrawal,
+        "manual_review",
+    )
+    .await?;
+    set_remint_signatures(&pool, null_nonce, sigs()).await?;
+    sqlx::query("UPDATE transactions SET withdrawal_nonce = NULL WHERE id = $1")
+        .bind(null_nonce)
+        .execute(&pool)
+        .await?;
+    let empty_sigs = seed_with_status(
+        &pool,
+        &storage,
+        "q_empty",
+        TransactionType::Withdrawal,
+        "manual_review",
+    )
+    .await?;
+    set_remint_signatures(&pool, empty_sigs, Some(Vec::new())).await?;
+    let no_sigs = seed_with_status(
+        &pool,
+        &storage,
+        "q_null",
+        TransactionType::Withdrawal,
+        "manual_review",
+    )
+    .await?;
+    set_remint_signatures(&pool, no_sigs, None).await?;
+    // Reachable on a database upgraded between the two column migrations:
+    // signatures present, the parallel heights array never backfilled.
+    let no_heights = seed_with_status(
+        &pool,
+        &storage,
+        "q_heights",
+        TransactionType::Withdrawal,
+        "manual_review",
+    )
+    .await?;
+    sqlx::query("UPDATE transactions SET remint_signatures = $2 WHERE id = $1")
+        .bind(no_heights)
+        .bind(vec!["sig-orphan".to_string()])
+        .execute(&pool)
+        .await?;
+
+    let found = storage
+        .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 100)
+        .await?;
+    assert_eq!(
+        found.iter().map(|t| t.id).collect::<Vec<_>>(),
+        vec![oldest, middle, newest],
+        "only rows with usable evidence, oldest updated_at first"
+    );
+
+    let found_remint = storage
+        .get_stalled_withdrawals_with_signatures(TransactionStatus::PendingRemint, 100)
+        .await?;
+    assert_eq!(
+        found_remint.iter().map(|t| t.id).collect::<Vec<_>>(),
+        vec![remint],
+        "the status bind must not leak rows from the other stalled status"
+    );
+
+    let limited = storage
+        .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 2)
+        .await?;
+    assert_eq!(
+        limited.iter().map(|t| t.id).collect::<Vec<_>>(),
+        vec![oldest, middle],
+        "LIMIT must truncate the oldest-first ordering, not an arbitrary slice"
+    );
+    Ok(())
+}
+
+async fn remint_columns_of(
+    pool: &PgPool,
+    id: i64,
+) -> Result<(Option<Vec<String>>, Option<Vec<i64>>), Box<dyn std::error::Error>> {
+    let row: (Option<Vec<String>>, Option<Vec<i64>>) = sqlx::query_as(
+        "SELECT remint_signatures, remint_last_valid_block_heights FROM transactions WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await?;
+    Ok(row)
+}
+
+/// I3: the quarantine CAS stores the evidence in the same statement that flips
+/// the status, and a `None` call leaves the columns exactly as they were.
+#[tokio::test(flavor = "multi_thread")]
+async fn quarantine_cas_writes_signatures_and_coalesces_none(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pool, storage, _pg) = start_postgres().await?;
+    let sigs = vec!["sig-quarantine".to_string()];
+
+    let with_sigs = seed_with_status(
+        &pool,
+        &storage,
+        "q3_write",
+        TransactionType::Withdrawal,
+        "processing",
+    )
+    .await?;
+    let captured = updated_at_of(&pool, with_sigs).await;
+    let quarantined = storage
+        .try_quarantine_processing(with_sigs, captured, Some(sigs.clone()), Some(vec![777i64]))
+        .await?;
+    assert!(quarantined, "fresh CAS must succeed");
+    assert_eq!(status_of(&pool, with_sigs).await, "manual_review");
+    let (stored_sigs, stored_heights) = remint_columns_of(&pool, with_sigs).await?;
+    assert_eq!(stored_sigs, Some(sigs));
+    assert_eq!(stored_heights, Some(vec![777i64]));
+
+    // NOW() is the transaction timestamp, so these two agree only if the status
+    // flip and the column write happened in one statement. A "write columns,
+    // then CAS" pair would leave two distinct timestamps (and the CAS could
+    // never match, since the first write already bumped updated_at).
+    let (updated, processed): (chrono::DateTime<Utc>, Option<chrono::DateTime<Utc>>) =
+        sqlx::query_as("SELECT updated_at, processed_at FROM transactions WHERE id = $1")
+            .bind(with_sigs)
+            .fetch_one(&pool)
+            .await?;
+    assert!(updated > captured, "the trigger must bump updated_at");
+    assert_eq!(
+        Some(updated),
+        processed,
+        "one statement means one NOW(); a second write would desync these"
+    );
+
+    // A None call must not erase columns an earlier transition already wrote.
+    let preloaded = seed_with_status(
+        &pool,
+        &storage,
+        "q3_keep",
+        TransactionType::Withdrawal,
+        "processing",
+    )
+    .await?;
+    set_remint_signatures(&pool, preloaded, Some(vec!["sig-existing".to_string()])).await?;
+    let captured = updated_at_of(&pool, preloaded).await;
+    assert!(
+        storage
+            .try_quarantine_processing(preloaded, captured, None, None)
+            .await?
+    );
+    let (kept_sigs, kept_heights) = remint_columns_of(&pool, preloaded).await?;
+    assert_eq!(kept_sigs, Some(vec!["sig-existing".to_string()]));
+    assert_eq!(kept_heights, Some(vec![0i64]));
+
+    // A losing racer writes nothing at all, columns included.
+    let stale_row = seed_with_status(
+        &pool,
+        &storage,
+        "q3_stale",
+        TransactionType::Withdrawal,
+        "processing",
+    )
+    .await?;
+    let stale = updated_at_of(&pool, stale_row).await - chrono::Duration::seconds(60);
+    assert!(
+        !storage
+            .try_quarantine_processing(
+                stale_row,
+                stale,
+                Some(vec!["sig-race".to_string()]),
+                Some(vec![1])
+            )
+            .await?
+    );
+    assert_eq!(status_of(&pool, stale_row).await, "processing");
+    assert_eq!(remint_columns_of(&pool, stale_row).await?, (None, None));
+    Ok(())
+}

--- a/indexer/tests/postgres_db_test.rs
+++ b/indexer/tests/postgres_db_test.rs
@@ -1436,17 +1436,22 @@ async fn stalled_withdrawal_query_predicates_and_ordering() -> Result<(), Box<dy
         .execute(&pool)
         .await?;
 
+    // Ids ascend in insertion order, which is deliberately not `updated_at`
+    // order here: a row left untouched keeps its `updated_at` forever, so the
+    // sweep pages on the one key that always advances.
+    let by_id = vec![newest, oldest, middle];
+
     let found = storage
-        .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 100)
+        .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 0, 100)
         .await?;
     assert_eq!(
         found.iter().map(|t| t.id).collect::<Vec<_>>(),
-        vec![oldest, middle, newest],
-        "only rows with usable evidence, oldest updated_at first"
+        by_id,
+        "only rows with usable evidence, ascending id"
     );
 
     let found_remint = storage
-        .get_stalled_withdrawals_with_signatures(TransactionStatus::PendingRemint, 100)
+        .get_stalled_withdrawals_with_signatures(TransactionStatus::PendingRemint, 0, 100)
         .await?;
     assert_eq!(
         found_remint.iter().map(|t| t.id).collect::<Vec<_>>(),
@@ -1454,13 +1459,23 @@ async fn stalled_withdrawal_query_predicates_and_ordering() -> Result<(), Box<dy
         "the status bind must not leak rows from the other stalled status"
     );
 
-    let limited = storage
-        .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 2)
+    // Paging must cover every row exactly once: the second page starts strictly
+    // after the last id of the first, so nothing repeats and nothing is skipped.
+    let page_one = storage
+        .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, 0, 2)
         .await?;
     assert_eq!(
-        limited.iter().map(|t| t.id).collect::<Vec<_>>(),
-        vec![oldest, middle],
-        "LIMIT must truncate the oldest-first ordering, not an arbitrary slice"
+        page_one.iter().map(|t| t.id).collect::<Vec<_>>(),
+        by_id[..2].to_vec(),
+        "first page is the two lowest ids"
+    );
+    let page_two = storage
+        .get_stalled_withdrawals_with_signatures(TransactionStatus::ManualReview, by_id[1], 2)
+        .await?;
+    assert_eq!(
+        page_two.iter().map(|t| t.id).collect::<Vec<_>>(),
+        by_id[2..].to_vec(),
+        "the cursor must resume after the previous page, not repeat it"
     );
     Ok(())
 }

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1498,3 +1498,105 @@ async fn it15_manual_review_without_signatures_stays_quarantined() {
     );
     mock.shutdown().await;
 }
+
+// IT-16: the boot pre-flight's own path, against real Postgres. A PendingRemint
+// withdrawal whose release finalized is promoted, and the nonce then appears in
+// the completed set the SMT gate rebuilds from. That last assertion is the whole
+// point: it proves the promotion feeds the exact query that refuses the boot,
+// which the MockStorage unit test cannot show.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it16_pending_remint_landed_release_enters_completed_nonce_set() {
+    let (db, url, _container) = start_pg("it16_preflight").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 30);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    // The insert omits withdrawal_nonce, so a trigger assigns it from a sequence.
+    // Read back the value the row actually holds rather than the seeded one.
+    let nonce_u64 =
+        sqlx::query_scalar::<_, i64>("SELECT withdrawal_nonce FROM transactions WHERE id = $1")
+            .bind(tx_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap() as u64;
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(tx_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // The release broadcast that could not be confirmed, parked for a later check.
+    let landed_sig = Signature::new_unique();
+    storage
+        .set_pending_remint(
+            tx_id,
+            vec![landed_sig.to_string()],
+            vec![100],
+            Utc::now() + ChronoDuration::seconds(32),
+        )
+        .await
+        .unwrap();
+
+    // The wedge: the chain has this nonce, the completed set the gate rebuilds
+    // from does not, so validate_smt_root would diverge and refuse to start.
+    assert!(
+        !storage
+            .get_completed_withdrawal_nonces(0, 1000)
+            .await
+            .unwrap()
+            .contains(&nonce_u64),
+        "a pending_remint row must start outside the completed set"
+    );
+
+    let mock = MockRpcServer::start().await;
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": {"slot": 200},
+            "value": [{
+                "slot": 100,
+                "confirmations": null,
+                "err": null,
+                "status": {"Ok": null},
+                "confirmationStatus": "finalized"
+            }]
+        })),
+    );
+    let client = test_client(mock.url());
+    let metric_before = snapshot_recovered("withdraw", "pending_remint_cleared", "withdrawal");
+
+    test_hooks::reconcile_stalled_withdrawals_once(
+        &storage,
+        &client,
+        private_channel_indexer::storage::TransactionStatus::PendingRemint,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "completed");
+    assert_eq!(
+        counterpart_sig_of(&pool, tx_id).await,
+        Some(landed_sig.to_string())
+    );
+    assert!(
+        storage
+            .get_completed_withdrawal_nonces(0, 1000)
+            .await
+            .unwrap()
+            .contains(&nonce_u64),
+        "the promoted nonce must now be in the set the SMT gate rebuilds from, \
+         or the boot would still refuse to start"
+    );
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    assert_recovered_increment(
+        "withdraw",
+        "pending_remint_cleared",
+        "withdrawal",
+        metric_before,
+        "IT-16",
+    );
+    mock.shutdown().await;
+}

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1600,3 +1600,89 @@ async fn it16_pending_remint_landed_release_enters_completed_nonce_set() {
     );
     mock.shutdown().await;
 }
+
+// IT-17: a full batch of rows that can never clear must not hide the rows behind
+// them. Nothing is written for a non-landed verdict, so an ordering that is
+// stable across sweeps would hand back the same blocked rows forever and starve
+// every later row, including a landed one that is still wedging the boot gate.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it17_stuck_batch_does_not_starve_later_stalled_rows() {
+    let (db, url, _container) = start_pg("it17_starve").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let deadline = Utc::now() + ChronoDuration::seconds(32);
+
+    // Exactly one full batch of rows that are fetched but can never classify:
+    // the stored signature does not parse, so each is skipped without an RPC.
+    let mut blocked = Vec::new();
+    for _ in 0..100 {
+        let tx = make_withdrawal(&Signature::new_unique().to_string(), 0);
+        let id = db.insert_transaction_internal(&tx).await.unwrap();
+        sqlx::query(
+            "UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        storage
+            .set_pending_remint(id, vec!["not-a-signature".to_string()], vec![100], deadline)
+            .await
+            .unwrap();
+        blocked.push(id);
+    }
+
+    // Inserted last, so it sorts behind the whole blocked batch under any
+    // ordering the sweep might use.
+    let landed_sig = Signature::new_unique();
+    let target = make_withdrawal(&Signature::new_unique().to_string(), 0);
+    let target_id = db.insert_transaction_internal(&target).await.unwrap();
+    sqlx::query("UPDATE transactions SET status = 'processing'::transaction_status WHERE id = $1")
+        .bind(target_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    storage
+        .set_pending_remint(target_id, vec![landed_sig.to_string()], vec![100], deadline)
+        .await
+        .unwrap();
+
+    let mock = MockRpcServer::start().await;
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": {"slot": 200},
+            "value": [{
+                "slot": 100,
+                "confirmations": null,
+                "err": null,
+                "status": {"Ok": null},
+                "confirmationStatus": "finalized"
+            }]
+        })),
+    );
+    let client = test_client(mock.url());
+
+    test_hooks::reconcile_stalled_withdrawals_once(
+        &storage,
+        &client,
+        private_channel_indexer::storage::TransactionStatus::PendingRemint,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        status_of(&pool, target_id).await,
+        "completed",
+        "a landed row behind a full batch of unclearable rows must still be reached"
+    );
+    assert_eq!(
+        status_of(&pool, blocked[0]).await,
+        "pending_remint",
+        "rows that cannot classify stay exactly where they are"
+    );
+    mock.shutdown().await;
+}

--- a/integration/tests/indexer/stuck_processing_recovery.rs
+++ b/integration/tests/indexer/stuck_processing_recovery.rs
@@ -1360,3 +1360,141 @@ async fn threshold_boundary_returns_only_strictly_older_rows() {
         "5:01-old row MUST be returned (older than threshold)"
     );
 }
+
+// IT-14: a withdrawal quarantined on RPC uncertainty carries its release
+// signatures on the row, so a later tick can prove the release landed and clear
+// it, even though the signature journal has since been GC'd.
+
+async fn remint_signatures_of(pool: &sqlx::PgPool, id: i64) -> Option<Vec<String>> {
+    sqlx::query_scalar::<_, Option<Vec<String>>>(
+        "SELECT remint_signatures FROM transactions WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn journal_len(pool: &sqlx::PgPool, id: i64) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM pending_release_signatures WHERE transaction_id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it14_manual_review_landed_release_clears_to_completed() {
+    let (db, url, _container) = start_pg("it8_clears").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 21);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+    let landed_sig = Signature::new_unique();
+    db.insert_release_signature_internal(tx_id, landed_sig.to_string(), 100)
+        .await
+        .unwrap();
+
+    // Pass 1: nothing scripted, so every getSignatureStatuses errors and the
+    // classifier reports Uncertain, which quarantines.
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
+
+    assert_eq!(status_of(&pool, tx_id).await, "manual_review");
+    assert_eq!(
+        remint_signatures_of(&pool, tx_id).await,
+        Some(vec![landed_sig.to_string()]),
+        "the quarantine must copy the evidence onto the row"
+    );
+
+    // Pass 2: the RPC recovers and reports the release finalized.
+    mock.enqueue(
+        "getSignatureStatuses",
+        Reply::result(json!({
+            "context": {"slot": 200},
+            "value": [{
+                "slot": 100,
+                "confirmations": null,
+                "err": null,
+                "status": {"Ok": null},
+                "confirmationStatus": "finalized"
+            }]
+        })),
+    );
+    let metric_before = snapshot_recovered("withdraw", "manual_review_cleared", "withdrawal");
+
+    test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        journal_len(&pool, tx_id).await,
+        0,
+        "the GC at the top of pass 2 removes the journal, so the promotion below \
+         can only have come from the row's own columns"
+    );
+    assert_eq!(status_of(&pool, tx_id).await, "completed");
+    assert_eq!(
+        counterpart_sig_of(&pool, tx_id).await,
+        Some(landed_sig.to_string())
+    );
+    assert_eq!(mock.call_count("sendTransaction"), 0);
+    assert_recovered_increment(
+        "withdraw",
+        "manual_review_cleared",
+        "withdrawal",
+        metric_before,
+        "IT-14",
+    );
+    mock.shutdown().await;
+}
+
+// IT-15: a withdrawal quarantined with no evidence at all stays quarantined and
+// never costs an RPC round trip, on this tick or any later one.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn it15_manual_review_without_signatures_stays_quarantined() {
+    let (db, url, _container) = start_pg("it9_no_evidence").await;
+    let storage = Arc::new(Storage::Postgres(db.clone()));
+    storage.init_schema().await.unwrap();
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    let tx = make_withdrawal(&Signature::new_unique().to_string(), 22);
+    let tx_id = db.insert_transaction_internal(&tx).await.unwrap();
+    seed_backdated_processing(&pool, tx_id, ChronoDuration::minutes(10)).await;
+
+    let mock = MockRpcServer::start().await;
+    let client = test_client(mock.url());
+    let (storage_tx, _rx) = mpsc::channel::<TransactionStatusUpdate>(8);
+
+    for pass in 1..=2 {
+        test_hooks::run_recovery_once(&storage, &client, ProgramType::Withdraw, &storage_tx)
+            .await
+            .unwrap();
+        assert_eq!(
+            status_of(&pool, tx_id).await,
+            "manual_review",
+            "pass {pass}: a row with no evidence must stay for a human"
+        );
+    }
+
+    assert_eq!(
+        remint_signatures_of(&pool, tx_id).await,
+        None,
+        "there was nothing to record, so COALESCE must leave the column NULL"
+    );
+    assert_eq!(
+        mock.call_count("getSignatureStatuses"),
+        0,
+        "the permanently-stuck population must be filtered in SQL, never re-classified"
+    );
+    mock.shutdown().await;
+}


### PR DESCRIPTION
## Summary

### Problem

The withdraw boot gate rebuilds the local SMT from `completed` rows only, so a release that landed on-chain while its row was in `manual_review` or `pending_remint` was invisible to the gate, causing `SmtRootMismatch` and a permanent restart loop. Quarantined rows could also lose their signature journal to GC, leaving no way to recover automatically.

### Change

`try_quarantine_processing` now saves broadcast signatures when moving a row to `manual_review`. A new `reconcile_landed_withdrawals` sweep re-checks stalled rows with signatures and promotes them to `completed` only when the existing signature classifier proves the release landed. The update uses a CAS with the allowed source statuses to avoid races.

`recover_once` runs the reconciliation for `manual_review` on every tick and at boot, while `run_withdraw_preflight` checks `pending_remint` once before the sender starts. This allows already-settled withdrawals to repair themselves and prevents them from permanently blocking startup.
### Coverage Report

| Component | Lines Hit | Lines Total | Coverage | Artifact |
|-----------|-----------|-------------|----------|----------|
| Core | 12,065 | 13,690 | 88.1% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31490488699) |
| Indexer | 23,998 | 27,172 | 88.3% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31490488699) |
| Gateway | 1,055 | 1,230 | 85.8% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31490488699) |
| Auth | 830 | 949 | 87.5% | [rust-unit-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31490488699) |
| Withdraw Program | - | - | - | - |
| Escrow Program | - | - | - | - |
| DvP Swap Program | - | - | - | - |
| E2E Integration | 12,564 | 15,648 | 80.3% | [e2e-coverage-reports](https://github.com/solana-foundation/solana-private-channels/actions/runs/31490488699) |
| **Total** | **50,512** | **58,689** | **86.1%** | |

> Last updated: 2026-08-11 12:43:54 UTC by E2E Integration